### PR TITLE
CI/Appimage: Suppress error when no tags are present

### DIFF
--- a/.github/workflows/scripts/linux/appimage-qt.sh
+++ b/.github/workflows/scripts/linux/appimage-qt.sh
@@ -206,7 +206,7 @@ GIT_VERSION=$(git tag --points-at HEAD)
 
 if [[ "${GIT_VERSION}" == "" ]]; then
 	# In the odd event that we run this script before the release gets tagged.
-	GIT_VERSION=$(git describe --tags)
+	GIT_VERSION=$(git describe --tags || true)
 	if [[ "${GIT_VERSION}" == "" ]]; then
 		GIT_VERSION=$(git rev-parse HEAD)
 	fi


### PR DESCRIPTION
### Description of Changes
Suppress the error return code for `git describe --tags`

### Rationale behind Changes
This command will return error if the repo has zero tags
We already handle the failure by checking the stdout of the command (which is empty as the error message goes to stderr)

### Suggested Testing Steps
Test this change on a fork that lacks tags
I've tested locally, but I've not tested on the CI
