### PR TITLE
DEV9: Various Socket Fixes

### DIFF
--- a/pcsx2/DEV9/AdapterUtils.cpp
+++ b/pcsx2/DEV9/AdapterUtils.cpp
@@ -384,7 +384,8 @@ std::vector<IP_Address> AdapterUtils::GetGateways(const Adapter* adapter)
 		if (ReadAddressFamily(address->Address.lpSockaddr) == AF_INET)
 		{
 			const sockaddr_in* sockaddr = reinterpret_cast<sockaddr_in*>(address->Address.lpSockaddr);
-			collection.push_back(std::bit_cast<IP_Address>(sockaddr->sin_addr));
+			if (sockaddr->sin_addr.S_un.S_addr != 0)
+				collection.push_back(std::bit_cast<IP_Address>(sockaddr->sin_addr));
 		}
 		address = address->Next;
 	}

--- a/pcsx2/DEV9/PacketReader/IP/IP_Packet.cpp
+++ b/pcsx2/DEV9/PacketReader/IP/IP_Packet.cpp
@@ -4,6 +4,7 @@
 #include "IP_Packet.h"
 #include "DEV9/PacketReader/NetLib.h"
 
+#include "common/BitUtils.h"
 #include "common/Console.h"
 
 namespace PacketReader::IP
@@ -209,8 +210,8 @@ namespace PacketReader::IP
 		for (size_t i = 0; i < options.size(); i++)
 			opOffset += options[i]->GetLength();
 
-		opOffset += opOffset % 4; //needs to be a whole number of 32bits
-		headerLength = opOffset;
+		//needs to be a whole number of 32bits
+		headerLength = Common::AlignUpPow2(opOffset, 4);
 	}
 
 	void IP_Packet::CalculateChecksum()

--- a/pcsx2/DEV9/PacketReader/IP/IP_Packet.cpp
+++ b/pcsx2/DEV9/PacketReader/IP/IP_Packet.cpp
@@ -17,7 +17,7 @@ namespace PacketReader::IP
 	{
 		return (dscp >> 2) & 0x3F;
 	}
-	void IP_Packet::GetDscpValue(u8 value)
+	void IP_Packet::SetDscpValue(u8 value)
 	{
 		dscp = (dscp & ~(0x3F << 2)) | ((value & 0x3F) << 2);
 	}

--- a/pcsx2/DEV9/PacketReader/IP/IP_Packet.h
+++ b/pcsx2/DEV9/PacketReader/IP/IP_Packet.h
@@ -86,7 +86,7 @@ namespace PacketReader::IP
 		 * bit0: Set to zero
 		 */
 		u8 GetDscpValue();
-		void GetDscpValue(u8 value);
+		void SetDscpValue(u8 value);
 
 		/* 2 bits
 		 * In TOS, defined as follows

--- a/pcsx2/DEV9/PacketReader/IP/TCP/TCP_Packet.cpp
+++ b/pcsx2/DEV9/PacketReader/IP/TCP/TCP_Packet.cpp
@@ -4,6 +4,7 @@
 #include "TCP_Packet.h"
 #include "DEV9/PacketReader/NetLib.h"
 
+#include "common/BitUtils.h"
 #include "common/Console.h"
 
 namespace PacketReader::IP::TCP
@@ -232,8 +233,8 @@ namespace PacketReader::IP::TCP
 		for (size_t i = 0; i < options.size(); i++)
 			opOffset += options[i]->GetLength();
 
-		opOffset += opOffset % 4; //needs to be a whole number of 32bits
-		headerLength = opOffset;
+		//needs to be a whole number of 32bits
+		headerLength = Common::AlignUpPow2(opOffset, 4);
 
 		//Also write into dataOffsetAndNS_Flag
 		u8 ns = dataOffsetAndNS_Flag & 1;

--- a/pcsx2/DEV9/PacketReader/IP/UDP/DNS/DNS_Classes.h
+++ b/pcsx2/DEV9/PacketReader/IP/UDP/DNS/DNS_Classes.h
@@ -43,9 +43,5 @@ namespace PacketReader::IP::UDP::DNS
 		virtual void WriteBytes(u8* buffer, int* offset);
 
 		virtual ~DNS_ResponseEntry(){};
-
-	private:
-		void ReadDNSString(u8* buffer, int* offset, std::string* value);
-		void WriteDNSString(u8* buffer, int* offset, std::string value);
 	};
 } // namespace PacketReader::IP::UDP::DNS

--- a/pcsx2/DEV9/ThreadSafeMap.h
+++ b/pcsx2/DEV9/ThreadSafeMap.h
@@ -37,10 +37,10 @@ public:
 		map[key] = value;
 	}
 
-	void Remove(Key key)
+	bool Remove(Key key)
 	{
 		std::unique_lock modifyLock(accessMutex);
-		map.erase(key);
+		return map.erase(key) == 1;
 	}
 
 	void Clear()

--- a/pcsx2/DEV9/sockets.cpp
+++ b/pcsx2/DEV9/sockets.cpp
@@ -527,7 +527,8 @@ int SocketAdapter::SendFromConnection(ConnectionKey Key, IP_Packet* ipPkt)
 void SocketAdapter::HandleConnectionClosed(BaseSession* sender)
 {
 	const ConnectionKey key = sender->key;
-	connections.Remove(key);
+	if (!connections.Remove(key))
+		return;
 
 	// Defer deleting the connection untill we have left the calling session's callstack
 	if (std::this_thread::get_id() == sendThreadId)
@@ -558,7 +559,8 @@ void SocketAdapter::HandleConnectionClosed(BaseSession* sender)
 void SocketAdapter::HandleFixedPortClosed(BaseSession* sender)
 {
 	const ConnectionKey key = sender->key;
-	connections.Remove(key);
+	if (!connections.Remove(key))
+		return;
 	fixedUDPPorts.Remove(key.ps2Port);
 
 	// Defer deleting the connection untill we have left the calling session's callstack


### PR DESCRIPTION
### Description of Changes
Skip over invalid gateways for DHCP Auto Gateways on Windows
Correct `SetDscpValue()` function definition and remove unused duplicate definitions for `Read/WriteDNSString()`
Guard against out of bound reads when handling ICMP port rejected packets
Use Common functions for aligning header length
Fix possible race-condition when removing closed connections

### Rationale behind Changes
A gateway of 0.0.0.0 is not usable, code to exclude this existed for other platforms.

Function definitions should not be incorrect.

When handling malformed ICMP packets, the offset to the contained IP packet was not accounted for when reading said IP packet.
Additionally, make sure we don't loop (potentially) infinitely if we get a _really_ malformed packet.

Existing alignment for IP and TCP options was correct enough to work, but not actually correct.

If you are unlucky, a connection could close itself while the adapter was reset (potentially closing itself again),
This would result in our connection close handler trying to delete the connection twice.
Check if the connection is in our connections map, if it isn't then we are already handling it.

I opted to group these into a single PR, If it is preferred to separate then out into their own PRs, then I can do so.

### Suggested Testing Steps
Test online games with Sockets