### PR TITLE
ChdFileReader: Migrate libchdr patch into PCSX2

### DIFF
--- a/3rdparty/libchdr/include/libchdr/chd.h
+++ b/3rdparty/libchdr/include/libchdr/chd.h
@@ -407,7 +407,6 @@ CHD_EXPORT const chd_header *chd_get_header(chd_file *chd);
 CHD_EXPORT chd_error chd_read_header_core_file(core_file *file, chd_header *header);
 CHD_EXPORT chd_error chd_read_header_file(FILE *file, chd_header *header);
 CHD_EXPORT chd_error chd_read_header(const char *filename, chd_header *header);
-CHD_EXPORT bool chd_is_matching_parent(const chd_header* header, const chd_header* parent_header);
 
 
 

--- a/3rdparty/libchdr/src/libchdr_chd.c
+++ b/3rdparty/libchdr/src/libchdr_chd.c
@@ -2281,27 +2281,6 @@ CHD_EXPORT chd_error chd_read_header(const char *filename, chd_header *header)
 	return err;
 }
 
-CHD_EXPORT bool chd_is_matching_parent(const chd_header* header, const chd_header* parent_header)
-{
-  /* check MD5 if it isn't empty */
-  if (memcmp(nullmd5, header->parentmd5, sizeof(header->parentmd5)) != 0 &&
-      memcmp(nullmd5, parent_header->md5, sizeof(parent_header->md5)) != 0 &&
-      memcmp(parent_header->md5, header->parentmd5, sizeof(header->parentmd5)) != 0)
-	{
-		return false;
-	}
-
-  /* check SHA1 if it isn't empty */
-  if (memcmp(nullsha1, header->parentsha1, sizeof(header->parentsha1)) != 0 &&
-      memcmp(nullsha1, parent_header->sha1, sizeof(parent_header->sha1)) != 0 &&
-      memcmp(parent_header->sha1, header->parentsha1, sizeof(header->parentsha1)) != 0)
-	{
-		return false;
-	}
-
-	return true;
-}
-
 /***************************************************************************
     CORE DATA READ/WRITE
 ***************************************************************************/


### PR DESCRIPTION
### Description of Changes
Migrate added `chd_is_matching_parent` function into PCSX2 code

### Rationale behind Changes
Such patches can be missed when updating dependencies, potentially leading to difficulty updating.

Added function works just as well when within PCSX2 code.

### Suggested Testing Steps
Test CHD files with parent CHD files and see if they still open. (see https://github.com/PCSX2/pcsx2/pull/12076 for how to create them)
