### PR TITLE
SaveState: Fix comparison warning

### DIFF
--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -315,7 +315,7 @@ memLoadingState::memLoadingState(const VmStateBuffer& load_from)
 // Loading of state data from a memory buffer...
 void memLoadingState::FreezeMem( void* data, int size )
 {
-	if (m_idx + size > m_memory.size())
+	if (static_cast<u32>(m_idx + size) > m_memory.size())
 		m_error = true;
 
 	if (m_error)


### PR DESCRIPTION
### Description of Changes
Add a cast to the bounds check I added in https://github.com/PCSX2/pcsx2/pull/12041

### Rationale behind Changes
Fixes warning

### Suggested Testing Steps
Check log for warning
Make sure nothing explodes
