### PR TITLE
ChdFileReader: Correct extension check

### DIFF
--- a/pcsx2/CDVD/ChdFileReader.cpp
+++ b/pcsx2/CDVD/ChdFileReader.cpp
@@ -105,7 +105,7 @@ static chd_file* OpenCHD(const std::string& filename, FileSystem::ManagedCFilePt
 			parent_dir.c_str(), "*.*", FILESYSTEM_FIND_FILES | FILESYSTEM_FIND_HIDDEN_FILES | FILESYSTEM_FIND_KEEP_ARRAY, &parent_files);
 		for (FILESYSTEM_FIND_DATA& fd : parent_files)
 		{
-			if (StringUtil::EndsWithNoCase(Path::GetExtension(fd.FileName), ".chd"))
+			if (!StringUtil::EndsWithNoCase(Path::GetExtension(fd.FileName), "chd"))
 				continue;
 
 			// Re-check the header, it might have changed since we last opened.


### PR DESCRIPTION
### Description of Changes
This check would fail if the returned extension was `.chd`
Additionally, `GetExtension` would return the extension without `.`, so no file would fail

### Rationale behind Changes
This issue only impacts chd files with parent chd files
When searching for the parent chd, we would trying to examine every file as a chd, instead of only examining chd files

### Suggested Testing Steps
Test CHD files with parent CHD files and see if they still open

Such files can be created with `chdman createdvd -i "disc.iso" -op "parent.chd" -o "disc.chd"`

I'll note that chdman 0.271 and 0.272 currently has [issues](https://github.com/mamedev/mame/issues/13029) creating such files for PS2 sized games, so use an older version.
