### PR TITLE
EE Cache: Writeback dirty cache entries when exiting the interpreter.

### DIFF
--- a/pcsx2/Cache.cpp
+++ b/pcsx2/Cache.cpp
@@ -163,6 +163,17 @@ void resetCache()
 	std::memset(&cache, 0, sizeof(cache));
 }
 
+void writebackCache()
+{
+	for (int i = 0; i < 64; i++)
+	{
+		for (int j = 0; j < 2; j++)
+		{
+			cache.lineAt(i, j).writeBackIfNeeded();
+		}
+	}
+}
+
 static bool findInCache(const CacheSet& set, uptr ppf, int* way)
 {
 	auto check = [&](int checkWay) -> bool {

--- a/pcsx2/Cache.h
+++ b/pcsx2/Cache.h
@@ -8,6 +8,9 @@
 #include "common/SingleRegisterTypes.h"
 
 void resetCache();
+// Dumps all dirty cache entries to memory
+// This is necessary to fix a bug when enabled the recompiler while the cache was enabled.
+void writebackCache();
 void writeCache8(u32 mem, u8 value, bool validPFN = true);
 void writeCache16(u32 mem, u16 value, bool validPFN = true);
 void writeCache32(u32 mem, u32 value, bool validPFN = true);

--- a/pcsx2/Interpreter.cpp
+++ b/pcsx2/Interpreter.cpp
@@ -5,6 +5,7 @@
 #include "R5900OpcodeTables.h"
 #include "VMManager.h"
 #include "Elfheader.h"
+#include "Cache.h"
 
 #include "DebugTools/Breakpoints.h"
 
@@ -555,6 +556,8 @@ static void intEventTest()
 	if (intExitExecution)
 	{
 		intExitExecution = false;
+		if (CHECK_EEREC)
+			writebackCache();
 		fastjmp_jmp(&intJmpBuf, 1);
 	}
 }
@@ -566,7 +569,11 @@ static void intSafeExitExecution()
 	if (eeEventTestIsActive)
 		intExitExecution = true;
 	else
+	{
+		if (CHECK_EEREC)
+			writebackCache();
 		fastjmp_jmp(&intJmpBuf, 1);
+	}
 }
 
 static void intCancelInstruction()


### PR DESCRIPTION
### Description of Changes
Introducing another fix that affects 0.01% of users. 🥳 
When the interpreter shuts down and control goes to the recompiler I've made it so all EE cache entries are written back to memory.

### Rationale behind Changes
This fixes #6637

### Suggested Testing Steps
Run a game, enable the EE cache, disable the recompiler, and then enable the recompiler. It some instances it would cause PCSX2 to crash or the game to TLB miss and freeze. This should have been addressed in this PR.
