### PR TITLE
R5900: Improve the EE cache performance

### DIFF
--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -36,6 +36,8 @@ u32 EEoCycle;
 
 alignas(16) cpuRegistersPack _cpuRegistersPack;
 alignas(16) tlbs tlb[48];
+cachedTlbs_t cachedTlbs;
+
 R5900cpu *Cpu = NULL;
 
 static constexpr uint eeWaitCycles = 3072;
@@ -59,6 +61,7 @@ void cpuReset()
 	std::memset(&cpuRegs, 0, sizeof(cpuRegs));
 	std::memset(&fpuRegs, 0, sizeof(fpuRegs));
 	std::memset(&tlb, 0, sizeof(tlb));
+	cachedTlbs.count = 0;
 
 	cpuRegs.pc				= 0xbfc00000; //set pc reg to stack
 	cpuRegs.CP0.n.Config	= 0x440;

--- a/pcsx2/R5900.h
+++ b/pcsx2/R5900.h
@@ -5,6 +5,8 @@
 
 #include "common/Pcsx2Defs.h"
 
+#include <array>
+
 // --------------------------------------------------------------------------------------
 //  EE Bios function name tables.
 // --------------------------------------------------------------------------------------
@@ -160,17 +162,69 @@ struct fpuRegisters {
 	u32 ACCflag;        // an internal accumulator overflow flag
 };
 
+union PageMask_t
+{
+	struct
+	{
+		u32 : 13;
+		u32 Mask : 12;
+		u32 : 7;
+	};
+	u32 UL;
+
+	constexpr u32 nMask() const { return ~Mask & 0xfff; };
+};
+
+union EntryHi_t
+{
+	struct
+	{
+		u32 ASID:8;
+		u32 : 5;
+		u32 VPN2:19;
+	};
+	u32 UL;
+};
+
+union EntryLo_t
+{
+	struct
+	{
+		u32 G:1;
+		u32 V:1;
+		u32 D:1;
+		u32 C:3;
+		u32 PFN:20;
+		u32 : 5;
+		u32 S : 1; // Only used in EntryLo0
+	};
+	u32 UL;
+
+	constexpr bool isCached() const { return C == 0x3; }
+};
+
 struct tlbs
 {
-	u32 PageMask,EntryHi;
-	u32 EntryLo0,EntryLo1;
-	u32 Mask, nMask;
-	u32 G;
-	u32 ASID;
-	u32 VPN2;
-	u32 PFN0;
-	u32 PFN1;
-	u32 S;
+	PageMask_t PageMask;
+	EntryHi_t EntryHi;
+	EntryLo_t EntryLo0;
+	EntryLo_t EntryLo1;
+
+	// (((cpuRegs.CP0.n.EntryLo0 >> 6) & 0xFFFFF) & (~tlb[i].Mask())) << 12;
+	constexpr u32 PFN0() const { return (EntryLo0.PFN & ~Mask()) << 12; }
+	constexpr u32 PFN1() const { return (EntryLo1.PFN & ~Mask()) << 12; }
+	constexpr u32 VPN2() const {return ((EntryHi.VPN2) & (~Mask())) << 13; }
+	constexpr u32 Mask() const { return PageMask.Mask; }
+	constexpr bool isGlobal() const { return EntryLo0.G && EntryLo1.G; }
+	constexpr bool isSPR() const { return EntryLo0.S; }
+
+	constexpr bool operator==(const tlbs& other) const
+	{
+		return PageMask.UL == other.PageMask.UL &&
+			   EntryHi.UL == other.EntryHi.UL &&
+			   EntryLo0.UL == other.EntryLo0.UL &&
+			   EntryLo1.UL == other.EntryLo1.UL;
+	}
 };
 
 #ifndef _PC_
@@ -210,6 +264,19 @@ struct cpuRegistersPack
 
 alignas(16) extern cpuRegistersPack _cpuRegistersPack;
 alignas(16) extern tlbs tlb[48];
+
+struct cachedTlbs_t
+{
+	u32 count;
+
+	alignas(16) std::array<u32, 48> PageMasks;
+	alignas(16) std::array<u32, 48> PFN1s;
+	alignas(16) std::array<u32, 48> CacheEnabled1;
+	alignas(16) std::array<u32, 48> PFN0s;
+	alignas(16) std::array<u32, 48> CacheEnabled0;
+};
+
+extern cachedTlbs_t cachedTlbs;
 
 static cpuRegisters& cpuRegs = _cpuRegistersPack.cpuRegs;
 static fpuRegisters& fpuRegs = _cpuRegistersPack.fpuRegs;

--- a/pcsx2/R5900.h
+++ b/pcsx2/R5900.h
@@ -171,8 +171,6 @@ union PageMask_t
 		u32 : 7;
 	};
 	u32 UL;
-
-	constexpr u32 nMask() const { return ~Mask & 0xfff; };
 };
 
 union EntryHi_t
@@ -201,6 +199,7 @@ union EntryLo_t
 	u32 UL;
 
 	constexpr bool isCached() const { return C == 0x3; }
+	constexpr bool isValidCacheMode() const { return C == 0x2 || C == 0x3 || C == 0x7; }
 };
 
 struct tlbs

--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -183,6 +183,7 @@ bool SaveStateBase::FreezeInternals(Error* error)
 	Freeze(psxRegs);		// iop regs
 	Freeze(fpuRegs);
 	Freeze(tlb);			// tlbs
+	Freeze(cachedTlbs);		// cached tlbs
 	Freeze(AllowParams1);	//OSDConfig written (Fast Boot)
 	Freeze(AllowParams2);
 

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -25,7 +25,7 @@ enum class FreezeAction
 // [SAVEVERSION+]
 // This informs the auto updater that the users savestates will be invalidated.
 
-static const u32 g_SaveVersion = (0x9A52 << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A53 << 16) | 0x0000;
 
 
 // the freezing data between submodules and core


### PR DESCRIPTION
### Description of Changes
I had a list of optimizations here beforehand (you can view the edit history), but I've replaced it all with SIMD.
When we check to see if an address is part of a cached TLB entry we can do 4 at a time instead of one.
 
### Rationale behind Changes
I want to get more familiar with VTune profiling. The EE cache is also very slow.

### Suggested Testing Steps
Test games that require EE cache with this PR (ensure any patches we have for the game are disabled)
Run the EE cache and compare the speed to master.
