### PR TITLE
FileSystem: Prevent Path::RealPath from returning paths containing '.' and '..' components

### DIFF
--- a/common/FileSystem.cpp
+++ b/common/FileSystem.cpp
@@ -453,6 +453,11 @@ std::string Path::RealPath(const std::string_view path)
 			}
 		}
 	}
+
+	// If any relative symlinks were resolved, there may be '.' and '..'
+	// components in the resultant path, which must be removed.
+	realpath = Path::Canonicalize(realpath);
+
 #endif
 
 	return realpath;

--- a/common/FileSystem.cpp
+++ b/common/FileSystem.cpp
@@ -1925,6 +1925,26 @@ bool FileSystem::SetPathCompression(const char* path, bool enable)
 	return result;
 }
 
+bool FileSystem::CreateSymLink(const char* link, const char* target)
+{
+	// convert to wide string
+	const std::wstring wlink = GetWin32Path(link);
+	if (wlink.empty())
+		return false;
+
+	const std::wstring wtarget = GetWin32Path(target);
+	if (wtarget.empty())
+		return false;
+
+	// check if it's a directory
+	DWORD flags = 0;
+	if (DirectoryExists(target))
+		flags |= SYMBOLIC_LINK_FLAG_DIRECTORY;
+
+	// create the symbolic link
+	return CreateSymbolicLinkW(wlink.c_str(), wtarget.c_str(), flags) != 0;
+}
+
 bool FileSystem::IsSymbolicLink(const char* path)
 {
 	// convert to wide string
@@ -2503,6 +2523,11 @@ bool FileSystem::SetWorkingDirectory(const char* path)
 bool FileSystem::SetPathCompression(const char* path, bool enable)
 {
 	return false;
+}
+
+bool FileSystem::CreateSymLink(const char* link, const char* target)
+{
+	return symlink(target, link) == 0;
 }
 
 bool FileSystem::IsSymbolicLink(const char* path)

--- a/common/FileSystem.h
+++ b/common/FileSystem.h
@@ -169,6 +169,10 @@ namespace FileSystem
 	/// Does nothing and returns false on non-Windows platforms.
 	bool SetPathCompression(const char* path, bool enable);
 
+	// Creates a symbolic link. Note that on Windows this requires elevated
+	// privileges so this is mostly useful for testing purposes.
+	bool CreateSymLink(const char* link, const char* target);
+
 	/// Checks if a file or directory is a symbolic link.
 	bool IsSymbolicLink(const char* path);
 

--- a/tests/ctest/common/filesystem_tests.cpp
+++ b/tests/ctest/common/filesystem_tests.cpp
@@ -7,8 +7,6 @@
 
 #ifdef __linux__
 
-#include <unistd.h>
-
 static std::optional<std::string> create_test_directory()
 {
 	for (u16 i = 0; i < UINT16_MAX; i++)
@@ -42,7 +40,7 @@ TEST(FileSystem, RecursiveDeleteDirectoryDontFollowSymbolicLinks)
 	std::string dir_to_delete = Path::Combine(*test_dir, "dir_to_delete");
 	ASSERT_TRUE(FileSystem::CreateDirectoryPath(dir_to_delete.c_str(), false));
 	std::string symlink_path = Path::Combine(dir_to_delete, "link");
-	ASSERT_EQ(symlink(target_dir.c_str(), symlink_path.c_str()), 0);
+	ASSERT_TRUE(FileSystem::CreateSymLink(symlink_path.c_str(), target_dir.c_str()));
 
 	// Delete the directory containing the symlink.
 	ASSERT_TRUE(dir_to_delete.starts_with("/tmp/pcsx2_filesystem_test_"));

--- a/tests/ctest/common/filesystem_tests.cpp
+++ b/tests/ctest/common/filesystem_tests.cpp
@@ -45,10 +45,10 @@ TEST(FileSystem, RecursiveDeleteDirectoryDontFollowSymbolicLinks)
 	ASSERT_EQ(symlink(target_dir.c_str(), symlink_path.c_str()), 0);
 
 	// Delete the directory containing the symlink.
-	ASSERT_TRUE(dir_to_delete.starts_with("/tmp/"));
+	ASSERT_TRUE(dir_to_delete.starts_with("/tmp/pcsx2_filesystem_test_"));
 	ASSERT_TRUE(FileSystem::RecursiveDeleteDirectory(dir_to_delete.c_str()));
 
-	// Make sure the target file didn't get deleted.
+	// Make sure the file in the target directory didn't get deleted.
 	ASSERT_TRUE(FileSystem::FileExists(file_path.c_str()));
 
 	// Clean up.


### PR DESCRIPTION
### Description of Changes
When resolving relative symlinks that contain `.` and `..` components on Linux, `Path::RealPath` will now return canonical paths instead of paths that contain said `.` an `..` components.

The `FileSystem::CreateSymLink` function has been added so I no longer have to call a POSIX-specific function in the test code (although the tests are still only run on Linux since on Windows they would require elevated privileges or developer mode to create the symbolic links).

While I was at it, I neatened up the recursive directory deletion test a little bit.

### Rationale behind Changes
One symptom of this was that if you created a circular symbolic link in a recursively scanned game directory on Linux or macOS, PCSX2 would go crazy scanning the same games again and again. This happened because the `RecursiveFindFiles` function does string comparisons on the result of `Path::RealPath` to try and detect cycles.

### Suggested Testing Steps
Try the following setup:
```
games/
  link/ -> games/
  game.iso
```
and
```
games/
  dir/
    link/ -> games/
  game.iso
```
where `games` is a game directory that PCSX2 is configured to scan recursively and `lhs -> rhs` denotes a symbolic link from `lhs` to `rhs`.