### PR TITLE
GS/HW: Use proper alpha min max for palettes when looking up a source, adjust dither on blend mix.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4553,7 +4553,8 @@ void GSRendererHW::EmulateBlending(int rt_alpha_min, int rt_alpha_max, const boo
 			// Disable dithering on blend mix if needed.
 			if (m_conf.ps.dither)
 			{
-				const bool can_dither = (m_conf.ps.blend_a == 0 && m_conf.ps.blend_b == 1 && alpha_eq_less_one);
+				// TODO: Either exclude BMIX1_ALPHA_HIGH_ONE case or allow alpha > 1.0 on dither adjust, case is currently disabled.
+				const bool can_dither = (m_conf.ps.blend_a == 0 && m_conf.ps.blend_b == 1) || (m_conf.ps.blend_a == 1 && m_conf.ps.blend_b == 0);
 				m_conf.ps.dither = can_dither;
 				m_conf.ps.dither_adjust = can_dither;
 			}

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1742,9 +1742,12 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const bool is_color, const 
 			TEX0.TBP0, psm_s.pal > 0 ? TEX0.CBP : 0,
 			psm_str(TEX0.PSM));
 
-		// If it's from a target, we need to make sure the alpha information is up to date, especially in 16/24 bit formats where it can change draw to draw.
+		// If it's an old source made from target make sure it isn't a palette,
+		// alphas need to be used from the palette then.
+		// If it's from a target, we need to make sure the alpha information is up to date,
+		// especially in 16/24 bit formats where it can change draw to draw.
 		// Guard against merged targets which don't actually link.
-		if (src->m_target && src->m_from_target)
+		if (!src->m_palette && src->m_target && src->m_from_target)
 		{
 			src->m_valid_alpha_minmax = true;
 			if (src->m_target_direct)


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/TC: Use proper alpha min max for palettes when looking up a source.
If it's an old source made from target make sure it isn't a palette, alphas need to be used from the palette then.

GS/HW: Adjust how we handle dithering on blend mix.
Allow dither adjust regardless of alpha. usually it is clamed to 1 anyway so we can expand it if alpha max is higher than 128. 
Expand dither adjust to work in rev subtract conditions.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Accuracy.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test variety of games, dumb runner didn't show anything broken, some comparisons are below.