### PR TITLE
Debugger: Add Reset button

### DIFF
--- a/pcsx2-qt/Debugger/DebuggerWindow.cpp
+++ b/pcsx2-qt/Debugger/DebuggerWindow.cpp
@@ -27,6 +27,7 @@ DebuggerWindow::DebuggerWindow(QWidget* parent)
 #endif
 
 	connect(m_ui.actionRun, &QAction::triggered, this, &DebuggerWindow::onRunPause);
+	connect(m_ui.actionReset, &QAction::triggered, this, &DebuggerWindow::onReset);
 	connect(m_ui.actionStepInto, &QAction::triggered, this, &DebuggerWindow::onStepInto);
 	connect(m_ui.actionStepOver, &QAction::triggered, this, &DebuggerWindow::onStepOver);
 	connect(m_ui.actionStepOut, &QAction::triggered, this, &DebuggerWindow::onStepOut);
@@ -111,6 +112,11 @@ void DebuggerWindow::onVMStateChanged()
 void DebuggerWindow::onRunPause()
 {
 	g_emu_thread->setVMPaused(!QtHost::IsVMPaused());
+}
+
+void DebuggerWindow::onReset()
+{
+	g_emu_thread->resetVM();
 }
 
 void DebuggerWindow::onStepInto()

--- a/pcsx2-qt/Debugger/DebuggerWindow.h
+++ b/pcsx2-qt/Debugger/DebuggerWindow.h
@@ -18,6 +18,7 @@ public:
 public slots:
 	void onVMStateChanged();
 	void onRunPause();
+	void onReset();
 	void onStepInto();
 	void onStepOver();
 	void onStepOut();
@@ -30,6 +31,7 @@ protected:
 private:
 	Ui::DebuggerWindow m_ui;
 	QAction* m_actionRunPause;
+	QAction* m_actionReset;
 	QAction* m_actionStepInto;
 	QAction* m_actionStepOver;
 	QAction* m_actionStepOut;

--- a/pcsx2-qt/Debugger/DebuggerWindow.ui
+++ b/pcsx2-qt/Debugger/DebuggerWindow.ui
@@ -51,6 +51,7 @@
     <bool>false</bool>
    </attribute>
    <addaction name="actionRun"/>
+   <addaction name="actionReset"/>
    <addaction name="actionStepInto"/>
    <addaction name="actionStepOver"/>
    <addaction name="actionStepOut"/>
@@ -63,6 +64,14 @@
    </property>
    <property name="text">
     <string>Run</string>
+   </property>
+  </action>
+  <action name="actionReset">
+   <property name="icon">
+    <iconset theme="restart-line"/>
+   </property>
+   <property name="text">
+    <string>Reset</string>
    </property>
   </action>
   <action name="actionStepInto">


### PR DESCRIPTION
### Description of Changes
Add a handy 'Reset' button next to the 'Run' button.

### Rationale behind Changes
As an emulator developer, resetting while working with the debugger is a pretty common occurrence. Having to reach out to the main window, then clicking on System -> Reset is somewhat cumbersome.

### Suggested Testing Steps
Open debugger, click on the 'Reset' button, voila!

### Screenshot
![image](https://github.com/user-attachments/assets/d1881cee-8bd1-4844-a938-455083807005)
