### PR TITLE
GameDB: Fix incorrect field order in Silent Hill 3 FMVs

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -16715,6 +16715,7 @@ SLES-51434:
     - SoftwareRendererFMVHack # Fixes blackscreen when FMV.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes menu transparancy effects and text.
+    deinterlace: 9 # Fixes incorrect field order in FMVs.
   memcardFilters:
     - "SLES-51434"
     - "SLES-50382"
@@ -29241,6 +29242,7 @@ SLKA-25065:
     - SoftwareRendererFMVHack # Fixes blackscreen when FMV.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes menu transparancy effects and text.
+    deinterlace: 9 # Fixes incorrect field order in FMVs.
 SLKA-25066:
   name: "Zone of the Enders - The 2nd Runner SE"
   region: "NTSC-K"
@@ -38472,6 +38474,7 @@ SLPM-65257:
     - SoftwareRendererFMVHack # Fixes blackscreen when FMV.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes menu transparancy effects and text.
+    deinterlace: 9 # Fixes incorrect field order in FMVs.
   memcardFilters:
     - "SLPM-65257"
     - "SLPM-65622"
@@ -40463,6 +40466,7 @@ SLPM-65622:
     - SoftwareRendererFMVHack # Fixes blackscreen when FMV.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes menu transparancy effects and text.
+    deinterlace: 9 # Fixes incorrect field order in FMVs.
   memcardFilters:
     - "SLPM-65257"
     - "SLPM-65622"
@@ -42715,6 +42719,7 @@ SLPM-66018:
     - SoftwareRendererFMVHack # Fixes blackscreen when FMV.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes menu transparancy effects and text.
+    deinterlace: 9 # Fixes incorrect field order in FMVs.
   memcardFilters:
     - "SLPM-65257"
     - "SLPM-65622"
@@ -61354,6 +61359,7 @@ SLUS-20622:
     - SoftwareRendererFMVHack # Fixes blackscreen when FMV.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes menu transparancy effects and text.
+    deinterlace: 9 # Fixes incorrect field order in FMVs.
   memcardFilters: # Reads Silent Hill 2 for easter egg.
     - "SLUS-20622"
     - "SLUS-20228"


### PR DESCRIPTION
### Description of Changes
Fixes incorrect field order in FMVs by using Adaptive BFF.

Automatic:
![image](https://github.com/user-attachments/assets/74573677-12b8-43de-a299-c393e46ef590)

Adaptive BFF:
![image](https://github.com/user-attachments/assets/3d6e4420-7a96-4f78-9f6c-19f2242dbc53)

### Rationale behind Changes
Incorrect field order looks gross as heck.

### Suggested Testing Steps
Make sure CI is happy boyo.
