### PR TITLE
Qt/Patches: Get rid of the global WS/NI toggle

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -88,8 +88,6 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.interlacing, "EmuCore/GS", "deinterlace_mode", DEFAULT_INTERLACE_MODE);
 	SettingWidgetBinder::BindWidgetToIntSetting(
 		sif, m_ui.bilinearFiltering, "EmuCore/GS", "linear_present_mode", static_cast<int>(GSPostBilinearMode::BilinearSmooth));
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.widescreenPatches, "EmuCore", "EnableWideScreenPatches", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.noInterlacingPatches, "EmuCore", "EnableNoInterlacingPatches", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.integerScaling, "EmuCore/GS", "IntegerScaling", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.PCRTCOffsets, "EmuCore/GS", "pcrtc_offsets", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.PCRTCOverscan, "EmuCore/GS", "pcrtc_overscan", false);
@@ -321,25 +319,17 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 	}
 #endif
 
-	// Get rid of widescreen/no-interlace checkboxes from per-game settings, unless the user previously had them set.
-	if (m_dialog->isPerGameSettings())
-	{
-		if ((m_dialog->containsSettingValue("EmuCore", "EnableWideScreenPatches") || m_dialog->containsSettingValue("EmuCore", "EnableNoInterlacingPatches")) &&
-			QMessageBox::question(QtUtils::GetRootWidget(this), tr("Remove Unsupported Settings"),
-				tr("You currently have the <strong>Enable Widescreen Patches</strong> or <strong>Enable No-Interlacing Patches</strong> options enabled for this game.<br><br>"
-				   "We no longer support these options, instead <strong>you should select the \"Patches\" section, and explicitly enable the patches you want.</strong><br><br>"
-				   "Do you want to remove these options from your game configuration now?"),
+// Get rid of widescreen/no-interlace, unless the user previously had them set.
+	if ((m_dialog->containsSettingValue("EmuCore", "EnableWideScreenPatches") || m_dialog->containsSettingValue("EmuCore","EnableNoInterlacingPatches")) &&
+		QMessageBox::question(QtUtils::GetRootWidget(this), tr("Remove Unsupported Settings"),
+			tr("You previously have the <strong>Enable Widescreen Patches</strong> or <strong>Enable No-Interlacing Patches</strong> options enabled.<br><br>"
+				"We no longer provides these options, instead <strong>you should select the \"Patches\" section, and explicitly enable the patches you want.</strong><br><br>"
+				"Do you want to remove these options from your configuration now?"),
 				QMessageBox::Yes, QMessageBox::No) == QMessageBox::Yes)
 		{
 			m_dialog->removeSettingValue("EmuCore", "EnableWideScreenPatches");
 			m_dialog->removeSettingValue("EmuCore", "EnableNoInterlacingPatches");
 		}
-
-		m_ui.displayGridLayout->removeWidget(m_ui.widescreenPatches);
-		m_ui.displayGridLayout->removeWidget(m_ui.noInterlacingPatches);
-		safe_delete(m_ui.widescreenPatches);
-		safe_delete(m_ui.noInterlacingPatches);
-	}
 
 	// Hide advanced options by default.
 	if (!QtHost::ShouldShowAdvancedSettings())
@@ -428,12 +418,6 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 
 	// Display tab
 	{
-		dialog->registerWidgetHelp(m_ui.widescreenPatches, tr("Enable Widescreen Patches"), tr("Unchecked"),
-			tr("Automatically loads and applies widescreen patches on game start. Can cause issues."));
-
-		dialog->registerWidgetHelp(m_ui.noInterlacingPatches, tr("Enable No-Interlacing Patches"), tr("Unchecked"),
-			tr("Automatically loads and applies no-interlacing patches on game start. Can cause issues."));
-
 		dialog->registerWidgetHelp(m_ui.DisableInterlaceOffset, tr("Disable Interlace Offset"), tr("Unchecked"),
 			tr("Disables interlacing offset which may reduce blurring in some situations."));
 

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -404,28 +404,28 @@
        </item>
        <item row="8" column="0" colspan="2">
         <layout class="QGridLayout" name="displayGridLayout">
-         <item row="1" column="1">
+         <item row="0" column="1">
           <widget class="QCheckBox" name="integerScaling">
            <property name="text">
             <string>Integer Scaling</string>
            </property>
           </widget>
          </item>
-         <item row="0" column="0">
-          <widget class="QCheckBox" name="widescreenPatches">
+         <item row="2" column="0">
+          <widget class="QCheckBox" name="PCRTCOverscan">
            <property name="text">
-            <string>Apply Widescreen Patches</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QCheckBox" name="noInterlacingPatches">
-           <property name="text">
-            <string>Apply No-Interlacing Patches</string>
+            <string>Show Overscan</string>
            </property>
           </widget>
          </item>
          <item row="1" column="0">
+          <widget class="QCheckBox" name="PCRTCOffsets">
+           <property name="text">
+            <string>Screen Offsets</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
           <widget class="QCheckBox" name="PCRTCAntiBlur">
            <property name="text">
             <string>Anti-Blur</string>
@@ -435,24 +435,10 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="1">
+         <item row="1" column="1">
           <widget class="QCheckBox" name="DisableInterlaceOffset">
            <property name="text">
             <string>Disable Interlace Offset</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QCheckBox" name="PCRTCOffsets">
-           <property name="text">
-            <string>Screen Offsets</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QCheckBox" name="PCRTCOverscan">
-           <property name="text">
-            <string>Show Overscan</string>
            </property>
           </widget>
          </item>
@@ -2125,7 +2111,7 @@
            </widget>
           </item>
           <item row="10" column="0" colspan="2">
-           <layout class="QGridLayout" name="gridLayout_9">
+           <layout class="QGridLayout" name="advancedOptionsGrid">
             <item row="2" column="0">
              <widget class="QCheckBox" name="disableMailboxPresentation">
               <property name="text">

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1268,8 +1268,6 @@ struct Pcsx2Config
 		EnablePatches : 1, // enables patch detection and application
 		EnableCheats : 1, // enables cheat detection and application
 		EnablePINE : 1, // enables inter-process communication
-		EnableWideScreenPatches : 1,
-		EnableNoInterlacingPatches : 1,
 		EnableFastBoot : 1,
 		EnableFastBootFastForward : 1,
 		EnableThreadPinning : 1,

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3705,15 +3705,6 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 		"EmuCore/GS", "StretchY", 100, 10, 300, FSUI_CSTR("%d%%"));
 	DrawIntRectSetting(bsi, FSUI_CSTR("Crop"), FSUI_CSTR("Crops the image, while respecting aspect ratio."), "EmuCore/GS", "CropLeft", 0,
 		"CropTop", 0, "CropRight", 0, "CropBottom", 0, 0, 720, 1, FSUI_CSTR("%dpx"));
-
-	if (!IsEditingGameSettings(bsi))
-	{
-		DrawToggleSetting(bsi, FSUI_CSTR("Enable Widescreen Patches"), FSUI_CSTR("Enables loading widescreen patches from pnach files."),
-			"EmuCore", "EnableWideScreenPatches", false);
-		DrawToggleSetting(bsi, FSUI_CSTR("Enable No-Interlacing Patches"),
-			FSUI_CSTR("Enables loading no-interlacing patches from pnach files."), "EmuCore", "EnableNoInterlacingPatches", false);
-	}
-
 	DrawIntListSetting(bsi, FSUI_CSTR("Bilinear Upscaling"), FSUI_CSTR("Smooths out the image when upscaling the console to the screen."),
 		"EmuCore/GS", "linear_present_mode", static_cast<int>(GSPostBilinearMode::BilinearSharp), s_bilinear_present_options,
 		std::size(s_bilinear_present_options), true);

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -397,10 +397,9 @@ __ri void ImGuiManager::DrawSettingsOverlay(float scale, float margin, float spa
 		EmuConfig.Cpu.Recompiler.GetEEClampMode(), static_cast<unsigned>(EmuConfig.Cpu.VU0FPCR.GetRoundMode()),
 		EmuConfig.Cpu.Recompiler.GetVUClampMode(), EmuConfig.GS.VsyncQueueSize);
 
-	if (EmuConfig.EnableCheats || EmuConfig.EnableWideScreenPatches || EmuConfig.EnableNoInterlacingPatches)
+	if (EmuConfig.EnableCheats)
 	{
-		APPEND("C={}{}{} ", EmuConfig.EnableCheats ? "C" : "", EmuConfig.EnableWideScreenPatches ? "W" : "",
-			EmuConfig.EnableNoInterlacingPatches ? "N" : "");
+		APPEND("CHT ");
 	}
 
 	if (GSIsHardwareRenderer())

--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -588,24 +588,6 @@ void Patch::ReloadEnabledLists()
 		s_enabled_cheats = {};
 
 	s_enabled_patches = Host::GetStringListSetting(PATCHES_CONFIG_SECTION, PATCH_ENABLE_CONFIG_KEY);
-
-	// Name based matching for widescreen/NI settings.
-	if (EmuConfig.EnableWideScreenPatches)
-	{
-		if (std::none_of(s_enabled_patches.begin(), s_enabled_patches.end(),
-				[](const std::string& it) { return (it == WS_PATCH_NAME); }))
-		{
-			s_enabled_patches.emplace_back(WS_PATCH_NAME);
-		}
-	}
-	if (EmuConfig.EnableNoInterlacingPatches)
-	{
-		if (std::none_of(s_enabled_patches.begin(), s_enabled_patches.end(),
-				[](const std::string& it) { return (it == NI_PATCH_NAME); }))
-		{
-			s_enabled_patches.emplace_back(NI_PATCH_NAME);
-		}
-	}
 }
 
 u32 Patch::EnablePatches(const PatchList& patches, const EnablePatchList& enable_list)

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1922,8 +1922,6 @@ void Pcsx2Config::LoadSaveCore(SettingsWrapper& wrap)
 	SettingsWrapBitBool(EnablePatches);
 	SettingsWrapBitBool(EnableCheats);
 	SettingsWrapBitBool(EnablePINE);
-	SettingsWrapBitBool(EnableWideScreenPatches);
-	SettingsWrapBitBool(EnableNoInterlacingPatches);
 	SettingsWrapBitBool(EnableFastBoot);
 	SettingsWrapBitBool(EnableFastBootFastForward);
 	SettingsWrapBitBool(EnableThreadPinning);

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -2885,8 +2885,6 @@ void VMManager::CheckForEmulationSpeedConfigChanges(const Pcsx2Config& old_confi
 void VMManager::CheckForPatchConfigChanges(const Pcsx2Config& old_config)
 {
 	if (EmuConfig.EnableCheats == old_config.EnableCheats &&
-		EmuConfig.EnableWideScreenPatches == old_config.EnableWideScreenPatches &&
-		EmuConfig.EnableNoInterlacingPatches == old_config.EnableNoInterlacingPatches &&
 		EmuConfig.EnablePatches == old_config.EnablePatches)
 	{
 		return;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
This PR completely deprecates the Global WS/NI patches toggle so that the user would actually uses the patch section ~~like god intended.~~

![image](https://github.com/user-attachments/assets/65daf587-1128-4628-b4f1-636ff4d66e88)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

So user use the patches section like intended instead of blindly enabling WS patches globally and risking breaking their game unintentionally.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Check if the patches still works.