### PR TITLE
ChdFileReader: Use core_file instead of modifing chd_open_file

### DIFF
--- a/3rdparty/libchdr/include/libchdr/chd.h
+++ b/3rdparty/libchdr/include/libchdr/chd.h
@@ -259,7 +259,6 @@ extern "C" {
 /* CHD open values */
 #define CHD_OPEN_READ				1
 #define CHD_OPEN_READWRITE			2
-#define CHD_OPEN_TRANSFER_FILE 4 /* Freeing of the FILE* is now libchdr's responsibility if open was successful */
 
 /* error types */
 enum _chd_error

--- a/3rdparty/libchdr/src/libchdr_chd.c
+++ b/3rdparty/libchdr/src/libchdr_chd.c
@@ -1737,13 +1737,7 @@ CHD_EXPORT chd_error chd_open_file(FILE *file, int mode, chd_file *parent, chd_f
 	stream->fclose = core_stdio_fclose_nonowner;
 	stream->fseek = core_stdio_fseek;
 
-	chd_error err = chd_open_core_file(stream, mode, parent, chd);
-	if (err != CHDERR_NONE)
-		return err;
-
-	// swap out the fclose so that we close it on chd clost
-	stream->fclose = core_stdio_fclose;
-	return CHDERR_NONE;
+	return chd_open_core_file(stream, mode, parent, chd);
 }
 
 /*-------------------------------------------------


### PR DESCRIPTION
### Description of Changes
Removes the patches applied to chd_open_file, and instead uses libchdr's virtual IO API to achieve the same behaviour

### Rationale behind Changes
Such patches can be missed when updating dependencies, potentially leading to difficulty updating or introduction of bugs

Additionally, this patch did not check for `CHD_OPEN_TRANSFER_FILE` before taking ownership, this issue, however, didn't actually impact us as we always wanted that anyway.

This could in future allow use to implement precaching ourselves, rather then relying on the (patched) implementation provided by libchdr.

### Suggested Testing Steps
Test using CHD files
