### PR TITLE
IOPBios: use memcpy read/write functions instead of 8 bit loops

### DIFF
--- a/pcsx2/IopBios.cpp
+++ b/pcsx2/IopBios.cpp
@@ -852,8 +852,16 @@ namespace R3000A
 
 				v0 = file->read(buf.get(), count);
 
-				for (s32 i = 0; i < (s32)v0; i++)
-					iopMemWrite8(data + i, buf[i]);
+				[[likely]]
+				if (v0 >= 0 && iopMemSafeWriteBytes(data, buf.get(), v0))
+				{
+					psxCpu->Clear(data, (v0 + 3) / 4);
+				}
+				else
+				{
+					for (s32 i = 0; i < static_cast<s32>(v0); i++)
+						iopMemWrite8(data + i, buf[i]);
+				}
 
 				pc = ra;
 				return 1;

--- a/pcsx2/IopBios.cpp
+++ b/pcsx2/IopBios.cpp
@@ -907,8 +907,12 @@ namespace R3000A
 			{
 				auto buf = std::make_unique<char[]>(count);
 
-				for (u32 i = 0; i < count; i++)
-					buf[i] = iopMemRead8(data + i);
+				[[unlikely]]
+				if (!iopMemSafeReadBytes(data, buf.get(), count))
+				{
+					for (u32 i = 0; i < count; i++)
+						buf[i] = iopMemRead8(data + i);
+				}
 
 				v0 = file->write(buf.get(), count);
 


### PR DESCRIPTION
### Description of Changes
Instead of moving data in 8-bit loops, use safeiopmem(read/write) functions which use an underlying memcpy.

### Rationale behind Changes
Minor performance increase in medium to large ioman I/O

When reading hostfs on master, our hottest point (besides the EE JIT) was the recClearIOP function called by each iopMemWrite8.
With this PR we now see faster execution times (~8.5%) with my hostfs bench-marking tool, and more CPU time on read().

### Suggested Testing Steps
See if games and homebrew that uses HostFS still work.
