### PR TITLE
Fix GameTitle(JPN) & Set 2 gsHWFixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -60,7 +60,7 @@ ALCH-00008:
 ALCH-00009:
   name: "ひぐらしのなく頃に祭 [初回限定版]"
   name-sort: "ひぐらしのなくころにまつり [しょかいげんていばん]"
-  name-en: "Higurashi no Naku Koro ni Matsuri [First Print Limited Edition]"
+  name-en: "Higurashi no Naku Koro ni Matsuri [First Limited Edition]"
   region: "NTSC-J"
 ALCH-00010:
   name: "この青空に約束を ～melody of the sun and sea～ [限定版]"
@@ -80,7 +80,7 @@ ALCH-00014:
 ALCH-00015:
   name: "Sugar+Spice！ ～あの子のステキな何もかも～ [初回限定版]"
   name-sort: "しゅがーすぱいす あのこのすてきななにもかも [しょかいげんていばん]"
-  name-en: "Sugar+Spice! - Anoko no Suteki na Nanimokamo [First Press Limited Edition]"
+  name-en: "Sugar+Spice！ - Anoko no Suteki na Nanimokamo [First Limited Edition]"
   region: "NTSC-J"
 ALCH-00016:
   name: "恋する乙女と守護の楯 -The shield of AIGIS- [限定版]"
@@ -145,7 +145,7 @@ FVGK-0007:
 FVGK-0015:
   name: "伯爵と妖精 ～夢と絆に思いを馳せて～ [初回限定版]"
   name-sort: "はくしゃくとようせい ゆめときずなにおもいをはせて [しょかいげんていばん]"
-  name-en: "Hakushaku to Yousei - Yume to Kizuna ni Omoi o Hasete [Limited Edition]"
+  name-en: "Hakushaku to Yousei - Yume to Kizuna ni Omoi o Hasete [First Limited Edition]"
   region: "NTSC-J"
 GUST-00009:
   name: "マナケミア ～学園の錬金術師たち～ [プレミアムボックス]"
@@ -161,7 +161,7 @@ GUST-00009:
 GWS-0007:
   name: "ナデプロ!! ～キサマも声優やってみろ!～ [限定版]"
   name-sort: "なでぷろ!! きさまもせいゆうやってみろ! [げんていばん]"
-  name-en: "NadePro!! Kisama mo Seiyuu Yatte Miro! [Limited Edition]"
+  name-en: "NadePro！！ Kisama mo Seiyuu Yatte Miro！ [Limited Edition]"
   region: "NTSC-J"
 PAPX-90020:
   name: "攻殻機動隊 STAND ALONE COMPLEX [体験版]"
@@ -378,7 +378,7 @@ PAPX-90236:
 PAPX-90330:
   name: "サルゲッチュ2 ウッキーウッキーディスク"
   name-sort: "さるげっちゅ2 うっきーうっきーでぃすく"
-  name-en: "Saru! Get You! 2 - Ukki Ukki Disc"
+  name-en: "Saru！ Get You！ 2 - Ukki Ukki Disc"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes interlacing.
@@ -389,7 +389,7 @@ PAPX-90501:
   name: "ダーククラウド [体験版]"
   name-sort: "だーくくらうど [たいけんばん]"
   name-en: "Dark Cloud [Trial]"
-  region: "NTSC-J"
+  Region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Distance is less blurry, game has reduced LOD so it will still look blurry.
 PAPX-90502:
@@ -529,12 +529,12 @@ PAPX-90524:
 PBGP-0061:
   name: "水夏A.S+ Eternal Name [初回限定版]"
   name-sort: "すいかA.Sぷらすえたーなるねーむ [しょかいげんていばん]"
-  name-en: "Suika A.S+ Eternal Name [First Press Limited Edition]"
+  name-en: "Suika A.S+ Eternal Name [First Limited Edition]"
   region: "NTSC-J"
 PBGP-0063:
   name: "最終試験くじら - Alive [初回限定版]"
   name-sort: "さいしゅうしけんくじら あらいぶ [しょかいげんていばん]"
-  name-en: "Saishuu Shiken Kujira - Alive [First Press Limited Edition]"
+  name-en: "Saishuu Shiken Kujira - Alive [First Limited Edition]"
   region: "NTSC-J"
 PBGP-0065:
   name: "D.C. ダ・カーポ The Origin [初回限定版]"
@@ -652,6 +652,8 @@ PBPX-95251:
   region: "NTSC-U"
 PBPX-95501:
   name: "PS2 Linux Beta Release 1"
+  name-sort: "PS2 Linux Beta Release 1"
+  nem-en: "PS2 Linux Beta Release 1"
   region: "NTSC-J"
 PBPX-95502:
   name: "GRAN TURISMO 3 - A-Spec [本体同梱版]"
@@ -907,7 +909,7 @@ PCPX-96324:
 PCPX-96328:
   name: "3タイトルスペシャルディスク「サルゲッチュ2・ポポロクロイス-はじまりの冒険-・ぼくのなつやすみ2」 [体験版]"
   name-sort: "3たいとるすぺしゃるでぃすく さるげっちゅ2 ぽぽぽくろいす はじまりのぼうけん ぼくのなつやすみ2 [たいけんばん]"
-  name-en: "3 Title Special Disc (Saru! Get You! 2 - PoPoLoCrois: Hajimari no Bouken - Boku no Natsuyasumi 2) [Trial]"
+  name-en: "3 Title Special Disc (Saru！ Get You！ 2 - PoPoLoCrois: Hajimari no Bouken - Boku no Natsuyasumi 2) [Trial]"
   region: "NTSC-J"
 PCPX-96330:
   name: "アークザラッド 精霊の黄昏 Premiere Disc [店頭体験版]"
@@ -926,7 +928,7 @@ PCPX-96603:
   name: "ダーククラウド [体験版]"
   name-sort: "だーくくらうど [たいけんばん]"
   name-en: "Dark Cloud [Trial]"
-  region: "NTSC-J"
+  Region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Distance is less blurry, game has reduced LOD so it will still look blurry.
 PCPX-96605:
@@ -1153,7 +1155,7 @@ PCPX-96656:
 PCPX-96657:
   name: "サルゲッチュ3 [店頭用体験版]"
   name-sort: "さるげっちゅ3 [てんとうようたいけんばん]"
-  name-en: "Saru! Get You! 3 [Demo]"
+  name-en: "Saru！ Get You！ 3 [Demo]"
   region: "NTSC-J"
   roundModes:
     vu0RoundMode: 2 # Fixes light sabre SPS in specific positions.
@@ -1186,7 +1188,7 @@ PCPX-98017:
 PCPX-98041:
   name: "サルゲッチュ ミリオンモンキーズ [体験版]"
   name-sort: "さるげっちゅ みりおんもんきーず [たいけんばん]"
-  name-en: "Saru! Get You! - Million Monkeys [Trial]"
+  name-en: "Saru！ Get You！ - Million Monkeys [Trial]"
   region: "NTSC-J"
 PCPX-98042:
   name: "みんなのテニス [体験版]"
@@ -1214,7 +1216,7 @@ SCAJ-10001:
   name: "Makai Senki Disgaea"
   region: "NTSC-Unk"
 SCAJ-10003:
-  name: "Taiko no Tatsujin - Doki! Shinkyoku Darake no Haru Matsuri"
+  name: "Taiko no Tatsujin - Doki！ Shinkyoku Darake no Haru Matsuri"
   region: "NTSC-Unk"
 SCAJ-10004:
   name: "Time Crisis 2 [PlayStation2 the Best]"
@@ -1228,7 +1230,7 @@ SCAJ-10007:
   name: "Taiko no Tatsujin - Waku Waku Anime Matsuri"
   region: "NTSC-Unk"
 SCAJ-10008:
-  name: "Taiko no Tatsujin - Atsumare! Matsuri da!! Yondaime"
+  name: "Taiko no Tatsujin - Atsumare！ Matsuri da！！ Yondaime"
   region: "NTSC-Unk"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
@@ -1242,7 +1244,7 @@ SCAJ-10010:
   region: "NTSC-Unk"
   compat: 5
 SCAJ-10011:
-  name: "Taiko no Tatsujin - Go! Go! Godaime"
+  name: "Taiko no Tatsujin - Go！ Go！ Godaime"
   region: "NTSC-Unk"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
@@ -1252,17 +1254,17 @@ SCAJ-10012:
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SCAJ-10013:
-  name: "Taiko no Tatsujin - Tobikkiri! Anime Special"
+  name: "Taiko no Tatsujin - Tobikkiri！ Anime Special"
   region: "NTSC-Unk"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SCAJ-10014:
-  name: "Taiko no Tatsujin - Wai Wai Happy! Rokudaime"
+  name: "Taiko no Tatsujin - Wai Wai Happy！ Rokudaime"
   region: "NTSC-Unk"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SCAJ-10015:
-  name: "Taiko no Tatsujin - Doka! to Oomori Nanadaime"
+  name: "Taiko no Tatsujin - Doka！ to Oomori Nanadaime"
   region: "NTSC-Unk"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
@@ -1476,7 +1478,7 @@ SCAJ-20040:
   name-sort: "King of Fighters 2001, The"
   region: "NTSC-Unk"
 SCAJ-20041:
-  name: "Energy Airforce - Aim Strike!"
+  name: "Energy Airforce - Aim Strike！"
   region: "NTSC-Unk"
   gsHWFixes:
     autoFlush: 2 # Corrects post-processing effect on jet exhausts.
@@ -1701,7 +1703,7 @@ SCAJ-20082:
   name: "Gungrave OD"
   region: "NTSC-Unk"
 SCAJ-20083:
-  name: "Bakuso! Mountain Bikers"
+  name: "Bakuso！ Mountain Bikers"
   region: "NTSC-Unk"
   gsHWFixes:
     autoFlush: 2 # Fixes speed effect intensity.
@@ -1778,7 +1780,7 @@ SCAJ-20097:
   name: "EyeToy - FuriFuri Dance Tengoku"
   region: "NTSC-Unk"
 SCAJ-20098:
-  name: "EyeToy - Oosawagi! Ukkiiuki Game Tenkomori!!"
+  name: "EyeToy - Oosawagi！ Ukkiiuki Game Tenkomori！！"
   region: "NTSC-Unk"
 SCAJ-20099:
   name: "ICO"
@@ -1831,7 +1833,7 @@ SCAJ-20105:
       replacement:
         - { offset: 0x4, value: 0x3442CCE0 }
 SCAJ-20107:
-  name: "Bakufuu Slash! Kizna Arashi"
+  name: "Bakufuu Slash！ Kizna Arashi"
   region: "NTSC-Unk"
 SCAJ-20108:
   name: "Arc the Lad - Generation"
@@ -2709,8 +2711,8 @@ SCCS-40017:
   compat: 5
 SCCS-40018:
   name: "比波猴@爱淘儿 一起欢聚比波猴乐园吧！"
-  name-sort: "Bibohou Aitaoer Yiqi Huanju Bibohou Leyuan Ba!"
-  name-en: "Saru EyeToy - Oosawagi! Ukkiuki Game Tenkomori!!"
+  name-sort: "Bibohou Aitaoer Yiqi Huanju Bibohou Leyuan Ba！"
+  name-en: "Saru EyeToy - Oosawagi！ Ukkiuki Game Tenkomori！！"
   region: "NTSC-C"
   compat: 5
 SCCS-40019:
@@ -3265,22 +3267,22 @@ SCED-51540:
   name: "Official PlayStation 2 Magazine Demo 39"
   region: "PAL-M5"
 SCED-51541:
-  name: "Official PlayStation 2 Magazine-UK Special Edition 12 - PlayStation 2 Blockbusters!"
+  name: "Official PlayStation 2 Magazine-UK Special Edition 12 - PlayStation 2 Blockbusters！"
   region: "PAL-E"
 SCED-51542:
-  name: "Official PlayStation 2 Magazine-UK Special Edition 13 - Girls! Motors! Guns! War! Monsters!"
+  name: "Official PlayStation 2 Magazine-UK Special Edition 13 - Girls！ Motors！ Guns！ War！ Monsters！"
   region: "PAL-E"
 SCED-51543:
   name: "Official PlayStation 2 Magazine-UK Special Edition 14 - The Hit Squad"
   region: "PAL-E"
 SCED-51544:
-  name: "Official PlayStation 2 Magazine-UK Special Edition 15 - Summer Blockbusters!"
+  name: "Official PlayStation 2 Magazine-UK Special Edition 15 - Summer Blockbusters！"
   region: "PAL-E"
 SCED-51545:
   name: "Official PlayStation 2 Magazine-UK Special Edition 16 - Buyers Guide"
   region: "PAL-E"
 SCED-51546:
-  name: "Official PlayStation 2 Magazine-UK Special Edition 17 - The Best Games of 2003!"
+  name: "Official PlayStation 2 Magazine-UK Special Edition 17 - The Best Games of 2003！"
   region: "PAL-E"
 SCED-51549:
   name: "Official PlayStation 2 Magazine Germany Special Edition 2003/02"
@@ -4376,7 +4378,7 @@ SCED-54208:
   name: "Magazine Ufficiale PlayStation 2 Italia 06/2006"
   region: "PAL-I"
 SCED-54238:
-  name: "Buzz! The Sports Quiz"
+  name: "Buzz！ The Sports Quiz"
   region: "PAL-E"
 SCED-54314:
   name: "Magazine Ufficiale PlayStation 2 Demo Italia 07-2006"
@@ -4385,10 +4387,10 @@ SCED-54338:
   name: "Bonus Demo 11"
   region: "PAL-M5"
 SCED-54345:
-  name: "Buzz! Junior - Jungle Party"
+  name: "Buzz！ Junior - Jungle Party"
   region: "PAL-M14"
 SCED-54363:
-  name: "Buzz! The Sports Quiz"
+  name: "Buzz！ The Sports Quiz"
   region: "PAL-M4"
 SCED-54397:
   name: "Bonus Demo 12 (You)"
@@ -4510,7 +4512,7 @@ SCED-54758:
   name: "Official PlayStation 2 Magazine Demo 84" # German
   region: "PAL-G"
 SCED-54808:
-  name: "Buzz! Junior - RoboJam + Buzz! Junior - Jungle Party"
+  name: "Buzz！ Junior - RoboJam + Buzz！ Junior - Jungle Party"
   region: "PAL-M14"
 SCED-55113:
   name: "Official PlayStation 2 Magazine Demo 94"
@@ -4537,7 +4539,7 @@ SCED-55120:
   name: "Official PlayStation 2 Magazine Demo 101"
   region: "PAL-NL"
 SCED-55432:
-  name: "Buzz! Junior - Ace Racers [Demo]"
+  name: "Buzz！ Junior - Ace Racers [Demo]"
   region: "PAL-M15"
 SCES-50000:
   name: "Ridge Racer V"
@@ -5367,7 +5369,6 @@ SCES-52033:
     autoFlush: 2 # Fixes lights going through walls.
     preloadFrameData: 1 # Fixes light flicker.
     halfPixelOffset: 2 # Corrects light position.
-    bilinearUpscale: 1 # Smooths out bloom on lights.
   gameFixes:
     - EETimingHack # Fixes random hangs.
   patches:
@@ -5827,16 +5828,16 @@ SCES-53300:
   gsHWFixes:
     minimumBlendingLevel: 4 # Mitigates grayer text font in bottom left.
 SCES-53304:
-  name: "Buzz! The Music Quiz"
+  name: "Buzz！ The Music Quiz"
   region: "PAL-E"
 SCES-53305:
-  name: "Buzz! The Music Quiz"
+  name: "Buzz！ The Music Quiz"
   region: "PAL-M4"
 SCES-53307:
-  name: "Buzz! The Music Quiz"
+  name: "Buzz！ The Music Quiz"
   region: "PAL-SC"
 SCES-53308:
-  name: "Buzz! The Music Quiz"
+  name: "Buzz！ The Music Quiz"
   region: "PAL-P-S"
 SCES-53310:
   name: "Roland Garros 2005"
@@ -5957,10 +5958,10 @@ SCES-53642:
     halfPixelOffset: 2 # Fixes misaligned blur.
     autoFlush: 2 # Fixes corruption in cutscenes and brightens the image.
 SCES-53663:
-  name: "Buzz! The Music Quiz"
+  name: "Buzz！ The Music Quiz"
   region: "PAL-M3"
 SCES-53669:
-  name: "Buzz! The Music Quiz"
+  name: "Buzz！ The Music Quiz"
   region: "PAL-E"
 SCES-53680:
   name: "WRC avec Sébastien Loeb"
@@ -6011,66 +6012,66 @@ SCES-53851:
         patch=0,EE,002E2B44,word,48449000
         patch=0,EE,002E2B4C,word,4BC949FF
 SCES-53879:
-  name: "Buzz! The Big Quiz"
+  name: "Buzz！ The Big Quiz"
   region: "PAL-E"
 SCES-53880:
-  name: "Buzz! The Big Quiz"
+  name: "Buzz！ The Big Quiz"
   region: "PAL-E"
 SCES-53881:
-  name: "Buzz! Le Grand Quiz"
+  name: "Buzz！ Le Grand Quiz"
   region: "PAL-F"
 SCES-53882:
-  name: "Buzz! The Big Quiz"
+  name: "Buzz！ The Big Quiz"
   region: "PAL-I"
   gameFixes:
     - EETimingHack # Fixes freezes.
 SCES-53883:
-  name: "Buzz! The Big Quiz"
+  name: "Buzz！ The Big Quiz"
   region: "PAL-G"
   gameFixes:
     - EETimingHack # Fixes freezes.
 SCES-53884:
-  name: "Buzz! El GRAN Reto"
+  name: "Buzz！ El GRAN Reto"
   region: "PAL-S"
   compat: 2
   gameFixes:
     - EETimingHack # Fixes freezes.
 SCES-53889:
-  name: "SingStar Rocks!"
+  name: "SingStar Rocks！"
   region: "PAL-E"
 SCES-53890:
-  name: "SingStar Rocks!"
+  name: "SingStar Rocks！"
   region: "PAL-E"
 SCES-53891:
-  name: "SingStar Rocks!"
+  name: "SingStar Rocks！"
   region: "PAL-G"
 SCES-53893:
-  name: "SingStar Rocks! [Promo]"
+  name: "SingStar Rocks！ [Promo]"
   region: "PAL-NL"
 SCES-53894:
-  name: "SingStar Rocks!"
+  name: "SingStar Rocks！"
   region: "PAL-HR"
 SCES-53895:
-  name: "SingStar Rocks! [Promo]"
+  name: "SingStar Rocks！ [Promo]"
   region: "PAL-S"
 SCES-53897:
-  name: "SingStar Rocks!"
+  name: "SingStar Rocks！"
   region: "PAL-F"
 SCES-53898:
-  name: "SingStar Rocks!"
+  name: "SingStar Rocks！"
   region: "PAL-I"
 SCES-53925:
-  name: "Buzz! The Big Quiz"
+  name: "Buzz！ The Big Quiz"
   region: "PAL-M3"
   compat: 5
 SCES-53926:
-  name: "Buzz! The Big Quiz"
+  name: "Buzz！ The Big Quiz"
   region: "PAL-SC"
 SCES-53927:
-  name: "Buzz! The Big Quiz"
+  name: "Buzz！ The Big Quiz"
   region: "PAL-FI"
 SCES-53929:
-  name: "Buzz! The Big Quiz"
+  name: "Buzz！ The Big Quiz"
   region: "PAL-P"
 SCES-53931:
   name: "Shinobido - Way of the Ninja"
@@ -6090,7 +6091,7 @@ SCES-53960:
     halfPixelOffset: 4 # Aligns post effects.
     nativeScaling: 1 # Fixes post processing position.
 SCES-54025:
-  name: "SingStar Rocks!"
+  name: "SingStar Rocks！"
   region: "PAL-IR"
 SCES-54041:
   name: "Ace Combat - The Belkan War"
@@ -6119,10 +6120,10 @@ SCES-54068:
   name: "AFL Premiership 2006"
   region: "PAL-A"
 SCES-54071:
-  name: "Buzz! The Big Quiz"
+  name: "Buzz！ The Big Quiz"
   region: "PAL-Unk"
 SCES-54073:
-  name: "Buzz! The Big Quiz"
+  name: "Buzz！ The Big Quiz"
   region: "PAL-R"
 SCES-54077:
   name: "SingStar top.it"
@@ -6172,49 +6173,49 @@ SCES-54206:
     autoFlush: 1 # Fixes sun occlusion.
     nativeScaling: 1 # Fixes light blooms.
 SCES-54219:
-  name: "Buzz! Junior - Jungle Party"
+  name: "Buzz！ Junior - Jungle Party"
   region: "PAL-M7"
 SCES-54220:
-  name: "Buzz! Junior - Jungle Party"
+  name: "Buzz！ Junior - Jungle Party"
   region: "PAL-M8"
 SCES-54257:
   name: "SingStar Legends"
   region: "PAL-S"
 SCES-54258:
-  name: "Buzz! The Sports Quiz"
+  name: "Buzz！ The Sports Quiz"
   region: "PAL-E"
 SCES-54259:
-  name: "Buzz! The Sports Quiz"
+  name: "Buzz！ The Sports Quiz"
   region: "PAL-G"
 SCES-54260:
-  name: "Buzz! Le Quiz du Sport"
+  name: "Buzz！ Le Quiz du Sport"
   region: "PAL-F"
 SCES-54261:
-  name: "Buzz! The Sports Quiz"
+  name: "Buzz！ The Sports Quiz"
   region: "PAL-I"
 SCES-54262:
-  name: "Buzz! - El Gran Concurso de Deportes"
+  name: "Buzz！ - El Gran Concurso de Deportes"
   region: "PAL-S"
 SCES-54263:
-  name: "Buzz! The Sports Quiz"
+  name: "Buzz！ The Sports Quiz"
   region: "PAL-P"
 SCES-54264:
-  name: "Buzz! The Sports Quiz"
+  name: "Buzz！ The Sports Quiz"
   region: "PAL-E"
 SCES-54265:
-  name: "Buzz! The Sports Quiz"
+  name: "Buzz！ The Sports Quiz"
   region: "PAL-M3"
 SCES-54266:
-  name: "Buzz! The Sports Quiz"
+  name: "Buzz！ The Sports Quiz"
   region: "PAL-SC"
 SCES-54267:
-  name: "Buzz! The Sports Quiz"
+  name: "Buzz！ The Sports Quiz"
   region: "PAL-FI"
 SCES-54268:
-  name: "Buzz! The Sports Quiz"
+  name: "Buzz！ The Sports Quiz"
   region: "PAL-M3"
 SCES-54269:
-  name: "Buzz! The Sports Quiz"
+  name: "Buzz！ The Sports Quiz"
   region: "PAL-Unk"
 SCES-54325:
   name: "SingStar Legendat"
@@ -6257,40 +6258,40 @@ SCES-54477:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Mitigates grayer text font in bottom left but stuff in front can lower or increase opacity.
 SCES-54496:
-  name: "Buzz! The Mega Quiz"
+  name: "Buzz！ The Mega Quiz"
   region: "PAL-E"
 SCES-54497:
-  name: "Buzz! Le Mega Quiz"
+  name: "Buzz！ Le Mega Quiz"
   region: "PAL-F"
 SCES-54498:
-  name: "Buzz! The Mega Quiz"
+  name: "Buzz！ The Mega Quiz"
   region: "PAL-I"
 SCES-54499:
-  name: "Buzz! Das Mega-Quiz"
+  name: "Buzz！ Das Mega-Quiz"
   region: "PAL-G"
 SCES-54500:
-  name: "Buzz! El Mega Concurso"
+  name: "Buzz！ El Mega Concurso"
   region: "PAL-S"
 SCES-54501:
-  name: "Buzz! The Mega Quiz"
+  name: "Buzz！ The Mega Quiz"
   region: "PAL-A"
 SCES-54503:
-  name: "Buzz! Megavisa"
+  name: "Buzz！ Megavisa"
   region: "PAL-FI"
 SCES-54504:
-  name: "Buzz! O Mega Quiz"
+  name: "Buzz！ O Mega Quiz"
   region: "PAL-P"
 SCES-54505:
-  name: "Buzz! The Mega Quiz"
+  name: "Buzz！ The Mega Quiz"
   region: "PAL-M3"
 SCES-54507:
-  name: "Buzz! The Mega Quiz"
+  name: "Buzz！ The Mega Quiz"
   region: "PAL-M3"
 SCES-54524:
-  name: "Buzz! Junior - Jungle Party"
+  name: "Buzz！ Junior - Jungle Party"
   region: "PAL-SW" # Austria + Switzerland
 SCES-54526:
-  name: "The Big! Sports Quiz"
+  name: "The Big！ Sports Quiz"
   region: "PAL-M"
 SCES-54535:
   name: "Everybody's Tennis"
@@ -6318,7 +6319,7 @@ SCES-54552:
         // Fixes Vedan Myna area out of bounds glitch.
         patch=1,EE,00124898,word,3442fffe
 SCES-54556:
-  name: "The Big! Mega Quiz"
+  name: "The Big！ Mega Quiz"
   region: "PAL-G"
 SCES-54570:
   name: "SingStar Pop Hits"
@@ -6360,7 +6361,7 @@ SCES-54613:
   name: "SingStar Pop Hits"
   region: "PAL-E"
 SCES-54625:
-  name: "Buzz! Junior - Monster Rumble"
+  name: "Buzz！ Junior - Monster Rumble"
   region: "PAL-M7"
 SCES-54637:
   name: "Gaelic Games - Hurling"
@@ -6377,22 +6378,22 @@ SCES-54641:
   name: "SingStar - Après-Ski Party 2"
   region: "PAL-G"
 SCES-54676:
-  name: "Buzz! Junior - RoboJam"
+  name: "Buzz！ Junior - RoboJam"
   region: "PAL-M7"
 SCES-54688:
   name: "ATV Offroad Fury 4"
   region: "PAL-M12"
 SCES-54689:
-  name: "Buzz! The Maha Quiz"
+  name: "Buzz！ The Maha Quiz"
   region: "PAL-IN"
 SCES-54690:
-  name: "Buzz! Mega Quiz"
+  name: "Buzz！ Mega Quiz"
   region: "PAL-PL"
 SCES-54701:
-  name: "Buzz! Junior - RoboJam"
+  name: "Buzz！ Junior - RoboJam"
   region: "PAL-M8"
 SCES-54703:
-  name: "Buzz! Junior - Monster Rumble"
+  name: "Buzz！ Junior - Monster Rumble"
   region: "PAL-M9"
 SCES-54704:
   name: "Monsterspass"
@@ -6404,10 +6405,10 @@ SCES-54748:
   name: "WipEout Pulse"
   region: "PAL-M5"
 SCES-54749:
-  name: "Buzz! Junior - Dino Den"
+  name: "Buzz！ Junior - Dino Den"
   region: "PAL-M8"
 SCES-54750:
-  name: "Buzz! Junior - Dino Den"
+  name: "Buzz！ Junior - Dino Den"
   region: "PAL-M8"
 SCES-54760:
   name: "SingStar R&B"
@@ -6443,35 +6444,35 @@ SCES-54823:
   name: "SingStar Bollywood"
   region: "PAL-E"
 SCES-54844:
-  name: "Buzz! The Hollywood Quiz"
+  name: "Buzz！ The Hollywood Quiz"
   region: "PAL-E"
   gameFixes:
     - EETimingHack # Fixes long delays between questions.
 SCES-54845:
-  name: "Buzz! The Hollywood Quiz"
+  name: "Buzz！ The Hollywood Quiz"
   region: "PAL-G"
   gameFixes:
     - EETimingHack # Fixes long delays between questions.
 SCES-54848:
-  name: "Buzz! Hollywood"
+  name: "Buzz！ Hollywood"
   region: "PAL-P-S"
   gameFixes:
     - EETimingHack # Fixes long delays between questions.
 SCES-54851:
-  name: "Buzz! The Hollywood Quiz"
+  name: "Buzz！ The Hollywood Quiz"
   region: "PAL-M3"
   gameFixes:
     - EETimingHack # Fixes long delays between questions.
 SCES-54852:
-  name: "Buzz! The Hollywood Quiz"
+  name: "Buzz！ The Hollywood Quiz"
   region: "PAL-F"
   gameFixes:
     - EETimingHack # Fixes long delays between questions.
 SCES-54854:
-  name: "Buzz! Hollywood Quiz"
+  name: "Buzz！ Hollywood Quiz"
   region: "PAL-NL-E-FR"
 SCES-54856:
-  name: "Buzz! The Hollywood Quiz"
+  name: "Buzz！ The Hollywood Quiz"
   region: "PAL-P"
   gameFixes:
     - EETimingHack # Fixes long delays between questions.
@@ -6488,7 +6489,7 @@ SCES-54924:
   name: "NBA 08"
   region: "PAL-M5"
 SCES-54941:
-  name: "Buzz! The Schools Quiz"
+  name: "Buzz！ The Schools Quiz"
   region: "PAL-E"
 SCES-55019:
   name: "Ratchet & Clank - Size Matters"
@@ -6512,7 +6513,7 @@ SCES-55060:
   name: "SingStar Summer Party"
   region: "PAL-D"
 SCES-55061:
-  name: "SingStar Wakacyjna Impreza!"
+  name: "SingStar Wakacyjna Impreza！"
   region: "PAL-PL"
 SCES-55062:
   name: "SingStar Pop Hits 3"
@@ -6524,28 +6525,28 @@ SCES-55083:
   name: "EyeToy Play - PomPom Party"
   region: "PAL-M15"
 SCES-55093:
-  name: "Buzz! The Pop Quiz"
+  name: "Buzz！ The Pop Quiz"
   region: "PAL-E"
 SCES-55094:
-  name: "Buzz! The Pop Quiz"
+  name: "Buzz！ The Pop Quiz"
   region: "PAL-M3"
 SCES-55095:
-  name: "Buzz! The Pop Quiz"
+  name: "Buzz！ The Pop Quiz"
   region: "PAL-P-S"
 SCES-55096:
-  name: "Buzz! The Pop Quiz"
+  name: "Buzz！ The Pop Quiz"
   region: "PAL-SC"
 SCES-55097:
-  name: "Buzz! The Pop Quiz"
+  name: "Buzz！ The Pop Quiz"
   region: "PAL-FI"
 SCES-55098:
-  name: "Buzz! The Pop Quiz"
+  name: "Buzz！ The Pop Quiz"
   region: "PAL-M3"
 SCES-55100:
-  name: "Buzz! The Pop Quiz"
+  name: "Buzz！ The Pop Quiz"
   region: "PAL-A"
 SCES-55107:
-  name: "Buzz! Pop Quiz"
+  name: "Buzz！ Pop Quiz"
   region: "PAL-PL"
 SCES-55127:
   name: "SingStar Summer Party"
@@ -6587,13 +6588,13 @@ SCES-55183:
   name: "SingStar Turkish Party [Promo]"
   region: "PAL-TU"
 SCES-55210:
-  name: "Buzz! Junior - Ace Racers"
+  name: "Buzz！ Junior - Ace Racers"
   region: "PAL-M6"
 SCES-55211:
-  name: "Buzz! Junior - Ace Racers"
+  name: "Buzz！ Junior - Ace Racers"
   region: "PAL-M8"
 SCES-55213:
-  name: "Buzz! Escuela de Talentos"
+  name: "Buzz！ Escuela de Talentos"
   region: "PAL-S"
 SCES-55241:
   name: "SingStar Russian Hit"
@@ -6632,40 +6633,40 @@ SCES-55362:
   name: "SingStar Hottest Hits"
   region: "PAL-G"
 SCES-55385:
-  name: "Buzz! Brain of the UK"
+  name: "Buzz！ Brain of the UK"
   region: "PAL-E"
 SCES-55386:
-  name: "Buzz! Le Plus Malin des Francais"
+  name: "Buzz！ Le Plus Malin des Francais"
   region: "PAL-F"
 SCES-55387:
-  name: "Buzz! Deutschlands Superquiz"
+  name: "Buzz！ Deutschlands Superquiz"
   region: "PAL-G"
 SCES-55388:
-  name: "Buzz! Brain of Spain-Portugal"
+  name: "Buzz！ Brain of Spain-Portugal"
   region: "PAL-M2"
 SCES-55389:
-  name: "Buzz! Il Quizzone Nazionale"
+  name: "Buzz！ Il Quizzone Nazionale"
   region: "PAL-I"
 SCES-55401:
   name: "SingStar Zingt met Disney"
   region: "PAL-NL"
 SCES-55419:
-  name: "Buzz! Brain of Oz"
+  name: "Buzz！ Brain of Oz"
   region: "PAL-A"
 SCES-55420:
-  name: "Buzz! De Slimste van Nederland"
+  name: "Buzz！ De Slimste van Nederland"
   region: "PAL-BE"
 SCES-55421:
-  name: "Buzz! Brain of Switzerland"
+  name: "Buzz！ Brain of Switzerland"
   region: "PAL-M"
 SCES-55423:
-  name: "Buzz! Brain of the World"
+  name: "Buzz！ Brain of the World"
   region: "PAL-D-E-NW"
 SCES-55424:
-  name: "Buzz! Brain of the World"
+  name: "Buzz！ Brain of the World"
   region: "PAL-Unk"
 SCES-55425:
-  name: "Buzz! Brain of the World"
+  name: "Buzz！ Brain of the World"
   region: "PAL-SC"
 SCES-55435:
   name: "SingStar ABBA"
@@ -7076,7 +7077,6 @@ SCKA-20032:
     autoFlush: 2 # Fixes lights going through walls.
     preloadFrameData: 1 # Fixes light flicker.
     halfPixelOffset: 2 # Corrects light position.
-    bilinearUpscale: 1 # Smooths out bloom on lights.
   gameFixes:
     - EETimingHack # Fixes random hangs.
   patches:
@@ -7395,7 +7395,7 @@ SCKA-20073:
   name: "Final Fantasy XII"
   region: "NTSC-K"
 SCKA-20074:
-  name: "Sly Cooper 2 - Goedo Brothers Daejakjeon!"
+  name: "Sly Cooper 2 - Goedo Brothers Daejakjeon！"
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes chromatic effect.
@@ -7820,7 +7820,7 @@ SCKA-90011:
   name: "Arc the Lad - Jeongryeongui Hwanghon - Premiere Disc"
   region: "NTSC-K"
 SCKA-90016:
-  name: "Goehon - Gulryeora! Wangjanim!"
+  name: "Goehon - Gulryeora！ Wangjanim！"
   region: "NTSC-K"
   roundModes:
     vu1RoundMode: 0 # Fixes SPS.
@@ -7948,7 +7948,7 @@ SCPS-11004:
 SCPS-11005:
   name: "探しに行こうよ"
   name-sort: "さがしにいこうよ"
-  name-en: "Sagashi ni Ikouyo - Go to Find It!"
+  name-en: "Sagashi ni Ikouyo - Go to Find It！"
   region: "NTSC-J"
 SCPS-11006:
   name: "スカイガンナー"
@@ -8285,9 +8285,9 @@ SCPS-15022:
     deinterlace: 9 # Game looks better with Adaptive BFF.
     halfPixelOffset: 4 # Improves offset blur.
 SCPS-15023:
-  name: "ワイルドアームズ アドヴァンスドサード プレミアムボックス"
+  name: "ワイルドアームズ アドヴァンスドサード [プレミアムボックス]"
   name-sort: "わいるどあーむず あどゔぁんすどさーど [ぷれみあむぼっくす]"
-  name-en: "Wild ARMs - Advanced 3rd"
+  name-en: "Wild ARMs - Advanced 3rd [Premium Box]"
   region: "NTSC-J"
   gsHWFixes:
     forceEvenSpritePosition: 1 # Fixes font artifacts and out-of-bound 2D textures.
@@ -8408,14 +8408,14 @@ SCPS-15037:
 SCPS-15038:
   name: "OPERATOR'S SIDE [マイク同梱版]"
   name-sort: "おぺれーたーずさいど [まいくどうこんばん]"
-  name-en: "Operator's Side"
+  name-en: "Operator's Side [wtih MIC]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SCPS-15039:
   name: "OPERATOR'S SIDE [通常版]"
   name-sort: "おぺれーたーずさいど [つうじょうばん]"
-  name-en: "Operator's Side"
+  name-en: "Operator's Side [Standard Edition]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
@@ -8586,7 +8586,7 @@ SCPS-15061:
 SCPS-15062:
   name: "爆走マウンテンバイカーズ"
   name-sort: "ばくそうまうんてんばいかーず"
-  name-en: "Bakuso! Mountain Bikers"
+  name-en: "Bakuso！ Mountain Bikers"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 2 # Fixes speed effect intensity.
@@ -8735,7 +8735,7 @@ SCPS-15078:
 SCPS-15079:
   name: "爆封スラッシュ！ キズナ 嵐 [EyeToyカメラ同梱版]"
   name-sort: "ばくふうすらっしゅ！ きずな あらし [あいとーいかめらどうこんばん]"
-  name-en: "Bakufuu Slash! Kizna Arashi [EyeToy Camera Doukonban]"
+  name-en: "Bakufuu Slash！ Kizna Arashi [EyeToy Camera Doukonban]"
   region: "NTSC-J"
 SCPS-15080:
   name: "我が竜を見よ"
@@ -8760,7 +8760,7 @@ SCPS-15083:
 SCPS-15084:
   name: "ラチェット&クランク3 突撃！ガラクチック★レンジャーズ"
   name-sort: "らちぇっとあんどくらんく3 とつげき！がらくちっくれんじゃーず"
-  name-en: "Ratchet & Clank 3 - Charge! Galactic Rangers"
+  name-en: "Ratchet & Clank 3 - Charge！ Galactic Rangers"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes SPR errors while going in-game.
@@ -8786,7 +8786,7 @@ SCPS-15085:
 SCPS-15086:
   name: "爆封スラッシュ！ キズナ 嵐 [ソフト単体]"
   name-sort: "ばくふうすらっしゅ！ きずな あらし [そふとたんたい]"
-  name-en: "Bakufuu Slash! Kizna Arashi [Game Only]"
+  name-en: "Bakufuu Slash！ Kizna Arashi [Game Only]"
   region: "NTSC-J"
 SCPS-15087:
   name: "BLEACH ～選ばれし魂～"
@@ -8813,9 +8813,9 @@ SCPS-15090:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes chromatic effect.
 SCPS-15091:
-  name: "ワイルドアームズ ザ フォースデトネイター 初回生産版"
+  name: "ワイルドアームズ ザ フォースデトネイター [初回生産版]"
   name-sort: "わいるどあーむず ざ ふぉーすでとねいたー [しょかいせいさんばん]"
-  name-en: "Wild ARMs - The 4th Detonator"
+  name-en: "Wild ARMs - The 4th Detonator [Limited Edition]"
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1
@@ -8875,7 +8875,7 @@ SCPS-15095:
 SCPS-15096:
   name: "サルゲッチュ3"
   name-sort: "さるげっちゅ3"
-  name-en: "Saru Get You! 3"
+  name-en: "Saru Get You！ 3"
   region: "NTSC-J"
   compat: 5
   roundModes:
@@ -9002,7 +9002,7 @@ SCPS-15106:
         patch=0,EE,0013AB64,word,48449000
         patch=0,EE,0013AB6C,word,4BC949FF
 SCPS-15107:
-  name: "ガンパレード・オーケストラ 緑の章 ～狼と彼の少年～ 限定版"
+  name: "ガンパレード・オーケストラ 緑の章 ～狼と彼の少年～ [限定版]"
   name-sort: "がんぱれーど おーけすとら みどりのしょう おおかみとかのしょうねん [げんていばん]"
   name-en: "Gunparade Orchestra - Midori no Shou [Limited Edition]"
   region: "NTSC-J"
@@ -9026,7 +9026,7 @@ SCPS-15108:
     - "SCPS-15107"
     - "SCPS-15108"
 SCPS-15109:
-  name: "ガンパレード・オーケストラ 青の章 ～光の海から手紙を送ります～ 限定版"
+  name: "ガンパレード・オーケストラ 青の章 ～光の海から手紙を送ります～ [限定版]"
   name-sort: "がんぱれーど おーけすとら あおのしょう ひかりのうみからてがみをおくります [げんていばん]"
   name-en: "Gunparade Orchestra - Ao no Shou [Limited Edition]"
   region: "NTSC-J"
@@ -9118,7 +9118,7 @@ SCPS-15119:
 SCPS-15120:
   name: "ラチェット&クランク5 激突！ドデカ銀河のミリミリ軍団"
   name-sort: "らちぇっとあんどくらんく5 げきとつ！どでかぎんがのみりみりぐんだん"
-  name-en: "Ratchet & Clank 5 - Gekitotsu! Dodeka Ginga no Mirimiri Gundan"
+  name-en: "Ratchet & Clank 5 - Gekitotsu！ Dodeka Ginga no Mirimiri Gundan"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes vendor and other bloom.
@@ -9279,7 +9279,7 @@ SCPS-19151:
 SCPS-19152:
   name: "サルゲッチュ2 [PlayStation2 the Best]"
   name-sort: "さるげっちゅ2 [PlayStation2 the Best]"
-  name-en: "Saru Get You! 2 [PlayStation2 the Best]"
+  name-en: "Saru Get You！ 2 [PlayStation2 the Best]"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes interlacing.
@@ -9731,7 +9731,7 @@ SCPS-19324:
 SCPS-19325:
   name: "サルゲッチュ ミリオンモンキーズ [PlayStation2 the Best]"
   name-sort: "さるげっちゅ みりおんもんきーず [PlayStation2 the Best]"
-  name-en: "Saru! Get You! - Million Monkeys [PlayStation2 the Best]"
+  name-en: "Saru！ Get You！ - Million Monkeys [PlayStation2 the Best]"
   region: "NTSC-J"
 SCPS-19326:
   name: "SIREN2 [PlayStation2 the Best]"
@@ -9915,7 +9915,7 @@ SCPS-55001:
 SCPS-55002:
   name: "零 ～zero～"
   name-sort: "ぜろ"
-  name-en: "Fatal Frame"
+  name-en: "Zero"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blurriness.
@@ -10011,13 +10011,12 @@ SCPS-55015:
 SCPS-55016:
   name: "ジェットでGO！2"
   name-sort: "じぇっとでGO！2"
-  name-en: "Jet de Go! 2"
+  name-en: "Jet de Go！ 2"
   region: "NTSC-J"
 SCPS-55017:
   name: "鉄拳2"
   name-sort: "てっけん4"
   name-en: "Tekken 4"
-  region: "NTSC-J"
   compat: 3
   gsHWFixes:
     alignSprite: 1
@@ -10128,7 +10127,7 @@ SCPS-55032:
 SCPS-55035:
   name: "サルゲッチュ2"
   name-sort: "さるげっちゅ2"
-  name-en: "Saru Get You! 2"
+  name-en: "Saru Get You！ 2"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes interlacing.
@@ -10173,7 +10172,7 @@ SCPS-55042:
 SCPS-55043:
   name: "零 ～zero～"
   name-sort: "ぜろ"
-  name-en: "Fatal Frame"
+  name-en: "Zero"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blurriness.
@@ -11109,7 +11108,6 @@ SCUS-97264:
     autoFlush: 2 # Fixes lights going through walls.
     preloadFrameData: 1 # Fixes light flicker.
     halfPixelOffset: 2 # Corrects light position.
-    bilinearUpscale: 1 # Smooths out bloom on lights.
   gameFixes:
     - EETimingHack # Fixes random hangs.
   patches:
@@ -11452,7 +11450,6 @@ SCUS-97377:
     autoFlush: 2 # Fixes lights going through walls.
     preloadFrameData: 1 # Fixes light flicker.
     halfPixelOffset: 2 # Corrects light position.
-    bilinearUpscale: 1 # Smooths out bloom on lights.
 SCUS-97378:
   name: "EyeToy and EyeToy Play [Demo]"
   region: "NTSC-U"
@@ -11526,7 +11523,7 @@ SCUS-97400:
   name: "EyeToy - Groove"
   region: "NTSC-U"
 SCUS-97401:
-  name: "Hot Shots Golf FORE!"
+  name: "Hot Shots Golf FORE！"
   region: "NTSC-U"
   compat: 5
 SCUS-97402:
@@ -11646,7 +11643,7 @@ SCUS-97425:
   name: "Online Start-Up Disc v3.0"
   region: "NTSC-U"
 SCUS-97427:
-  name: "Hot Shots Golf FORE! [Online Public Beta]"
+  name: "Hot Shots Golf FORE！ [Online Public Beta]"
   region: "NTSC-U"
 SCUS-97428:
   name: "Kiosk Demo Disc Q3-Q4 2004"
@@ -11668,7 +11665,7 @@ SCUS-97429:
     - "SCUS-97429"
     - "SCUS-97465"
 SCUS-97430:
-  name: "Hot Shots Golf FORE! [Regular Demo]"
+  name: "Hot Shots Golf FORE！ [Regular Demo]"
   region: "NTSC-U"
 SCUS-97431:
   name: "Killzone Public Beta V1.0"
@@ -12107,7 +12104,7 @@ SCUS-97514:
   name: "ATV Offroad Fury 3 [Greatest Hits]"
   region: "NTSC-U"
 SCUS-97515:
-  name: "Hot Shots Golf FORE! [Greatest Hits]"
+  name: "Hot Shots Golf FORE！ [Greatest Hits]"
   region: "NTSC-U"
 SCUS-97516:
   name: "Jak 3 [Greatest Hits]"
@@ -12157,9 +12154,8 @@ SCUS-97520:
     autoFlush: 2 # Fixes lights going through walls.
     preloadFrameData: 1 # Fixes light flicker.
     halfPixelOffset: 2 # Corrects light position.
-    bilinearUpscale: 1 # Smooths out bloom on lights.
 SCUS-97523:
-  name: "EyeToy - Operation Spy!"
+  name: "EyeToy - Operation Spy！"
   region: "NTSC-U"
 SCUS-97527:
   name: "Sly 3 - Honor Among Thieves [Regular Demo]"
@@ -12300,7 +12296,7 @@ SCUS-97568:
   name: "MLB '07 - The Show [Demo]"
   region: "NTSC-U"
 SCUS-97571:
-  name: "SingStar Rocks!"
+  name: "SingStar Rocks！"
   region: "NTSC-U"
   compat: 3
 SCUS-97572:
@@ -12349,36 +12345,36 @@ SCUS-97589:
   name: "NBA '08 featuring The Life Vol.3"
   region: "NTSC-U"
 SCUS-97590:
-  name: "SingStar Rocks!"
+  name: "SingStar Rocks！"
   region: "NTSC-U"
 SCUS-97591:
   name: "SingStar Pop"
   region: "NTSC-U"
 SCUS-97592:
-  name: "Buzz! The Mega Quiz"
+  name: "Buzz！ The Mega Quiz"
   region: "NTSC-U"
   compat: 5
 SCUS-97594:
-  name: "Buzz! The Hollywood Quiz [Bundle]"
+  name: "Buzz！ The Hollywood Quiz [Bundle]"
   region: "NTSC-U"
   compat: 5
   gameFixes:
     - EETimingHack # Fixes long delays between questions.
 SCUS-97596:
-  name: "Buzz! Junior Jungle Party"
+  name: "Buzz！ Junior Jungle Party"
   region: "NTSC-U"
 SCUS-97597:
-  name: "Buzz! Jr. RoboJam [Bundle]"
+  name: "Buzz！ Jr. RoboJam [Bundle]"
   region: "NTSC-U"
   compat: 5
 SCUS-97600:
   name: "EyeToy"
   region: "NTSC-U"
 SCUS-97601:
-  name: "Buzz! The Mega Quiz [Game Only]"
+  name: "Buzz！ The Mega Quiz [Game Only]"
   region: "NTSC-U"
 SCUS-97602:
-  name: "Buzz! Jr. Jungle Party [Game Only]"
+  name: "Buzz！ Jr. Jungle Party [Game Only]"
   region: "NTSC-U"
 SCUS-97610:
   name: "Hot Shots Tennis"
@@ -12424,7 +12420,7 @@ SCUS-97621:
   clampModes:
     vu1ClampMode: 3 # Fixes missing textures.
   gsHWFixes:
-    recommendedBlendingLevel: 4 # Fixes menu text brightness and smoke effects.
+    recommendedBlendingLevel: 2 # Fixes smoke effects.
   gameFixes:
     - VUSyncHack # Fixes black doors on vehicles.
   patches:
@@ -12460,12 +12456,12 @@ SCUS-97627:
   region: "NTSC-U"
   compat: 3
 SCUS-97633:
-  name: "Buzz! The Hollywood Quiz [Game Only]"
+  name: "Buzz！ The Hollywood Quiz [Game Only]"
   region: "NTSC-U"
   gameFixes:
     - EETimingHack # Fixes long delays between questions.
 SCUS-97634:
-  name: "Buzz! Jr. RoboJam [Game Only]"
+  name: "Buzz！ Jr. RoboJam [Game Only]"
   region: "NTSC-U"
 SCUS-97636:
   name: "SingStar '90s"
@@ -12955,7 +12951,7 @@ SLED-50439:
   name: "MX 2002 featuring Ricky Carmichael [Demo]"
   region: "PAL-E"
 SLED-50478:
-  name: "WWF SmackDown! - Just Bring It [Demo]"
+  name: "WWF SmackDown！ - Just Bring It [Demo]"
   region: "PAL-E"
 SLED-50484:
   name: "Rayman M [Demo]"
@@ -13658,8 +13654,8 @@ SLED-54315:
   name: "LEGO Star Wars II - The Original Trilogy [Demo]"
   region: "PAL-M5"
   gsHWFixes:
-    halfPixelOffset: 1 # Aligns post processing.
-    nativeScaling: 2 # Fixes post processing smoothness and position.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
 SLED-54327:
   name: "FIFA 07"
   region: "PAL-M7"
@@ -13674,7 +13670,7 @@ SLED-54328:
     cpuSpriteRenderBW: 2 # Fixes broken sprite rendering and crowd rendering.
     cpuSpriteRenderLevel: 2 # Needed for above.
 SLED-54401:
-  name: "Destroy All Humans! 2 [Demo]"
+  name: "Destroy All Humans！ 2 [Demo]"
   region: "PAL-E"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves metal sheen and reflections.
@@ -14849,7 +14845,7 @@ SLES-50472:
   region: "PAL-M5"
   compat: 5
 SLES-50477:
-  name: "WWF SmackDown! - Just Bring It"
+  name: "WWF SmackDown！ - Just Bring It"
   region: "PAL-E"
 SLES-50479:
   name: "Turok - Evolution"
@@ -15428,7 +15424,7 @@ SLES-50769:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLES-50770:
-  name: "Mad Maestro!"
+  name: "Mad Maestro！"
   region: "PAL-M4"
 SLES-50771:
   name: "Blood Omen 2 - The Legacy of Kain Series"
@@ -15998,7 +15994,7 @@ SLES-50972:
   region: "PAL-M5"
   compat: 5
 SLES-50974:
-  name: "Zapper - One Wicked Cricket!"
+  name: "Zapper - One Wicked Cricket！"
   region: "PAL-M6"
 SLES-50975:
   name: "The Thing"
@@ -16081,16 +16077,16 @@ SLES-51014:
   name: "Blade II"
   region: "PAL-F"
 SLES-51017:
-  name: "Scooby-Doo! Night of 100 Frights"
+  name: "Scooby-Doo！ Night of 100 Frights"
   region: "PAL-E"
 SLES-51018:
-  name: "Scooby-Doo! La Nuit des 100 Frissons"
-  name-sort: "Scooby-Doo! Nuit des 100 Frissons, La"
-  name-en: "Scooby-Doo! Night of 100 Frights"
+  name: "Scooby-Doo！ La Nuit des 100 Frissons"
+  name-sort: "Scooby-Doo！ Nuit des 100 Frissons, La"
+  name-en: "Scooby-Doo！ Night of 100 Frights"
   region: "PAL-F"
 SLES-51019:
-  name: "Scooby-Doo! Nacht der 100 Schrecken"
-  name-en: "Scooby-Doo! Night of 100 Frights"
+  name: "Scooby-Doo！ Nacht der 100 Schrecken"
+  name-en: "Scooby-Doo！ Night of 100 Frights"
   region: "PAL-G"
 SLES-51022:
   name: "Virtual Racer - Jaques Villeneuve"
@@ -16180,7 +16176,7 @@ SLES-51058:
   speedHacks:
     mvuFlag: 0
 SLES-51060:
-  name: "Butt-Ugly Martians - Zoom or Doom!"
+  name: "Butt-Ugly Martians - Zoom or Doom！"
   region: "PAL-M5"
   clampModes:
     vuClampMode: 0 # Fixes SPS.
@@ -16398,7 +16394,7 @@ SLES-51144:
     halfPixelOffset: 4 # Aligns UI.
     nativeScaling: 2 # Fixes window reflections.
 SLES-51145:
-  name: "Monopoly Party!"
+  name: "Monopoly Party！"
   region: "PAL-M5"
   clampModes:
     vuClampMode: 0 # Fixes missing game board.
@@ -16815,7 +16811,7 @@ SLES-51282:
   name: "Tiger Woods PGA Tour 2003"
   region: "PAL-E"
 SLES-51283:
-  name: "WWE SmackDown! Shut Your Mouth"
+  name: "WWE SmackDown！ Shut Your Mouth"
   region: "PAL-E"
 SLES-51284:
   name: "Contra - Shattered Soldier"
@@ -17168,7 +17164,6 @@ SLES-51434:
     - SoftwareRendererFMVHack # Fixes blackscreen when FMV.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes menu transparancy effects and text.
-    deinterlace: 9 # Fixes incorrect field order in FMVs.
   memcardFilters:
     - "SLES-51434"
     - "SLES-50382"
@@ -17400,7 +17395,7 @@ SLES-51557:
   region: "PAL-M3"
   compat: 5
 SLES-51579:
-  name: "Yu-Gi-Oh! - The Duelists of the Roses"
+  name: "Yu-Gi-Oh！ - The Duelists of the Roses"
   region: "PAL-E"
   roundModes:
     eeRoundMode: 2 # Partially fixes battle animation.
@@ -18162,7 +18157,7 @@ SLES-51881:
   name: "Mercedes Bens World Racing"
   region: "PAL-F-G"
 SLES-51883:
-  name: "Scooby-Doo! Mystery Mayhem"
+  name: "Scooby-Doo！ Mystery Mayhem"
   region: "PAL-M3"
 SLES-51885:
   name: "Mega Man X7"
@@ -18565,7 +18560,7 @@ SLES-52034:
     halfPixelOffset: 4 # Fixes misaligned bloom.
     autoFlush: 2 # Fixes sun occlusion and heat radiosity.
 SLES-52036:
-  name: "WWE SmackDown! - Here Comes the Pain!"
+  name: "WWE SmackDown！ - Here Comes the Pain！"
   region: "PAL-E"
   compat: 5
 SLES-52038:
@@ -18679,7 +18674,7 @@ SLES-52101:
   gsHWFixes:
     textureInsideRT: 1 # Fixes flashing and some models still very broken in hardware mode.
 SLES-52102:
-  name: "Hugo Bukkazoom!"
+  name: "Hugo Bukkazoom！"
   region: "PAL-M12"
 SLES-52103:
   name: "Tak & Le Pouvoir de Juju"
@@ -18702,7 +18697,7 @@ SLES-52109:
   name: "Underworld - The Eternal War"
   region: "PAL-M5"
 SLES-52111:
-  name: "Mojo!"
+  name: "Mojo！"
   region: "PAL-M6"
   compat: 5
 SLES-52116:
@@ -18963,8 +18958,6 @@ SLES-52256:
 SLES-52257:
   name: "P.T.O. IV - Pacific Theater of Operations IV"
   region: "PAL-E"
-  gsHWFixes:
-    minimumBlendingLevel: 3 # Fixes graphical flickering.
 SLES-52258:
   name: "Romance of the Three Kingdoms VIII"
   region: "PAL-E"
@@ -18972,17 +18965,17 @@ SLES-52259:
   name: "Outlaw Volleyball"
   region: "PAL-M3"
 SLES-52265:
-  name: "Energy Airforce - Aim Strike!"
+  name: "Energy Airforce - Aim Strike！"
   region: "PAL-E"
   gsHWFixes:
     autoFlush: 2 # Corrects post-processing effect on jet exhausts.
 SLES-52266:
-  name: "Energy Airforce - Aim Strike!"
+  name: "Energy Airforce - Aim Strike！"
   region: "PAL-F"
   gsHWFixes:
     autoFlush: 2 # Corrects post-processing effect on jet exhausts.
 SLES-52267:
-  name: "Energy Airforce - Aim Strike!"
+  name: "Energy Airforce - Aim Strike！"
   region: "PAL-I"
   gsHWFixes:
     autoFlush: 2 # Corrects post-processing effect on jet exhausts.
@@ -19160,9 +19153,6 @@ SLES-52325:
     - BlitInternalFPSHack # Fixes internal fps detection in some areas.
   gsHWFixes:
     estimateTextureRegion: 1 # Improves performance.
-    roundSprite: 1 # Fixes lines in menus HUD and in game.
-    halfPixelOffset: 2 # Fixes edge garbage.
-    PCRTCOverscan: 1 # Fixes offscreen image.
 SLES-52326:
   name: "Spawn - Armageddon"
   region: "PAL-M5"
@@ -19263,9 +19253,6 @@ SLES-52373:
     - BlitInternalFPSHack # Fixes internal fps detection in some areas.
   gsHWFixes:
     estimateTextureRegion: 1 # Improves performance.
-    roundSprite: 1 # Fixes lines in menus HUD and in game.
-    halfPixelOffset: 2 # Fixes edge garbage.
-    PCRTCOverscan: 1 # Fixes offscreen image.
 SLES-52374:
   name: "Fight Night 2004"
   region: "PAL-M3"
@@ -19513,7 +19500,7 @@ SLES-52479:
   name: "Samurai Jack - The Shadow of Aku"
   region: "PAL-M5"
 SLES-52480:
-  name: "Yu-Gi-Oh! - The Duelists of the Roses"
+  name: "Yu-Gi-Oh！ - The Duelists of the Roses"
   region: "PAL-M4"
   roundModes:
     eeRoundMode: 2 # Partially fixes battle animation.
@@ -19695,7 +19682,7 @@ SLES-52541:
     autoFlush: 1 # Fixes post processing.
     halfPixelOffset: 4 # Helps align radiosity closer to native.
 SLES-52542:
-  name: "All Music Dance!"
+  name: "All Music Dance！"
   region: "PAL-I"
 SLES-52544:
   name: "Trivial Pursuit Unhinged"
@@ -19845,7 +19832,7 @@ SLES-52573:
   roundModes:
     eeRoundMode: 2 # Fixes abnormal character behaviour.
 SLES-52576:
-  name: "Yu-Gi-Oh! Capsule Monster Coliseum"
+  name: "Yu-Gi-Oh！ Capsule Monster Coliseum"
   region: "PAL-M5"
 SLES-52579:
   name: "Legends of Wrestling - Showdown"
@@ -20355,7 +20342,7 @@ SLES-52730:
     halfPixelOffset: 4 # Aligns post effects.
     nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLES-52731:
-  name: "One Piece - Round the Land!"
+  name: "One Piece - Round the Land！"
   region: "PAL-M3"
 SLES-52733:
   name: "Driven to Destruction"
@@ -20399,7 +20386,7 @@ SLES-52750:
   region: "PAL-E"
   compat: 5
 SLES-52751:
-  name: "Offroad Extreme!"
+  name: "Offroad Extreme！"
   region: "PAL-E"
 SLES-52752:
   name: "Playboy - The Mansion"
@@ -20463,7 +20450,7 @@ SLES-52779:
   name: "Poker Masters"
   region: "PAL-M6"
 SLES-52781:
-  name: "WWE SmackDown! vs. RAW"
+  name: "WWE SmackDown！ vs. RAW"
   region: "PAL-E"
 SLES-52782:
   name: "Call of Duty - Finest Hour"
@@ -21333,7 +21320,6 @@ SLES-53039:
     estimateTextureRegion: 1 # Improves performance.
     roundSprite: 1 # Fixes lines in menus HUD and in game.
     halfPixelOffset: 2 # Fixes erroneous line in menus.
-    PCRTCOverscan: 1 # Fixes offscreen image.
   memcardFilters: # Allows import of characters from first game.
     - "SLES-53039"
     - "SLES-52325"
@@ -21529,7 +21515,7 @@ SLES-53099:
   speedHacks:
     instantVU1: 0 # Improves speed by a moderate amount.
 SLES-53100:
-  name: "Scooby-Doo! Unmasked"
+  name: "Scooby-Doo！ Unmasked"
   region: "PAL-M4"
 SLES-53104:
   name: "Tom Clancy's Rainbow Six - Lockdown"
@@ -21740,7 +21726,7 @@ SLES-53195:
     recommendedBlendingLevel: 2
     roundSprite: 2 # Fixes font artifacts and sizing like the letter c.
 SLES-53196:
-  name: "Destroy All Humans!"
+  name: "Destroy All Humans！"
   region: "PAL-M4"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves metal sheen and reflections.
@@ -21749,7 +21735,7 @@ SLES-53196:
     autoFlush: 1 # Fixes sun occlusion and brightness.
     textureInsideRT: 1 # Fixes shadow maps.
 SLES-53197:
-  name: "Destroy All Humans!"
+  name: "Destroy All Humans！"
   region: "PAL-G"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves metal sheen and reflections.
@@ -21966,42 +21952,47 @@ SLES-53332:
   region: "PAL-M4"
   compat: 5
   gsHWFixes:
-    recommendedBlendingLevel: 3 # Fixes banding and level lighting.
+    recommendedBlendingLevel: 2
     autoFlush: 1 # Fixes sun shinging through surfaces and graphical corruptions.
     halfPixelOffset: 2 # Fixes misaligned blur.
-    nativeScaling: 2 # Fixes bloom misaligment.
+    cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SLES-53333:
   name: "Medal of Honor - Les Faucons de Guerre"
   region: "PAL-F"
   gsHWFixes:
-    recommendedBlendingLevel: 3 # Fixes banding and level lighting.
+    recommendedBlendingLevel: 2
     autoFlush: 1 # Fixes sun shinging through surfaces and graphical corruptions.
     halfPixelOffset: 2 # Fixes misaligned blur.
-    nativeScaling: 2 # Fixes bloom misaligment.
+    cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SLES-53334:
   name: "Medal of Honor - European Assault"
   region: "PAL-G"
   gsHWFixes:
-    recommendedBlendingLevel: 3 # Fixes banding and level lighting.
+    recommendedBlendingLevel: 2
     autoFlush: 1 # Fixes sun shinging through surfaces and graphical corruptions.
     halfPixelOffset: 2 # Fixes misaligned blur.
-    nativeScaling: 2 # Fixes bloom misaligment.
+    cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SLES-53335:
   name: "Medal of Honor - European Assault"
   region: "PAL-I"
   gsHWFixes:
-    recommendedBlendingLevel: 3 # Fixes banding and level lighting.
+    recommendedBlendingLevel: 2
     autoFlush: 1 # Fixes sun shinging through surfaces and graphical corruptions.
     halfPixelOffset: 2 # Fixes misaligned blur.
-    nativeScaling: 2 # Fixes bloom misaligment.
+    cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SLES-53336:
   name: "Medal of Honor - European Assault"
   region: "PAL-S"
   gsHWFixes:
-    recommendedBlendingLevel: 3 # Fixes banding and level lighting.
+    recommendedBlendingLevel: 2
     autoFlush: 1 # Fixes sun shinging through surfaces and graphical corruptions.
     halfPixelOffset: 2 # Fixes misaligned blur.
-    nativeScaling: 2 # Fixes bloom misaligment.
+    cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SLES-53338:
   name: "Victorious Boxers 2 - Fighting Spirit"
   region: "PAL-M3"
@@ -22155,7 +22146,7 @@ SLES-53387:
     autoFlush: 2 # Fixes lighting misalignment.
     halfPixelOffset: 2 # Fixes lighting misalignment.
 SLES-53388:
-  name: "Rhythmic Star!"
+  name: "Rhythmic Star！"
   region: "PAL-M5"
 SLES-53390:
   name: "Ultimate Spider-Man"
@@ -22467,7 +22458,7 @@ SLES-53492:
     halfPixelOffset: 4 # Mostly aligns post processing.
     nativeScaling: 1 # Fixes post processing smoothness and position.
 SLES-53494:
-  name: "Nickelodeon SpongeBob SquarePants - Lights, Camera, Pants!"
+  name: "Nickelodeon SpongeBob SquarePants - Lights, Camera, Pants！"
   region: "PAL-E"
   compat: 5
   gsHWFixes:
@@ -22475,42 +22466,42 @@ SLES-53494:
     halfPixelOffset: 4 # Aligns post processing.
     nativeScaling: 2 # Fixes post effects.
 SLES-53495:
-  name: "Nickelodeon Bob L'éponge - Silence on Tourne!"
+  name: "Nickelodeon Bob L'éponge - Silence on Tourne！"
   region: "PAL-F"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes missing lights.
     halfPixelOffset: 4 # Aligns post processing.
     nativeScaling: 2 # Fixes post effects.
 SLES-53496:
-  name: "Nickelodeon SpongeBob - Ciak si Gira!"
+  name: "Nickelodeon SpongeBob - Ciak si Gira！"
   region: "PAL-I"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes missing lights.
     halfPixelOffset: 4 # Aligns post processing.
     nativeScaling: 2 # Fixes post effects.
 SLES-53497:
-  name: "Nickelodeon SpongeBob Schwammkopf - Film ab!"
+  name: "Nickelodeon SpongeBob Schwammkopf - Film ab！"
   region: "PAL-G"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes missing lights.
     halfPixelOffset: 4 # Aligns post processing.
     nativeScaling: 2 # Fixes post effects.
 SLES-53498:
-  name: "Nickelodeon Bob Esponja - ¡Luces, Cámara, Esponja!"
+  name: "Nickelodeon Bob Esponja - ¡Luces, Cámara, Esponja！"
   region: "PAL-S"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes missing lights.
     halfPixelOffset: 4 # Aligns post processing.
     nativeScaling: 2 # Fixes post effects.
 SLES-53499:
-  name: "Nickelodeon SpongeBob SquarePants - Licht uit, Camera aan!"
+  name: "Nickelodeon SpongeBob SquarePants - Licht uit, Camera aan！"
   region: "PAL-NL"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes missing lights.
     halfPixelOffset: 4 # Aligns post processing.
     nativeScaling: 2 # Fixes post effects.
 SLES-53500:
-  name: "Nickelodeon Svampbob Fyrkant - Tystnad, Tagning, TvÃ¤ttsvamp!"
+  name: "Nickelodeon Svampbob Fyrkant - Tystnad, Tagning, TvÃ¤ttsvamp！"
   region: "PAL-SW"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes missing lights.
@@ -22911,7 +22902,7 @@ SLES-53561:
     minimumBlendingLevel: 2 # Fixes door transitions.
     halfPixelOffset: 4 # Reduces ghosting.
 SLES-53563:
-  name: "Nickelodeon SpongeBob SquarePants and Friends Unite!"
+  name: "Nickelodeon SpongeBob SquarePants and Friends Unite！"
   region: "PAL-M6"
   gsHWFixes:
     autoFlush: 2 # Fixes glows. Also needed for recursive mipmap rendering.
@@ -23103,7 +23094,7 @@ SLES-53633:
   name: "Dance - UK XL Lite"
   region: "PAL-UK"
 SLES-53634:
-  name: "Nicktoons Unite!"
+  name: "Nicktoons Unite！"
   region: "PAL-A"
   gsHWFixes:
     autoFlush: 2 # Fixes glows. Also needed for recursive mipmap rendering.
@@ -23132,7 +23123,7 @@ SLES-53640:
   name: "Das Große deutsche Fußball-Quiz"
   region: "PAL-G"
 SLES-53641:
-  name: "Destroy All Humans!"
+  name: "Destroy All Humans！"
   region: "PAL-R"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves metal sheen and reflections.
@@ -23220,13 +23211,13 @@ SLES-53672:
     autoFlush: 2 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
     halfPixelOffset: 2
 SLES-53676:
-  name: "WWE SmackDown! vs. RAW 2006"
+  name: "WWE SmackDown！ vs. RAW 2006"
   region: "PAL-E"
   compat: 5
   gsHWFixes:
     textureInsideRT: 1 # Fixes Hollywood Hulk Hogan's entrance and slow-mo finisher.
 SLES-53677:
-  name: "WWE SmackDown! vs. RAW 2006"
+  name: "WWE SmackDown！ vs. RAW 2006"
   region: "PAL-I"
   gsHWFixes:
     textureInsideRT: 1 # Fixes Hollywood Hulk Hogan's entrance and slow-mo finisher.
@@ -23686,7 +23677,7 @@ SLES-53805:
   roundModes:
     eeDivRoundMode: 1 # Fixes the cursor not being visible.
 SLES-53809:
-  name: "K-1 Premium Dynamite!!"
+  name: "K-1 Premium Dynamite！！"
   region: "PAL-E"
   gameFixes:
     - XGKickHack # Fixes black and white fighters.
@@ -24424,7 +24415,7 @@ SLES-54108:
   name: "Habitrail - Hamster Ball"
   region: "PAL-I"
 SLES-54109:
-  name: "Off-Road Extreme! [Special Edition]"
+  name: "Off-Road Extreme！ [Special Edition]"
   region: "PAL-E"
 SLES-54110:
   name: "Monster Trux Arenas [Special Edition]"
@@ -24560,7 +24551,7 @@ SLES-54150:
     halfPixelOffset: 2 # Aligns post effects.
     nativeScaling: 2 # Fixes post processing and position.
 SLES-54151:
-  name: "Let's Make a Soccer Team!"
+  name: "Let's Make a Soccer Team！"
   region: "PAL-M5"
   compat: 5
   clampModes:
@@ -24572,8 +24563,6 @@ SLES-54152:
   name: "The Ant Bully"
   name-sort: "Ant Bully, The"
   region: "PAL-M5"
-  gsHWFixes:
-    nativeScaling: 2 # Fixes misaligned post effects.
 SLES-54153:
   name: "Virtua Pro Football"
   region: "PAL-M5"
@@ -24698,8 +24687,6 @@ SLES-54178:
   name: "The Ant Bully"
   name-sort: "Ant Bully, The"
   region: "PAL-E-F"
-  gsHWFixes:
-    nativeScaling: 2 # Fixes misaligned post effects.
 SLES-54179:
   name: "Pirates of the Caribbean - At World's End"
   region: "PAL-M6"
@@ -24853,8 +24840,8 @@ SLES-54221:
   name: "LEGO Star Wars II - The Original Trilogy"
   region: "PAL-M6"
   gsHWFixes:
-    halfPixelOffset: 1 # Aligns post processing.
-    nativeScaling: 2 # Fixes post processing smoothness and position.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
   memcardFilters: # Allows import of characters from Lego Star Wars 1.
     - "SLES-54221"
     - "SLES-53194"
@@ -25312,7 +25299,7 @@ SLES-54383:
   name: "Casper and The Ghostly Trio"
   region: "PAL-M6"
 SLES-54384:
-  name: "Destroy All Humans! 2"
+  name: "Destroy All Humans！ 2"
   region: "PAL-M5"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves metal sheen and reflections.
@@ -25507,7 +25494,7 @@ SLES-54452:
   name: "Disney Chicken Little - As en Acción"
   region: "PAL-S"
 SLES-54453:
-  name: "Chicken Little - Asso Spaziale!"
+  name: "Chicken Little - Asso Spaziale！"
   region: "PAL-I"
 SLES-54454:
   name: "Disgaea 2 - Cursed Memories"
@@ -25657,12 +25644,12 @@ SLES-54487:
   name: "Tokobot Plus - Mysteries of the Karakuri"
   region: "PAL-M5"
 SLES-54488:
-  name: "WWE SmackDown! vs. RAW 2007"
+  name: "WWE SmackDown！ vs. RAW 2007"
   region: "PAL-I"
   gsHWFixes:
     textureInsideRT: 1 # Fixes Hollywood Hulk Hogan's entrance and slow-mo finisher.
 SLES-54489:
-  name: "WWE SmackDown! vs. RAW 2007"
+  name: "WWE SmackDown！ vs. RAW 2007"
   region: "PAL-E"
   compat: 5
   gsHWFixes:
@@ -25933,7 +25920,7 @@ SLES-54596:
   name: "Heatseeker"
   region: "PAL-M3"
 SLES-54604:
-  name: "¡Qué pasa Neng! El videojuego"
+  name: "¡Qué pasa Neng！ El videojuego"
   region: "PAL-S"
 SLES-54606:
   name: "Harley-Davidson - Race to the Rally"
@@ -26539,7 +26526,7 @@ SLES-54792:
   name: "World Wrestling Championship"
   region: "PAL-E"
 SLES-54793:
-  name: "WWE SmackDown! vs. Raw 2008"
+  name: "WWE SmackDown！ vs. Raw 2008"
   region: "PAL-E"
   compat: 5
 SLES-54795:
@@ -26675,7 +26662,7 @@ SLES-54835:
     halfPixelOffset: 4 # Mostly aligns post processing.
     nativeScaling: 2 # Fixes post processing position.
 SLES-54836:
-  name: "Disney High School Musical - Sing It!"
+  name: "Disney High School Musical - Sing It！"
   region: "PAL-M5"
 SLES-54837:
   name: "Disney Princess - Enchanted Journey"
@@ -26790,7 +26777,7 @@ SLES-54878:
     halfPixelOffset: 2 # Aligns post effects.
     nativeScaling: 2 # Fixes post effects.
 SLES-54879:
-  name: "WWE SmackDown! vs. Raw 2008"
+  name: "WWE SmackDown！ vs. Raw 2008"
   region: "PAL-M5"
 SLES-54880:
   name: "NBA 2K8"
@@ -27038,7 +27025,7 @@ SLES-54952:
   region: "PAL-M5"
   compat: 5
 SLES-54953:
-  name: "Totally Spies! Totally Party"
+  name: "Totally Spies！ Totally Party"
   region: "PAL-M6"
   gameFixes:
     - VUSyncHack # Partially fixes graphical issues also needs EE+3 to be fully fixed.
@@ -27097,7 +27084,7 @@ SLES-54964:
     nativeScaling: 1 # Fixes post processing smoothness and position.
     autoFlush: 1 # Fixes bloom positioning.
 SLES-54971:
-  name: "Hot Wheels - Beat That!"
+  name: "Hot Wheels - Beat That！"
   region: "PAL-M4"
   gsHWFixes:
     roundSprite: 1 # Fixes font artifacts.
@@ -27305,7 +27292,7 @@ SLES-55016:
     halfPixelOffset: 4 # Fixes bloom on sunlight.
     nativeScaling: 2 # Fixes lighting positioning.
 SLES-55017:
-  name: "Yu-Gi-Oh! GX - Tag Force Evolution"
+  name: "Yu-Gi-Oh！ GX - Tag Force Evolution"
   region: "PAL-M5"
 SLES-55018:
   name: "Shin Megami Tensei - Persona 3"
@@ -27547,7 +27534,7 @@ SLES-55110:
   region: "PAL-M5"
   compat: 5
 SLES-55111:
-  name: "Nick Jr. Go Diego Go! Safari Rescue"
+  name: "Nick Jr. Go Diego Go！ Safari Rescue"
   region: "PAL-E"
 SLES-55112:
   name: "Nick Jr. Dora the Explorer - Dora Saves the Mermaids"
@@ -27596,7 +27583,7 @@ SLES-55135:
     halfPixelOffset: 4 # Mostly aligns post processing.
     nativeScaling: 1 # Fixes post processing smoothness and position.
 SLES-55136:
-  name: "Let's Ride! Silver Buckle Stables"
+  name: "Let's Ride！ Silver Buckle Stables"
   region: "PAL-M4"
 SLES-55138:
   name: "Nickelodeon El Tigre - The Adventures of Manny Rivera"
@@ -27734,7 +27721,7 @@ SLES-55188:
     halfPixelOffset: 4 # Aligns Post Effect.
     nativeScaling: 2 # Fixes Post effect.
 SLES-55189:
-  name: "Nick Jr. Go Diego Go! Safari Rescue"
+  name: "Nick Jr. Go Diego Go！ Safari Rescue"
   region: "PAL-E-F"
 SLES-55190:
   name: "Steam Express"
@@ -28003,10 +27990,10 @@ SLES-55249:
         patch=1,EE,003482b8,word,4A800460
         patch=1,EE,003482bc,word,4B7103BC
 SLES-55250:
-  name: "WWE SmackDown! vs. Raw 2009"
+  name: "WWE SmackDown！ vs. Raw 2009"
   region: "PAL-A"
 SLES-55251:
-  name: "WWE SmackDown! vs. Raw 2009"
+  name: "WWE SmackDown！ vs. Raw 2009"
   region: "PAL-M5"
   compat: 5
 SLES-55252:
@@ -28074,7 +28061,7 @@ SLES-55281:
   name: "Nickelodeon Dora the Explorer - Dora Saves the Snow Princess"
   region: "PAL-M3"
 SLES-55284:
-  name: "Nickelodeon Go Diego Go! Great Dinosaur Rescue"
+  name: "Nickelodeon Go Diego Go！ Great Dinosaur Rescue"
   region: "PAL-M3"
   gsHWFixes:
     nativeScaling: 2 # Fixes shadow smoothness.
@@ -28082,7 +28069,7 @@ SLES-55288:
   name: "Nick Jr. Dora the Explorer - Dora Saves the Mermaids"
   region: "PAL-M4"
 SLES-55289:
-  name: "Nick Jr. Go Diego Go! Safari Rescue"
+  name: "Nick Jr. Go Diego Go！ Safari Rescue"
   region: "PAL-M3"
 SLES-55292:
   name: "Samurai Shodown Anthology"
@@ -28334,16 +28321,16 @@ SLES-55390:
   name: "DreamWorks Madagaskar 2"
   region: "PAL-SW"
 SLES-55392:
-  name: "Disney Sing It!"
+  name: "Disney Sing It！"
   region: "PAL-M6"
 SLES-55393:
-  name: "Disney Sing It!"
+  name: "Disney Sing It！"
   region: "PAL-M4"
 SLES-55394:
-  name: "Disney TH!NK Fast"
+  name: "Disney TH！NK Fast"
   region: "PAL-E"
 SLES-55395:
-  name: "Disney TH!NK Fast"
+  name: "Disney TH！NK Fast"
   region: "PAL-M3"
 SLES-55396:
   name: "Disney Sing It - High School Musical 3 - Senior Year"
@@ -28352,7 +28339,7 @@ SLES-55397:
   name: "Disney Sing It - High School Musical 3 - Senior Year"
   region: "PAL-M4"
 SLES-55398:
-  name: "Disney High School Musical 3 - Senior Year Dance!"
+  name: "Disney High School Musical 3 - Senior Year Dance！"
   region: "PAL-M6"
 SLES-55402:
   name: "Nickelodeon SpongeBob SquarePants featuring Nicktoons - Globs of Doom"
@@ -28380,13 +28367,13 @@ SLES-55411:
   clampModes:
     vuClampMode: 3 # Fixes SPS.
 SLES-55415:
-  name: "Disney TH!NK Fast"
+  name: "Disney TH！NK Fast"
   region: "PAL-I-S"
 SLES-55418:
   name: "Tube Mania"
   region: "PAL-F-DU"
 SLES-55421:
-  name: "Buzz! Brain of Switzerland"
+  name: "Buzz！ Brain of Switzerland"
   region: "PAL-SWI"
 SLES-55428:
   name: "Disney Bolt"
@@ -28401,7 +28388,7 @@ SLES-55431:
   name: "Disney Bolt"
   region: "PAL-R"
 SLES-55433:
-  name: "Disney TH!NK Fast"
+  name: "Disney TH！NK Fast"
   region: "PAL-R"
 SLES-55434:
   name: "Disney Sing It"
@@ -28507,7 +28494,7 @@ SLES-55474:
     halfPixelOffset: 4 # Mostly aligns post processing.
     nativeScaling: 1 # Fixes post processing smoothness and position.
 SLES-55476:
-  name: "Scooby-Doo! First Frights"
+  name: "Scooby-Doo！ First Frights"
   region: "PAL-M5"
   roundModes:
     eeDivRoundMode: 3 # Fixes AI pathing.
@@ -28685,7 +28672,7 @@ SLES-55544:
   roundModes:
     vu1RoundMode: 0 # Fixes VU size spam and potential graphical issues with GH3 engine.
 SLES-55545:
-  name: "WWE SmackDown! vs. Raw 2010"
+  name: "WWE SmackDown！ vs. Raw 2010"
   region: "PAL-M5"
   compat: 5
 SLES-55546:
@@ -28817,7 +28804,7 @@ SLES-55605:
     vu0ClampMode: 3 # Fixes bad dialog backgrounds.
     vu1ClampMode: 3 # Fixes SPS on characters.
 SLES-55609:
-  name: "Scooby-Doo! and the Spooky Swamp"
+  name: "Scooby-Doo！ and the Spooky Swamp"
   region: "PAL-M5"
 SLES-55610:
   name: "Springdale"
@@ -28849,7 +28836,7 @@ SLES-55628:
   name: "Disney Sing It - Party Hits"
   region: "PAL-M3"
 SLES-55635:
-  name: "WWE SmackDown! vs. Raw 2011"
+  name: "WWE SmackDown！ vs. Raw 2011"
   region: "PAL-M4"
   compat: 5
 SLES-55636:
@@ -29360,7 +29347,7 @@ SLKA-15013:
   name: "Grand Slam 2003 Tennis" # Hard Hitter 2
   region: "NTSC-K"
 SLKA-15015:
-  name: "Ichigeki Sacchuu!! HoiHoi-San"
+  name: "Ichigeki Sacchuu！！ HoiHoi-San"
   region: "NTSC-K"
 SLKA-15016:
   name: "Harry Potter - Quidditch World Cup"
@@ -29399,7 +29386,7 @@ SLKA-15025:
   name: "Space Invaders Anniversary"
   region: "NTSC-K"
 SLKA-15028:
-  name: "Simple 2000 Series Ultimate Vol. 6 - Love - Upper!"
+  name: "Simple 2000 Series Ultimate Vol. 6 - Love - Upper！"
   region: "NTSC-K"
 SLKA-15029:
   name: "Simple 2000 Series Vol. 37 - The Shooting - Double Shienryu"
@@ -29430,7 +29417,7 @@ SLKA-15041:
   name: "Simple 2000 Series Vol. 55 - The Catfight: Joneko Densetsu"
   region: "NTSC-K"
 SLKA-15042:
-  name: "Simple 2000 Series Vol. 63 - Mogitate Mizugi! Onna Mamire no: The Suiei Taikai"
+  name: "Simple 2000 Series Vol. 63 - Mogitate Mizugi！ Onna Mamire no: The Suiei Taikai"
   region: "NTSC-K"
 SLKA-15043:
   name: "Super Puzzle Bobble Collection Vol 1"
@@ -29555,7 +29542,7 @@ SLKA-25029:
   clampModes:
     vuClampMode: 3 # Fixes missing environment.
 SLKA-25030:
-  name: "WWE SmackDown! Shut Your Mouth"
+  name: "WWE SmackDown！ Shut Your Mouth"
   region: "NTSC-K"
 SLKA-25031:
   name: "Tom Clancy's Ghost Recon"
@@ -29699,7 +29686,6 @@ SLKA-25065:
     - SoftwareRendererFMVHack # Fixes blackscreen when FMV.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes menu transparancy effects and text.
-    deinterlace: 9 # Fixes incorrect field order in FMVs.
 SLKA-25066:
   name: "Zone of the Enders - The 2nd Runner SE"
   region: "NTSC-K"
@@ -29887,7 +29873,7 @@ SLKA-25115:
   gsHWFixes:
     disablePartialInvalidation: 1 # Fixes black screens.
 SLKA-25116:
-  name: "WWE SmackDown! Here Comes the Pain"
+  name: "WWE SmackDown！ Here Comes the Pain"
   region: "NTSC-K"
 SLKA-25117:
   name: "World Soccer Winning Eleven 7 International"
@@ -30074,7 +30060,7 @@ SLKA-25167:
   name-sort: "King of Fighters XI, The"
   region: "NTSC-K"
 SLKA-25168:
-  name: "WWE SmackDown! vs. RAW 2007"
+  name: "WWE SmackDown！ vs. RAW 2007"
   region: "NTSC-K"
   gsHWFixes:
     textureInsideRT: 1 # Fixes Hollywood Hulk Hogan's entrance and slow-mo finisher.
@@ -30249,7 +30235,7 @@ SLKA-25207:
   region: "NTSC-K"
   compat: 5
 SLKA-25208:
-  name: "From TV Animation - One Piece - Round the Land!"
+  name: "From TV Animation - One Piece - Round the Land！"
   region: "NTSC-K"
 SLKA-25209:
   name: "FIFA 2005"
@@ -30397,7 +30383,7 @@ SLKA-25237:
     halfPixelOffset: 4 # Aligns post processing.
     nativeScaling: 2 # Corrects post processing smoothness.
 SLKA-25240:
-  name: "WWE SmackDown! Shut Your Mouth"
+  name: "WWE SmackDown！ Shut Your Mouth"
   region: "NTSC-K"
 SLKA-25241:
   name: "Need for Speed - Underground 2"
@@ -30411,12 +30397,13 @@ SLKA-25243:
   name: "Medal of Honor - European Assault"
   region: "NTSC-K"
   gsHWFixes:
-    recommendedBlendingLevel: 3 # Fixes banding and level lighting.
+    recommendedBlendingLevel: 2
     autoFlush: 1 # Fixes sun shinging through surfaces and graphical corruptions.
     halfPixelOffset: 2 # Fixes misaligned blur.
-    nativeScaling: 2 # Fixes bloom misaligment.
+    cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SLKA-25244:
-  name: "WWE SmackDown! vs. Raw"
+  name: "WWE SmackDown！ vs. Raw"
   region: "NTSC-K"
 SLKA-25245:
   name: "SpongeBob SquarePants - Movin' With Friends"
@@ -30645,7 +30632,7 @@ SLKA-25298:
   name: "Winning Eleven 9"
   region: "NTSC-K"
 SLKA-25299:
-  name: "From TV Animation - One Piece - Grand Battle! Combat Rush"
+  name: "From TV Animation - One Piece - Grand Battle！ Combat Rush"
   region: "NTSC-K"
 SLKA-25300:
   name: "Digital Devil Saga [Special Package]"
@@ -30744,13 +30731,13 @@ SLKA-25317:
   name: "Shin Sangoku Musou 3 [PlayStation 2 - Big Hit Series]"
   region: "NTSC-K"
 SLKA-25318:
-  name: "WWE SmackDown! vs. RAW 2006"
+  name: "WWE SmackDown！ vs. RAW 2006"
   region: "NTSC-K"
   gsHWFixes:
     textureInsideRT: 1 # Fixes Hollywood Hulk Hogan's entrance and slow-mo finisher.
 SLKA-25319:
-  name: "보글보글 스폰지밥 - 레디, 액션!"
-  name-en: "Nickelodeon SpongeBob SquarePants - Lights, Camera, Pants!"
+  name: "보글보글 스폰지밥 - 레디, 액션！"
+  name-en: "Nickelodeon SpongeBob SquarePants - Lights, Camera, Pants！"
   region: "NTSC-K"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes missing lights.
@@ -31001,7 +30988,7 @@ SLKA-25365:
   name: "WWE Smack Down Vs RAW 2008"
   region: "NTSC-K"
 SLKA-25366:
-  name: "Naruto - Uzumaki Chronicles 2" # Naruto: Konoha Spirits!!"
+  name: "Naruto - Uzumaki Chronicles 2" # Naruto: Konoha Spirits！！"
   region: "NTSC-K"
   compat: 5
   gameFixes:
@@ -31173,7 +31160,7 @@ SLKA-25406:
   name-sort: "King of Fighters, The - Maximum Impact - Regulation A"
   region: "NTSC-K"
 SLKA-25407:
-  name: "Dragon Ball Z - Sparkling! Meteor"
+  name: "Dragon Ball Z - Sparkling！ Meteor"
   region: "NTSC-K"
   compat: 5
   gsHWFixes:
@@ -31317,7 +31304,7 @@ SLKA-25447:
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blurriness.
 SLKA-25448:
-  name: "WWE SmackDown! vs. Raw 2009"
+  name: "WWE SmackDown！ vs. Raw 2009"
   region: "NTSC-K"
 SLKA-25449:
   name: "Call of Duty - World at War - Final Fronts"
@@ -31329,7 +31316,7 @@ SLKA-25450:
   name: "Jikkyou Powerful Major League 3"
   region: "NTSC-K"
 SLKA-25451:
-  name: "WWE SmackDown! vs. Raw 2008"
+  name: "WWE SmackDown！ vs. Raw 2008"
   region: "NTSC-K"
 SLKA-25452:
   name: "Viewtiful Joe - A New Hope"
@@ -31377,7 +31364,7 @@ SLKA-25459:
         patch=1,EE,0016ee38,word,3464fff0
         patch=1,EE,0016ee58,word,3464fffc
 SLKA-25463:
-  name: "WWE SmackDown! vs. Raw 2010"
+  name: "WWE SmackDown！ vs. Raw 2010"
   region: "NTSC-K"
 SLKA-25464:
   name: "FIFA 10"
@@ -31487,7 +31474,7 @@ SLPM-20391:
   region: "NTSC-J"
   compat: 5
 SLPM-20436:
-  name: "Sakigake!! Otokojuku (SLPS-20436 ?)"
+  name: "Sakigake！！ Otokojuku (SLPS-20436 ?)"
   region: "NTSC-J"
   compat: 5
 SLPM-55002:
@@ -31554,12 +31541,12 @@ SLPM-55010:
 SLPM-55011:
   name: "っポイ！ ひと夏の経験！？ [限定版]"
   name-sort: "っぽい！ ひとなつのけいけん！？ [げんていばん]"
-  name-en: "Ppoi! Hito Natsu no Keiken!? [Limited Edition]"
+  name-en: "Ppoi！ Hito Natsu no Keiken！? [Limited Edition]"
   region: "NTSC-J"
 SLPM-55012:
   name: "っポイ！ ひと夏の経験！？ [通常版]"
   name-sort: "っぽい！ ひとなつのけいけん！？ [つうじょうばん]"
-  name-en: "Ppoi! Hito Natsu no Keiken!? [Standard Edition]"
+  name-en: "Ppoi！ Hito Natsu no Keiken！? [Standard Edition]"
   region: "NTSC-J"
 SLPM-55013:
   name: "ソラユメ"
@@ -31654,12 +31641,12 @@ SLPM-55029:
 SLPM-55030:
   name: "魔人探偵脳噛ネウロ バトルだヨ！犯人集合！ [限定版]"
   name-sort: "まじんたんていのうがみねうろ ばとるだよ！はんにんしゅうごう！ [げんていばん]"
-  name-en: "Majin Tantei Nougami Neuro - Battle da yo! Hannin Shuugou![Limited Edition]"
+  name-en: "Majin Tantei Nougami Neuro - Battle da yo！ Hannin Shuugou！[Limited Edition]"
   region: "NTSC-J"
 SLPM-55031:
   name: "魔人探偵脳噛ネウロ バトルだヨ！犯人集合！ [通常版]"
   name-sort: "まじんたんていのうがみねうろ ばとるだよ！はんにんしゅうごう！ [つうじょうばん]"
-  name-en: "Majin Tantei Nougami Neuro - Battle da yo! Hannin Shuugou![Standard Edition]"
+  name-en: "Majin Tantei Nougami Neuro - Battle da yo！ Hannin Shuugou！[Standard Edition]"
   region: "NTSC-J"
 SLPM-55032:
   name: "ピヨたん ～お屋敷潜入大作戦～"
@@ -31710,10 +31697,11 @@ SLPM-55037:
   name-en: "Medal of Honor - European Assault [EA:SY! 1980]"
   region: "NTSC-J"
   gsHWFixes:
-    recommendedBlendingLevel: 3 # Fixes banding and level lighting.
+    recommendedBlendingLevel: 2
     autoFlush: 1 # Fixes sun shinging through surfaces and graphical corruptions.
     halfPixelOffset: 2 # Fixes misaligned blur.
-    nativeScaling: 2 # Fixes bloom misaligment.
+    cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SLPM-55038:
   name: "グランド・セフト・オート：Liberty City Stories [Best Price]"
   name-sort: "ぐらんど・せふと・おーと3.3 りばてぃしてぃー すとーりーず [Best Price]"
@@ -31747,8 +31735,8 @@ SLPM-55044:
   name-en: "Heart no Kuni no Alice - Wonderful Wonder World"
   region: "NTSC-J"
 SLPM-55046:
-  name: "TOCA RACE DRIVER 3 THE ULTIMATE RACING SIMULATOR [BEST PRICE]"
-  name-sort: "とか れーすどらいばー3 じ あるてぃめっと れーしんぐ しみゅれーたー [BEST PRICE]"
+  name: "TOCA RACE DRIVER 3 THE ULTIMATE RACING SIMULATOR [Best Price]"
+  name-sort: "とか れーすどらいばー3 じ あるてぃめっと れーしんぐ しみゅれーたー [Best Price]"
   name-en: "TOCA Race Driver 3 - The Ultimate Racing Simulator [Best Price]"
   region: "NTSC-J"
   gsHWFixes:
@@ -31761,7 +31749,7 @@ SLPM-55046:
 SLPM-55047:
   name: "Sugar+Spice！ ～あの子のステキな何もかも～"
   name-sort: "しゅがーすぱいす あのこのすてきななにもかも"
-  name-en: "Sugar+Spice! - Anoko no Suteki na Nanimokamo"
+  name-en: "Sugar+Spice！ - Anoko no Suteki na Nanimokamo"
   region: "NTSC-J"
 SLPM-55048:
   name: "真・三國無双4 Empires"
@@ -31838,7 +31826,7 @@ SLPM-55062:
   name-en: "Jikkyou Powerful Major League 3"
   region: "NTSC-J"
 SLPM-55063:
-  name: "薄桜鬼 新選組奇譚 限定版"
+  name: "薄桜鬼 新選組奇譚 [限定版]"
   name-sort: "はくおうき しんせんぐみきたん [げんていばん]"
   name-en: "Hakuouki - Shinsengumi Kitan [Limited Edition]"
   region: "NTSC-J"
@@ -32025,7 +32013,7 @@ SLPM-55101:
 SLPM-55102:
   name: "Piaキャロットへようこそ！！G.P. ～学園プリンセス～"
   name-sort: "ぴあきゃろっとへようこそ！！ G.P. ～がくえんぷりんせす～"
-  name-en: "Pia Carrot he Youkoso!! G.O. - Gakuen Princess -"
+  name-en: "Pia Carrot he Youkoso！！ G.O. - Gakuen Princess -"
   region: "NTSC-J"
   gsHWFixes:
     beforeDraw: "OI_PointListPalette"
@@ -32084,8 +32072,8 @@ SLPM-55113:
   name-en: "WinBack 2 - Project Poseidon [KOEI The Best]"
   region: "NTSC-J"
 SLPM-55114:
-  name: "マナケミア２ ～おちた学園と錬金術士たち～ [ガストベストプライス]"
-  name-sort: "まなけみあ2 おちたがくえんとれんきんじゅつしたち [がすとべすとぷらいす]"
+  name: "マナケミア２ ～おちた学園と錬金術士たち～ [ガストBest Price]"
+  name-sort: "まなけみあ2 おちたがくえんとれんきんじゅつしたち [がすとBest Price]"
   name-en: "Mana Khemia 2 - Ochita Gakuen to Renkinjutsushi Tachi"
   region: "NTSC-J"
   gsHWFixes:
@@ -32117,8 +32105,8 @@ SLPM-55119:
   memcardFilters:
     - "SLPM-55118"
 SLPM-55120:
-  name: "不確定世界の探偵紳士 ～悪行双麻の事件ファイル～ 初回限定版"
-  name-sort: "ふかくていせかいのたんていしんし ～あくぎょうそうあさのじけんふぁいる～ しょかいげんていばん"
+  name: "不確定世界の探偵紳士 ～悪行双麻の事件ファイル～ [初回限定版]"
+  name-sort: "ふかくていせかいのたんていしんし ～あくぎょうそうあさのじけんふぁいる～ [しょかいげんていばん]"
   name-en: "Fukakutei Sekai no Tantei Shinshi - Akugyou Souma no Jiken File [Limited Edition]"
   region: "NTSC-J"
 SLPM-55121:
@@ -32224,7 +32212,7 @@ SLPM-55140:
 SLPM-55141:
   name: "デストロイ オール ヒューマンズ！ [THQ Collection]"
   name-sort: "ですとろい おーる ひゅーまんず！ [THQ Collection]"
-  name-en: "Destroy All Humans! [THQ Collection]"
+  name-en: "Destroy All Humans！ [THQ Collection]"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves metal sheen and reflections.
@@ -32258,7 +32246,7 @@ SLPM-55146:
 SLPM-55147:
   name: "すっごい！ アルカナハート2"
   name-sort: "すっごい！ あるかなはーと2"
-  name-en: "Suggoi! Arcana Heart 2"
+  name-en: "Suggoi！ Arcana Heart 2"
   region: "NTSC-J"
 SLPM-55148:
   name: "007 - 慰めの報酬"
@@ -32320,7 +32308,7 @@ SLPM-55158:
 SLPM-55159:
   name: "ヒャッコ よろずや事件簿！"
   name-sort: "ひゃっこ よろずやじけんぼ！"
-  name-en: "Hyakko - Yorozuya Jikenbo!"
+  name-en: "Hyakko - Yorozuya Jikenbo！"
   region: "NTSC-J"
 SLPM-55160:
   name: "カヌチ 黒き翼の章 [限定版]"
@@ -32365,17 +32353,17 @@ SLPM-55167:
 SLPM-55168:
   name: "アルコバレーノ！ [限定版]"
   name-sort: "あるこばれーの [げんていばん]"
-  name-en: "Arcobaleno! [Limited Edition]"
+  name-en: "Arcobaleno！ [Limited Edition]"
   region: "NTSC-J"
 SLPM-55169:
   name: "アルコバレーノ！ [通常版]"
   name-sort: "あるこばれーの [つうじょうばん]"
-  name-en: "Arcobaleno! [Standard Edition]"
+  name-en: "Arcobaleno！ [Standard Edition]"
   region: "NTSC-J"
 SLPM-55170:
   name: "スキップ・ビート"
   name-sort: "すきっぷ・びーと"
-  name-en: "Skip Beat!"
+  name-en: "Skip Beat！"
   region: "NTSC-J"
 SLPM-55173:
   name: "ストライクウィッチーズ あなたとできること [限定版]"
@@ -32463,12 +32451,12 @@ SLPM-55191:
 SLPM-55192:
   name: "NUGA-CEL! - Nurture Garment Celebration [限定版]"
   name-sort: "ぬがせる！- Nurture Garment Celebration [げんていばん]"
-  name-en: "Nuga-Cel! Nurture Garment Celebration [Limited Edition]"
+  name-en: "Nuga-Cel！ Nurture Garment Celebration [Limited Edition]"
   region: "NTSC-J"
 SLPM-55193:
   name: "NUGA-CEL! - Nurture Garment Celebration [通常版]"
   name-sort: "ぬがせる！- Nurture Garment Celebration [つうじょうばん]"
-  name-en: "Nuga-Cel! Nurture Garment Celebration [Standard Edition]"
+  name-en: "Nuga-Cel！ Nurture Garment Celebration [Standard Edition]"
   region: "NTSC-J"
 SLPM-55194:
   name: "Luxury & Beauty - Lucian Bee's - RESURRECTION SUPERNOVA [通常版]"
@@ -32478,7 +32466,7 @@ SLPM-55194:
 SLPM-55195:
   name: "プリンセスラバー！ Eternal Love For My Lady [初回限定版]"
   name-sort: "ぷりんせすらばー！ Eternal Love For My Lady [しょかいげんていばん]"
-  name-en: "Princess Lover! Eternal Love for My Lady [First Limited Edition]"
+  name-en: "Princess Lover！ Eternal Love for My Lady [First Limited Edition]"
   region: "NTSC-J"
 SLPM-55197:
   name: "Memories Off 6 Next Relation"
@@ -32489,7 +32477,7 @@ SLPM-55198:
   name: " naxat soft reach mania vol.1 - CRギャラクシーエンジェル [naxat Best]"
   name-sort: "なぐざっと そふと りーち まにあ Vol.1 CRぎゃらくしーえんじぇる [naxat Best]"
   name-en: "Naxat Soft Reach Mania Vol. 1 - CR Galaxy Angel [naxat Best]"
-  region: "NTSC-J"
+  Region: "NTSC-J"
 SLPM-55200:
   name: "桃華月憚 ～光風の陵王～ [通常版]"
   name-sort: "とうかげったん こうふうのりょうおう [つうじょうばん]"
@@ -32508,7 +32496,7 @@ SLPM-55202:
 SLPM-55203:
   name: "リトルバスターズ！ Converted Edition"
   name-sort: "りとるばすたーず！ こんばてぃっど えでぃしょん"
-  name-en: "Little Busters! Converted Edition"
+  name-en: "Little Busters！ Converted Edition"
   region: "NTSC-J"
 SLPM-55204:
   name: "ARIA The ORIGINATION ～蒼い惑星のエルシエロ～ [アルケベスト]"
@@ -32612,7 +32600,7 @@ SLPM-55222:
 SLPM-55223:
   name: "ナデプロ!! ～キサマも声優やってみろ!～ [通常版]"
   name-sort: "なでぷろ!! きさまもせいゆうやってみろ! [つうじょうばん]"
-  name-en: "NadePro!! Kisama mo Seiyuu Yatte Miro! [Standard Edition]"
+  name-en: "NadePro！！ Kisama mo Seiyuu Yatte Miro！ [Standard Edition]"
   region: "NTSC-J"
 SLPM-55225:
   name: "戦極姫 ～戦乱に舞う乙女達～"
@@ -32657,7 +32645,7 @@ SLPM-55231:
   region: "NTSC-J"
 SLPM-55233:
   name: "金色のコルダ [KOEI The Best]"
-  name-sort: "きんいろのこるだ [ [KOEI The Best]"
+  name-sort: "きんいろのこるだ [KOEI The Best]"
   name-en: "Kin'iro no Corda [KOEI The Best]"
   region: "NTSC-J"
 SLPM-55234:
@@ -32883,7 +32871,7 @@ SLPM-55282:
   name-en: "Armen Noir"
   region: "NTSC-J"
 SLPM-55283:
-  name: "薄桜鬼 黎明録 限定版"
+  name: "薄桜鬼 黎明録 [限定版]"
   name-sort: "はくおうき れいめいろく [げんていばん]"
   name-en: "Hakuouki - Reimeiroku [Limited Edition]"
   region: "NTSC-J"
@@ -32905,7 +32893,7 @@ SLPM-55288:
 SLPM-55289:
   name: "三国恋戦記 ～オトメの兵法！"
   name-sort: "さんごくれんせんき おとめのへいほう"
-  name-en: "Sangoku Rensenki - Otome no Heihou!"
+  name-en: "Sangoku Rensenki - Otome no Heihou！"
   region: "NTSC-J"
 SLPM-55290:
   name: "スカーレッドライダー ゼクス - STARDUST LOVERS"
@@ -33056,7 +33044,7 @@ SLPM-60122:
 SLPM-60123:
   name: "劇空間プロ野球 -AT THE END OF THE CENTURY 1999 [体験版]"
   name-sort: "げきくうかんぷろやきゅう -AT THE END OF THE CENTURY 1999 [たいけんばん]"
-  name-en: "Gekikuukan Pro Yakyuu - The End of the Century 1999 [Trial]"
+  name-en: "Gekikuukan Pro Yakyuu - At The End of the Century 1999 [Trial]"
   region: "NTSC-J"
 SLPM-60124:
   name: "エクストリーム・レーシング SSX [体験版]"
@@ -33109,7 +33097,9 @@ SLPM-60133:
   name-en: "Zeonic Front - Kidou Senshi Gundam 0079 [Trial]"
   region: "NTSC-J"
 SLPM-60134:
-  name: "Technictix"
+  name: "テクニクティクス [体験版]"
+  name-sort: "てくにくてぃくす [たいけんばん]"
+  name-en: "Technictix [Treial]"
   region: "NTSC-J"
 SLPM-60135:
   name: "Shadow of Memories [店頭放映用ムービー版]"
@@ -33119,10 +33109,14 @@ SLPM-60135:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
 SLPM-60136:
-  name: "Bloody Roar 3"
+  name: "ブラッディロア 3 [体験版]"
+  name-sort: "ぶらっでぃろあ 3 [たいけんばん]"
+  name-en: "Bloody Roar 3 [Trial]"
   region: "NTSC-J"
 SLPM-60138:
-  name: "Klonoa 2 - Lunatea's Veil [Trial]"
+  name: "風のクロノア2 ～世界が望んだ忘れもの～ [体験版]"
+  name-sort: "かぜのくろのあ2 せかいがのぞんだわすれもの [たいけんばん]"
+  name-en: "Kaze no Klonoa 2 - Sekai ga Nozonda Wasuremono [Trial]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Objects appear in wrong places without it.
@@ -33132,13 +33126,19 @@ SLPM-60138:
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes shadows, object and enemy colours, platform transitions.
 SLPM-60140:
-  name: "Lilie no Atelier - Salburg no Renkinjutsushi 3"
+  name: "リリーのアトリエ ～ザールブルグの錬金術士3～ [体験版]"
+  name-sort: "りりーのあとりえ ざーるぶるぐのれんきんじゅつし3 [たいけんばん]"
+  name-en: "Lilie no Atelier - Salburg no Renkinjutsushi 3 [Trial]"
   region: "NTSC-J"
 SLPM-60141:
-  name: "Golful Golf"
+  name: "ゴルフルGOLF [体験版]"
+  name-sort: "ごるふるごるふ [たいけんばん]"
+  name-en: "Golful Golf [Trial]"
   region: "NTSC-J"
 SLPM-60142:
-  name: "Densha de Go! 3 - Tsuukin-hen"
+  name: "電車でGO！3 通勤編 [体験版]"
+  name-sort: "でんしゃでごー3 つうきんへん [たいけんばん]"
+  name-en: "Densha de Go！ 3 - Tsuukin-hen [Trial]"
   region: "NTSC-J"
 SLPM-60143:
   name: "鉄甲機ミカズキ [体験版]"
@@ -33157,7 +33157,9 @@ SLPM-60145:
     halfPixelOffset: 4 # Fixes lighting misalignment.
     nativeScaling: 2 # Fixes lighting smoothness.
 SLPM-60146:
-  name: "Tetsu One - Densha de Battle!"
+  name: "鉄1 ～電車でバトル～ [体験版]"
+  name-sort: "てつ1 ～でんしゃでばとる～ [たいけんばん]"
+  name-en: "Tetsu-One Train Battle [Trial]"
   region: "NTSC-J"
 SLPM-60147:
   name: "牧場物語3 ～ ハートに火をつけて [体験版]"
@@ -33165,10 +33167,14 @@ SLPM-60147:
   name-en: "Bokujou Monogatari 3 - Heart ni Hi wo Tsukete [Trial]"
   region: "NTSC-J"
 SLPM-60148:
-  name: "Yanya! Caballista featuring Gawoo"
+  name: "ヤンヤ カバジスタ ～featuring Gawoo～ [体験版]"
+  name-sort: "やんや かばじすた ～featuring Gawoo～ [たいけんばん]"
+  name-en: "Yanya Caballista - featuring Gawoo [Trial]"
   region: "NTSC-J"
 SLPM-60149:
-  name: "Ace Combat 04 - Shattered Skies [Trial]"
+  name: "エースコンバット04 シャッタードスカイ [体験版]"
+  name-sort: "えーすこんばっと04 しゃったーどすかい [たいけんばん]"
+  name-en: "Ace Combat 04 - Shattered Skies [Trial]"
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes FMVs disabling hash cache.
@@ -33181,7 +33187,9 @@ SLPM-60149:
     cpuSpriteRenderLevel: 0 # Needed for above.
     nativeScaling: 2 # Smooths post processing.
 SLPM-60150:
-  name: "Tamamayu Monogatari 2 - Horobi no Mushi"
+  name: "玉繭物語2 ～滅びの蟲～ MOVIE DISC [体験版]"
+  name-sort: "たままゆものがたり2 ほろびのむし MOVIE DISC [たいけんばん]"
+  name-en: "Tamamayu Story 2 - Horobi no Mushi [Trial]"
   region: "NTSC-J"
 SLPM-60152:
   name: "NBA STREET [体験版]"
@@ -33189,22 +33197,32 @@ SLPM-60152:
   name-en: "NBA Street [Trial]"
   region: "NTSC-J"
 SLPM-60153:
-  name: "Garakuta Meisaku Gekijou - Rakugaki Oukoku"
+  name: "ガラクタ名作劇場 ラクガキ王国 [体験版]"
+  name-sort: "がらくためいさくげきじょう らくがきおうこく [たいけんばん]"
+  name-en: "Galacta Meisaku Gekijou - Rakugaki Oukouku [Trial]"
   region: "NTSC-J"
 SLPM-60154:
-  name: "Touge 3"
+  name: "峠3 [体験版]"
+  name-sort: "とうげ3 [たいけんばん]"
+  name-en: "Touge 3 [Trial]"
   region: "NTSC-J"
 SLPM-60157:
-  name: "BuileBaku"
+  name: "ビルバク [体験版]"
+  name-sort: "びるばく [たいけんばん]"
+  name-en: "Buile Baku [Trial]"
   region: "NTSC-J"
 SLPM-60158:
-  name: "Hippa Linda"
+  name: "ひっぱリンダ [体験版]"
+  name-sort: "ひっぱりんだ [たいけんばん]"
+  name-en: "Hippa Linda [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 4 # Aligns post effects.
     autoFlush: 1 # Fixes ghosting.
 SLPM-60159:
-  name: "Dengeki PS2 PlayStation D47"
+  name: "電撃PS2 / 電撃PlayStation D47"
+  name-sort: "でんげき PS2 でんげきPlayStation D47"
+  name-en: "Dengeki PS2 / DengekiPlayStation D47"
   region: "NTSC-J"
 SLPM-60162:
   name: "GUILTY GEAR X PLUS [体験版]"
@@ -33212,15 +33230,19 @@ SLPM-60162:
   name-en: "Guilty Gear X Plus [Trial]"
   region: "NTSC-J"
 SLPM-60165:
-  name: "Maximo"
+  name: "マキシモ [体験版]"
+  name-sort: "まきしも [たいけんばん]"
+  name-en: "Maximo [Trial]"
   region: "NTSC-J"
 SLPM-60166:
   name: "ジェットでGO！2 [体験版]"
   name-sort: "じぇっとでGO！2 [たいけんばん]"
-  name-en: "Jet de Go! 2 [Trial]"
+  name-en: "Jet de Go！ 2 [Trial]"
   region: "NTSC-J"
 SLPM-60167:
-  name: "Zero [Trial]"
+  name: "零 ～zero～ [体験版]"
+  name-sort: "ぜろ [たいけんばん]"
+  name-en: "Zero [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blurriness.
@@ -33231,19 +33253,27 @@ SLPM-60169:
   name-en: "Exciting Pro Wres 3 [Trial]"
   region: "NTSC-J"
 SLPM-60171:
-  name: "Soul Reaver 2"
+  name: "ソウルリーバー2 [体験版]"
+  name-sort: "そうるりーばー2 [たいけんばん]"
+  name-en: "Soul Reaver 2 - Legacy of Kain [Trial]"
   region: "NTSC-J"
 SLPM-60172:
-  name: "Itadaki Street 3 - Okuman Chouja ni Shiteageru"
+  name: "いただきストリート3 億万長者にしてあげる！ [体験版]"
+  name-sort: "いただきすとりーと3 おくまんちょうじゃにしてあげる！ [たいけんばん]"
+  name-en: "Itadaki Street 3 - Okuman Chouja ni Shiteageru！ [Trial]"
   region: "NTSC-J"
 SLPM-60174:
-  name: "Zettai Zetsumei Toshi"
+  name: "絶体絶命都市 [体験版]"
+  name-sort: "ぜったいぜつめいとし [たいけんばん]"
+  name-en: "Zettai Zetsumei Toshi [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 1 # Fixes incorrect blur effect.
     halfPixelOffset: 4 # Improves blur.
 SLPM-60175:
-  name: "Wangan Midnight [Trial]"
+  name: "湾岸ミッドナイト [体験版]"
+  name-sort: "わんがんみっどないと [たいけんばん]"
+  name-en: "Wangan Midnight [Trial]"
   region: "NTSC-J"
 SLPM-60176:
   name: "U - underwater unit [体験版]"
@@ -33251,27 +33281,41 @@ SLPM-60176:
   name-en: "U - Underwater Unit [Trial]"
   region: "NTSC-J"
 SLPM-60177:
-  name: "Kengou 2"
+  name: "剣豪2 [体験版]"
+  name-sort: "けんごう2 [たいけんばん]"
+  name-en: "Kengo 2 [Trial]"
   region: "NTSC-J"
 SLPM-60178:
-  name: "Nihon Daihyou Senshu ni Narou!"
+  name: "ドラマティックサッカーゲーム 日本代表選手になろう！ [体験版]"
+  name-sort: "どらまてぃっくさっかーげーむ にほんだいひょうせんしゅになろう！ [たいけんばん]"
+  name-en: "Dramatic Soccer Game - Nihon Daihyou Senshu ni Narou！ [Trial]"
   region: "NTSC-J"
 SLPM-60179:
-  name: "Densha de Go! Ryojou-hen"
+  name: "電車でGO！ ～旅情編～ [体験版]"
+  name-sort: "でんしゃでごー りょじょうへん [たいけんばん]"
+  name-en: "Densha de Go！ Ryojou-hen [Trial]"
   region: "NTSC-J"
 SLPM-60180:
-  name: "Disney Golf Classics [Trial]"
+  name: "ディズニーゴルフ クラシック [体験版]"
+  name-sort: "でぃずにーごるふ くらしっく [たいけんばん]"
+  name-en: "Disney Golf Classics [Trial]"
   region: "NTSC-J"
   roundModes:
     eeDivRoundMode: 3 # Fixes random game crashing.
 SLPM-60181:
-  name: "Street Golfer"
+  name: "Street Golfer [体験版]"
+  name-sort: "すとりーと ごるふぁー [たいけんばん]"
+  name-en: "Street Golfer [Trial]"
   region: "NTSC-J"
 SLPM-60182:
-  name: "Zoku Segare Ijiri - Henchin Tama Segare"
+  name: "続せがれいじり 変珍たませがれ [体験版]"
+  name-sort: "ぞくせがれいじり へんちんたませがれ [たいけんばん]"
+  name-en: "Zoku Segare Ijiri - Henchin Tama Segare [Trial]"
   region: "NTSC-J"
 SLPM-60183:
-  name: "Energy Airforce [Trial]"
+  name: "エナジーエアフォース TRIAL VERSION [体験版]"
+  name-sort: "えなじーえあふぉーす TRIAL VERSION [たいけんばん]"
+  name-en: "Energy Airforce TRIAL VERSION [Trial]"
   region: "NTSC-J"
 SLPM-60184:
   name: "GUNGRAVE [体験版]"
@@ -33284,15 +33328,19 @@ SLPM-60188:
   name-en: "Marvel vs. Capcom 2 New Age of Heroes [Trial]"
   region: "NTSC-J"
 SLPM-60189:
-  name: "Dengeki PS2 PlayStation D54"
+  name: "電撃PS2 / 電撃PlayStation D54"
+  name-sort: "でんげき PS2 でんげきPlayStation D54"
+  name-en: "Dengeki PS2 / DengekiPlayStation D54"
   region: "NTSC-J"
 SLPM-60190:
-  name: "Ultraman - Fighting Evolution 2"
+  name: "ウルトラマン Fighting Evolution 2 [体験版]"
+  name-sort: "うるとらまん Fighting Evolution 2 [たいけんばん]"
+  name-en: "Ultraman Fighting Evolution 2 [Trial]"
   region: "NTSC-J"
 SLPM-60192:
-  name: "忍 -Shinobi-"
-  name-sort: "しのび"
-  name-en: "Shinobi"
+  name: "忍 -Shinobi- [体験版]"
+  name-sort: "しのび [たいけんばん]"
+  name-en: "Shinobi [Trial]"
   region: "NTSC-J"
 SLPM-60193:
   name: "GUILTY GEAR XX THE MIDNIGHT CARNIVAL [体験版]"
@@ -33305,7 +33353,9 @@ SLPM-60194:
   name-en: "Kotoba no Puzzle - Mojipittan [Trial]"
   region: "NTSC-J"
 SLPM-60195:
-  name: "Kaido Battle - Nikko, Haruna, Rokko, Hakone [Trial]"
+  name: "街道バトル ～日光・榛名・六甲・箱根～ [体験版]"
+  name-sort: "かいどうばとる にっこう はるな ろっこう はこね [たいけんばん]"
+  name-en: "Kaido Battle - Nikko, Haruna, Rokko, Hakone [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting during Rain.
@@ -33324,10 +33374,14 @@ SLPM-60198:
   gsHWFixes:
     roundSprite: 2 # Fixes lines at the edges of the HUD.
 SLPM-60199:
-  name: "Dengeki PS2 PlayStation D58"
+  name: "電撃PS2 / 電撃PlayStation D58"
+  name-sort: "でんげき PS2 でんげきPlayStation D58"
+  name-en: "Dengeki PS2 / DengekiPlayStation D58"
   region: "NTSC-J"
 SLPM-60200:
-  name: "Anubis - Zone of the Enders"
+  name: "Visual Works of ANUBIS [体験版]"
+  name-sort: "びじゅあるわーくす おぶ あぬびす [たいけんばん]"
+  name-en: "Visual Works of Anubis [Trial]"
   region: "NTSC-J"
 SLPM-60202:
   name: "R-TYPE FINAL [体験版]"
@@ -33345,14 +33399,18 @@ SLPM-60205:
   name-en: "Initial D - Special Stage [Special Trial]"
   region: "NTSC-J"
 SLPM-60206:
-  name: "Shutokou Battle 01 [Trial]"
+  name: "首都高バトル01 [体験版]"
+  name-sort: "しゅとこうばとる01 [たいけんばん]"
+  name-en: "Shutokou Battle 01 [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     forceEvenSpritePosition: 1 # Improves visual clarity whilst upscaling.
     roundSprite: 1 # Reduces graphics garbage on UI whilst upscaling.
 SLPM-60207:
-  name: "Rockman X7"
+  name: "ロックマンX7 [体験版]"
+  name-sort: "ろっくまんえっくす7 [たいけんばん]"
+  name-en: "Rockman X7 [Trial]"
   region: "NTSC-J"
   compat: 5
   clampModes:
@@ -33362,7 +33420,7 @@ SLPM-60207:
 SLPM-60208:
   name: "テニスの王子様 Smash Hit！ [体験版]"
   name-sort: "てにすのおうじさま Smash Hit！ [たいけんばん]"
-  name-en: "Tennis no Oji-Sama - Smash-Hit! [Trial]"
+  name-en: "Tennis no Oji-Sama - Smash-Hit！ [Trial]"
   region: "NTSC-J"
 SLPM-60209:
   name: "REAL SPORTS プロ野球 [体験版]"
@@ -33370,13 +33428,19 @@ SLPM-60209:
   name-en: "Real Sports Pro Yakyuu [Trial]"
   region: "NTSC-J"
 SLPM-60211:
-  name: "Bujingai"
+  name: "武刃街 -BUJINGAI- [体験版]"
+  name-sort: "ぶじんがい [たいけんばん]"
+  name-en: "Bujingai [Trial]"
   region: "NTSC-J"
 SLPM-60212:
-  name: "Makai Eiyuuki Maximo - Machine Monster no Yabou"
+  name: "魔界英雄記マキシモ ～マシンモンスターの野望～ [体験版]"
+  name-sort: "まかいえいゆうきまきしも ましんもんすたーのやぼう [たいけんばん]"
+  name-en: "Makai Eiyuuki Maximo - Machine Monster no Yabou [Trial]"
   region: "NTSC-J"
 SLPM-60213:
-  name: "Katamari Damacy [Demo]"
+  name: "塊魂 [体験版]"
+  name-sort: "かたまりだましい [たいけんばん]"
+  name-en: "Katamari Damacy [Trial]"
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 0 # Fixes SPS.
@@ -33396,7 +33460,9 @@ SLPM-60214:
     halfPixelOffset: 4 # Fixes shadow positioning.
     autoFlush: 2 # Makes the shadow monsters appear.
 SLPM-60215:
-  name: "Dengeki PS2 PlayStation D63"
+  name: "電撃PS2 / 電撃PlayStation D63"
+  name-sort: "でんげき PS2 でんげきPlayStation D63"
+  name-en: "Dengeki PS2 / DengekiPlayStation D63"
   region: "NTSC-J"
 SLPM-60216:
   name: "R:RACING EVOLUTION [体験版]"
@@ -33431,7 +33497,9 @@ SLPM-60220:
   name-en: "Hajime no Ippo II - Victorious Road [Trial]"
   region: "NTSC-J"
 SLPM-60225:
-  name: "Fuuun Shinsengumi"
+  name: "風雲新撰組 [体験版]"
+  name-sort: "ふううん しんせんぐみ [たいけんばん]"
+  name-en: "Fuuun Shinsengumi [Trial]"
   region: "NTSC-J"
 SLPM-60226:
   name: "シャドウハーツⅡ [体験版]"
@@ -33442,17 +33510,23 @@ SLPM-60226:
     halfPixelOffset: 4 # Fixes shadow positioning.
     autoFlush: 2 # Makes the shadow monsters appear.
 SLPM-60228:
-  name: "Kaido Battle 2 - Chain Reaction [Trial]"
+  name: "街道バトル2 CHAIN REACTION [体験版]"
+  name-sort: "かいどうばとる2 CHAIN REACTION [たいけんばん]"
+  name-en: "Kaido Battle 2 - Chain Reaction [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting during Rain/Storm.
     alignSprite: 1 # Fixes vertical lines.
     forceEvenSpritePosition: 1 # De-blurs the 3D image.
 SLPM-60237:
-  name: "Densha de Go! Final"
+  name: "電車でGO！FINAL [体験版]"
+  name-sort: "でんしゃでごーFINAL [たいけんばん]"
+  name-en: "Densha de Go！ Final [Trial]"
   region: "NTSC-J"
 SLPM-60239:
-  name: "Katamari Damacy [Trial]"
+  name: "塊魂 [店頭体験版]"
+  name-sort: "かたまりだましい [てんとうたいけんばん]"
+  name-en: "Katamari Damacy [Store Demo]"
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 0 # Fixes SPS.
@@ -33464,10 +33538,14 @@ SLPM-60239:
     halfPixelOffset: 4 # Aligns post effects.
     nativeScaling: 2 # Fixes post effects.
 SLPM-60240:
-  name: "Dengeki PS2 PlayStation D67"
+  name: "電撃PS2 / 電撃PlayStation D67"
+  name-sort: "でんげき PS2 でんげきPlayStation D67"
+  name-en: "Dengeki PS2 / DengekiPlayStation D67"
   region: "NTSC-J"
 SLPM-60241:
-  name: "Sakurazaka Shouboutai"
+  name: "桜坂消防隊 [体験版]"
+  name-sort: "さくらざかしょうぼうたい [たいけんばん]"
+  name-en: "Sakurazaka Shouboutai [Trial]"
   region: "NTSC-J"
 SLPM-60242:
   name: "バーチャファイターサイバージェネレーション ～ジャッジメントシックスの野望～ [体験版]"
@@ -33475,7 +33553,9 @@ SLPM-60242:
   name-en: "Virtua Fighter Cyber Generation - Ambition of the Judgement Six [Trial]"
   region: "NTSC-J"
 SLPM-60243:
-  name: "Full House Kiss [Trial]"
+  name: "フルハウスキス [体験版]"
+  name-sort: "ふるはうすきす [たいけんばん]"
+  name-en: "Full House Kiss [Trial]"
   region: "NTSC-J"
 SLPM-60245:
   name: "バーチャファイターサイバージェネレーション ～ジャッジメントシックスの野望～ [体験版]"
@@ -33504,7 +33584,9 @@ SLPM-60247:
   name-en: "Gradius V [Trial]"
   region: "NTSC-J"
 SLPM-60248:
-  name: "Dororo [Trial]"
+  name: "どろろ [体験版]"
+  name-sort: "どろろ [たいけんばん]"
+  name-en: "Dororo [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     minimumBlendingLevel: 2 # Fixes dark font to more bright like software mode.
@@ -33526,7 +33608,9 @@ SLPM-60251:
     halfPixelOffset: 4 # Aligns post effects.
     nativeScaling: 2 # Fixes post processing and lighting smoothness and position.
 SLPM-60252:
-  name: "Futakoi"
+  name: "双恋—フタコイ— [体験版]"
+  name-sort: "ふたこい [たいけんばん]"
+  name-en: "Futakoi [Trial]"
   region: "NTSC-J"
 SLPM-60253:
   name: "絶体絶命都市2 -凍てついた記憶たち- [体験版 Type-B]"
@@ -33547,16 +33631,22 @@ SLPM-60254:
     nativeScaling: 2 # Fixes post effects.
     getSkipCount: "GSC_ZettaiZetsumeiToshi2"
 SLPM-60255:
-  name: "Ponkotsu Roman Daikatsugeki Bumpy Trot [Trial]"
+  name: "ポンコツ浪漫大活劇バンピートロット [体験版]"
+  name-sort: "ぽんこつろまんだいかつげきばんぴーとろっと [たいけんばん]"
+  name-en: "Ponkotsu Roeman Daikatsugeki Bumpy Trot [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     getSkipCount: "GSC_SteambotChronicles" # Causes green (incorrect) water but removes depth and blur issues.
     roundSprite: 1 # Fixes colored 3D anaglyph bleeding effects.
 SLPM-60256:
-  name: "Dengeki PS2 PlayStation D73"
+  name: "電撃PS2 / 電撃PlayStation D73"
+  name-sort: "でんげき PS2 でんげきPlayStation D73"
+  name-en: "Dengeki PS2 / DengekiPlayStation D73"
   region: "NTSC-J"
 SLPM-60257:
-  name: "Death by Degrees"
+  name: "デス バイ ディグリーズ 鉄拳:ニーナ ウィリアムズ [体験版]"
+  name-sort: "です ばい でぃぐりーず てっけん にーな うぃりあむず [たいけんばん]"
+  name-en: "Death by Degrees - Tekken - Nina Williams [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes FMV lines.
@@ -33571,7 +33661,7 @@ SLPM-60258:
 SLPM-60259:
   name: "実戦パチスロ必勝法！ 北斗の拳 プレミアムディスク [体験版]"
   name-sort: "じっせんぱちすろひっしょうほう！ ほくとのけん ぷれみあむでぃすく [たいけんばん]"
-  name-en: "Jissen Pachi-Slot Hisshouhou! Hokuto no Ken Premium Disc [Trial]"
+  name-en: "Jissen Pachi-Slot Hisshouhou！ Hokuto no Ken Premium Disc [Trial]"
   region: "NTSC-J"
 SLPM-60260:
   name: "D1 GRAND PRIX SERIES - PROFESSIONAL DRIFT [体験版]"
@@ -33582,9 +33672,13 @@ SLPM-60260:
     eeClampMode: 3 # Fixes black void.
 SLPM-60262:
   name: "10th Anniversary Memorial Save Data [Disc 2]"
+  name-sort: "10th あにばーさりー めもりある せーぶ でーた [Disc 2]"
+  name-en: "10th Anniversary Memorial Save Data [Disc 2]"
   region: "NTSC-J"
 SLPM-60263:
-  name: "Dengeki PS2 PlayStation D78"
+  name: "電撃PS2 / 電撃PlayStation D78"
+  name-sort: "でんげき PS2 でんげきPlayStation D78"
+  name-en: "Dengeki PS2 / DengekiPlayStation D78"
   region: "NTSC-J"
 SLPM-60264:
   name: "シャドウハーツ フロム・ザ・ニュー・ワールド [体験版]"
@@ -33592,19 +33686,27 @@ SLPM-60264:
   name-en: "Shadow Hearts - From the New World [Trial]"
   region: "NTSC-J"
 SLPM-60265:
-  name: "10th Anniversary PlayStation & PlayStation 2 All-Soft Catalogue Special SaveData Collection [PS2 Disc]"
+  name: "スチームボーイ [体験版]"
+  name-sort: "すちーむぼーい [たいけんばん]"
+  name-en: "Steamboy [Trial]"
   region: "NTSC-J"
 SLPM-60266:
-  name: "Ponkotsu Roman Daikatsugeki Bumpy Trot [Trial]"
+  name: "ポンコツ浪漫大活劇バンピートロット [体験版]"
+  name-sort: "ぽんこつろまんだいかつげきばんぴーとろっと [たいけんばん]"
+  name-en: "Ponkotsu Roeman Daikatsugeki Bumpy Trot [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     getSkipCount: "GSC_SteambotChronicles" # Causes green (incorrect) water but removes depth and blur issues.
     roundSprite: 1 # Fixes colored 3D anaglyph bleeding effects.
 SLPM-60267:
-  name: "Garouden Breakblow [Trial]"
+  name: "餓狼伝 Breakblow [体験版]"
+  name-sort: "がろうでん Breakblow [たいけんばん]"
+  name-en: "Garouden Break Blow [Trial]"
   region: "NTSC-J"
 SLPM-60268:
-  name: "Minna Daisuki Katamari Damacy"
+  name: "みんな大好き塊魂 [店頭体験版]"
+  name-sort: "みんなだいすきかたまりだましい [てんとうたいけんばん]"
+  name-en: "Minna Daisuki Katamari Damacy [Store Demo]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 4 # Aligns post effects.
@@ -33630,7 +33732,9 @@ SLPM-60271:
   clampModes:
     eeClampMode: 3 # Fixes black screen.
 SLPM-60272:
-  name: "Urban Reign [Trial]"
+  name: "アーバンレイン [体験版]"
+  name-sort: "あーばんれいん [たいけんばん]"
+  name-en: "Urban Reign [Trial]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Mitigates bounciness of vertical shaking but better fix with EE cyclerate +1.
@@ -33647,46 +33751,68 @@ SLPM-60273:
     cpuCLUTRender: 1 # Fixes some shading/shadows.
     getSkipCount: "GSC_ZettaiZetsumeiToshi2"
 SLPM-60274:
-  name: "Full House Kiss 2 [Trial]"
+  name: "フルハウスキス2 [体験版]"
+  name-sort: "ふるはうすきす2 [たいけんばん]"
+  name-en: "Full House Kiss 2 [Trial]"
   region: "NTSC-J"
 SLPM-60275:
-  name: "Dengeki PS2 - PlayStation 2 Save Data Collection 2006"
+  name: "電撃PS2 PlayStation 2 SAVE DATA COLLECTION 2006"
+  name-sort: "でんげきPS2 ぷれいすてーしょん 2 せーぶ でーた これくしょん 2006"
+  name-en: "Dengeki PS2 - PlayStation 2 Save Data Collection 2006"
   region: "NTSC-J"
 SLPM-60277:
   name: "実戦パチスロ必勝法！ 北斗の拳SE [体験版]"
   name-sort: "じっせんぱちすろひっしょうほう！ ほくとのけんSE [たいけんばん]"
-  name-en: "Jissen Pachi-Slot Hisshouhou! Hokuto no Ken SE [Trial]"
+  name-en: "Jissen Pachi-Slot Hisshouhou！ Hokuto no Ken SE [Trial]"
   region: "NTSC-J"
 SLPM-60278:
-  name: "Wrestle Kingdom"
+  name: "レッスルキングダム [体験版]"
+  name-sort: "れっするきんぐだむ [たいけんばん]"
+  name-en: "Wrestle Kingdom [Trial]"
   region: "NTSC-J"
 SLPM-60279:
-  name: "Kamen Rider Kabuto"
+  name: "仮面ライダー カブト [体験版]"
+  name-sort: "かめんらいだー かぶと [たいけんばん]"
+  name-en: "Kamen Rider Kabuto [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 1 # Fixes garbage corruptions on the bottom of the screen.
 SLPM-60280:
-  name: "Dengeki PS2 - PlayStation 2 Save Data Collection 2007"
+  name: "電撃PS2 PlayStation 2 SAVE DATA COLLECTION 2007"
+  name-sort: "でんげきPS2 ぷれいすてーしょん 2 せーぶ でーた これくしょん 2007"
+  name-en: "Dengeki PS2 - PlayStation 2 Save Data Collection 2007"
   region: "NTSC-J"
 SLPM-60281:
-  name: "Dengeki PS2 PlayStation D94"
+  name: "電撃PS2 / 電撃PlayStation D94"
+  name-sort: "でんげき PS2 でんげきPlayStation D94"
+  name-en: "Dengeki PS2 / DengekiPlayStation D94"
   region: "NTSC-J"
 SLPM-60282:
-  name: "Lucky Star - RAvish Romance [Trial]"
+  name: "らき☆すた - RAvish Romance [体験版]"
+  name-sort: "らきすた - RAvish Romance [たいけんばん]"
+  name-en: "Lucky Star - RAvish Romance [Trial]"
   region: "NTSC-J"
 SLPM-60283:
-  name: "Dengeki PS2 PlayStation D95"
+  name: "電撃PS2 / 電撃PlayStation D95"
+  name-sort: "でんげき PS2 でんげきPlayStation D95"
+  name-en: "Dengeki PS2 / DengekiPlayStation D95"
   region: "NTSC-J"
 SLPM-60284:
-  name: "Dengeki PS2 - PlayStation 2 Save Data Collection 2008"
+  name: "電撃PS2 PlayStation 2 SAVE DATA COLLECTION 2008"
+  name-sort: "でんげきPS2 ぷれいすてーしょん 2 せーぶ でーた これくしょん 2008"
+  name-en: "Dengeki PS2 - PlayStation 2 Save Data Collection 2008"
   region: "NTSC-J"
 SLPM-61001:
-  name: "Onimusha [Trial]"
+  name: "鬼武者 [体験版]"
+  name-sort: "おにむしゃ [たいけんばん]"
+  name-en: "Onimusha [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
 SLPM-61002:
-  name: "Dengeki PlayStation D40 - Konami Fan Book"
+  name: "電撃PlayStation D40 -  KONAMI Fan BOOK"
+  name-sort: "でんげきPlayStation D40 - KONAMI Fan BOOK"
+  name-en: "DengekiPlayStation D40- Konami Fan Book"
   region: "NTSC-J"
 SLPM-61004:
   name: "Shadow of Memories / ZONE OF THE ENDERS - Z.O.E [店頭放映用ムービー版]"
@@ -33696,7 +33822,9 @@ SLPM-61004:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
 SLPM-61007:
-  name: "Maken Shao [Trial]"
+  name: "魔剣爻 -MAKEN SHAO- [体験版]"
+  name-sort: "まけんしゃお -MAKEN SHAO- [たいけんばん]"
+  name-en: "Maken Shao [Trial]"
   region: "NTSC-J"
   speedHacks:
     mvuFlag: 0
@@ -33737,7 +33865,9 @@ SLPM-61011:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes menu transparancy and effects.
 SLPM-61012:
-  name: "Dengeki PS2 PlayStation D46"
+  name: "電撃PS2 / 電撃PlayStation D46"
+  name-sort: "でんげき PS2 でんげきPlayStation D46"
+  name-en: "Dengeki PS2 / DengekiPlayStation D46"
   region: "NTSC-J"
 SLPM-61013:
   name: "タイムクライシス2 & ヴァンパイアナイト [体験版]"
@@ -33745,7 +33875,9 @@ SLPM-61013:
   name-en: "Time Crisis 2 & Vampire Night [Shop Trial]"
   region: "NTSC-J"
 SLPM-61018:
-  name: "Abarenbou Princess [Trial]"
+  name: "暴れん坊プリンセス [体験版]"
+  name-sort: "あばれんぼうぷりんせす [たいけんばん]"
+  name-en: "Abarenbou Princess [Trial]"
   region: "NTSC-J"
 SLPM-61019:
   name: "実名実況競馬 ドリームクラシック2001 Autumn [体験版]"
@@ -33753,16 +33885,24 @@ SLPM-61019:
   name-en: "Jitsumei Jikkyou Keiba - Dream Classic 2001 Autumn [Trial]"
   region: "NTSC-J"
 SLPM-61020:
-  name: "Gun Survivor 2 - Biohazard - Code - Veronica"
+  name: "ガンサバイバー2 バイオハザード コード:ベロニカ [店頭体験版]"
+  name-sort: "がんさばいばー2 ばいおはざーど こーど:べろにか [てんとうたいけんばん]"
+  name-en: "Gun Survivor 2 - BioHazard CODE - Veronica [Store Demo]"
   region: "NTSC-J"
 SLPM-61022:
-  name: "Dengeki PS2 PlayStation D48 - Konami Fan Book"
+  name: "電撃PS2 / 電撃PlayStation D48 - KONAMI Fan Book"
+  name-sort: "でんげき PS2 でんげきPlayStation D48 - KONAMI Fan Book"
+  name-en: "Dengeki PS2 / DengekiPlayStation D48 - Konami Fan Book"
   region: "NTSC-J"
 SLPM-61023:
-  name: "Dengeki PS2 PlayStation D49"
+  name: "電撃PS2 / 電撃PlayStation D49"
+  name-sort: "でんげき PS2 でんげきPlayStation D49"
+  name-en: "Dengeki PS2 / DengekiPlayStation D49"
   region: "NTSC-J"
 SLPM-61024:
-  name: "Dengeki PS2 PlayStation D50"
+  name: "電撃PS2 / 電撃PlayStation D50"
+  name-sort: "でんげき PS2 でんげきPlayStation D50"
+  name-en: "Dengeki PS2 / DengekiPlayStation D50"
   region: "NTSC-J"
 SLPM-61025:
   name: "キングダム ハーツ [体験版]"
@@ -33777,13 +33917,19 @@ SLPM-61026:
   clampModes:
     vu1ClampMode: 3 # Fixes flashing in some scenes.
 SLPM-61027:
-  name: "Prismix - PlayStation 2 Sen'you Music Visual Soft - Demo Disc Vol. 1"
+  name: "Prismix - PlayStation 2 専用 ミュージックビジュアルソフト [Demo Disc Vol.1]"
+  name-sort: "ぷりずみっくす - PlayStation 2 せんよう みゅーじっくびじゅあるそふと [Demo Disc Vol.1]"
+  name-en: "Prismix - PlayStation 2 Sen'you Music Visual Soft - Demo Disc Vol. 1"
   region: "NTSC-J"
 SLPM-61028:
-  name: "Dengeki PS2 PlayStation D51"
+  name: "電撃PS2 / 電撃PlayStation D51"
+  name-sort: "でんげき PS2 でんげきPlayStation D51"
+  name-en: "Dengeki PS2 / DengekiPlayStation D51"
   region: "NTSC-J"
 SLPM-61029:
-  name: "Shin Combat Choro Q"
+  name: "新コンバットチョロQ [体験版]"
+  name-sort: "しんこんばっとちょろQ [たいけんばん]"
+  name-en: "Shin Combat Choro Q [Trial]"
   region: "NTSC-J"
 SLPM-61030:
   name: "ジョジョの奇妙な冒険 黄金の旋風 [体験版]"
@@ -33793,19 +33939,29 @@ SLPM-61030:
   gsHWFixes:
     recommendedBlendingLevel: 2 # Fixes text box opacity.
 SLPM-61031:
-  name: "Dengeki PS2 PlayStation D52"
+  name: "電撃PS2 / 電撃PlayStation D52"
+  name-sort: "でんげき PS2 でんげきPlayStation D52"
+  name-en: "Dengeki PS2 / DengekiPlayStation D52"
   region: "NTSC-J"
 SLPM-61032:
-  name: "Dengeki PS2 PlayStation D53"
+  name: "電撃PS2 / 電撃PlayStation D53"
+  name-sort: "でんげき PS2 でんげきPlayStation D53"
+  name-en: "Dengeki PS2 / DengekiPlayStation D53"
   region: "NTSC-J"
 SLPM-61033:
-  name: "Dengeki PS2 PlayStation D55"
+  name: "電撃PS2 / 電撃PlayStation D55"
+  name-sort: "でんげき PS2 でんげきPlayStation D55"
+  name-en: "Dengeki PS2 / DengekiPlayStation D55"
   region: "NTSC-J"
 SLPM-61034:
-  name: "Dengeki PS2 PlayStation D56"
+  name: "電撃PS2 / 電撃PlayStation D56"
+  name-sort: "でんげき PS2 でんげきPlayStation D56"
+  name-en: "Dengeki PS2 / DengekiPlayStation D56"
   region: "NTSC-J"
 SLPM-61035:
-  name: "Anubis - Zone of the Enders [Trial]"
+  name: "ANUBIS ZONE OF THE ENDERS [体験版]"
+  name-sort: "あぬびす ぞーん おぶ えんだーず [たいけんばん]"
+  name-en: "Anubis - Zone of the Enders [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 4 # Aligns post effects.
@@ -33821,10 +33977,14 @@ SLPM-61037:
   name-en: "Devil May Cry 2 [Trial]"
   region: "NTSC-J"
 SLPM-61038:
-  name: "Dengeki PS2 PlayStation D57"
+  name: "電撃PS2 / 電撃PlayStation D57"
+  name-sort: "でんげき PS2 でんげきPlayStation D57"
+  name-en: "Dengeki PS2 / DengekiPlayStation D57"
   region: "NTSC-J"
 SLPM-61039:
-  name: "Gun Survivor 4 - BioHazard - Heroes Never Die [Demo]"
+  name: "ガンサバイバー4 バイオハザード ヒーローズ ネバーダイ [店頭体験版]"
+  name-sort: "がんさばいばー4 ばいおはざーど ひーろーず ねばーだい [てんとうたいけんばん]"
+  name-en: "BioHazard Gun Survivor 4 - Heroes Never Die [Store Demo]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 4 # Fixes character offset with flashlight and blurriness.
@@ -33847,41 +34007,63 @@ SLPM-61043:
   name-en: "Devil May Cry 2 [Trial]"
   region: "NTSC-J"
 SLPM-61044:
-  name: "Dengeki PS2 PlayStation D59"
+  name: "電撃PS2 / 電撃PlayStation D59"
+  name-sort: "でんげき PS2 でんげきPlayStation D59"
+  name-en: "Dengeki PS2 / DengekiPlayStation D59"
   region: "NTSC-J"
 SLPM-61046:
-  name: "Dennou Senki - Virtual-On Marz [Trial]"
+  name: "電脳戦機バーチャロン マーズ [体験版]"
+  name-sort: "でんのうせんきばーちゃろん まーず [たいけんばん]"
+  name-en: "Dennou Senki - Virtual-On Marz [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     cpuSpriteRenderBW: 1 # Fixes CLUT colours.
     cpuSpriteRenderLevel: 2 # Needed for above.
     gpuPaletteConversion: 2 # Improves FPS and reduces HC size.
 SLPM-61048:
-  name: "Dengeki PS2 PlayStation D60"
+  name: "電撃PS2 / 電撃PlayStation D60"
+  name-sort: "でんげき PS2 でんげきPlayStation D60"
+  name-en: "Dengeki PS2 / DengekiPlayStation D60"
   region: "NTSC-J"
 SLPM-61050:
-  name: "Hanjuku Hero tai 3D"
+  name: "半熟英雄 対 3D [初体験版]"
+  name-sort: "はんじゅくひーろー たい 3D [はつたいけんばん]"
+  name-en: "Hanjuku Hero VS 3-D [Trial]"
   region: "NTSC-J"
 SLPM-61051:
-  name: "Dengeki PS2 PlayStation D61"
+  name: "電撃PS2 / 電撃PlayStation D61"
+  name-sort: "でんげき PS2 でんげきPlayStation D61"
+  name-en: "Dengeki PS2 / DengekiPlayStation D61"
   region: "NTSC-J"
 SLPM-61052:
-  name: "Gekitou Pro Yakyuu - Mizushima Shinji All Stars vs. Pro Yakyuu"
+  name: "激闘プロ野球 水島新司オールスターズ VS プロ野球 [体験版]"
+  name-sort: "げきとうぷろやきゅう みずしましんじおーるすたーず VS ぷろやきゅう [たいけんばん]"
+  name-en: "Gekitou Pro Yakyuu - Mizushima Shinji All Stars vs. Pro Yakyuu [Trial]"
   region: "NTSC-J"
 SLPM-61053:
-  name: "Jikkyou Powerful Pro Yakyuu 10"
+  name: "実況パワフルプロ野球10 [体験版]"
+  name-sort: "じっきょうぱわふるぷろやきゅう10 [たいけんばん]"
+  name-en: "Jikkyou Powerful Pro Yakyuu 10 [Trial]"
   region: "NTSC-J"
 SLPM-61054:
-  name: "Sidewinder V"
+  name: "サイドワインダーV [体験版]"
+  name-sort: "さいどわいんだーV [たいけんばん]"
+  name-en: "Sidewinder V [Trial]"
   region: "NTSC-J"
 SLPM-61055:
-  name: "Gregory Horror Show - Soul Collector"
+  name: "グレゴリーホラーショー ソウルコレクター [体験版]"
+  name-sort: "ぐれごりーほらーしょー そうるこれくたー [たいけんばん]"
+  name-en: "Gregory Horror Show - Soul Collector [Trial]"
   region: "NTSC-J"
 SLPM-61056:
-  name: "NHK Tensai Bit-kun - Glamon Battle"
+  name: "NHK 天才ビットくん グラモンバトル [体験版]"
+  name-sort: "NHK てんさいびっとくん ぐらもんばとる [たいけんばん]"
+  name-en: "NHK Tensai Bit-Kun - Guramon Battle [Trial]"
   region: "NTSC-J"
 SLPM-61058:
-  name: "Dengeki PS2 PlayStation D62"
+  name: "電撃PS2 / 電撃PlayStation D62"
+  name-sort: "でんげき PS2 でんげきPlayStation D62"
+  name-en: "Dengeki PS2 / DengekiPlayStation D62"
   region: "NTSC-J"
 SLPM-61059:
   name: "Kunoichi -忍- [体験版]"
@@ -33896,82 +34078,126 @@ SLPM-61060:
   name-en: "BUSIN 0 ～Wizardry Alternative NEO～ [Trial]"
   region: "NTSC-J"
 SLPM-61062:
-  name: "Castlevania [Demo]"
+  name: "キャッスルヴァニア [体験版]"
+  name-sort: "きゃっするゔぁにあ [たいけんばん]"
+  name-en: "Castlevania [Trial]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes cutscene freezes.
 SLPM-61065:
-  name: "Dengeki PS2 PlayStation D64"
+  name: "電撃PS2 / 電撃PlayStation D64"
+  name-sort: "でんげき PS2 でんげきPlayStation D64"
+  name-en: "Dengeki PS2 / DengekiPlayStation D64"
   region: "NTSC-J"
 SLPM-61066:
-  name: "Dengeki PS2 PlayStation D65"
+  name: "電撃PS2 / 電撃PlayStation D65"
+  name-sort: "でんげき PS2 でんげきPlayStation D65"
+  name-en: "Dengeki PS2 / DengekiPlayStation D65"
   region: "NTSC-J"
 SLPM-61067:
-  name: "Gako Zouryuu - Crouching Tiger, Hidden Dragon"
+  name: "クラウチングタイガー・ヒドゥンドラゴン [体験版]"
+  name-sort: "くらうちんぐたいがー ひどぅんどらごん [たいけんばん]"
+  name-en: "Crouching Tiger Hidden Dragon [Trial]"
   region: "NTSC-J"
   gameFixes:
     - InstantDMAHack # Fixes FMVs to be visible.
 SLPM-61070:
-  name: "Dengeki PS2 PlayStation D66"
+  name: "電撃PS2 / 電撃PlayStation D66"
+  name-sort: "でんげき PS2 でんげきPlayStation D66"
+  name-en: "Dengeki PS2 / DengekiPlayStation D66"
   region: "NTSC-J"
 SLPM-61072:
-  name: "Puyo Puyo Fever"
+  name: "ぷよぷよフィーバー [体験版]"
+  name-sort: "ぷよぷよふぃーばー [たいけんばん]"
+  name-en: "Puyo Puyo Fever [Trial]"
   region: "NTSC-J"
 SLPM-61073:
-  name: "Galaxy Angel - Moonlit Lovers"
+  name: "ギャラクシーエンジェル Moonlit Lovers [体験版]"
+  name-sort: "ぎゃらくしーえんじぇる Moonlit Lovers [たいけんばん]"
+  name-en: "Galaxy Angel - Moonlit Lovers [Trial]"
   region: "NTSC-J"
 SLPM-61074:
-  name: "Konjiki no Gashbell!! Yuujou Tag Battle"
+  name: "金色のガッシュベル！！ 友情タッグバトル [特別体験版]"
+  name-sort: "こんじきのがっしゅべる！！ ゆうじょうたっぐばとる [とくべつたいけんばん]"
+  name-en: "Konjiki no Gashbell！！ - Yuujou Tag Battle [Special Trial]"
   region: "NTSC-J"
 SLPM-61076:
-  name: "Panzer Front Ausf.B"
+  name: "PANZER FRONT Ausf.B [体験版]"
+  name-sort: "ぱんつぁー ふろんとT Ausf.B [たいけんばん]"
+  name-en: "Panzer Frony - Ausf. B [Trial]"
   region: "NTSC-J"
 SLPM-61077:
-  name: "Sega Ages 2500 Taikenban"
+  name: "SEGA AGES 2500シリーズ [体験版]"
+  name-sort: "せが えいじす 2500しりーず [たいけんばん]"
+  name-en: "Sega Ages 2500 Series [Trial]"
   region: "NTSC-J"
 SLPM-61079:
-  name: "Dengeki PS2 PlayStation D68"
+  name: "電撃PS2 / 電撃PlayStation D68"
+  name-sort: "でんげき PS2 でんげきPlayStation D68"
+  name-en: "Dengeki PS2 / DengekiPlayStation D68"
   region: "NTSC-J"
 SLPM-61080:
-  name: "Ultraman"
+  name: "ウルトラマン [体験版]"
+  name-sort: "うるとらまん [たいけんばん]"
+  name-en: "Ultraman [Trial]"
   region: "NTSC-J"
 SLPM-61081:
-  name: "Dengeki PS2 PlayStation D69"
+  name: "電撃PS2 / 電撃PlayStation D69"
+  name-sort: "でんげき PS2 でんげきPlayStation D69"
+  name-en: "Dengeki PS2 / DengekiPlayStation D69"
   region: "NTSC-J"
 SLPM-61082:
-  name: "TV Magazine Ultraman Special Disc"
+  name: "テレビマガジン ウルトラマン スペシャル ディスク [体験版]"
+  name-sort: "てれびまがじん うるとらまん すぺしゃる でぃすく [たいけんばん]"
+  name-en: "TV Magazine Ultraman Special Disc [Trial]"
   region: "NTSC-J"
 SLPM-61083:
-  name: "Dengeki PS2 PlayStation D70"
+  name: "電撃PS2 / 電撃PlayStation D70"
+  name-sort: "でんげき PS2 でんげきPlayStation D70"
+  name-en: "Dengeki PS2 / DengekiPlayStation D70"
   region: "NTSC-J"
 SLPM-61084:
-  name: "Meiwaku Seijin - Panic Maker"
+  name: "めいわく星人 パニックメーカー [体験版]"
+  name-sort: "めいわくせいじん ぱにっくめーかー [たいけんばん]"
+  name-en: "Meiwaku Seijin Panic Maker [Trial]"
   region: "NTSC-J"
 SLPM-61086:
-  name: "Kengou 3"
+  name: "剣豪3 [体験版]"
+  name-sort: "けんごう3 [たいけんばん]"
+  name-en: "Kengo 3 [Trial]"
   region: "NTSC-J"
 SLPM-61087:
-  name: "Fullmetal Alchemist 2 - Curse of the Crimson Elixir [Trial]"
+  name: "鋼の錬金術師2 赤きエリクシルの悪魔 [体験版]"
+  name-sort: "はがねのれんきんじゅつし2 あかきえりくしるのあくま [たいけんばん]"
+  name-en: "Hagane no Renkinjutsushi - Akaki Elixir no Akuma [Trial]"
   region: "NTSC-J"
 SLPM-61089:
-  name: "Dengeki PS2 PlayStation D72"
+  name: "電撃PS2 / 電撃PlayStation D72"
+  name-sort: "でんげき PS2 でんげきPlayStation D72"
+  name-en: "Dengeki PS2 / DengekiPlayStation D72"
   region: "NTSC-J"
 SLPM-61090:
-  name: "Tim Burton's The Nightmare Before Christmas [Trial]"
+  name: "ティム・バートン ナイトメアー・ビフォア・クリスマス ブギーの逆襲 [体験版]"
+  name-sort: "てぃむ・ばーとん ないとめあー・びふぉあ・くりすます ぶぎーのぎゃくしゅう [たいけんばん]"
+  name-en: "Tim Burton's The Nightmare Before Christmas - Oogie no Gyakushuu [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Aligns post Effect and bloom.
     nativeScaling: 2 # Fixes post effect position and alignment.
     autoFlush: 1 # Fixes light glow and alignment.
 SLPM-61091:
-  name: "Berserk - Millennium Falcon-hen - Seima Senki no Shou"
+  name: "ベルセルク 千年帝国の鷹篇 聖魔戦記の章 [体験版]"
+  name-sort: "べるせるく みれにあむ ふぁるこんへん せいませんきのしょう [たいけんばん]"
+  name-en: "Berserk - Millennium Falcon-hen - Seima Senki no Shou [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Partially fixes HUD elements.
     halfPixelOffset: 1 # Fixes misaligned blur around objects and enemies.
     PCRTCOverscan: 1 # Fixes offscreen image.
 SLPM-61092:
-  name: "Driv3r [Trial]"
+  name: "DRIV3R [体験版]"
+  name-sort: "どらいばー3 [たいけんばん]"
+  name-en: "Driv3r [Trial]"
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
@@ -33984,19 +34210,29 @@ SLPM-61092:
     cpuSpriteRenderBW: 4 # Alleviates text and sky rendering issues.
     cpuSpriteRenderLevel: 2 # Needed for above.
 SLPM-61093:
-  name: "Ultraman - Fighting Evolution 3"
+  name: "ウルトラマン Fighting Evolution 3 [体験版]"
+  name-sort: "うるとらまん Fighting Evolution 3 [たいけんばん]"
+  name-en: "Ultraman Fighting Evolution 3 [Trial]"
   region: "NTSC-J"
 SLPM-61094:
-  name: "Viewtiful Joe 2 - Black Film no Nazo"
+  name: "ビューティフルジョー2 ブラックフィルムの謎 [体験版]"
+  name-sort: "びゅーてぃふるじょー2 ぶらっくふぃるむのなぞ [たいけんばん]"
+  name-en: "Viewtiful Joe 2 - Black Film no Nazo [Trial]"
   region: "NTSC-J"
 SLPM-61095:
-  name: "Dengeki PS2 PlayStation D74"
+  name: "電撃PS2 / 電撃PlayStation D74"
+  name-sort: "でんげき PS2 でんげきPlayStation D74"
+  name-en: "Dengeki PS2 / DengekiPlayStation D74"
   region: "NTSC-J"
 SLPM-61096:
-  name: "Fuuun Bakumatsuden"
+  name: "風雲幕末伝 [体験版]"
+  name-sort: "ふううんばくまつでん [たいけんばん]"
+  name-en: "Fuuun Bakumatsu-den [Trial]"
   region: "NTSC-J"
 SLPM-61097:
-  name: "Dengeki PS2 PlayStation D75"
+  name: "電撃PS2 / 電撃PlayStation D75"
+  name-sort: "でんげき PS2 でんげきPlayStation D75"
+  name-en: "Dengeki PS2 / DengekiPlayStation D75"
   region: "NTSC-J"
 SLPM-61098:
   name: "エキサイティングプロレス 6 - WWE SMACKDOWN! vs. RAW [体験版]"
@@ -34004,16 +34240,24 @@ SLPM-61098:
   name-en: "Exciting Pro Wrestling 6 - WWE SMACKDOWN! vs. RAW [Trial]"
   region: "NTSC-J"
 SLPM-61100:
-  name: "Juuouki - Project Altered Beast"
+  name: "獣王記 -PROJECT ALTERED BEAST- [体験版]"
+  name-sort: "じゅうおうき -PROJECT ALTERED BEAST- [たいけんばん]"
+  name-en: "Project Altered Beast [Trial]"
   region: "NTSC-J"
 SLPM-61101:
-  name: "Shinsengumi Gunrouden"
+  name: "新選組群狼伝 [体験版]"
+  name-sort: "しんせんぐみぐんろうでん [たいけんばん]"
+  name-en: "Shinsengumi Gunrou-den [Trial]"
   region: "NTSC-J"
 SLPM-61102:
-  name: "Tsukiyo ni Saraba"
+  name: "ツキヨニサラバ [体験版]"
+  name-sort: "つきよにさらば [たいけんばん]"
+  name-en: "Tsukiyo ni Saraba [Trial]"
   region: "NTSC-J"
 SLPM-61103:
-  name: "Kessen III"
+  name: "決戦Ⅲ [体験版]"
+  name-sort: "けっせん3 [たいけんばん]"
+  name-en: "Kessen III [Trial]"
   region: "NTSC-J"
 SLPM-61104:
   name: "サムライウエスタン 活劇侍道 [体験版]"
@@ -34025,15 +34269,19 @@ SLPM-61104:
 SLPM-61105:
   name: "はじめの一歩 ALL☆STARS [体験版]"
   name-sort: "はじめのいっぽ おーるすたーず [たいけんばん]"
-  name-en: "Hajime no Ippo - All-Stars {Trial]"
+  name-en: "Hajime no Ippo - All-Stars [Trial]"
   region: "NTSC-J"
 SLPM-61106:
-  name: "Rumble Roses [Trial]"
+  name: "RUMBLE ROSES [体験版]"
+  name-sort: "らんぶるろーず [たいけんばん]"
+  name-en: "Rumble Roses [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 4 # Aligns offset blur.
 SLPM-61107:
-  name: "Dengeki PS2 PlayStation D76"
+  name: "電撃PS2 / 電撃PlayStation D76"
+  name-sort: "でんげき PS2 でんげきPlayStation D76"
+  name-en: "Dengeki PS2 / DengekiPlayStation D76"
   region: "NTSC-J"
 SLPM-61109:
   name: "SHADOW OF ROME [体験版]"
@@ -34062,10 +34310,14 @@ SLPM-61111:
   name-en: "Dragon Ball Z 3 [Trial]"
   region: "NTSC-J"
 SLPM-61112:
-  name: "Tensei - Swords of Destiny"
+  name: "天星 ソード オブ デスティニー [体験版]"
+  name-sort: "てんせい そーど おぶ ですてぃにー [たいけんばん]"
+  name-en: "Swords of Destiny [Trial]"
   region: "NTSC-J"
 SLPM-61113:
-  name: "Dengeki PlayStation D77"
+  name: "電撃PS2 / 電撃PlayStation D77"
+  name-sort: "でんげき PS2 でんげきPlayStation D77"
+  name-en: "Dengeki PS2 / DengekiPlayStation D77"
   region: "NTSC-J"
 SLPM-61114:
   name: "SHADOW OF ROME [体験版]"
@@ -34076,16 +34328,22 @@ SLPM-61114:
     halfPixelOffset: 2 # Fixes post positioning.
     nativeScaling: 2 # Fixes post effects.
 SLPM-61115:
-  name: "Racing Battle - C1 Grand Prix [Trial]"
+  name: "レーシングバトル -C1 GRAND PRIX- [体験版]"
+  name-sort: "れーしんぐばとる -C1 GRAND PRIX- [たいけんばん]"
+  name-en: "Racing Battle - C1 Grand Prix [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     forceEvenSpritePosition: 1 # De-blurs the 3D image.
 SLPM-61116:
-  name: "Bouken-ou Beet - Darkness Century"
+  name: "冒険王ビィト ダークネスセンチュリー [体験版]"
+  name-sort: "ぼうけんおうびぃと だーくねすせんちゅりー [たいけんばん]"
+  name-en: "Bouken-ou Beet - Darkness Century [Trial]"
   region: "NTSC-J"
 SLPM-61117:
-  name: "Musashiden II - Blademaster [Trial]"
+  name: "武蔵伝Ⅱ ブレイドマスター [体験版]"
+  name-sort: "むさしでん2 ぶれいどますたー [たいけんばん]"
+  name-en: "Musashiden II - Blademaster [Trial]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes garbled character animation.
@@ -34119,14 +34377,18 @@ SLPM-61120:
     mergeSprite: 1 # Align sprite fixes FMVs but not garbage in-game, so needs merge sprite instead.
     texturePreloading: 1 # Performs better with partial preload because it is slow on locations outside gameplay foremost.
 SLPM-61121:
-  name: "Kaido - Touge no Densetsu [Trial]"
+  name: "KAIDO ～峠の伝説～ [体験版]"
+  name-sort: "かいどう とうげのでんせつ [たいけんばん]"
+  name-en: "Kaido Touge no Densetsu [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting during Rain/Storm.
     alignSprite: 1 # Fixes vertical lines.
     forceEvenSpritePosition: 1 # De-blurs the 3D image.
 SLPM-61122:
-  name: "Dengeki PS2 PlayStation D81"
+  name: "電撃PS2 / 電撃PlayStation D81"
+  name-sort: "でんげき PS2 でんげきPlayStation D81"
+  name-en: "Dengeki PS2 / DengekiPlayStation D81"
   region: "NTSC-J"
 SLPM-61123:
   name: "NARUTO-ナルト- うずまき忍伝 [体験版]"
@@ -34139,7 +34401,9 @@ SLPM-61123:
     halfPixelOffset: 2 # Aligns post effects.
     nativeScaling: 2 # Fixes post effects.
 SLPM-61124:
-  name: "Ookami - Fude-hajime no Maki"
+  name: "大神 - 筆はじめの巻 [体験版]"
+  name-sort: "おおかみ ふではじめのまき [たいけんばん]"
+  name-en: "Okami - Fude-hajime no Maki [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 4 # Aligns post effects.
@@ -34150,19 +34414,27 @@ SLPM-61125:
   name-en: "Tokyo Game Show Bandai Namco Booth Distribution Disc 2005"
   region: "NTSC-J"
 SLPM-61126:
-  name: "Dengeki PS2 PlayStation D84"
+  name: "電撃PS2 / 電撃PlayStation D84"
+  name-sort: "でんげき PS2 でんげきPlayStation D84"
+  name-en: "Dengeki PS2 / DengekiPlayStation D84"
   region: "NTSC-J"
 SLPM-61127:
-  name: "FlatOut [Trial]"
+  name: "レーシングゲーム「注意!!!!」 [体験版]"
+  name-sort: "れーしんぐげーむ「ちゅうい!!!!」 [たいけんばん]"
+  name-en: "Racing Game - Chuui!!!! [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
     autoFlush: 1
 SLPM-61129:
-  name: "Famitsu PS2 Special Disc - Capcom Game Collection"
+  name: "ファミ通PS2 スペシャルディスク ～CAPCOM GAME COLLECTION～"
+  name-sort: "ふぁみつうPS2 すぺしゃるでぃすく ～CAPCOM GAME COLLECTION～"
+  name-en: "Famitsu PS2 Special Disc - Capcom Game Collection"
   region: "NTSC-J"
 SLPM-61130:
-  name: "Ikusa Gami [Trial Version]"
+  name: "戦神 -いくさがみ- [体験版]"
+  name-sort: "いくさがみ [たいけんばん]"
+  name-en: "Ikusa Gami [Trial]"
   region: "NTSC-J"
   gameFixes:
     - VIF1StallHack # Fixes black screen on boot.
@@ -34172,10 +34444,14 @@ SLPM-61130:
     halfPixelOffset: 4 # Fixes misaligned lighting and bloom.
     bilinearUpscale: 1 # Smooths out bloom.
 SLPM-61131:
-  name: "Dengeki PS2 PlayStation D85"
+  name: "電撃PS2 / 電撃PlayStation D85"
+  name-sort: "でんげき PS2 でんげきPlayStation D85"
+  name-en: "Dengeki PS2 / DengekiPlayStation D85"
   region: "NTSC-J"
 SLPM-61132:
-  name: "Ikusa Gami [Trial Version]"
+  name: "戦神-いくさがみ- [店頭体験版]"
+  name-sort: "いくさがみ [てんとうたいけんばん]"
+  name-en: "Ikusa Gami [Store Demo]"
   region: "NTSC-J"
   gameFixes:
     - VIF1StallHack # Fixes black screen on boot.
@@ -34185,7 +34461,9 @@ SLPM-61132:
     halfPixelOffset: 4 # Fixes misaligned lighting and bloom.
     bilinearUpscale: 1 # Smooths out bloom.
 SLPM-61133:
-  name: "SoulCalibur III [Trial Version]"
+  name: "ソウルキャリバーⅢ [体験版]"
+  name-sort: "そうるきゃりばー3 [たいけんばん]"
+  name-en: "SoulCalibur III [Trial]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes bad colours on character select when in Progressive Scan.
@@ -34195,7 +34473,9 @@ SLPM-61133:
     alignSprite: 1 # Fixes vertical lines.
     nativeScaling: 2 # Fixes misaligned bloom.
 SLPM-61134:
-  name: "Kidou Senshi Gundam Seed - Rengou vs. Z.A.F.T."
+  name: "機動戦士ガンダムSEED 連合vs.Z.A.F.T [体験版]"
+  name-sort: "きどうせんしがんだむしーど れんごうvs.Z.A.F.T [たいけんばん]"
+  name-en: "Kidou Senshi Gundam SEED - Rengou vs. Z.A.F.T. [Trial]"
   region: "NTSC-J"
 SLPM-61135:
   name: "NARUTO-ナルト- ナルティメットヒーロー3 [体験版]"
@@ -34218,35 +34498,51 @@ SLPM-61137:
     halfPixelOffset: 2 # Correct shadow position.
     nativeScaling: 2 # Smooths shadows.
 SLPM-61138:
-  name: "Akumajou Dracula - Yami no Juin"
+  name: "悪魔城ドラキュラ 闇の呪印 [店頭体験版]"
+  name-sort: "あくまじょうどらきゅら やみのじゅいん [てんとうたいけんばん]"
+  name-en: "Akumajo Dracula - Yami no Juin [Store Demo]"
   region: "NTSC-J"
 SLPM-61139:
-  name: "Puyo Puyo Fever 2"
+  name: "ぷよぷよフィーバー2 [チュー！] [体験版]"
+  name-sort: "ぷよぷよふぃーばー2 [たいけんばん]"
+  name-en: "Puyo Puyo Fever 2 [Trial]"
   region: "NTSC-J"
 SLPM-61140:
-  name: "Ryuu ga Gotoku [Trial]"
+  name: "龍が如く [体験版]"
+  name-sort: "りゅうがごとく [たいけんばん]"
+  name-en: "Ryu Ga Gotoku [Trial]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Fixes flickering.
   gsHWFixes:
     alignSprite: 1 # Helps align bloom.
 SLPM-61141:
-  name: "Dengeki PS2 PlayStation D87"
+  name: "電撃PS2 / 電撃PlayStation D87"
+  name-sort: "でんげき PS2 でんげきPlayStation D87"
+  name-en: "Dengeki PS2 / DengekiPlayStation D87"
   region: "NTSC-J"
 SLPM-61142:
-  name: "Shin Onimusha - Dawn of Dreams / Ookami"
+  name: "新 鬼武者 DAWN OF DREAMS / 大神 筆はじめノ巻 [体験版]"
+  name-sort: "しん おにむしゃ / おおかみ ひではじめの巻 [たいけんばん]"
+  name-en: "Shin Onimusha - Dawn of Dreams / Ookami [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 4 # Mostly aligns post processing.
     nativeScaling: 2 # Fixes post processing smoothness and position.
 SLPM-61144:
-  name: "Ninkyouden - Toseinin Ichidaiki"
+  name: "任侠伝 渡世人一代記 [体験版]"
+  name-sort: "にんきょうでん とせいにんいちだいき [たいけんばん]"
+  name-en: "Ninkyouden Toseinin Ichidaiki [Trial]"
   region: "NTSC-J"
 SLPM-61146:
-  name: "Dengeki PS2 PlayStation D90"
+  name: "電撃PS2 / 電撃PlayStation D90"
+  name-sort: "でんげき PS2 でんげきPlayStation D90"
+  name-en: "Dengeki PS2 / DengekiPlayStation D90"
   region: "NTSC-J"
 SLPM-61147:
-  name: "Xenosaga Episode III - Also Sprach Zarathustra [Demo]"
+  name: "ゼノサーガ エピソードⅢ [ツァラトゥストラはかく語りき] [体験版]"
+  name-sort: "ぜのさーが えぴそーど3 [つぁらとぅすとらはかくかたりき] [たいけんばん]"
+  name-en: "Xenosaga Episode III - Also Sprach Zarathustra [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     autoFlush: 1 # Fixes shadows.
@@ -34260,10 +34556,14 @@ SLPM-61148:
   gsHWFixes:
     moveHandler: "MV_Growlanser" # Fixes precomputed depth buffer.
 SLPM-61149:
-  name: "Dengeki PS2 PlayStation D91"
+  name: "電撃PS2 / 電撃PlayStation D91"
+  name-sort: "でんげき PS2 でんげきPlayStation D91"
+  name-en: "Dengeki PS2 / DengekiPlayStation D91"
   region: "NTSC-J"
 SLPM-61150:
-  name: "Kinnikuman - Muscle Grand Prix Max"
+  name: "キン肉マン マッスルグランプリ MAX [体験版]"
+  name-sort: "きんにくまん まっするぐらんぷり MAX [たいけんばん]"
+  name-en: "Kinnikuman Muscle Grand Prix Max [Trial]"
   region: "NTSC-J"
 SLPM-61152:
   name: "ドラゴンボールZ スパーキング！ ネオ [体験版]"
@@ -34274,10 +34574,14 @@ SLPM-61152:
     halfPixelOffset: 2 # Fixes character outlines and minor bloom.
     beforeDraw: "OI_DBZBTGames"
 SLPM-61153:
-  name: "Dengeki PS2 PlayStation D92"
+  name: "電撃PS2 / 電撃PlayStation D92"
+  name-sort: "でんげき PS2 でんげきPlayStation D92"
+  name-en: "Dengeki PS2 / DengekiPlayStation D92"
   region: "NTSC-J"
 SLPM-61154:
-  name: "Ryuu ga Gotoku 2"
+  name: "龍が如く2 [体験版]"
+  name-sort: "りゅうがごとく2 [たいけんばん]"
+  name-en: "Ryu Ga Gotoku 2 [Trial]"
   region: "NTSC-J"
 SLPM-61155:
   name: "トゥームレイダー レジェンド [体験版]"
@@ -34291,7 +34595,9 @@ SLPM-61155:
     nativeScaling: 1 # Fixes post processing.
     halfPixelOffset: 4 # Fixes offset post processing.
 SLPM-61156:
-  name: "Dengeki PS2 PlayStation D93"
+  name: "電撃PS2 / 電撃PlayStation D93"
+  name-sort: "でんげき PS2 でんげきPlayStation D93"
+  name-en: "Dengeki PS2 / DengekiPlayStation D93"
   region: "NTSC-J"
 SLPM-61157:
   name: "NARUTO-ナルト- 疾風伝 ナルティメットアクセル [体験版]"
@@ -34307,14 +34613,16 @@ SLPM-61157:
     vu0ClampMode: 3 # Fixes bad dialog backgrounds.
     vu1ClampMode: 3 # Fixes SPS on characters.
 SLPM-61158:
-  name: "Saint Seiya - Meiou Hades Juunikyuu-hen"
+  name: "聖闘士星矢 -冥王ハーデス十二宮編- [体験版]"
+  name-sort: "せいんとせいや めいおうはーですじゅうにきゅうへん [たいけんばん]"
+  name-en: "Saint Seiya - Meiou Hades Juunikyuu Hen [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 4 # Fixes blooming and lighting offset.
     nativeScaling: 2 # Fixes post processing.
 SLPM-61161:
-  name: "ゴッド・オブ・ウォー II 終焉への序曲 [体験版]"
-  name-sort: "ごっど・おぶ・うぉー II しゅうえんへのじょきょく [たいけんばん]"
+  name: "ゴッド・オブ・ウォーⅡ 終焉への序曲 [体験版]"
+  name-sort: "ごっど・おぶ・うぉー2 しゅうえんへのじょきょく [たいけんばん]"
   name-en: "God of War II - The End Begins [Trial]"
   region: "NTSC-J"
   speedHacks:
@@ -34328,7 +34636,7 @@ SLPM-61161:
 SLPM-61162:
   name: "ドラゴンボールZ スパーキング！ メテオ [体験版]"
   name-sort: "どらごんぼーるZ すぱーきんぐ めてお [たいけんばん]"
-  name-en: "Dragon Ball Z Sparking! Meteor [Trial]"
+  name-en: "Dragon Ball Z Sparking！ Meteor [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes character outlines and minor bloom.
@@ -34339,7 +34647,9 @@ SLPM-61163:
   name-en: "Seaman 2 - Peking Genjin Ikusei Kit [Trial]"
   region: "NTSC-J"
 SLPM-61164:
-  name: "Dengeki PS2 PlayStation D96"
+  name: "電撃PS2 / 電撃PlayStation D96"
+  name-sort: "でんげき PS2 でんげきPlayStation D96"
+  name-en: "Dengeki PS2 / DengekiPlayStation D96"
   region: "NTSC-J"
 SLPM-62001:
   name: "ドラムマニア"
@@ -34360,7 +34670,7 @@ SLPM-62003:
 SLPM-62004:
   name: "麻雀やろうぜ！2"
   name-sort: "まーじゃんやろうぜ！2"
-  name-en: "Mahjong Yarouze! 2"
+  name-en: "Mahjong Yarouze！ 2"
   region: "NTSC-J"
 SLPM-62005:
   name: "真・三國無双"
@@ -34433,7 +34743,7 @@ SLPM-62020:
   name-en: "G1 JOCKEY2"
   region: "NTSC-J"
 SLPM-62021:
-  name: "アンジェリーク トロワ プレミアムBOX"
+  name: "アンジェリーク トロワ [プレミアムBOX]"
   name-sort: "あんじぇりーく とろわ [ぷれみあむBOX]"
   name-en: "Angelique Trois [Premium Box]"
   region: "NTSC-J"
@@ -34483,7 +34793,7 @@ SLPM-62029:
 SLPM-62030:
   name: "麻雀宣言 叫んでロン！"
   name-sort: "まーじゃんせんげん さけんでろん！"
-  name-en: "Mahjong Sengen - Saken de Ron!"
+  name-en: "Mahjong Sengen - Saken de Ron！"
   region: "NTSC-J"
 SLPM-62031:
   name: "Primal Image FOR PRINTER"
@@ -34503,7 +34813,7 @@ SLPM-62034:
 SLPM-62035:
   name: "いくぜ！温泉卓球！！"
   name-sort: "いくぜ！おんせんたっきゅう！！"
-  name-en: "Iku ze! Onsen Takkyuu!!"
+  name-en: "Iku ze！ Onsen Takkyuu！！"
   region: "NTSC-J"
 SLPM-62036:
   name: "超高速リバーシ"
@@ -34580,22 +34890,22 @@ SLPM-62048:
 SLPM-62049:
   name: "電車でGO！3 通勤編"
   name-sort: "でんしゃでごー3 つうきんへん"
-  name-en: "Densha de Go! 3 - Tsuukin-hen"
+  name-en: "Densha de Go！ 3 - Tsuukin-hen"
   region: "NTSC-J"
 SLPM-62050:
   name: "電車でGO！新幹線 山陽新幹線編 [体験版]"
   name-sort: "でんしゃでごーしんかんせん さんようしんかんせんへん [たいけんばん]"
-  name-en: "Densha de Go! Shinkansen Sanyou Shinkansen-hen [Trial]"
+  name-en: "Densha de Go！ Shinkansen Sanyou Shinkansen-hen [Trial]"
   region: "NTSC-J"
 SLPM-62051:
-  name: "ヤンヤ カバジスタ～featuring Gawoo～"
-  name-sort: "やんや かばじすた～featuring Gawoo～"
+  name: "ヤンヤ カバジスタ ～featuring Gawoo～"
+  name-sort: "やんや かばじすた ～featuring Gawoo～"
   name-en: "Yanya Caballista - featuring Gawoo"
   region: "NTSC-J"
 SLPM-62052:
   name: "beatmania打打打！！"
   name-sort: "びーとまにあだだだ！！"
-  name-en: "Beatmania Da Da Da!!"
+  name-en: "Beatmania Da Da Da！！"
   region: "NTSC-J"
 SLPM-62053:
   name: "ワールドサッカーウイニングイレブン5"
@@ -34774,7 +35084,7 @@ SLPM-62092:
 SLPM-62093:
   name: "SIMPLE2000シリーズ Ultimate Vol.1 ラブ★スマッシュ"
   name-sort: "しんぷる2000しりーず あるてぃめっと Vol. 1 らぶ すまっしゅ"
-  name-en: "Simple 2000 Series Ultimate Vol. 1 - Love - Smash!"
+  name-en: "Simple 2000 Series Ultimate Vol. 1 - Love - Smash！"
   region: "NTSC-J"
 SLPM-62094:
   name: "SIMPLE2000シリーズ Vol.2 THE パーティーゲーム"
@@ -34869,7 +35179,7 @@ SLPM-62111:
 SLPM-62112:
   name: "いただきストリート3 億万長者にしてあげる！ ～家庭教師付き！～"
   name-sort: "いただきすとりーと3 おくまんちょうじゃにしてあげる！ かていきょうしつき"
-  name-en: "Itadaki Street 3"
+  name-en: "Itadaki Street 3 - Okuman Chouja ni Shiteageru！ Kateikyoushi-tsuki"
   region: "NTSC-J"
 SLPM-62113:
   name: "ワールドサッカーウイニングイレブン5 ファイナルエヴォリューション"
@@ -34879,7 +35189,7 @@ SLPM-62113:
 SLPM-62114:
   name: "クラッシュ・バンディクー4 さくれつ！魔神パワー"
   name-sort: "くらっしゅばんでぃくー4 さくれつ まじんぱわー"
-  name-en: "Crash Bandicoot 4 - Sakuretsu! Majin Power"
+  name-en: "Crash Bandicoot 4 - Sakuretsu！ Majin Power"
   region: "NTSC-J"
   gsHWFixes:
     nativePaletteDraw: 1
@@ -34897,7 +35207,7 @@ SLPM-62116:
 SLPM-62117:
   name: "桃太郎電鉄Ⅹ ～九州編もあるばい～"
   name-sort: "ももたろうでんてつ10ばってん きゅうしゅうへんもあるばい"
-  name-en: "Momotaro Train X"
+  name-en: "Momotaro Train X - Kyuushuu hen mo Arubai"
   region: "NTSC-J"
 SLPM-62118:
   name: "ボンバーマンカート"
@@ -35045,8 +35355,6 @@ SLPM-62145:
   name-sort: "ていとくのけつだん4"
   name-en: "Teitoku no Ketsudan IV"
   region: "NTSC-J"
-  gsHWFixes:
-    minimumBlendingLevel: 3 # Fixes graphical flickering.
 SLPM-62146:
   name: "超高速麻雀プラス"
   name-sort: "ちょうこうそくまーじゃんぷらす"
@@ -35127,7 +35435,7 @@ SLPM-62163:
 SLPM-62164:
   name: "Generation of Chaos Next ～失われし絆～ [通常版]"
   name-sort: "じぇねれーしょんおぶかおす 2 ねくすと うしなわれしきずな [つうじょうばん]"
-  name-en: "Generation of Chaos - Next"
+  name-en: "Generation of Chaos - Next [Standard Edition]"
   region: "NTSC-J"
 SLPM-62165:
   name: "式神の城"
@@ -35170,7 +35478,7 @@ SLPM-62174:
 SLPM-62175:
   name: "beatmania打打打！！THE BEST打"
   name-sort: "びーとまにあだだだ！！THE BESTだ"
-  name-en: "Beatmania Da Da Da!! THE BEST Da"
+  name-en: "Beatmania Da Da Da！！ THE BEST Da"
   region: "NTSC-J"
 SLPM-62176:
   name: "EGBROWSER BB"
@@ -35294,7 +35602,7 @@ SLPM-62201:
     vuClampMode: 3 # Fixes missing 3D polygons when going ingame.
 SLPM-62202:
   name: "Winning Post4 MAXIMUM 2001 [コーエーサマーチャンス 2002]"
-  name-sort: "ういにんぐぽすと4 MAXIMUM 2001  [こーえーさまーちゃんす 2002]"
+  name-sort: "ういにんぐぽすと4 MAXIMUM 2001 [こーえーさまーちゃんす 2002]"
   name-en: "Winning Post 4 Maximum 2001 [KOEI Summer Chance 2002]"
   region: "NTSC-J"
 SLPM-62203:
@@ -35406,7 +35714,7 @@ SLPM-62223:
 SLPM-62224:
   name: "SIMPLE2000シリーズ Ultimate Vol.3 最速！族車キング～仏恥義理伝説～"
   name-sort: "しんぷる2000しりーず あるてぃめっと Vol. 3 さいそく ぞくしゃきんぐ ぶっちぎりでんせつ"
-  name-en: "Simple 2000 Series Ultimate Vol. 3 - Saisoku! Zokusha King - Bucchigiri Densetsu"
+  name-en: "Simple 2000 Series Ultimate Vol. 3 - Saisoku！ Zokusha King - Bucchigiri Densetsu"
   region: "NTSC-J"
 SLPM-62225:
   name: "信長の野望・嵐世記 with パワーアップキット"
@@ -35520,7 +35828,7 @@ SLPM-62247:
 SLPM-62248:
   name: "SIMPLE2000シリーズ Ultimate Vol.5 ラブ★マージャン！"
   name-sort: "しんぷる2000しりーず あるてぃめっと Vol. 5 らぶまーじゃん！"
-  name-en: "Simple 2000 Series Ultimate Vol. 5 - Love - Mahjong!"
+  name-en: "Simple 2000 Series Ultimate Vol. 5 - Love - Mahjong！"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes SPS.
@@ -35622,7 +35930,7 @@ SLPM-62265:
 SLPM-62266:
   name: "桃太郎電鉄11 ブラックボンビー出現の巻"
   name-sort: "ももたろうでんてつ11 ぶらっくぼんびーしゅつげんのまき"
-  name-en: "Momotarou Dentetsu XI"
+  name-en: "Momotarou Dentetsu XI - Black Bobii Syutsugen no Maki"
   region: "NTSC-J"
 SLPM-62268:
   name: "ワールドサッカーウイニングイレブン6 ファイナルエヴォリューション"
@@ -35678,18 +35986,18 @@ SLPM-62277:
   name-en: "G1 Jockey 3"
   region: "NTSC-J"
 SLPM-62278:
-  name: "HUNTER×HUNTER 龍派の祭壇 コナミ ザ ベスト"
+  name: "HUNTER×HUNTER 龍派の祭壇 [KONAMI The BEST]"
   name-sort: "はんたーはんたー りゅうはのさいだん [KONAMI The BEST]"
   name-en: "Hunter x Hunter"
   region: "NTSC-J"
 SLPM-62279:
-  name: "GⅠ JOCKEY3 & Winning Post5 MAXIMUM 2002 プレミアムパック"
-  name-sort: "じーわんじょっきー3 じーわんじょっきー3 & ういにんぐぽすと5 MAXIMUM 2002 ぷれみあむぱっく"
+  name: "GⅠ JOCKEY3 & Winning Post5 MAXIMUM 2002 [プレミアムパック]"
+  name-sort: "じーわんじょっきー3 じーわんじょっきー3 & ういにんぐぽすと5 MAXIMUM 2002 [ぷれみあむぱっく]"
   name-en: "G1 Jockey 3 & Winning Post5 Maximum 2002 [Premium Pack]"
   region: "NTSC-J"
 SLPM-62280:
-  name: "GⅠ JOCKEY3 & Winning Post5 MAXIMUM 2002 プレミアムパック"
-  name-sort: "ういにんぐぽすと5 MAXIMUM 2002 じーわんじょっきー3 & ういにんぐぽすと5 MAXIMUM 2002 ぷれみあむぱっく"
+  name: "GⅠ JOCKEY3 & Winning Post5 MAXIMUM 2002 [プレミアムパック]"
+  name-sort: "ういにんぐぽすと5 MAXIMUM 2002 じーわんじょっきー3 & ういにんぐぽすと5 MAXIMUM 2002 [ぷれみあむぱっく]"
   name-en: "G1 Jockey 3 & Winning Post5 Maximum 2002 [Premium Pack]"
   region: "NTSC-J"
 SLPM-62281:
@@ -35733,7 +36041,7 @@ SLPM-62287:
 SLPM-62288:
   name: "ポップンミュージック ベストヒッツ！"
   name-sort: "ぽっぷんみゅーじっく べすとひっつ！"
-  name-en: "Pop'n music Best Hits!"
+  name-en: "Pop'n music Best Hits！"
   region: "NTSC-J"
 SLPM-62290:
   name: "TV蔵衛門"
@@ -35763,18 +36071,18 @@ SLPM-62294:
 SLPM-62295:
   name: "SIMPLE2000シリーズ Vol.22 THE 通勤電車運転士 ～電車でGO！3通勤編～"
   name-sort: "しんぷる2000しりーず Vol.  22 THEつうきんでんしゃうんてんし ～でんしゃでごー3つうきんへん～"
-  name-en: "Simple 2000 Series Vol. 22 - The Tsuukin Densha Untenshi - Densha de Go! 3 Tsuukin Hen"
+  name-en: "Simple 2000 Series Vol. 22 - The Tsuukin Densha Untenshi - Densha de Go！ 3 Tsuukin Hen"
   region: "NTSC-J"
 SLPM-62296:
   name: "SIMPLE2000シリーズ Ultimate Vol.6 ラブ★アッパー！"
   name-sort: "しんぷる2000しりーず あるてぃめっと Vol. 6 らぶあっぱー"
-  name-en: "Simple 2000 Series Ultimate Vol. 6 - Love Upper!"
+  name-en: "Simple 2000 Series Ultimate Vol. 6 - Love Upper！"
   region: "NTSC-J"
   compat: 5
 SLPM-62297:
   name: "いくぜ！温泉卓球 [彩京べすと]"
   name-sort: "いくぜ！おんせんたっきゅう [さいきょうべすと]"
-  name-en: "Got To Do! Hot Spring Table Tennis [Psikyo Best]"
+  name-en: "Got To Do！ Hot Spring Table Tennis [Psikyo Best]"
   region: "NTSC-J"
 SLPM-62298:
   name: "プチコプター"
@@ -35850,7 +36158,7 @@ SLPM-62313:
 SLPM-62314:
   name: "SIMPLE2000シリーズ Ultimate Vol.7 最強！白バイキング～SECURITY POLICE～"
   name-sort: "しんぷる2000しりーず あるてぃめっと Vol. 7 さいきょう！しろばいきんぐ SECURITY POLICE"
-  name-en: "Simple 2000 Series Vol. 7 - Saikyou! Shiro Biking Security Police"
+  name-en: "Simple 2000 Series Vol. 7 - Saikyou！ Shiro Biking Security Police"
   region: "NTSC-J"
 SLPM-62315:
   name: "プチコプター [ラジコンプロポ型コントローラセット]"
@@ -35880,7 +36188,7 @@ SLPM-62319:
 SLPM-62320:
   name: "2003年開幕 がんばれ球界王 いわゆるプロ野球なんですね～"
   name-sort: "2003ねんかいまく がんばれきゅうかいおう いわゆるぷろやきゅうなんですね～"
-  name-en: "2003-nen Kaimaku - Ganbare Kyuukai-ou - Iwayuru Pro Yakyuu desu ne"
+  name-en: "2003-nen Kaimaku - Ganbare Kyuukai-ou - Iwayuru Pro Yakyuu Nandesu ne"
   region: "NTSC-J"
 SLPM-62321:
   name: "ロボコップ～新たなる危機～"
@@ -35900,7 +36208,7 @@ SLPM-62323:
 SLPM-62324:
   name: "SIMPLE2000シリーズ Ultimate Vol.8 激闘！迷路キング"
   name-sort: "しんぷる2000しりーず あるてぃめっと Vol. 8 げきとう！めいろきんぐ"
-  name-en: "Simple 2000 Series Vol. 8 - Gekitou! Meiro King"
+  name-en: "Simple 2000 Series Vol. 8 - Gekitou！ Meiro King"
   region: "NTSC-J"
 SLPM-62325:
   name: "ハイヒートメジャーリーグベースボール 2003 [THE BEST タカラモノ]"
@@ -36048,7 +36356,7 @@ SLPM-62352:
 SLPM-62353:
   name: "SIMPLE2000シリーズ Vol.33 THE ジェットコースター"
   name-sort: "しんぷる2000しりーず Vol.  33 THEじぇっとこーすたー"
-  name-en: "Simple 2000 Series Vol. 33 - The Jet Coaster - Yuuenchi Otsukkurou!"
+  name-en: "Simple 2000 Series Vol. 33 - The Jet Coaster - Yuuenchi Otsukkurou！"
   region: "NTSC-J"
 SLPM-62354:
   name: "スペースインベーダー アニバーサリー"
@@ -36071,17 +36379,17 @@ SLPM-62356:
 SLPM-62357:
   name: "テニスの王子様 Smash Hit！ Original Anime Game"
   name-sort: "てにすのおうじさま Smash Hit！ Original Anime Game"
-  name-en: "Tennis no Oji-Sama - Smash-Hit! Original Anime Game"
+  name-en: "Tennis no Oji-Sama - Smash-Hit！ Original Anime Game"
   region: "NTSC-J"
 SLPM-62358:
   name: "テニスの王子様 Smash Hit！ Original Anime Game"
   name-sort: "てにすのおうじさま Smash Hit！ Original Anime Game"
-  name-en: "Tennis no Oji-Sama - Smash-Hit! Original Anime Game"
+  name-en: "Tennis no Oji-Sama - Smash-Hit！ Original Anime Game"
   region: "NTSC-J"
 SLPM-62359:
   name: "テニスの王子様 Smash Hit！ Original Anime Game"
   name-sort: "てにすのおうじさま Smash Hit！ Original Anime Game"
-  name-en: "Tennis no Oji-Sama - Smash-Hit! Original Anime Game"
+  name-en: "Tennis no Oji-Sama - Smash-Hit！ Original Anime Game"
   region: "NTSC-J"
 SLPM-62360:
   name: "超兄貴 ～聖なるプロテイン伝説～"
@@ -36239,14 +36547,14 @@ SLPM-62389:
   name-en: "Big Bass - Bass Tsuri Kanzen Kouryaku [SuperLite 2000 Series]"
   region: "NTSC-J"
 SLPM-62390:
-  name: "一撃殺虫！！ホイホイさん 限定版"
+  name: "一撃殺虫！！ホイホイさん [限定版]"
   name-sort: "いちげきさっちゅう！！ほいほいさん [げんていばん]"
-  name-en: "Ichigeki Sacchuu! HoiHoi-san [Limited Edition]"
+  name-en: "Ichigeki Sacchuu！ HoiHoi-san [Limited Edition]"
   region: "NTSC-J"
 SLPM-62391:
   name: "一撃殺虫！！ホイホイさん"
   name-sort: "いちげきさっちゅう！！ほいほいさん"
-  name-en: "Ichigeki Sacchuu! HoiHoi-san"
+  name-en: "Ichigeki Sacchuu！ HoiHoi-san"
   region: "NTSC-J"
 SLPM-62392:
   name: "GⅠ JOCKEY3 2003"
@@ -36254,8 +36562,8 @@ SLPM-62392:
   name-en: "G1 Jockey 3 2003"
   region: "NTSC-J"
 SLPM-62393:
-  name: "GⅠ JOCKEY3 2003 & Winning Post6 [Premium Pack]"
-  name-sort: "じーわんじょっきー3 2003 じーわんじょっきー3 2003 & ういにんぐぽすと6 [Premium Pack]"
+  name: "GⅠ JOCKEY3 2003 & Winning Post6 [プレミアムパック]"
+  name-sort: "じーわんじょっきー3 2003 じーわんじょっきー3 2003 & ういにんぐぽすと6 [ぷれみあむぱっく]"
   name-en: "G1 JOCKEY3 2003 & Winning Post6 [Premium Pack]"
   region: "NTSC-J"
 SLPM-62394:
@@ -36291,7 +36599,7 @@ SLPM-62398:
 SLPM-62399:
   name: "SIMPLE2000シリーズ Ultimate Vol.13 狂走！ 単車キング ～喝斗美！ 罵離罵離伝説～"
   name-sort: "しんぷる2000しりーず あるてぃめっと Vol.13 きょうそう たんしゃきんぐ かっとび ばりぞうごんでんせつ"
-  name-en: "Simple 2000 Series Ultimate Vol.13 - Kyousou! Tanhsa King Kattobi Barizougon"
+  name-en: "Simple 2000 Series Ultimate Vol.13 - Kyousou！ Tanhsa King Kattobi Barizougon"
   region: "NTSC-J"
 SLPM-62400:
   name: "SEGA AGES 2500シリーズ Vol.12 ぷよぷよ通 パーフェクト・セット"
@@ -36327,7 +36635,7 @@ SLPM-62406:
 SLPM-62407:
   name: "高橋尚子とマラソンしようよ！"
   name-sort: "たかはししょうことまらそんしようよ！"
-  name-en: "Takahashi Naoko no Marathon Shiyou yo!"
+  name-en: "Takahashi Naoko no Marathon Shiyou yo！"
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes missing text.
@@ -36353,7 +36661,7 @@ SLPM-62410:
 SLPM-62411:
   name: "バギーグランプリ ～かっとび！大作戦～"
   name-sort: "ばぎーぐらんぷり ～かっとび！だいさくせん～"
-  name-en: "Buggy Grand Prix - Kattobi! Daisakusen"
+  name-en: "Buggy Grand Prix - Kattobi！ Daisakusen"
   region: "NTSC-J"
   gameFixes:
     - GIFFIFOHack # Fixes random graphical corruption.
@@ -36380,12 +36688,12 @@ SLPM-62415:
 SLPM-62416:
   name: "桃太郎電鉄12 西日本編もありまっせー！"
   name-sort: "ももたろうでんてつ12 にしにほんへんもありまっせー！"
-  name-en: "Momotarou Dentetsu XII - West Japan Hen"
+  name-en: "Momotarou Dentetsu XII - Nishi Nihon hen mo Arimasse！"
   region: "NTSC-J"
 SLPM-62417:
   name: "魁！！クロマティ高校 これはひょっとしてゲームなのか?"
   name-sort: "さきがけ！！くろまてぃこうこう これはひょっとしてげーむなのか?"
-  name-en: "Sakigake!! Cromatier High School - Kore ha Hyottoshite Game Nanoka! Hen"
+  name-en: "Sakigake！！ Cromatier High School - Kore ha Hyottoshite Game Nanoka！ Hen"
   region: "NTSC-J"
 SLPM-62418:
   name: "ハドソンセレクションVOL.3 PC原人"
@@ -36406,7 +36714,7 @@ SLPM-62420:
 SLPM-62421:
   name: "石倉昇九段の囲碁講座 上級編 ～目指せ、実力初段！～"
   name-sort: "いしくらのぼるきゅうだんのいごこうざ じょうきゅうへん めざせ じつりょくしょだん！"
-  name-en: "Ishikura Noboru Kudan no Igo Kouza - Joukyuu-hen - Mezase Jitsuryoku Shodan!"
+  name-en: "Ishikura Noboru Kudan no Igo Kouza - Joukyuu-hen - Mezase Jitsuryoku Shodan！"
   region: "NTSC-J"
 SLPM-62422:
   name: "ハドソンセレクションVOL.4 高橋名人の冒険島"
@@ -36442,14 +36750,14 @@ SLPM-62427:
   region: "NTSC-J"
   compat: 5
 SLPM-62428:
-  name: "極 麻雀 DXII The 4th MONDO21Cup Competition"
-  name-sort: "きわめ まーじゃん DXII The 4th MONDO21Cup Competition"
+  name: "極 麻雀DXⅡ - The 4th MONDO21Cup Competition -"
+  name-sort: "きわめ まーじゃんDX2 - The 4th MONDO21Cup Competition -"
   name-en: "Kiwame Mahjong DXII - The 4th Mondo 21 Cup Competition"
   region: "NTSC-J"
 SLPM-62429:
   name: "SIMPLE2000シリーズ Ultimate Vol.15 ラブ★ピンポン"
   name-sort: "しんぷる2000しりーず あるてぃめっと Vol.15 らぶぴんぽん"
-  name-en: "Simple 2000 Series Ultimate Vol.15 - Love - Ping Pong!"
+  name-en: "Simple 2000 Series Ultimate Vol.15 - Love - Ping Pong！"
   region: "NTSC-J"
 SLPM-62430:
   name: "SIMPLE2000シリーズ Vol.43 THE 裁判 ～新米司法官 桃田 司の10の裁判ファイル"
@@ -36459,7 +36767,7 @@ SLPM-62430:
 SLPM-62431:
   name: "SIMPLE2000シリーズ Ultimate Vol.14 闘牌！ ドラマティック麻雀 ～天・天和通りの快男児～"
   name-sort: "しんぷる2000しりーず あるてぃめっと Vol.14 とうはい どらまてぃっくまーじゃん てん てんほーどおりのかいだんじ"
-  name-en: "Simple 2000 Series Ultimate Vol.14 - Touhai! Dramatic Mahjong Ten Tenho-toori no Kaidanji"
+  name-en: "Simple 2000 Series Ultimate Vol.14 - Touhai！ Dramatic Mahjong Ten Tenho-toori no Kaidanji"
   region: "NTSC-J"
 SLPM-62432:
   name: "SEGA AGES 2500シリーズ Vol.11 北斗の拳"
@@ -36476,7 +36784,7 @@ SLPM-62433:
 SLPM-62435:
   name: "テニスの王子様 Smash Hit 2！ Original Anime Game"
   name-sort: "てにすのおうじさま Smash Hit 2！ Original Anime Game"
-  name-en: "Tennis no Oji-Sama - Smash-Hit 2! Original Anime Game"
+  name-en: "Tennis no Oji-Sama - Smash-Hit 2！ Original Anime Game"
   region: "NTSC-J"
   gsHWFixes:
     forceEvenSpritePosition: 1 # Fixes screen shake when upscaling.
@@ -36528,8 +36836,8 @@ SLPM-62445:
   region: "NTSC-J"
   compat: 5
 SLPM-62446:
-  name: "SEGA AGES 2500シリーズ Vol.10 アフターバーナーII"
-  name-sort: "せが えいじす 2500しりーず Vol.10 あふたーばーなーII"
+  name: "SEGA AGES 2500シリーズ Vol.10 アフターバーナーⅡ"
+  name-sort: "せが えいじす 2500しりーず Vol.10 あふたーばーなー2"
   name-en: "Sega Ages 2500 Series Vol.10 - Afterburner II"
   region: "NTSC-J"
   compat: 5
@@ -36642,7 +36950,7 @@ SLPM-62467:
 SLPM-62468:
   name: "SIMPLE2000シリーズ Ultimate Vol.17 対戦！爆弾ポイポイ"
   name-sort: "しんぷる2000しりーず あるてぃめっと Vol.17 たいせん！ばくだんぽいぽい"
-  name-en: "Simple 2000 Series Ultimate Vol.17 - Taisen! Bakudan Poi Poi"
+  name-en: "Simple 2000 Series Ultimate Vol.17 - Taisen！ Bakudan Poi Poi"
   region: "NTSC-J"
 SLPM-62469:
   name: "ガンバード 1&2"
@@ -36655,8 +36963,6 @@ SLPM-62470:
   name-sort: "ていとくのけつだん4 うぃず ぱわーあっぷきっと"
   name-en: "Teitoku no Ketsudan IV with Power Up Kit"
   region: "NTSC-J"
-  gsHWFixes:
-    minimumBlendingLevel: 3 # Fixes graphical flickering.
   memcardFilters:
     - "SLPM-62145"
     - "SLPM-62470"
@@ -36679,12 +36985,12 @@ SLPM-62473:
 SLPM-62474:
   name: "SIMPLE2000シリーズ Vol.46 THE 漢字クイズ～チャレンジ！漢字検定～"
   name-sort: "しんぷる2000しりーず Vol.  46 THE かんじくいず～ちゃれんじ！かんじけんてい～"
-  name-en: "Simple 2000 Series Vol. 46 - The Kanji Quiz - Challenge! Kanji Kentei"
+  name-en: "Simple 2000 Series Vol. 46 - The Kanji Quiz - Challenge！ Kanji Kentei"
   region: "NTSC-J"
 SLPM-62475:
-  name: "桃太郎電鉄11 [HUDSON THE BEST]"
-  name-sort: "ももたろうでんてつ11 はどそん・ざ・べすと"
-  name-en: "Momotarou Dentetsu XI [Hudson The Best]"
+  name: "桃太郎電鉄11 ブラックボンビー出現の巻 [HUDSON THE BEST]"
+  name-sort: "ももたろうでんてつ11 ぶらっくぼんびーしゅつげんのまき [HUDSON THE BEST]"
+  name-en: "Momotarou Dentetsu XI - Black Bobii Syutsugen no Maki [HUDSON THE BEST]"
   region: "NTSC-J"
 SLPM-62476:
   name: "GetBackers奪還屋 裏新宿最強バトル"
@@ -36720,7 +37026,7 @@ SLPM-62481:
 SLPM-62482:
   name: "パチスロ闘魂伝承 猪木祭 - アントニオ猪木という名のパチスロ機 / アントニオ猪木自身がパチスロ機"
   name-sort: "ぱちすろとうこんでんしょう いのきまつり - あんとにおいのきというなのぱちすろき / あんとにおいのきじしんがぱちすろき"
-  name-en: "Pachinko Slot Tokodensho - Inoki Festival"
+  name-en: "Pachi-Slot Toukondensho - Inoki Matsuri - Antonio Inoki to iu Na no Pachi-Slot ki / Antonio Inoki Jishin ga Pachi-Slot ki"
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1 # Fixes on screen garbage.
@@ -36745,7 +37051,7 @@ SLPM-62485:
 SLPM-62486:
   name: "超最速！族車キングBU～仏恥義理伝説2～"
   name-sort: "ちょうさいそく ぞくしゃきんぐBU ぶっちぎりでんせつ2"
-  name-en: "Chou Saisoku! Zokusha King B.U. [Simple Series DX]"
+  name-en: "Chou Saisoku！ Zokusha King B.U. [Simple Series DX]"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes car colours.
@@ -36858,7 +37164,7 @@ SLPM-62505:
   name-en: "Fukuhara Love Ping Pong"
   region: "NTSC-J"
 SLPM-62506:
-  name: "ヴァンパイアパニック 限定版"
+  name: "ヴァンパイアパニック [限定版]"
   name-sort: "ゔぁんぱいあぱにっく [げんていばん]"
   name-en: "Vampire Panic"
   region: "NTSC-J"
@@ -36920,7 +37226,7 @@ SLPM-62515:
 SLPM-62516:
   name: "レッツプレイスポーツ！"
   name-sort: "れっつぷれいすぽーつ！"
-  name-en: "EyeToy Sports - Let's Play Sports!"
+  name-en: "EyeToy Sports - Let's Play Sports！"
   region: "NTSC-J"
 SLPM-62517:
   name: "Winning Post 5 [KOEI The Best]"
@@ -36932,8 +37238,6 @@ SLPM-62518:
   name-sort: "ていとくのけつだん4 [KOEI The Best]"
   name-en: "Teitoku no Ketsudan IV [Koei the Best]"
   region: "NTSC-J"
-  gsHWFixes:
-    minimumBlendingLevel: 3 # Fixes graphical flickering.
 SLPM-62519:
   name: "三國志Ⅷ [KOEI The Best]"
   name-sort: "さんごくし 8 [KOEI The Best]"
@@ -36945,8 +37249,8 @@ SLPM-62520:
   name-en: "Nobunaga no Yabou - Soutenroku"
   region: "NTSC-J"
 SLPM-62521:
-  name: "極麻雀DXII-The 4th MONDO21Cup Competition [Athena Best Collection Vol.2]"
-  name-sort: "きわめまーじゃんDXII-The 4th MONDO21Cup Competition [Athena Best Collection Vol.2]"
+  name: "極 麻雀DXⅡ - The 4th MONDO21Cup Competition - [Athena Best Collection Vol.2]"
+  name-sort: "きわめ まーじゃんDX2 - The 4th MONDO21Cup Competition - [Athena Best Collection Vol.2]"
   name-en: "Kiwame Mahjong DXII - The 4th Mondo 21 Cup Competition [Athena Best Collection]"
   region: "NTSC-J"
 SLPM-62523:
@@ -36957,7 +37261,7 @@ SLPM-62523:
 SLPM-62524:
   name: "SIMPLE2000シリーズ Vol.59 THE 宇宙人と話そう！～うちゅ～じんってなぁに?～"
   name-sort: "しんぷる2000しりーず Vol.  59 THE うちゅうじんとはなそう！ うちゅーじんってなぁに?"
-  name-en: "Simple 2000 Series Vol. 59 - The Uchyujin to Hanasou!"
+  name-en: "Simple 2000 Series Vol. 59 - The Uchyujin to Hanasou！"
   region: "NTSC-J"
   compat: 5
 SLPM-62525:
@@ -36991,7 +37295,7 @@ SLPM-62530:
 SLPM-62531:
   name: "麻雀やろうぜ！2 [コナミ殿堂セレクション]"
   name-sort: "まーじゃんやろうぜ！2 [こなみでんどうせれくしょん]"
-  name-en: "Mahjong Yarouze! 2 [Konami Palace Selection]"
+  name-en: "Mahjong Yarouze！ 2 [Konami Dendou Selection]"
   region: "NTSC-J"
 SLPM-62532:
   name: "イースⅢ ～ワンダラーズ フロム イース～"
@@ -37007,7 +37311,7 @@ SLPM-62533:
 SLPM-62534:
   name: "SIMPLE2000シリーズ Vol.63 もぎたて水着！女まみれの THE 水泳大会"
   name-sort: "しんぷる2000しりーず Vol.  63 もぎたてみずぎ！おんなまみれの THE すいえいたいかい"
-  name-en: "Simple 2000 Series Vol. 63 - Mogitate Mizugi! Onna Mamire no The Suieitaikai"
+  name-en: "Simple 2000 Series Vol. 63 - Mogitate Mizugi！ Onna Mamire no The Suieitaikai"
   region: "NTSC-J"
   compat: 5
 SLPM-62536:
@@ -37137,7 +37441,7 @@ SLPM-62557:
 SLPM-62558:
   name: "SIMPLE2000シリーズ Ultimate Vol.21 喧嘩上等！ヤンキー番長 ～昭和99年の伝説～"
   name-sort: "しんぷる2000しりーず あるてぃめっと Vol.21 けんかじょうとう！やんきーばんちょう ～しょうわ99ねんのでんせつ～"
-  name-en: "Simple 2000 Series Vol. 21 - Kenka Joutou! Yankee Banchou"
+  name-en: "Simple 2000 Series Vol. 21 - Kenka Joutou！ Yankee Banchou"
   region: "NTSC-J"
 SLPM-62559:
   name: "セガ スーパースターズ"
@@ -37171,7 +37475,7 @@ SLPM-62564:
 SLPM-62565:
   name: "ボボボーボ・ボーボボ 集まれ！！体感ボーボボ [カメラ同梱]"
   name-sort: "ぼぼぼーぼ・ぼーぼぼ あつまれ！！たいかんぼーぼぼ [かめらどうこん]"
-  name-en: "Boboboubo Boubobo - Atsumare!! Taikan Boubobo [Doukonban]"
+  name-en: "Boboboubo Boubobo - Atsumare！！ Taikan Boubobo [Doukonban]"
   region: "NTSC-J"
 SLPM-62566:
   name: "THE TYPING OF THE DEAD ZOMBIE PANIC"
@@ -37209,7 +37513,7 @@ SLPM-62571:
 SLPM-62572:
   name: "ボボボーボ・ボーボボ 集まれ！！体感ボーボボ"
   name-sort: "ぼぼぼーぼ ぼーぼぼ あつまれ たいかんぼーぼぼ"
-  name-en: "Boboboubo Boubobo - Atsumare!! Taikan Boubobo"
+  name-en: "Boboboubo Boubobo - Atsumare！！ Taikan Boubobo"
   region: "NTSC-J"
 SLPM-62573:
   name: "決戦Ⅲ - エンジョイディスク"
@@ -37224,12 +37528,12 @@ SLPM-62574:
 SLPM-62576:
   name: "実戦パチスロ必勝法！ 北斗の拳 Plus"
   name-sort: "じっせんぱちすろひっしょうほう！ ほくとのけん ぷらす"
-  name-en: "Jissen Pachi-Slot Hisshouhou! Hokuto no Ken Plus"
+  name-en: "Jissen Pachi-Slot Hisshouhou！ Hokuto no Ken Plus"
   region: "NTSC-J"
 SLPM-62577:
   name: "実戦パチスロ必勝法！ 北斗の拳 Plus [通常版]"
-  name-sort: "じっせんぱちすろひっしょうほう！ ほくとのけん ぷらす つうじょうばん"
-  name-en: "Jissen Pachi-Slot Hisshouhou! Hokuto no Ken Plus [Standard]"
+  name-sort: "じっせんぱちすろひっしょうほう！ ほくとのけん ぷらす [つうじょうばん]"
+  name-en: "Jissen Pachi-Slot Hisshouhou！ Hokuto no Ken Plus [Standard Edition]"
   region: "NTSC-J"
 SLPM-62578:
   name: "バズロッド ～フィッシングファンタジー"
@@ -37250,7 +37554,7 @@ SLPM-62580:
 SLPM-62581:
   name: "K-1 PREMIUM 2004 Dynamite！！"
   name-sort: "K-1 ぷれみあむ 2004 だいなまいと！！"
-  name-en: "K-1 Premium 2004 Dynamite!!"
+  name-en: "K-1 Premium 2004 Dynamite！！"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes black and white fighters.
@@ -37279,7 +37583,7 @@ SLPM-62584:
 SLPM-62585:
   name: "魁！クロマティ高校 [HUDSON THE BEST]"
   name-sort: "さきがけ！くろまてぃこうこう はどそん・ざ・べすと"
-  name-en: "Sakigake! Cromartie High School [Hudson The Best]"
+  name-en: "Sakigake！ Cromartie High School [Hudson The Best]"
   region: "NTSC-J"
 SLPM-62586:
   name: "SIMPLE2000シリーズ Vol.70 THE 鑑識官"
@@ -37297,8 +37601,8 @@ SLPM-62589:
   name-en: "Simple 2000 Series Vol. 72 - Ninkyou"
   region: "NTSC-J"
 SLPM-62590:
-  name: "GⅠ JOCKEY3 2005年度版 プレミアムパック"
-  name-sort: "じーわんじょっきー3 2005ねんどばん ぷれみあむぱっく"
+  name: "GⅠ JOCKEY3 2005年度版 [プレミアムパック]"
+  name-sort: "じーわんじょっきー3 2005ねんどばん [ぷれみあむぱっく]"
   name-en: "G1 Jockey 3 - 2005 [Premium Pack]"
   region: "NTSC-J"
 SLPM-62591:
@@ -37330,7 +37634,7 @@ SLPM-62596:
 SLPM-62597:
   name: "学園ヘヴン おかわりっ！"
   name-sort: "がくえんへゔん おかわりっ！"
-  name-en: "Gakuen Heaven - Okawari!"
+  name-en: "Gakuen Heaven - Okawari！"
   region: "NTSC-J"
 SLPM-62598:
   name: "サクラ大戦Ⅴ ～ さらば愛しき人よ [体験版]"
@@ -37383,7 +37687,7 @@ SLPM-62606:
     cpuSpriteRenderLevel: 2 # Needed for above.
     gpuPaletteConversion: 2 # Improves FPS and reduces HC size.
 SLPM-62607:
-  name: "式神の城Ⅱ  [TAITO The Best]"
+  name: "式神の城Ⅱ [TAITO The Best]"
   name-sort: "しきがみのしろ2 [TAITO The Best]"
   name-en: "Shikigami no Shiro II [TAITO BEST]"
   region: "NTSC-J"
@@ -37432,12 +37736,12 @@ SLPM-62615:
 SLPM-62616:
   name: "SIMPLE2000シリーズ Ultimate Vol.25 超最速！族車キングBUのBU ～仏恥義理伝説2改～"
   name-sort: "しんぷる2000しりーず あるてぃめっと Vol.25 ちょうさいそく！ぞくしゃきんぐBUのBU ぶっちぎりでんせつ2 かい"
-  name-en: "Simple 2000 Series Ultimate Vol.25 - Chou-Saisoku! Zokusha King BU no BU"
+  name-en: "Simple 2000 Series Ultimate Vol.25 - Chou-Saisoku！ Zokusha King BU no BU"
   region: "NTSC-J"
 SLPM-62617:
   name: "SIMPLE2000シリーズ Vol.79 - アッコにおまかせ！ THE パーティクイズ"
   name-sort: "しんぷる2000しりーず Vol.  79 - あっこにおまかせ THEぱーてぃーくいず"
-  name-en: "Simple 2000 Series Vol. 79 - Akko ni Omakase! The Party Quiz"
+  name-en: "Simple 2000 Series Vol. 79 - Akko ni Omakase！ The Party Quiz"
   region: "NTSC-J"
 SLPM-62618:
   name: "SIMPLE2000シリーズ Vol.78 THE 宇宙大戦争"
@@ -37539,7 +37843,7 @@ SLPM-62634:
 SLPM-62635:
   name: "SIMPLE2000シリーズ Ultimate Vol.26 ラブ★スマッシュ！5.1 ～テニスロボの反乱～"
   name-sort: "しんぷる2000しりーず あるてぃめっと Vol.26 らぶすまっしゅ！5.1 ～てにすろぼのはんらん～"
-  name-en: "Simple 2000 Series Ultimate Vol.26 - Love - Smash! 5.1 - Tennis Robo no Gyakushuu"
+  name-en: "Simple 2000 Series Ultimate Vol.26 - Love - Smash！ 5.1 - Tennis Robo no Gyakushuu"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes bad Geometry.
@@ -37730,8 +38034,8 @@ SLPM-62678:
   name-en: "Kurogane no Houkou - Warship Commander [Koei Selection Series]"
   region: "NTSC-J"
 SLPM-62679:
-  name: "リラックマ ～おじゃましてます2週間～ 初回限定ぬいぐるみパック"
-  name-sort: "りらっくま ～おじゃましてます2しゅうかん～ しょかいげんていぬいぐるみぱっく"
+  name: "リラックマ ～おじゃましてます2週間～ [初回限定ぬいぐるみパック]"
+  name-sort: "りらっくま ～おじゃましてます2しゅうかん～ [しょかいげんていぬいぐるみぱっく]"
   name-en: "Relakuma - Ojama Shitemasu 2 [Limited Edition]"
   region: "NTSC-J"
 SLPM-62680:
@@ -37790,8 +38094,8 @@ SLPM-62690:
   name-en: "Raiden III"
   region: "NTSC-J"
 SLPM-62691:
-  name: "SEGA AGES 2500シリーズ Vol.20 スペースハリアーII ～スペースハリアーコンプリートコレクション～"
-  name-sort: "せが えいじす 2500しりーず Vol.20 すぺーすはりあーII ～すぺーすはりあーこんぷりーとこれくしょん～"
+  name: "SEGA AGES 2500シリーズ Vol.20 スペースハリアーⅡ ～スペースハリアーコンプリートコレクション～"
+  name-sort: "せが えいじす 2500しりーず Vol.20 すぺーすはりあーⅡ ～すぺーすはりあーこんぷりーとこれくしょん～"
   name-en: "Sega Ages 2500 Series Vol.20 - Space Harrier Collection"
   region: "NTSC-J"
   compat: 5
@@ -37848,7 +38152,7 @@ SLPM-62701:
 SLPM-62702:
   name: "桃太郎電鉄15 五大ボンビー登場！の巻"
   name-sort: "ももたろうでんてつ15 ごだいぼんびーとうじょう！のまき"
-  name-en: "Momotarou Dentetsu 15"
+  name-en: "Momotarou Dentetsu 15 Godai Bobii Toujo！ no Maki"
   region: "NTSC-J"
 SLPM-62703:
   name: "SEGA RALLY CHAMPIONSHIP [SEGA RALLY 2006同梱版]"
@@ -37940,7 +38244,7 @@ SLPM-62718:
 SLPM-62719:
   name: "パチスロ 信長の野望 天下創世"
   name-sort: "ぱちすろ のぶながのやぼう てんかそうせい"
-  name-en: "Nobunaga no Yabou - Tenka Souyo"
+  name-en: "Pachi-Slot Nobunaga no Yabou - Tenka Sousei"
   region: "NTSC-J"
 SLPM-62720:
   name: "ウィザードリィ サマナー [TAITO The Best]"
@@ -37950,12 +38254,12 @@ SLPM-62720:
 SLPM-62721:
   name: "一撃殺虫！！ホイホイさん [KONAM the Best]"
   name-sort: "いちげきさっちゅう！！ほいほいさん [KONAM the Best]"
-  name-en: "Ichigeki Sacchuu! HoiHoi-san [KONAMI The BEST]"
+  name-en: "Ichigeki Sacchuu！ HoiHoi-san [KONAMI The BEST]"
   region: "NTSC-J"
 SLPM-62722:
   name: "実戦パチスロ必勝法！ 俺の空"
   name-sort: "じっせんぱちすろひっしょうほう！ おれのそら"
-  name-en: "Jissen Pachi-Slot Hisshouhou! Ore no Sora"
+  name-en: "Jissen Pachi-Slot Hisshouhou！ Ore no Sora"
   region: "NTSC-J"
 SLPM-62724:
   name: "ザ・コンビニ4 ～あの町を占拠せよ～"
@@ -37963,8 +38267,8 @@ SLPM-62724:
   name-en: "Conveni 4, The - Ano Machi o Dokusen seyo"
   region: "NTSC-J"
 SLPM-62725:
-  name: "麻雀覇王 段級バトルII"
-  name-sort: "まーじゃんはおう だんきゅうばとるII"
+  name: "麻雀覇王 段級バトルⅡ"
+  name-sort: "まーじゃんはおう だんきゅうばとる2"
   name-en: "Mahjong Hoah - Shinken Battle II"
   region: "NTSC-J"
 SLPM-62726:
@@ -38076,12 +38380,12 @@ SLPM-62748:
 SLPM-62749:
   name: "実戦パチスロ必勝法！ ミスターマジックネオ"
   name-sort: "じっせんぱちすろひっしょうほう！ みすたーまじっくねお"
-  name-en: "Jissen Pachi-Slot Hisshouhou! Mister Magic Neo"
+  name-en: "Jissen Pachi-Slot Hisshouhou！ Mister Magic Neo"
   region: "NTSC-J"
 SLPM-62750:
   name: "桃太郎電鉄16 北海道大移動！の巻"
   name-sort: "ももたろうでんてつ16 ほっかいどうだいいどう！のまき"
-  name-en: "Momotarou Dentetsu 16"
+  name: "Momotarou Dentetsu 16 - Hokkaido Daiidou no Maki！ [PlayStation2 the Best]"
   region: "NTSC-J"
 SLPM-62751:
   name: "真・三國無双シリーズコレクション 下巻 最強データ"
@@ -38101,7 +38405,7 @@ SLPM-62753:
 SLPM-62754:
   name: "ぷよぷよ！"
   name-sort: "ぷよぷよ！"
-  name-en: "Puyo Puyo! 15th Anniversary"
+  name-en: "Puyo Puyo！ 15th Anniversary"
   region: "NTSC-J"
 SLPM-62755:
   name: "麻雀覇王 真剣バトル [MYCOM BEST]"
@@ -38135,8 +38439,8 @@ SLPM-62760:
   region: "NTSC-J"
   compat: 5
 SLPM-62761:
-  name: "チョロQ HG2 ATLUS BEST COLLECTION"
-  name-sort: "ちょろQ HG2 ATLUS BEST COLLECTION"
+  name: "チョロQ HG2 [ATLUS BEST COLLECTION]"
+  name-sort: "ちょろQ HG2 [ATLUS BEST COLLECTION]"
   name-en: "Choro Q HG 2 [Atlus Best Collection]"
   region: "NTSC-J"
   gsHWFixes:
@@ -38189,8 +38493,8 @@ SLPM-62770:
   region: "NTSC-J"
   compat: 5
 SLPM-62771:
-  name: "チョロQ HG3 Atlus Best Collection"
-  name-sort: "ちょろQ HG3 Atlus Best Collection"
+  name: "チョロQ HG3 [ATLUS BEST COLLECTION]"
+  name-sort: "ちょろQ HG3 [ATLUS BEST COLLECTION]"
   name-en: "Choro Q HG 3 [Atlus Best Collection]"
   region: "NTSC-J"
 SLPM-62772:
@@ -38206,7 +38510,7 @@ SLPM-62773:
 SLPM-62774:
   name: "実戦パチスロ必勝法！ Selection ～サラリーマン金太郎・スロッター金太郎・俺の空～"
   name-sort: "じっせんぱちすろひっしょうほう！ せれくしょん さらりーまんきんたろう すろったーきんたろう おれのそら"
-  name-en: "Jissen Pachi-Slot Hisshouhou! Selection - Salaryman Kintarou - Slotter Kintarou - Ore no Sora"
+  name-en: "Jissen Pachi-Slot Hisshouhou！ Selection - Salaryman Kintarou - Slotter Kintarou - Ore no Sora"
   region: "NTSC-J"
 SLPM-62775:
   name: "SEGA AGES 2500シリーズ Vol.32 ファンタシースター コンプリートコレクション"
@@ -38226,11 +38530,11 @@ SLPM-62778:
 SLPM-62779:
   name: "ぷよぷよ！ スペシャルプライス"
   name-sort: "ぷよぷよ！ すぺしゃるぷらいす"
-  name-en: "Puyo Puyo! [Special Price]"
+  name-en: "Puyo Puyo！ [Special Price]"
   region: "NTSC-J"
 SLPM-62780:
-  name: "SEGA AGES 2500シリーズ Vol.33 ファンタジーゾーンコンプリートコレクション"
-  name-sort: "せが えいじす 2500しりーず Vol.33 ふぁんたじーぞーんこんぷりーとこれくしょん"
+  name: "SEGA AGES 2500シリーズ Vol.33 ファンタジーゾーン コンプリートコレクション"
+  name-sort: "せが えいじす 2500しりーず Vol.33 ふぁんたじーぞーん こんぷりーとこれくしょん"
   name-en: "Fantasy Zone Complete Collection"
   region: "NTSC-J"
   compat: 5
@@ -38357,7 +38661,7 @@ SLPM-64540:
   speedHacks:
     mtvu: 0 # Fixes bad graphics due to bad T-Bit handling.
 SLPM-64544:
-  name: "Tetsu 1 - Densha de Battle! World Grand Prix"
+  name: "Tetsu 1 - Densha de Battle！ World Grand Prix"
   region: "NTSC-K"
 SLPM-64549:
   name: "Siksin-ui Seong"
@@ -38630,7 +38934,7 @@ SLPM-65038:
 SLPM-65039:
   name: "電車でGO！新幹線 山陽新幹線編"
   name-sort: "でんしゃでごーしんかんせん さんようしんかんせんへん"
-  name-en: "Densha de Go! Shinkansen Sanyou Shinkansen-hen"
+  name-en: "Densha de Go！ Shinkansen Sanyou Shinkansen-hen"
   region: "NTSC-J"
 SLPM-65040:
   name: "ザ・フィアー [ディスク1/4]"
@@ -38702,7 +39006,7 @@ SLPM-65049:
 SLPM-65050:
   name: "遊戯王 真デュエルモンスターズⅡ 継承されし記憶"
   name-sort: "ゆうぎおう までゅえるもんすたーず2 けいしょうされしきおく"
-  name-en: "Yu-Gi-Oh! Shin Duel Monsters II"
+  name-en: "Yu-Gi-Oh！ Shin Duel Monsters II"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 2 # Partially fixes battle animation.
@@ -38747,8 +39051,8 @@ SLPM-65056:
   region: "NTSC-J"
 SLPM-65057:
   name: "7 BLADES [KONAMI The Best]"
-  name-sort: "せぶん ぶれーず  [KONAMI The Best]"
-  name-en: "7 Blades  [KONAMI The Best]"
+  name-sort: "せぶん ぶれーず [KONAMI The Best]"
+  name-en: "7 Blades [KONAMI The Best]"
   region: "NTSC-J"
 SLPM-65059:
   name: "ガンサバイバー2 バイオハザード コード:ベロニカ WITH ガンコン2"
@@ -38803,7 +39107,7 @@ SLPM-65072:
 SLPM-65073:
   name: "幻想水滸伝Ⅲ [初回生産分:特殊仕様]"
   name-sort: "げんそうすいこでん3 [しょかいせいさんぶん:とくしゅしよう]"
-  name-en: "Gensou Suikoden III"
+  name-en: "Gensou Suikoden III [Limited Edition]"
   region: "NTSC-J"
   memcardFilters: # This looks like a mess because it includes all serials for Suikoden 3, Suikoden 2, Suikogaiden 1, and Suikogaiden 2. A lot of these probably aren't actually required but it's not really hurting anything to have them here.
     - "SLPM-65073"
@@ -38941,7 +39245,7 @@ SLPM-65090:
 SLPM-65091:
   name: "遙かなる時空の中で2 [プレミアムBOX]"
   name-sort: "はるかなるときのなかで2 [ぷれみあむBOX]"
-  name-en: "Harukanaru Toki no Naka de 2  [Premium Box]"
+  name-en: "Harukanaru Toki no Naka de 2 [Premium Box]"
   region: "NTSC-J"
 SLPM-65092:
   name: "遙かなる時空の中で2"
@@ -38989,7 +39293,7 @@ SLPM-65098:
 SLPM-65100:
   name: "鬼武者 2 [初回生産限定版]"
   name-sort: "おにむしゃ 2 [しょかいせいさんげんていばん]"
-  name-en: "Onimusha 2"
+  name-en: "Onimusha 2 [Limited Edition]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 4 # Mostly aligns post processing.
@@ -39026,7 +39330,7 @@ SLPM-65107:
 SLPM-65108:
   name: "ジェットでGO！2"
   name-sort: "じぇっとでGO！2"
-  name-en: "Jet de Go! 2"
+  name-en: "Jet de Go！ 2"
   region: "NTSC-J"
 SLPM-65109:
   name: "サカつく2002 J.LEAGUE プロサッカークラブをつくろう！"
@@ -39128,14 +39432,14 @@ SLPM-65125:
   name-en: "Natsuiro no Sunadokei [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-65126:
-  name: "ときめきメモリアル Girl's Side 初回生産版"
-  name-sort: "ときめきめもりある がーるずさいど しょかいせいさんばん"
+  name: "ときめきメモリアル Girl's Side [初回生産版]"
+  name-sort: "ときめきめもりある がーるずさいど [しょかいせいさんばん]"
   name-en: "Tokimeki Memorial Girl's Side [Limited Edition]"
   region: "NTSC-J"
 SLPM-65130:
   name: "ドラマティックサッカーゲーム 日本代表選手になろう！"
   name-sort: "どらまてぃっくさっかーげーむ にほんだいひょうせんしゅになろう！"
-  name-en: "Dramatic Soccer Game - Becoming a National Team Member"
+  name-en: "Dramatic Soccer Game - Nihon Daihyou Senshu ni Narou！"
   region: "NTSC-J"
 SLPM-65131:
   name: "ユーディーのアトリエ ～グラムナートの錬金術士～"
@@ -39190,7 +39494,7 @@ SLPM-65140:
 SLPM-65141:
   name: "続せがれいじり 変珍たませがれ"
   name-sort: "ぞくせがれいじり へんちんたませがれ"
-  name-en: "Tsuzuse Gareijiri"
+  name-en: "Zoku Segare Ijiri - Henchin Tama Segare"
   region: "NTSC-J"
   compat: 5
 SLPM-65142:
@@ -39204,9 +39508,9 @@ SLPM-65143:
   name-en: "Anime Super Remix, The - Ashita no Joe 2"
   region: "NTSC-J"
 SLPM-65144:
-  name: "魔剣爻 アトラス・ベストコレクション"
-  name-sort: "まけんしゃお あとらす・べすとこれくしょん"
-  name-en: "Maken Shao"
+  name: "魔剣爻 [ATLUS BEST COLLECTION]"
+  name-sort: "まけんしゃお [ATLUS BEST COLLECTION]"
+  name-en: "Maken Shao [Atlus Best Collection]"
   region: "NTSC-J"
   speedHacks:
     mvuFlag: 0
@@ -39223,7 +39527,7 @@ SLPM-65146:
 SLPM-65148:
   name: "電車でGO！ ～旅情編～"
   name-sort: "でんしゃでごー りょじょうへん"
-  name-en: "Densha de Go! Ryojou-hen"
+  name-en: "Densha de Go！ Ryojou-hen"
   region: "NTSC-J"
 SLPM-65149:
   name: "チョロQ HG [THE BEST タカラモノ]"
@@ -39251,9 +39555,9 @@ SLPM-65153:
   name-en: "Gungrave [Standard Edition]"
   region: "NTSC-J"
 SLPM-65154:
-  name: "君が望む永遠 ～Rumbling hearts～ （初回限定版）"
-  name-sort: "きみがのぞむえいえん Rumbling hearts しょかいげんていばん"
-  name-en: "Rumbling Hearts"
+  name: "君が望む永遠 ～Rumbling hearts～ [初回限定版]"
+  name-sort: "きみがのぞむえいえん Rumbling hearts [しょかいげんていばん]"
+  name-en: "Rumbling Hearts [Limited Edition]"
   region: "NTSC-J"
 SLPM-65155:
   name: "君が望む永遠 ～Rumbling hearts～"
@@ -39301,7 +39605,7 @@ SLPM-65163:
         patch=0,EE,00276170,word,48438800
         patch=0,EE,0027617c,word,4BE521AC
 SLPM-65164:
-  name: "PROJECT MINERVA 限定版"
+  name: "PROJECT MINERVA [限定版]"
   name-sort: "ぷろじぇくと みねるゔぁ [げんていばん]"
   name-en: "Project Minerva [Limited Edition]"
   region: "NTSC-J"
@@ -39347,7 +39651,7 @@ SLPM-65172:
 SLPM-65173:
   name: "探偵 神宮寺三郎 Innocent Black"
   name-sort: "たんてい じんぐうじさぶろう Innocent Black"
-  name-en: "Innocent Black"
+  name-en: "Tantei Jinguuji Saburou - Innocent Black"
   region: "NTSC-J"
 SLPM-65174:
   name: "BRITNEY'S DANCE BEAT"
@@ -39498,7 +39802,7 @@ SLPM-65202:
   region: "NTSC-J"
 SLPM-65203:
   name: "ファントム -PHANTOM OF INFERNO- [初回限定版]"
-  name-sort: "ふぁんとむ PHANTOM OF INFERNO しょかいげんていばん"
+  name-sort: "ふぁんとむ PHANTOM OF INFERNO [しょかいげんていばん]"
   name-en: "Phantom of Inferno [Limited Edition]"
   region: "NTSC-J"
 SLPM-65204:
@@ -39607,8 +39911,8 @@ SLPM-65213:
   name-en: "Evolution Skateboarding"
   region: "NTSC-J"
 SLPM-65215:
-  name: "超・バトル封神&真・三國無双2 猛将伝 プレミアムパック"
-  name-sort: "ちょう・ばとるほうしん&しんさんごくむそう2 もうしょうでん ぷれみあむぱっく"
+  name: "超・バトル封神&真・三國無双2 猛将伝 [プレミアムパック]"
+  name-sort: "ちょう・ばとるほうしん&しんさんごくむそう2 もうしょうでん [ぷれみあむぱっく]"
   name-en: "Chou Battle Houshin - Bundle #2"
   region: "NTSC-J"
 SLPM-65217:
@@ -39622,9 +39926,9 @@ SLPM-65218:
   name-en: "Bomberman Jetters"
   region: "NTSC-J"
 SLPM-65219:
-  name: "はっぴーぶりーでぃんぐ ～Cheerful Party～ 初回限定版"
-  name-sort: "はっぴーぶりーでぃんぐ ～Cheerful Party～ しょかいげんていばん"
-  name-en: "Cheerful Party"
+  name: "はっぴーぶりーでぃんぐ ～Cheerful Party～ [初回限定版]"
+  name-sort: "はっぴーぶりーでぃんぐ ～Cheerful Party～ [しょかいげんていばん]"
+  name-en: "Cheerful Party [Limited Edition]"
   region: "NTSC-J"
 SLPM-65220:
   name: "はっぴーぶりーでぃんぐ ～Cheerful Party～"
@@ -39640,7 +39944,7 @@ SLPM-65221:
 SLPM-65222:
   name: "遊戯王真デュエルモンスターズⅡ 継承されし記憶 [コナミ殿堂セレクション]"
   name-sort: "ゆうぎおうしんでゅえるもんすたーず2 けいしょうされしきおく [こなみでんどうせれくしょん]"
-  name-en: "Yu-Gi-Oh!Shin Duel-Monsters 2 -Keishousaresshi Kioku [KONAMI Dendou Selection]"
+  name-en: "Yu-Gi-Oh！Shin Duel-Monsters 2 -Keishousaresshi Kioku [KONAMI Dendou Selection]"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 2 # Partially fixes battle animation.
@@ -39680,7 +39984,7 @@ SLPM-65226:
 SLPM-65227:
   name: "J.LEAGUE プロサッカークラブをつくろう！3"
   name-sort: "Jりーぐ ぷろさっかーくらぶをつくろう！ 3"
-  name-en: "J-League Pro Soccer Club - Tsukurou! 3"
+  name-en: "J-League Pro Soccer Club - Tsukurou！ 3"
   region: "NTSC-J"
 SLPM-65228:
   name: "大正もののけ異聞録"
@@ -39691,7 +39995,7 @@ SLPM-65228:
 SLPM-65229:
   name: "突撃！アーミーマン 史上最小の作戦"
   name-sort: "とつげき！あーみーまん しじょうさいしょうのさくせん"
-  name-en: "Totsugeki! Army Men - Shijou Saishou no Sakusen"
+  name-en: "Totsugeki！ Army Men - Shijou Saishou no Sakusen"
   region: "NTSC-J"
 SLPM-65230:
   name: "ときめきメモリアル3 約束のあの場所で [KONAMI The BEST]"
@@ -39772,7 +40076,7 @@ SLPM-65239:
 SLPM-65240:
   name: "プロ野球チームをつくろう！2"
   name-sort: "ぷろやきゅうちーむをつくろう2"
-  name-en: "Pro Yakyuu Team wo Tsukuro! 2"
+  name-en: "Pro Yakyuu Team wo Tsukuro！ 2"
   region: "NTSC-J"
 SLPM-65241:
   name: "真・女神転生Ⅲ - NOCTURNE [デラックスパック]"
@@ -39795,7 +40099,7 @@ SLPM-65242:
 SLPM-65243:
   name: "電車でGO！プロフェッショナル2"
   name-sort: "でんしゃでごーぷろふぇっしょなる2"
-  name-en: "Densha de Go! Professional 2"
+  name-en: "Densha de Go！ Professional 2"
   region: "NTSC-J"
 SLPM-65244:
   name: "トム・クランシーシリーズ ゴーストリコン"
@@ -39847,7 +40151,7 @@ SLPM-65249:
 SLPM-65250:
   name: "カットビ！！ ゴルフ"
   name-sort: "かっとび！！ ごるふ"
-  name-en: "Kattobi! Golf"
+  name-en: "Kattobi！ Golf"
   region: "NTSC-J"
 SLPM-65254:
   name: "ギャラクシーエンジェル"
@@ -39878,7 +40182,6 @@ SLPM-65257:
     - SoftwareRendererFMVHack # Fixes blackscreen when FMV.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes menu transparancy effects and text.
-    deinterlace: 9 # Fixes incorrect field order in FMVs.
   memcardFilters:
     - "SLPM-65257"
     - "SLPM-65622"
@@ -39904,7 +40207,7 @@ SLPM-65260:
 SLPM-65261:
   name: "TBS オールスター感謝祭 Vol.1 超豪華！ クイズ決定版"
   name-sort: "TBS おーるすたーかんしゃさい Vol.1 ちょうごうか！ くいずけっていばん"
-  name-en: "TBS All-Star Kansha-sai Vol. 1 - Chou Gouka! Quiz Ketteiban"
+  name-en: "TBS All-Star Kansha-sai Vol. 1 - Chou Gouka！ Quiz Ketteiban"
   region: "NTSC-J"
 SLPM-65262:
   name: "ボボボーボ・ボーボボ ハジけ祭"
@@ -40053,8 +40356,8 @@ SLPM-65284:
     halfPixelOffset: 2 # Aligns Depth of Field.
     nativeScaling: 2 # Fixes Depth of Field effect.
 SLPM-65285:
-  name: "ラブひな ごーじゃす ～チラっとハプニング！！～ 初回限定版"
-  name-sort: "らぶひな ごーじゃす ～ちらっとはぷにんぐ！！～ しょかいげんていばん"
+  name: "ラブひな ごーじゃす ～チラっとハプニング！！～ [初回限定版]"
+  name-sort: "らぶひな ごーじゃす ～ちらっとはぷにんぐ！！～ [しょかいげんていばん]"
   name-en: "Love Hina Gorgeous [First Limited Edition]"
   region: "NTSC-J"
   compat: 5
@@ -40091,7 +40394,7 @@ SLPM-65291:
 SLPM-65292:
   name: "ラブひな ごーじゃす ～チラっとハプニング！！～"
   name-sort: "らぶひな ごーじゃす ～ちらっとはぷにんぐ！！～"
-  name-en: "Love Hina Gorgeous - Chiratto Happening!!"
+  name-en: "Love Hina Gorgeous - Chiratto Happening！！"
   region: "NTSC-J"
 SLPM-65294:
   name: "カフェ・リトルウィッシュ ～魔法のレシピ～ [初回限定版]"
@@ -40132,12 +40435,12 @@ SLPM-65300:
 SLPM-65301:
   name: "とらかぷっ！だーっしゅ！！でらっくすぱっく"
   name-sort: "とらかぷっ だーっしゅ でらっくすぱっく"
-  name-en: "Torakapuu! Dash [Limited Edition]"
+  name-en: "Torakapuu！ Dash [Limited Edition]"
   region: "NTSC-J"
 SLPM-65302:
   name: "とらかぷっ！だーっしゅ！！"
   name-sort: "とらかぷっ だーっしゅ"
-  name-en: "Torakapuu! Dash"
+  name-en: "Torakapuu！ Dash"
   region: "NTSC-J"
 SLPM-65303:
   name: "電脳戦機バーチャロン マーズ"
@@ -40173,8 +40476,8 @@ SLPM-65305:
     - "SLPM-86953"
     - "SLPM-87262"
 SLPM-65306:
-  name: "SAKURA～雪月華～ 初回限定版"
-  name-sort: "さくら せつげっか しょかいげんていばん"
+  name: "SAKURA～雪月華～ [初回限定版]"
+  name-sort: "さくら せつげっか [しょかいげんていばん]"
   name-en: "Sakura - Yuki Gekka [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-65307:
@@ -40253,17 +40556,17 @@ SLPM-65320:
 SLPM-65321:
   name: "テニスの王子様 Smash Hit！ [初回SP限定版]"
   name-sort: "てにすのおうじさま Smash Hit！ [しょかいSPげんていばん]"
-  name-en: "Prince of Tennis - Smash Hit![Limited Edition]"
+  name-en: "Prince of Tennis - Smash Hit！[Limited Edition]"
   region: "NTSC-J"
 SLPM-65322:
   name: "テニスの王子様 Smash Hit！ [B-Type]"
   name-sort: "てにすのおうじさま Smash Hit！ [B-Type]"
-  name-en: "Prince of Tennis - Smash Hit! [B-Type]"
+  name-en: "Prince of Tennis - Smash Hit！ [B-Type]"
   region: "NTSC-J"
 SLPM-65323:
   name: "テニスの王子様 Smash Hit！ [C-Type]"
   name-sort: "てにすのおうじさま Smash Hit！ [C-Type]"
-  name-en: "Prince of Tennis - Smash Hit! [C-Type]"
+  name-en: "Prince of Tennis - Smash Hit！ [C-Type]"
   region: "NTSC-J"
 SLPM-65324:
   name: "グレゴリーホラーショー ソウルコレクター"
@@ -40283,7 +40586,7 @@ SLPM-65326:
 SLPM-65327:
   name: "テニスの王子様 Smash Hit！"
   name-sort: "てにすのおうじさま Smash Hit！"
-  name-en: "Prince of Tennis - Smash Hit! [Limited Edition]"
+  name-en: "Prince of Tennis - Smash Hit！ [Limited Edition]"
   region: "NTSC-J"
 SLPM-65328:
   name: "白中探検部"
@@ -40311,7 +40614,7 @@ SLPM-65331:
   gsHWFixes:
     disablePartialInvalidation: 1 # Fixes Fixes black screens.
 SLPM-65332:
-  name: "まほろまてぃっく 萌っと≠きらきらメイドさん。 限定版"
+  name: "まほろまてぃっく 萌っと≠きらきらメイドさん。 [限定版]"
   name-sort: "まほろまてぃっく もえっときらきらめいどさん [げんていばん]"
   name-en: "Mahoromatic Automatic Maiden [Limited Edition]"
   region: "NTSC-J"
@@ -40329,12 +40632,12 @@ SLPM-65334:
 SLPM-65335:
   name: "激闘プロ野球 水島新司オールスターズ VS プロ野球"
   name-sort: "げきとうぷろやきゅう みずしましんじおーるすたーず VS ぷろやきゅう"
-  name-en: "Gekitou Pro Yakyuu"
+  name-en: "Gekitou Pro Yakyuu - Mizushima Shinji All Stars vs. Pro Yakyuu"
   region: "NTSC-J"
 SLPM-65336:
   name: "K-1 WORLD GRAND PRIX THE BEAST ATTACK！"
   name-sort: "K-1 わーるど ぐらんぷり THE BEAST ATTACK！"
-  name-en: "K-1 World Grand Prix - The Beast Attack!"
+  name-en: "K-1 World Grand Prix - The Beast Attack！"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes upscaling lines.
@@ -40350,8 +40653,8 @@ SLPM-65338:
   name-en: "Juunikoku-ki - Guren no Shirube Koejin no Michi"
   region: "NTSC-J"
 SLPM-65339:
-  name: "悪代官 [グローバル ザ ベスト]"
-  name-sort: "あくだいかん [ぐろーばる ざ べすと]"
+  name: "悪代官 [GLOBAL The Best]"
+  name-sort: "あくだいかん [GLOBAL The Best]"
   name-en: "Akudaikan [Global The Best]"
   region: "NTSC-J"
 SLPM-65340:
@@ -40371,7 +40674,7 @@ SLPM-65341:
 SLPM-65342:
   name: "恐怖新聞【平成版】～怪奇！心霊ファイル～"
   name-sort: "きょうふしんぶん へいせいばん かいき！しんれいふぁいる"
-  name-en: "Kyoufu Shinbun (Heisei) Kaiki! Shinrei File"
+  name-en: "Kyoufu Shinbun (Heisei) Kaiki！ Shinrei File"
   region: "NTSC-J"
 SLPM-65343:
   name: "機甲兵団 J-PHOENIX2"
@@ -40389,7 +40692,7 @@ SLPM-65344:
 SLPM-65345:
   name: "SIMPLE2000シリーズ Ultimate Vol.9 爆走マンハッタン"
   name-sort: "しんぷる2000しりーず あるてぃめっと Vol. 9 ばくそうまんはったん"
-  name-en: "Simple 2000 Series Ultimate Vol. 9 - Bakusou! Manhattan - Runabout 3"
+  name-en: "Simple 2000 Series Ultimate Vol. 9 - Bakusou！ Manhattan - Runabout 3"
   region: "NTSC-J"
 SLPM-65346:
   name: "Winning Post6"
@@ -40402,7 +40705,7 @@ SLPM-65347:
   name-en: "Bistro Cupid 2 [Tokubetsu-ban]"
   region: "NTSC-J"
 SLPM-65348:
-  name: "ビストロ・きゅーぴっと2 通常版"
+  name: "ビストロ・きゅーぴっと2 [通常版]"
   name-sort: "びすとろ・きゅーぴっと2"
   name-en: "Bistro Cupid 2"
   region: "NTSC-J"
@@ -40414,7 +40717,7 @@ SLPM-65349:
 SLPM-65350:
   name: "SIMPLE2000シリーズ Ultimate Vol.11 ワンダバスタイル～突撃！みっくす生JUICE～"
   name-sort: "しんぷる2000しりーず あるてぃめっと Vol.11 わんだばすたいる とつげき！みっくすなまじゅーす"
-  name-en: "Simple 2000 Series Ultimate Vol. 11 - Wandaba Style - Totsugeki! Mix Ki Juice"
+  name-en: "Simple 2000 Series Ultimate Vol. 11 - Wandaba Style - Totsugeki！ Mix Ki Juice"
   region: "NTSC-J"
 SLPM-65352:
   name: "SIMPLE2000シリーズ Ultimate Vol.10 ラブ★ソングス♪"
@@ -40453,13 +40756,13 @@ SLPM-65358:
   region: "NTSC-J"
   compat: 5
 SLPM-65359:
-  name: "ユーディーのアトリエ ～グラムナート の錬金術士～ [ガストベストプライス]"
-  name-sort: "ゆーでぃーのあとりえ ～ぐらむなーとのれんきんじゅつし～ [がすとべすとぷらいす]"
+  name: "ユーディーのアトリエ ～グラムナート の錬金術士～ [ガストBest Price]"
+  name-sort: "ゆーでぃーのあとりえ ～ぐらむなーとのれんきんじゅつし～ [がすとBest Price]"
   name-en: "Judie no Atelier - Gramnad no Renkinjutsushi [Gust Best Price]"
   region: "NTSC-J"
 SLPM-65361:
   name: "ANUBIS ZONE OF THE ENDERS SPECIAL EDITION [限定版]"
-  name-sort: "ぞーん おぶ えんだーず あぬびす SPECIAL EDITION [げんていばん]"
+  name-sort: "あぬびす ぞーん おぶ えんだーず SPECIAL EDITION [げんていばん]"
   name-en: "Anubis - Zone of the Enders Special Edition [Limited Edition]"
   region: "NTSC-J"
   compat: 5
@@ -40468,7 +40771,7 @@ SLPM-65361:
     nativeScaling: 2 # Fixes post effects.
 SLPM-65362:
   name: "NHK 天才ビットくん グラモンバトル"
-  name-sort: "えぬえいちけい てんさいびっとくん ぐらもんばとる"
+  name-sort: "NHK てんさいびっとくん ぐらもんばとる"
   name-en: "NHK Tensai Bit-Kun - Guramon Battle"
   region: "NTSC-J"
 SLPM-65363:
@@ -40489,7 +40792,7 @@ SLPM-65365:
 SLPM-65366:
   name: "DEAR BOYS Fast Break！"
   name-sort: "でぃあ ぼーいず ふぁすと ぶれいく！"
-  name-en: "Dear Boys - Fast Break!"
+  name-en: "Dear Boys - Fast Break！"
   region: "NTSC-J"
 SLPM-65367:
   name: "魔界英雄記マキシモ ～マシンモンスターの野望～"
@@ -40507,7 +40810,7 @@ SLPM-65368:
 SLPM-65369:
   name: "TBS オールスター感謝祭2003秋 超豪華！ クイズ決定版"
   name-sort: "TBS おーるすたーかんしゃさい2003秋 ちょうごうか！ くいずけっていばん"
-  name-en: "TBS All-Star Kansha-sai 2003 Autumn - Chou Gouka! Quiz Ketteiban"
+  name-en: "TBS All-Star Kansha-sai 2003 Autumn - Chou Gouka！ Quiz Ketteiban"
   region: "NTSC-J"
 SLPM-65370:
   name: "テニスの王子様 SWEAT&TEARS 2"
@@ -40533,7 +40836,7 @@ SLPM-65373:
 SLPM-65374:
   name: "エナジーエアフォース エイムストライク！"
   name-sort: "えなじーえあふぉーす えいむすとらいく！"
-  name-en: "Energy Airforce - Aim Strike!"
+  name-en: "Energy Airforce - Aim Strike！"
   region: "NTSC-J"
   speedHacks:
     instantVU1: 0 # Fixes hanging while going ingame.
@@ -40595,8 +40898,8 @@ SLPM-65384:
   region: "NTSC-J"
   compat: 5
 SLPM-65385:
-  name: "GⅠ JOCKEY3 2003 & Winning Post6 [Premium Pack]"
-  name-sort: "ういにんぐぽすと6 じーわんじょっきー3 2003 & ういにんぐぽすと6 [Premium Pack]"
+  name: "GⅠ JOCKEY3 2003 & Winning Post6 [プレミアムパック]"
+  name-sort: "ういにんぐぽすと6 じーわんじょっきー3 2003 & ういにんぐぽすと6 [ぷれみあむぱっく]"
   name-en: "G1 JOCKEY3 2003 & Winning Post6 [Premium Pack]"
   region: "NTSC-J"
 SLPM-65386:
@@ -40642,7 +40945,7 @@ SLPM-65393:
 SLPM-65394:
   name: "ラブ★スマッシュ！5～テニスロボの反乱～"
   name-sort: "らぶすまっしゅ！5～てにすろぼのはんらん～"
-  name-en: "Love Smash! 5"
+  name-en: "Love Smash！ 5"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes bad Geometry.
@@ -40705,7 +41008,7 @@ SLPM-65405:
   gsHWFixes:
     texturePreloading: 1 # Performs much better with partial preload.
 SLPM-65406:
-  name: "キャッスルヴァニア 限定版"
+  name: "キャッスルヴァニア [限定版]"
   name-sort: "きゃっするゔぁにあ [げんていばん]"
   name-en: "Castlevania [Limited Edition]"
   region: "NTSC-J"
@@ -40823,18 +41126,18 @@ SLPM-65423:
   region: "NTSC-J"
 SLPM-65424:
   name: "モエかん ～もえっ娘島へようこそ～ [初回限定版]"
-  name-sort: "もえかん もえっこしまへようこそ しょかいげんていばん"
+  name-sort: "もえかん もえっこしまへようこそ [しょかいげんていばん]"
   name-en: "Moekko Company [Limited Edition]"
   region: "NTSC-J"
 SLPM-65425:
   name: "モエかん ～もえっ娘島へようこそ～ [通常版]"
-  name-sort: "もえかん もえっこしまへようこそ"
-  name-en: "Moekko Company"
+  name-sort: "もえかん もえっこしまへようこそ [つうじょうばん]"
+  name-en: "Moekko Company [Standard Edition]"
   region: "NTSC-J"
 SLPM-65426:
   name: "プロ野球チームをつくろう！2003"
   name-sort: "ぷろやきゅうちーむをつくろう2003"
-  name-en: "Pro Yakyuu Team wo Tsukuro! 2003"
+  name-en: "Pro Yakyuu Team wo Tsukuro！ 2003"
   region: "NTSC-J"
 SLPM-65427:
   name: "RSⅡ ～ライディング スピリッツ2～"
@@ -40923,7 +41226,7 @@ SLPM-65439:
 SLPM-65441:
   name: "あしたのジョー ～まっ白に燃え尽きろ！～"
   name-sort: "あしたのじょー まっしろにもえつきろ！"
-  name-en: "Ashita no Joe - Masshiro ni Moe Tsukiro!"
+  name-en: "Ashita no Joe - Masshiro ni Moe Tsukiro！"
   region: "NTSC-J"
 SLPM-65442:
   name: "ターミネーター3 -Rise of the machines-"
@@ -40931,8 +41234,8 @@ SLPM-65442:
   name-en: "Terminator 3, The - Rise of the Machines"
   region: "NTSC-J"
 SLPM-65443:
-  name: "フロントミッション フォース"
-  name-sort: "ふろんとみっしょん ふぉーす"
+  name: "フロントミッション4"
+  name-sort: "ふろんとみっしょん4 ふぉーす"
   name-en: "Front Mission 4"
   region: "NTSC-J"
   gsHWFixes:
@@ -40988,30 +41291,30 @@ SLPM-65450:
   name-en: "Tantei Gakuen Q - Kiokan no Satsui [First Limited Edition]"
   region: "NTSC-J"
 SLPM-65451:
-  name: "テニスの王子様 Smash Hit！2 初回SP限定版"
-  name-sort: "てにすのおうじさま Smash Hit！2 しょかいSPげんていばん"
-  name-en: "Prince of Tennis - Smash Hit! 2 [Shokai SP Genteiban A-Type]"
+  name: "テニスの王子様 Smash Hit！2 [初回SP限定版]"
+  name-sort: "てにすのおうじさま Smash Hit！2 [しょかいSPげんていばん]"
+  name-en: "Prince of Tennis - Smash Hit！ 2 [Shokai SP Genteiban A-Type]"
   region: "NTSC-J"
   gsHWFixes:
     forceEvenSpritePosition: 1 # Fixes screen shake when upscaling.
 SLPM-65452:
   name: "テニスの王子様 Smash Hit 2！ Original Anime Game [初回SP限定版 B-Type]"
   name-sort: "てにすのおうじさま Smash Hit 2！ Original Anime Game [しょかいSPげんていばん B-Type]"
-  name-en: "Tennis no Oji-Sama - Smash-Hit 2! Original Anime Game [Shokai SP Genteiban B-Type]"
+  name-en: "Tennis no Oji-Sama - Smash-Hit 2！ Original Anime Game [Shokai SP Genteiban B-Type]"
   region: "NTSC-J"
   gsHWFixes:
     forceEvenSpritePosition: 1 # Fixes screen shake when upscaling.
 SLPM-65453:
   name: "テニスの王子様 Smash Hit 2！ Original Anime Game [初回SP限定版 C-Type]"
   name-sort: "てにすのおうじさま Smash Hit 2！ Original Anime Game [しょかいSPげんていばん C-Type]"
-  name-en: "Tennis no Oji-Sama - Smash-Hit 2! Original Anime Game [Shokai SP Genteiban C-Type]"
+  name-en: "Tennis no Oji-Sama - Smash-Hit 2！ Original Anime Game [Shokai SP Genteiban C-Type]"
   region: "NTSC-J"
   gsHWFixes:
     forceEvenSpritePosition: 1 # Fixes screen shake when upscaling.
 SLPM-65454:
   name: "テニスの王子様 Smash Hit！2 [KONAMI The BEST]"
   name-sort: "てにすのおうじさま Smash Hit！2 [KONAMI The BEST]"
-  name-en: "Prince of Tennis - Smash Hit! 2 [KONAMI The BEST]"
+  name-en: "Prince of Tennis - Smash Hit！ 2 [KONAMI The BEST]"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -41023,12 +41326,12 @@ SLPM-65455:
   region: "NTSC-J"
 SLPM-65456:
   name: "ナースウィッチ小麦ちゃん マジカルて [初回限定版]"
-  name-sort: "なーすうぃっちこむぎちゃん まじかるて しょかいげんていばん"
+  name-sort: "なーすうぃっちこむぎちゃん まじかるて [しょかいげんていばん]"
   name-en: "Magical Nurse Witch Komugi-chan [Limited Edition]"
   region: "NTSC-J"
 SLPM-65457:
   name: "ナースウィッチ小麦ちゃん マジカルて [通常版]"
-  name-sort: "なーすうぃっちこむぎちゃん まじかるて"
+  name-sort: "なーすうぃっちこむぎちゃん まじかるて [つうじょうばん]"
   name-en: "Magical Nurse Witch Komugi-chan [Standard Edition]"
   region: "NTSC-J"
 SLPM-65458:
@@ -41118,7 +41421,7 @@ SLPM-65471:
 SLPM-65472:
   name: "TrainSimulator＋電車でGO！ 東京急行編"
   name-sort: "とれいんしみゅれーたー＋でんしゃでごー とうきょうきゅうこうへん"
-  name-en: "Train Simulator & Densha de Go! Tokyo Kyuukouhen"
+  name-en: "Train Simulator & Densha de Go！ Tokyo Kyuukouhen"
   region: "NTSC-J"
 SLPM-65473:
   name: "鋼の錬金術師 翔べない天使"
@@ -41128,7 +41431,7 @@ SLPM-65473:
   compat: 5
 SLPM-65474:
   name: "鋼鉄の咆哮2 - プレミアムパック [ウォーシップコマンダー&ウォーシップガンナー]"
-  name-sort: "くろがねのほうこう2 ぷれみあむぱっく [うぉーしっぷこまんだー&うぉーしっぷがんなー]"
+  name-sort: "くろがねのほうこう2 [ぷれみあむぱっく [うぉーしっぷこまんだー&うぉーしっぷがんなー]"
   name-en: "Kurogane no Houkou 2 - Premium Pack [Warship Commander & Warship Gunner] [Limited Edition]"
   region: "NTSC-J"
 SLPM-65477:
@@ -41192,8 +41495,8 @@ SLPM-65488:
   name-en: "Grand Theft Auto - Vice City"
   region: "NTSC-J"
 SLPM-65489:
-  name: "ワークジャム ベストコレクション vol.1 探偵 神宮寺三郎 Innocent Black"
-  name-sort: "わーくじゃむ べすとこれくしょん vol.1 たんてい じんぐうじさぶろう Innocent Black"
+  name: "探偵 神宮寺三郎 Innocent Black [ワークジャム ベストコレクション vol.1]"
+  name-sort: "んてい じんぐうじさぶろう Innocent Black [わーくじゃむ べすとこれくしょん vol.1 ]"
   name-en: "Tantei Jingiji Saburo - Innocent Black [WorkJam Best Collection]"
   region: "NTSC-J"
 SLPM-65490:
@@ -41212,9 +41515,9 @@ SLPM-65492:
   name-en: "Gungrave O.D."
   region: "NTSC-J"
 SLPM-65493:
-  name: "ふらせら Hurrah！Sailor 初回限定版"
-  name-sort: "ふらせら Hurrah！Sailor しょかいげんていばん"
-  name-en: "Hurrah! Sailor"
+  name: "ふらせら Hurrah！Sailor [初回限定版]"
+  name-sort: "ふらせら Hurrah！Sailor [しょかいげんていばん]"
+  name-en: "Hurrah！ Sailor [Limited Edition]"
   region: "NTSC-J"
 SLPM-65494:
   name: "風雲 新撰組"
@@ -41282,7 +41585,7 @@ SLPM-65503:
     vu1ClampMode: 3 # Fixes broken skybox and missing textures.
 SLPM-65504:
   name: "COOL GIRL [初回限定版] [ディスク1/2]"
-  name-sort: "くーる がーる しょかいげんていばん [でぃすく1/2]"
+  name-sort: "くーる がーる [しょかいげんていばん] [でぃすく1/2]"
   name-en: "Cool Girl [Limited Edition] [Disc 1 of 2]"
   region: "NTSC-J"
   memcardFilters:
@@ -41292,7 +41595,7 @@ SLPM-65504:
     - "SLPM-65742"
 SLPM-65505:
   name: "COOL GIRL [初回限定版] [ディスク2/2]"
-  name-sort: "くーる がーる しょかいげんていばん [でぃすく2/2]"
+  name-sort: "くーる がーる [しょかいげんていばん] [でぃすく2/2]"
   name-en: "Cool Girl [Limited Edition] [Disc 2 of 2]"
   region: "NTSC-J"
   memcardFilters:
@@ -41302,7 +41605,7 @@ SLPM-65505:
     - "SLPM-65742"
 SLPM-65506:
   name: "COOL GIRL [通常版] [ディスク1/2]"
-  name-sort: "くーる がーる つうじょうばん [でぃすく1/2]"
+  name-sort: "くーる がーる [つうじょうばん] [でぃすく1/2]"
   name-en: "Cool Girl [Standard Edition] [Disc 1 of 2]"
   region: "NTSC-J"
   memcardFilters:
@@ -41312,7 +41615,7 @@ SLPM-65506:
     - "SLPM-65742"
 SLPM-65507:
   name: "COOL GIRL [通常版] [ディスク2/2]"
-  name-sort: "くーる がーる つうじょうばん [でぃすく2/2]"
+  name-sort: "くーる がーる [つうじょうばん] [でぃすく2/2]"
   name-en: "Cool Girl [Standard Edition] [Disc 2 of 2]"
   region: "NTSC-J"
 SLPM-65508:
@@ -41337,7 +41640,7 @@ SLPM-65512:
   region: "NTSC-J"
 SLPM-65513:
   name: "Angel's Feather [通常版]"
-  name-sort: "えんじぇるずふぇざー"
+  name-sort: "えんじぇるずふぇざー [つうじょうばん]"
   name-en: "Angel's Feather [Standard Edition]"
   region: "NTSC-J"
 SLPM-65514:
@@ -41376,22 +41679,22 @@ SLPM-65520:
   region: "NTSC-J"
 SLPM-65521:
   name: "てんたま2wins [通常版]"
-  name-sort: "てんたま2wins"
+  name-sort: "てんたま2wins [つうじょうばん]"
   name-en: "Tentama 2 Wins [Standard Edition]"
   region: "NTSC-J"
 SLPM-65522:
   name: "爆笑！！ 人生回道 NOVAうさぎが見てるぞ！！"
   name-sort: "ばくしょう！！ じんせいかいどう NOVAうさぎがみているぞ！！"
-  name-en: "Bakushou!! Jinsei Kaidou - Nova Usagi ga Miteru zo!!"
+  name-en: "Bakushou！！ Jinsei Kaidou - Nova Usagi ga Miteru zo！！"
   region: "NTSC-J"
 SLPM-65523:
-  name: "ふらせら Hurrah！Sailor 通常版"
-  name-sort: "ふらせら Hurrah！Sailor"
-  name-en: "Hurrah! Sailor [Standard Edition]"
+  name: "ふらせら Hurrah！Sailor [通常版]"
+  name-sort: "ふらせら Hurrah！Sailor [つうじょうばん]"
+  name-en: "Hurrah！ Sailor [Standard Edition]"
   region: "NTSC-J"
 SLPM-65524:
-  name: "オレンジポケット -リュート- 初回限定版"
-  name-sort: "おれんじぽけっと -りゅーと- しょかいげんていばん"
+  name: "オレンジポケット -リュート- [初回限定版]"
+  name-sort: "おれんじぽけっと -りゅーと- [しょかいげんていばん]"
   name-en: "Orange Pocket - Root [Limited Edition]"
   region: "NTSC-J"
 SLPM-65525:
@@ -41433,8 +41736,8 @@ SLPM-65532:
   region: "NTSC-J"
 SLPM-65533:
   name: "ピューと吹く！ジャガー 明日のジャンプ [初回限定版]"
-  name-sort: "ぴゅーとふく！じゃがー あしたのじゃんぷ しょかいげんていばん"
-  name-en: "Pyu to Fuku! Jaguar Ashita no Japan"
+  name-sort: "ぴゅーとふく！じゃがー あしたのじゃんぷ [しょかいげんていばん]"
+  name-en: "Pyu to Fuku！ Jaguar Ashita no Japan [Limited Edition]"
   region: "NTSC-J"
 SLPM-65534:
   name: "ローグオプス"
@@ -41446,7 +41749,7 @@ SLPM-65534:
 SLPM-65535:
   name: "おしえて！ ぽぽたん"
   name-sort: "おしえて！ ぽぽたん"
-  name-en: "Oshiete! Popotan"
+  name-en: "Oshiete！ Popotan"
   region: "NTSC-J"
 SLPM-65536:
   name: "封神演義2 [KOEI The Best]"
@@ -41551,7 +41854,7 @@ SLPM-65553:
 SLPM-65554:
   name: "コロッケ！～バン王の危機を救え～"
   name-sort: "ころっけ！ ばんおうのききをすくえ"
-  name-en: "Croket! Ban-King no Kiki o Sukue"
+  name-en: "Croket！ Ban-King no Kiki o Sukue"
   region: "NTSC-J"
 SLPM-65555:
   name: "ドラゴンクエストⅤ 天空の花嫁"
@@ -41672,7 +41975,7 @@ SLPM-65579:
 SLPM-65580:
   name: "クラッシュ・バンディクー 爆走！ニトロカート"
   name-sort: "くらっしゅばんでぃくー ばくそう！にとろかーと"
-  name-en: "Crash Bandicoot - Bakuso! Nitro Kart"
+  name-en: "Crash Bandicoot - Bakuso！ Nitro Kart"
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
@@ -41732,9 +42035,9 @@ SLPM-65589:
   name-en: "Colorful Box - To Love [Standard Edition]"
   region: "NTSC-J"
 SLPM-65590:
-  name: "電車でGO！FINAL-"
-  name-sort: "でんしゃでごーFINAL-"
-  name-en: "Densha de Go! Final"
+  name: "電車でGO！FINAL"
+  name-sort: "でんしゃでごーFINAL"
+  name-en: "Densha de Go！ Final"
   region: "NTSC-J"
 SLPM-65591:
   name: "ロスト・アヤ・ソフィア [限定版]"
@@ -41759,7 +42062,7 @@ SLPM-65594:
 SLPM-65595:
   name: "勝負師伝説 哲也2 玄人頂上決戦 [Athena Best Collection Vol.1]"
   name-sort: "ぎゃんぶらーでんせつ てつや2 くろうとちょうじょうけっせん [Athena Best Collection Vol.1]"
-  name-en: "Gambler Densetsu Tetsuya 2  [Athena Best Collection]"
+  name-en: "Gambler Densetsu Tetsuya 2 [Athena Best Collection]"
   region: "NTSC-J"
 SLPM-65596:
   name: "十二国記 赫々たる王道紅緑の羽化"
@@ -41805,9 +42108,9 @@ SLPM-65603:
   name-en: "Run Like Hell"
   region: "NTSC-J"
 SLPM-65604:
-  name: "アニメバトル 烈火の炎 FINAL BURNING <初回生産限定仕様>"
+  name: "アニメバトル 烈火の炎 FINAL BURNING [初回生産限定仕様]"
   name-sort: "あにめばとる れっかのほのお FINAL BURNING [しょかいせいさんげんていしよう]"
-  name-en: "Anime Battle - Rekka no Honoo - Flame of Recca - Final Burning"
+  name-en: "Anime Battle - Rekka no Honoo - Flame of Recca - Final Burning [Limited Edition]"
   region: "NTSC-J"
   compat: 5
   patches:
@@ -41817,7 +42120,7 @@ SLPM-65604:
         patch=0,EE,00115c00,word,24200001
 SLPM-65607:
   name: "3LDK ～幸せになろうよ～ [初回限定版]"
-  name-sort: "3LDK しあわせになろうよ しょかいげんていばん"
+  name-sort: "3LDK しあわせになろうよ [しょかいげんていばん]"
   name-en: "3LDK - Shiawase ni Narou yo [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-65608:
@@ -41852,7 +42155,7 @@ SLPM-65612:
 SLPM-65613:
   name: "遊戯王 カプセルモンスターコロシアム"
   name-sort: "ゆうぎおう かぷせるもんすたーころしあむ"
-  name-en: "Yu-Gi-Oh! Capsule Monster Coliseum"
+  name-en: "Yu-Gi-Oh！ Capsule Monster Coliseum"
   region: "NTSC-J"
 SLPM-65614:
   name: "ニード・フォー・スピード アンダーグラウンド [EA BEST HITS]"
@@ -41881,8 +42184,8 @@ SLPM-65617:
   region: "NTSC-J"
 SLPM-65618:
   name: "ベルセルク 千年帝国の鷹篇 聖魔戦記の章 [体験版]"
-  name-sort: "べるせるく みれにあむ ふぁるこんへん せいませんきのしょう[たいけんばん]"
-  name-en: "Berserk - Sennenteikoku no Takahen Seimasenki no Shou [Trial]"
+  name-sort: "べるせるく みれにあむ ふぁるこんへん せいませんきのしょう [たいけんばん]"
+  name-en: "Berserk - Millennium Falcon-hen - Seima Senki no Shou [Trial]"
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Partially fixes HUD elements.
@@ -41894,8 +42197,8 @@ SLPM-65619:
   name-en: "Tom Clancy's Ghost Recon - Jungle Storm"
   region: "NTSC-J"
 SLPM-65620:
-  name: "悪代官2 ～妄想伝～ [グローバル ザ・ベスト]"
-  name-sort: "あくだいかん2 ～もうそうでん～ [ぐろーばる ざ・べすと]"
+  name: "悪代官2 ～妄想伝～ [GLOBAL The Best]"
+  name-sort: "あくだいかん2 ～もうそうでん～ [GLOBAL The Best]"
   name-en: "Akudaikan 2 - Mousouden [Global The Best]"
   region: "NTSC-J"
 SLPM-65621:
@@ -41915,7 +42218,6 @@ SLPM-65622:
     - SoftwareRendererFMVHack # Fixes blackscreen when FMV.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes menu transparancy effects and text.
-    deinterlace: 9 # Fixes incorrect field order in FMVs.
   memcardFilters:
     - "SLPM-65257"
     - "SLPM-65622"
@@ -41932,7 +42234,7 @@ SLPM-65623:
 SLPM-65624:
   name: "DEAR BOYS Fast Break！ [コナミ殿堂セレクション]"
   name-sort: "でぃあ ぼーいず ふぁすと ぶれいく！ [こなみでんどうせれくしょん]"
-  name-en: "Dear Boys Fast Break! [Konami Palace Collection]"
+  name-en: "Dear Boys Fast Break！ [Konami Palace Collection]"
   region: "NTSC-J"
 SLPM-65625:
   name: "あしたのジョー～まっ白に燃え尽きろ！～ [KONAMI The BEST]"
@@ -41942,10 +42244,10 @@ SLPM-65625:
 SLPM-65626:
   name: "恐怖新聞【平成版】～怪奇！心霊ファイル～ [KONAMI The BEST]"
   name-sort: "きょうふしんぶん へいせいばん かいき！しんれいふぁいる [KONAMI The BEST]"
-  name-en: "Kyoufu Shinbun (Heisei-Han) Kaiki! Shinrei File [KONAMI The BEST]"
+  name-en: "Kyoufu Shinbun (Heisei-Han) Kaiki！ Shinrei File [KONAMI The BEST]"
   region: "NTSC-J"
 SLPM-65627:
-  name: "ゲゲゲの鬼太郎 異聞妖怪奇譚  [KONAM the Best]"
+  name: "ゲゲゲの鬼太郎 異聞妖怪奇譚 [KONAM the Best]"
   name-sort: "げげげのきたろう いぶんようかいきたん [KONAM the Best]"
   name-en: "Gegege no Kitarou [KONAMI The BEST]"
   region: "NTSC-J"
@@ -42053,7 +42355,7 @@ SLPM-65646:
 SLPM-65647:
   name: "遊戯王真デュエルモンスターズⅡ 継承されし記憶 [KONAMI The Best]"
   name-sort: "ゆうぎおうしんでゅえるもんすたーず2 けいしょうされしきおく [KONAMI The Best]"
-  name-en: "Yu-Gi-Oh!Shin Duel-Monsters 2 -Keishousaresshi Kioku [KONAMI The BEST]"
+  name-en: "Yu-Gi-Oh！Shin Duel-Monsters 2 -Keishousaresshi Kioku [KONAMI The BEST]"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 2 # Partially fixes battle animation.
@@ -42098,7 +42400,7 @@ SLPM-65653:
 SLPM-65654:
   name: "解決！オサバキーナ"
   name-sort: "かいけつ！おさばきーな"
-  name-en: "Kaiketsu! Osabakiina"
+  name-en: "Kaiketsu！ Osabakiina"
   region: "NTSC-J"
 SLPM-65655:
   name: "ファインディング・ニモ YUKE'S the BEST"
@@ -42123,9 +42425,9 @@ SLPM-65660:
   name-en: "Shirachuu Tankenbu [TAITO BEST]"
   region: "NTSC-J"
 SLPM-65661:
-  name: "電車でGo！ プロフェッショナル2 [TAITO BEST]"
+  name: "電車でGO！ プロフェッショナル2 [TAITO BEST]"
   name-sort: "でんしゃでごー ぷろふぇっしょなる2 [TAITO BEST]"
-  name-en: "Densha de Go! Professional 2 [TAITO BEST]"
+  name-en: "Densha de Go！ Professional 2 [TAITO BEST]"
   region: "NTSC-J"
 SLPM-65662:
   name: "スパイダーマン 2"
@@ -42141,7 +42443,7 @@ SLPM-65662:
 SLPM-65663:
   name: "ツヴァイ！！"
   name-sort: "つゔぁい！！"
-  name-en: "Zwei!!"
+  name-en: "Zwei！！"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 2
@@ -42164,7 +42466,7 @@ SLPM-65666:
   clampModes:
     vuClampMode: 2 # Missing geometry with microVU.
 SLPM-65668:
-  name: "スペクトラルフォース ラジカルエレメンツ 限定版"
+  name: "スペクトラルフォース ラジカルエレメンツ [限定版]"
   name-sort: "すぺくとらるふぉーす らじかるえれめんつ [げんていばん]"
   name-en: "Spectral Force - Radical Elements [Limited Edition]"
   region: "NTSC-J"
@@ -42211,12 +42513,12 @@ SLPM-65676:
 SLPM-65677:
   name: "テニスの王子様 Smash Hit！ [KONAMI The BEST]"
   name-sort: "てにすのおうじさま Smash Hit！ [KONAMI The BEST]"
-  name-en: "Prince of Tennis - Smash Hit! [KONAMI The BEST]"
+  name-en: "Prince of Tennis - Smash Hit！ [KONAMI The BEST]"
   region: "NTSC-J"
 SLPM-65678:
   name: "テニスの王子様 Smash Hit！2 [KONAMI The BEST]"
   name-sort: "てにすのおうじさま Smash Hit！2 [KONAMI The BEST]"
-  name-en: "Prince of Tennis - Smash Hit! 2 [KONAMI The BEST]"
+  name-en: "Prince of Tennis - Smash Hit！ 2 [KONAMI The BEST]"
   region: "NTSC-J"
   gsHWFixes:
     forceEvenSpritePosition: 1 # Fixes screen shake when upscaling.
@@ -42241,8 +42543,8 @@ SLPM-65682:
   name-en: "Monochrome"
   region: "NTSC-J"
 SLPM-65683:
-  name: "ヴィオラートのアトリエ～グラムナートの錬金術士2～ [ガストベストプライス]"
-  name-sort: "ゔぃおらーとのあとりえ ぐらむなーとのれんきんじゅつし2 [がすとべすとぷらいす]"
+  name: "ヴィオラートのアトリエ～グラムナートの錬金術士2～ [ガストBest Price]"
+  name-sort: "ゔぃおらーとのあとりえ ぐらむなーとのれんきんじゅつし2 [がすとBest Price]"
   name-en: "Violet no Atelier - Gramnad no Renkinjutsushi [Gust Best Price]"
   region: "NTSC-J"
   gsHWFixes:
@@ -42316,7 +42618,7 @@ SLPM-65692:
 SLPM-65693:
   name: "ときめきメモリアル3 ～約束のあの場所で～ [コナミ殿堂セレクション]"
   name-sort: "ときめきめもりある3 やくそくのあのばしょで [こなみでんどうせれくしょん]"
-  name-en: "Tokimeki Memorial 3 [Konami Palace Selection]"
+  name-en: "Tokimeki Memorial 3 [Konami Dendou Selection]"
   region: "NTSC-J"
 SLPM-65694:
   name: "幻想水滸伝Ⅲ [コナミ殿堂セレクション]"
@@ -42465,7 +42767,7 @@ SLPM-65721:
   name-en: "Pro Yakyuu Spirits 2004 Climax"
   region: "NTSC-J"
 SLPM-65722:
-  name: "エアフォースデルタ ブルーウィングナイツ  [KONAMI The BEST]"
+  name: "エアフォースデルタ ブルーウィングナイツ [KONAMI The BEST]"
   name-sort: "えあふぉーすでるた ぶるーうぃんぐないつ [KONAMI The BEST]"
   name-en: "Airforce Delta - Blue Wing Knights [KONAMI The BEST]"
   region: "NTSC-J"
@@ -42551,7 +42853,7 @@ SLPM-65734:
   name-en: "Kita he - Diamond Dust [Hudson The Best]"
   region: "NTSC-J"
 SLPM-65735:
-  name: "蒼のままで・・・・・・ 限定版"
+  name: "蒼のままで・・・・・・ [限定版]"
   name-sort: "あおのままで [げんていばん]"
   name-en: "Ao no Mamade [Treasure Box]"
   region: "NTSC-J"
@@ -42573,7 +42875,7 @@ SLPM-65738:
 SLPM-65739:
   name: "ティム・バートン ナイトメアー・ビフォア・クリスマス ブギーの逆襲"
   name-sort: "てぃむばーとん ないとめあー びふぉあ くりすます ぶぎーのぎゃくしゅう"
-  name-en: "Nightmare Before Christmas"
+  name-en: "Tim Burton's The Nightmare Before Christmas - Oogie no Gyakushuu"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -42747,14 +43049,14 @@ SLPM-65763:
     halfPixelOffset: 4 # Fixes offset post processing.
     nativeScaling: 2 # Fixes post processing.
 SLPM-65764:
-  name: "メンアットワーク！3 愛と青春のハンター学園 初回限定版"
-  name-sort: "めんあっとわーく！3 あいとせいしゅんのはんたーがくえん しょかいげんていばん"
-  name-en: "Men at Work! 3 [First Print Limited Edition]"
+  name: "メンアットワーク！3 愛と青春のハンター学園 [初回限定版]"
+  name-sort: "めんあっとわーく！3 あいとせいしゅんのはんたーがくえん [しょかいげんていばん]"
+  name-en: "Men at Work！ 3 [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-65765:
   name: "メンアットワーク！3 愛と青春のハンター学園"
   name-sort: "めんあっとわーく！3 あいとせいしゅんのはんたーがくえん"
-  name-en: "Men at Work! 3"
+  name-en: "Men at Work！ 3"
   region: "NTSC-J"
 SLPM-65766:
   name: "ニード・フォー・スピード アンダーグラウンド2"
@@ -42805,7 +43107,7 @@ SLPM-65775:
   region: "NTSC-J"
   compat: 5
 SLPM-65776:
-  name: "天空断罪 スケルターヘブン 限定版"
+  name: "天空断罪 スケルターヘブン [限定版]"
   name-sort: "てんくうだんざい すけるたーへぶん [げんていばん]"
   name-en: "Tenkuu Danzai - Skelter Heaven [Limited Edition]"
   region: "NTSC-J"
@@ -42841,7 +43143,7 @@ SLPM-65783:
   region: "NTSC-J"
 SLPM-65785:
   name: "なついろ ～星屑のメモリー～ [初回限定版]"
-  name-sort: "なついろ ほしくずのめもりー しょかいげんていばん"
+  name-sort: "なついろ ほしくずのめもりー [しょかいげんていばん]"
   name-en: "Natsuiro - Hoshikuzu no Memory [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-65786:
@@ -42965,7 +43267,7 @@ SLPM-65800:
 SLPM-65801:
   name: "クラッシュ・バンディクー5 え～っクラッシュとコルテックスの野望?！?"
   name-sort: "くらっしゅばんでぃくー5 えーっくらっしゅとこるてっくすのやぼう?！?"
-  name-en: "Crash Bandicoot 5 - Eh Crash to Cortex no Yabou?!?"
+  name-en: "Crash Bandicoot 5 - Eh Crash to Cortex no Yabou?！?"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -43011,7 +43313,7 @@ SLPM-65807:
 SLPM-65808:
   name: "ダビつく4 ダービー馬をつくろう！"
   name-sort: "だびつく4 だーびーばをつくろう！"
-  name-en: "Derby Tsuku 4 - Derby Uma o Tsukurou!"
+  name-en: "Derby Tsuku 4 - Derby Uma o Tsukurou！"
   region: "NTSC-J"
 SLPM-65809:
   name: "NANO BREAKER"
@@ -43021,7 +43323,7 @@ SLPM-65809:
 SLPM-65810:
   name: "電車でGO！ ～旅情編～ [TAITO BEST]"
   name-sort: "でんしゃでごー りょじょうへん [TAITO BEST]"
-  name-en: "Densha de Go! Ryojou-hen [TAITO BEST]"
+  name-en: "Densha de Go！ Ryojou-hen [TAITO BEST]"
   region: "NTSC-J"
 SLPM-65811:
   name: "零式艦上戦闘記 [TAITO BEST]"
@@ -43031,10 +43333,10 @@ SLPM-65811:
 SLPM-65812:
   name: "爆笑！！人生回道 NOVAうさぎが見てるぞ！！ [TAITO BEST]"
   name-sort: "ばくしょう！！じんせいかいどう NOVAうさぎがみてるぞ！！ [TAITO BEST]"
-  name-en: "Bakushou! Jinsei Kaimichi [TAITO BEST]"
+  name-en: "Bakushou！ Jinsei Kaimichi [TAITO BEST]"
   region: "NTSC-J"
 SLPM-65813:
-  name: "風雲 幕末伝"
+  name: "風雲幕末伝"
   name-sort: "ふううん ばくまつでん"
   name-en: "Fu-un Bakumatsu Den"
   region: "NTSC-J"
@@ -43057,22 +43359,22 @@ SLPM-65816:
 SLPM-65817:
   name: "テニスの王子様 Love of Prince Sweet [コナミ殿堂セレクション]"
   name-sort: "てにすのおうじさま Love of Prince Sweet [こなみでんどうせれくしょん]"
-  name-en: "Tennis no Oji-Sama - Love of Prince Sweet [Konami Palace Selection]"
+  name-en: "Tennis no Oji-Sama - Love of Prince Sweet [Konami Dendou Selection]"
   region: "NTSC-J"
 SLPM-65818:
   name: "テニスの王子様 Love of Prince Bitter [コナミ殿堂セレクション]"
   name-sort: "てにすのおうじさま Love of Prince Bitter [こなみでんどうせれくしょん]"
-  name-en: "Tennis no Oji-Sama - Love of Prince Bitter [Konami Palace Selection]"
+  name-en: "Tennis no Oji-Sama - Love of Prince Bitter [Konami Dendou Selection]"
   region: "NTSC-J"
 SLPM-65819:
   name: "テニスの王子様 Kiss of Prince ICE [コナミ殿堂セレクション]"
   name-sort: "てにすのおうじさま Kiss of Prince ICE [こなみでんどうせれくしょん]"
-  name-en: "Tennis no Oji-Sama - Kiss of Prince - Ice Version [Konami Palace Selection]"
+  name-en: "Tennis no Oji-Sama - Kiss of Prince - Ice Version [Konami Dendou Selection]"
   region: "NTSC-J"
 SLPM-65820:
   name: "テニスの王子様 Kiss of Prince FLAME [コナミ殿堂セレクション]"
   name-sort: "てにすのおうじさま Kiss of Prince FLAME [こなみでんどうせれくしょん]"
-  name-en: "Tennis no Oji-Sama - Kiss of Prince - Flame Version [Konami Palace Selection]"
+  name-en: "Tennis no Oji-Sama - Kiss of Prince - Flame Version [Konami Dendou Selection]"
   region: "NTSC-J"
 SLPM-65821:
   name: "新世紀勇者大戦"
@@ -43092,7 +43394,7 @@ SLPM-65823:
 SLPM-65824:
   name: "ビューティフルジョー2 ブラックフィルムの謎"
   name-sort: "びゅーてぃふるじょー2 ぶらっくふぃるむのなぞ"
-  name-en: "Viewtiful Joe 2"
+  name-en: "Viewtiful Joe 2 - Black Film no Nazo"
   region: "NTSC-J"
   compat: 5
 SLPM-65825:
@@ -43109,7 +43411,7 @@ SLPM-65826:
 SLPM-65828:
   name: "AngelWish 君の笑顔にチュッ！"
   name-sort: "えんぜるうぃっしゅ きみのえがおにちゅっ"
-  name-en: "Angel Wish - Kimi no Egao ni Chu!"
+  name-en: "Angel Wish - Kimi no Egao ni Chu！"
   region: "NTSC-J"
 SLPM-65829:
   name: "イース ～ナピシュテムの匣～ [限定版]"
@@ -43120,8 +43422,8 @@ SLPM-65829:
     - EETimingHack
 SLPM-65830:
   name: "イース ～ナピシュテムの匣～ [初回生産版]"
-  name-sort: "いーす6 なぴしゅてむのはこ しょかいせいさんばん"
-  name-en: "Ys - The Ark of Napishtim"
+  name-sort: "いーす6 なぴしゅてむのはこ [しょかいせいさんばん]"
+  name-en: "Ys - The Ark of Napishtim [Limited Edition]"
   region: "NTSC-J"
   gameFixes:
     - EETimingHack
@@ -43369,9 +43671,9 @@ SLPM-65874:
   name-en: "Simple 2000 Series Vol. 71 - The Fantasy Renai Adventure - Kanojo no Densetsu"
   region: "NTSC-J"
 SLPM-65875:
-  name: "グローランサーⅣ ～ Wayfarer of the time ～ [Atlus Best Collection]"
-  name-sort: "ぐろーらんさー4 ～ Wayfarer of the time ～ [Atlus Best Collection]"
-  name-en: "Growlanser IV - Wayfarer of the Time [Atlus The Best]"
+  name: "グローランサーⅣ ～ Wayfarer of the time ～ [ATLUS BEST COLLECTION]"
+  name-sort: "ぐろーらんさー4 ～ Wayfarer of the time ～ [ATLUS BEST COLLECTION]"
+  name-en: "Growlanser IV - Wayfarer of the Time [Atlus Best Collection]"
   region: "NTSC-J"
 SLPM-65876:
   name: "BUSIN 0 ～Wizardry Alternative NEO～ [Atlus Best Collection]"
@@ -43479,8 +43781,8 @@ SLPM-65892:
   name-en: "Zill O'll Infinite"
   region: "NTSC-J"
 SLPM-65893:
-  name: "Winning Post6 Maximum 2005 プレミアムパック"
-  name-sort: "ういにんぐぽすと6 Maximum 2005 ぷれみあむぱっく"
+  name: "Winning Post6 Maximum 2005 [プレミアムパック]"
+  name-sort: "ういにんぐぽすと6 Maximum 2005 [ぷれみあむぱっく]"
   name-en: "Winning Post 6 Maximum 2005 [Premium Pack]"
   region: "NTSC-J"
 SLPM-65894:
@@ -43519,7 +43821,7 @@ SLPM-65899:
 SLPM-65900:
   name: "サクラ大戦3 ～巴里は燃えているか～ [初回プレス版]"
   name-sort: "さくらたいせん3 ぱりはもえているか [しょかいぷれすばん]"
-  name-en: "Sakura Taisen 3 - Remake"
+  name-en: "Sakura Taisen 3 - Remake [Limited Edition]"
   region: "NTSC-J"
   compat: 2
 SLPM-65901:
@@ -43644,7 +43946,7 @@ SLPM-65920:
 SLPM-65921:
   name: "Piaキャロットへようこそ！！3～round summer～ [ベスト版]"
   name-sort: "ぴあきゃろっとへようこそ！！3 ～らうんど さまー～ [べすとばん]"
-  name-en: "Welcome to Pia Carrot!! 3 - eound summer - [BEST Version]"
+  name-en: "Welcome to Pia Carrot！！ 3 - eound summer - [BEST Version]"
   region: "NTSC-J"
 SLPM-65922:
   name: "あいかぎ ～ぬくもりとひだまりの中で～ [ベスト版]"
@@ -43693,9 +43995,9 @@ SLPM-65929:
   name-en: "Pro Yakyuu Spirits 2"
   region: "NTSC-J"
 SLPM-65930:
-  name: "EVE burst error PLUS [ゲームビレッジ・ザ・ベスト]"
-  name-sort: "いヴ ばーすと えらー ぷらす [げーむびれっじ・ざ・べすと]"
-  name-en: "EVE - Burst Error Plus [GameBridge The Best]"
+  name: "EVE burst error PLUS [GameVillage The Best]"
+  name-sort: "いヴ ばーすと えらー ぷらす [GameVillage The Best]"
+  name-en: "EVE - Burst Error Plus [GameVillage The Best]"
   region: "NTSC-J"
 SLPM-65931:
   name: "新紀幻想スペクトラルソウルズ [IFコレクション]"
@@ -43738,8 +44040,8 @@ SLPM-65939:
   name-en: "Memories Off - After Rain Vol.3"
   region: "NTSC-J"
 SLPM-65940:
-  name: "マビノ×スタイル 初回限定版"
-  name-sort: "まびのすたいる しょかいげんていばん"
+  name: "マビノ×スタイル [初回限定版]"
+  name-sort: "まびのすたいる [しょかいげんていばん]"
   name-en: "Mabino x Style [Limited Edition]"
   region: "NTSC-J"
 SLPM-65941:
@@ -43762,9 +44064,9 @@ SLPM-65943:
   name-en: "Angel's Feather"
   region: "NTSC-J"
 SLPM-65944:
-  name: "ワークジャム ベストコレクション Vol.2 探偵 神宮寺三郎 KIND OF BLUE"
-  name-sort: "わーくじゃむ べすとこれくしょん Vol.2 たんてい じんぐうじさぶろう KIND OF BLUE"
-  name-en: "Detective Saburou Jinguiji 9 - Kind of Blue [Workjam Best Collection - Vol.2]"
+  name: "探偵 神宮寺三郎 KIND OF BLUE [ワークジャム ベストコレクション Vol.2 ]"
+  name-sort: "たんてい じんぐうじさぶろう KIND OF BLUE [わーくじゃむ べすとこれくしょん Vol.2]"
+  name-en: "Tantei Jinguuji Saburou - Kind of Blue [Workjam Best Collection - Vol.2]"
   region: "NTSC-J"
 SLPM-65945:
   name: "紅忍 ～血河の舞～"
@@ -43798,7 +44100,7 @@ SLPM-65948:
 SLPM-65949:
   name: "Get Ride！アムドライバー ～相克の真実～"
   name-sort: "げっと らいど！あむどらいばー そうこくのしんじつ"
-  name-en: "Get Ride! AM Driver - The Truth of Xiangke"
+  name-en: "Get Ride！ AM Driver - The Truth of Xiangke"
   region: "NTSC-J"
 SLPM-65950:
   name: "GANTZ"
@@ -43824,13 +44126,13 @@ SLPM-65953:
   name-en: "Final Fantasy XI [Entry Disc 2005]"
   region: "NTSC-J"
 SLPM-65954:
-  name: "トム・クランシーシリーズ ゴーストリコン [ユービーアイベスト]"
-  name-sort: "とむくらんしーしりーず ごーすとりこん [ゆーびーあいべすと]"
+  name: "トム・クランシーシリーズ ゴーストリコン [UBISOFT BEST]"
+  name-sort: "とむくらんしーしりーず ごーすとりこん [UBISOFT BEST]"
   name-en: "Tom Clancy's Ghost Recon [Ubisoft Best]"
   region: "NTSC-J"
 SLPM-65955:
-  name: "トム・クランシーシリーズ スプリンターセル [ユービーアイソフトベスト]"
-  name-sort: "とむくらんしーしりーず すぷりんたーせる [ゆーびーあいそふとべすと]"
+  name: "トム・クランシーシリーズ スプリンターセル [UBISOFT BEST]"
+  name-sort: "とむくらんしーしりーず すぷりんたーせる [UBISOFT BEST]"
   name-en: "Tom Clancy's Splinter Cell [Ubisoft Best]"
   region: "NTSC-J"
 SLPM-65957:
@@ -43881,7 +44183,7 @@ SLPM-65963:
   region: "NTSC-J"
 SLPM-65964:
   name: "まじかる☆ている ～ちっちゃな魔法使い～ [初回限定版]"
-  name-sort: "まじかるている ちっちゃなまほうつかい しょかいげんていばん"
+  name-sort: "まじかるている ちっちゃなまほうつかい [ょかいげんていばん]"
   name-en: "Magical Tale - Chitchana Mahoutsukai [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-65965:
@@ -43900,8 +44202,8 @@ SLPM-65967:
   name-en: "Spectral Force Chronicle"
   region: "NTSC-J"
 SLPM-65968:
-  name: "らぶドル ～Lovely Idol～ 初回限定版"
-  name-sort: "らぶどる ～Lovely Idol～ しょかいげんていばん"
+  name: "らぶドル ～Lovely Idol～ [初回限定版]"
+  name-sort: "らぶどる ～Lovely Idol～ [しょかいげんていばん]"
   name-en: "Lovely Doll - Lovely Idol [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-65969:
@@ -43912,7 +44214,7 @@ SLPM-65969:
 SLPM-65970:
   name: "カッパの飼い方 -How to breed kappas- [コナミ殿堂セレクション]"
   name-sort: "かっぱのかいかた -How to breed kappas- [こなみでんどうせれくしょん]"
-  name-en: "Kappa no Kai-Kata - How to Breed Kappas [Konami Palace Selection]"
+  name-en: "Kappa no Kai-Kata - How to Breed Kappas [Konami Dendou Selection]"
   region: "NTSC-J"
 SLPM-65971:
   name: "そして僕らは、・・・and he said"
@@ -43934,7 +44236,7 @@ SLPM-65973:
 SLPM-65974:
   name: "喧嘩番長 [初回生産版]"
   name-sort: "けんかばんちょう [しょかいせいさんばん]"
-  name-en: "Kenka Banchou"
+  name-en: "Kenka Banchou [First Limited Edition]"
   region: "NTSC-J"
 SLPM-65975:
   name: "WRC4"
@@ -44016,12 +44318,12 @@ SLPM-65985:
 SLPM-65986:
   name: "Quartett！～THE STAGE OF LOVE～ [初回限定版]"
   name-sort: "かるてっと！～ざ すてーじ おぶ らぶ～ [しょかいげんていばん]"
-  name-en: "Quartett! The Stage of Love [First Print Limited Edition]"
+  name-en: "Quartett！ The Stage of Love [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-65987:
   name: "Quartett！～THE STAGE OF LOVE～ [通常版]"
   name-sort: "かるてっと！～ざ すてーじ おぶ らぶ～ [つうじょうばん]"
-  name-en: "Quartett! The Stage of Love [Standard Edition]"
+  name-en: "Quartett！ The Stage of Love [Standard Edition]"
   region: "NTSC-J"
 SLPM-65988:
   name: "少女義経伝・弐 ～刻を超える契り～ [特別版]"
@@ -44036,7 +44338,7 @@ SLPM-65989:
 SLPM-65990:
   name: "NEO CONTRA [コナミ殿堂セレクション]"
   name-sort: "ねお こんとら [こなみでんどうせれくしょん]"
-  name-en: "Neo Contra [Konami Palace Selection]"
+  name-en: "Neo Contra [Konami Dendou Selection]"
   region: "NTSC-J"
   roundModes:
     eeRoundMode: 0 # Reduces FPU calculation errors.
@@ -44095,8 +44397,8 @@ SLPM-65999:
     mergeSprite: 1 # Align sprite fixes FMVs but not garbage in-game, so needs merge sprite instead.
     texturePreloading: 1 # Performs better with partial preload because it is slow on locations outside gameplay foremost.
 SLPM-66000:
-  name: "コンフリクトデルタII ～湾岸戦争1991～"
-  name-sort: "こんふりくとでるたII わんがんせんそう1991"
+  name: "コンフリクトデルタⅡ ～湾岸戦争1991～"
+  name-sort: "こんふりくとでるた2 わんがんせんそう1991"
   name-en: "Conflict Delta II - Gulf War 1991"
   region: "NTSC-J"
   gameFixes:
@@ -44154,29 +44456,29 @@ SLPM-66009:
 SLPM-66010:
   name: "テニスの王子様 Smash Hit！ [コナミ殿堂セレクション]"
   name-sort: "てにすのおうじさま Smash Hit！ [こなみでんどうせれくしょん]"
-  name-en: "Tennis no Oji-Sama - Smash-Hit! [Konami Palace Selection]"
+  name-en: "Tennis no Oji-Sama - Smash-Hit！ [Konami Dendou Selection]"
   region: "NTSC-J"
 SLPM-66011:
   name: "テニスの王子様 Smash Hit！2 [コナミ殿堂セレクション]"
   name-sort: "てにすのおうじさま Smash Hit！2 [こなみでんどうせれくしょん]"
-  name-en: "Tennis no Oji-Sama - Smash-Hit! 2 [Konami Palace Selection]"
+  name-en: "Tennis no Oji-Sama - Smash-Hit！ 2 [Konami Dendou Selection]"
   region: "NTSC-J"
   gsHWFixes:
     forceEvenSpritePosition: 1 # Fixes screen shake when upscaling.
 SLPM-66012:
   name: "テニスの王子様SWEAT&TEARS 2 [コナミ殿堂セレクション]"
   name-sort: "てにすのおうじさまSWEAT&TEARS 2 [こなみでんどうせれくしょん]"
-  name-en: "Tennis no Oji-Sama - Sweat & Tears 2 [Konami Palace Selection]"
+  name-en: "Tennis no Oji-Sama - Sweat & Tears 2 [Konami Dendou Selection]"
   region: "NTSC-J"
 SLPM-66013:
   name: "テニスの王子様最強チームを結成せよ！ [コナミ殿堂セレクション]"
   name-sort: "てにすのおうじさまさいきょうちーむをけっせいせよ！ [こなみでんどうせれくしょん]"
-  name-en: "Tennis no Oji-Sama - Form the Strongest Team [Konami Palace Selection]"
+  name-en: "Tennis no Oji-Sama - Form the Strongest Team [Konami Dendou Selection]"
   region: "NTSC-J"
 SLPM-66014:
   name: "テニスの王子様 RUSH&DREAM！ [コナミ殿堂セレクション]"
   name-sort: "てにすのおうじさま RUSH&DREAM！ [こなみでんどうせれくしょん]"
-  name-en: "Tennis no Oji-Sama - Rush & Dream [Konami Palace Selection]"
+  name-en: "Tennis no Oji-Sama - Rush & Dream [Konami Dendou Selection]"
   region: "NTSC-J"
 SLPM-66015:
   name: "SuperLite 2000 アドベンチャー 藍より青し"
@@ -44186,7 +44488,7 @@ SLPM-66015:
 SLPM-66016:
   name: "実戦パチスロ必勝法！ 鬼武者 3"
   name-sort: "じっせんぱちすろひっしょうほう！ おにむしゃ 3"
-  name-en: "Jissen Pachi-Slot Hisshouhou! Onimusha3"
+  name-en: "Jissen Pachi-Slot Hisshouhou！ Onimusha3"
   region: "NTSC-J"
 SLPM-66017:
   name: "FIRE FIGHTER F.D.18 [コナミ殿堂セレクション]"
@@ -44207,7 +44509,6 @@ SLPM-66018:
     - SoftwareRendererFMVHack # Fixes blackscreen when FMV.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes menu transparancy effects and text.
-    deinterlace: 9 # Fixes incorrect field order in FMVs.
   memcardFilters:
     - "SLPM-65257"
     - "SLPM-65622"
@@ -44388,8 +44689,8 @@ SLPM-66049:
   name-en: "D.C.P.S. - Da Capo Plus Situation [Kadokawa the Best]"
   region: "NTSC-J"
 SLPM-66050:
-  name: "第三帝国興亡記 II"
-  name-sort: "だいさんていこくこうぼうき II"
+  name: "第三帝国興亡記Ⅱ"
+  name-sort: "だいさんていこくこうぼうき2"
   name-en: "Daisan Teikoku Koubouki II - Aufstieg und Fall des Dritten Reich"
   region: "NTSC-J"
 SLPM-66051:
@@ -44459,12 +44760,12 @@ SLPM-66061:
 SLPM-66062:
   name: "魔法先生ネギま！ 2時間目 戦う乙女たち！ 麻帆良大運動会SP！ 金メダル版"
   name-sort: "まほうせんせいねぎま！ 2じかんめ たたかうおとめたち！ まほらだいうんどうかいSP！ きんめだるばん"
-  name-en: "Mahou Sensei Negima! Gold Medal"
+  name-en: "Mahou Sensei Negima！ Gold Medal"
   region: "NTSC-J"
 SLPM-66063:
   name: "魔法先生ネギま！ 2時間目 戦う乙女たち！ 麻帆良大運動会SP！ 銀メダル版"
   name-sort: "まほうせんせいねぎま！ 2じかんめ たたかうおとめたち！ まほらだいうんどうかいSP！ ぎんめだるばん"
-  name-en: "Mahou Sensei Negima! Silver Medal"
+  name-en: "Mahou Sensei Negima！ Silver Medal"
   region: "NTSC-J"
 SLPM-66064:
   name: "TOUGH DARK FIGHT"
@@ -44479,12 +44780,12 @@ SLPM-66065:
 SLPM-66066:
   name: "遊戯王 カプセルモンスターコロシアム [KONAMI The Best]"
   name-sort: "ゆうぎおう かぷせるもんすたーころしあむ [KONAMI The Best]"
-  name-en: "Yu-Gi-Oh! Capsule Monster Coliseum [KONAMI The BEST]"
+  name-en: "Yu-Gi-Oh！ Capsule Monster Coliseum [KONAMI The BEST]"
   region: "NTSC-J"
 SLPM-66067:
   name: "クラッシュ・バンディクー 爆走！ニトロカート [KONAMI The Best]"
   name-sort: "くらっしゅばんでぃくー ばくそう！にとろかーと [KONAMI The Best]"
-  name-en: "Crash Bandicoot - Bakuso! Nitro Kart [KONAMI The BEST]"
+  name-en: "Crash Bandicoot - Bakuso！ Nitro Kart [KONAMI The BEST]"
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
@@ -44576,10 +44877,11 @@ SLPM-66079:
   name-en: "Medal of Honor - European Assault"
   region: "NTSC-J"
   gsHWFixes:
-    recommendedBlendingLevel: 3 # Fixes banding and level lighting.
+    recommendedBlendingLevel: 2
     autoFlush: 1 # Fixes sun shinging through surfaces and graphical corruptions.
     halfPixelOffset: 2 # Fixes misaligned blur.
-    nativeScaling: 2 # Fixes bloom misaligment.
+    cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SLPM-66080:
   name: "Generation of Chaos Ⅲ ～時の封印～ [IFコレクション]"
   name-sort: "じぇねれーしょんおぶかおす 3 ときのふういん [あいであふぁくとりーこれくしょん]"
@@ -44634,7 +44936,7 @@ SLPM-66088:
 SLPM-66089:
   name: "3年B組金八先生 伝説の教壇に立て！ 完全版"
   name-sort: "3ねんBぐみきんぱちせんせい でんせつのきょうだんにたて かんぜんばん"
-  name-en: "3-nen B-gumi Kinpachi Sensei - Densetsu no Kyoudan ni Tate! Kanzenban"
+  name-en: "3-nen B-gumi Kinpachi Sensei - Densetsu no Kyoudan ni Tate！ Kanzenban"
   region: "NTSC-J"
 SLPM-66090:
   name: "クラッシュ・バンディクー がっちゃんこワールド"
@@ -44714,7 +45016,7 @@ SLPM-66101:
   gsHWFixes:
     autoFlush: 2 # Fixes sun luminosity.
 SLPM-66102:
-  name: "Zwei!! [TAITO BEST]"
+  name: "Zwei！！ [TAITO BEST]"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 2
@@ -44748,7 +45050,7 @@ SLPM-66105:
     - "SLPM-65599"
     - "SLPM-65600"
 SLPM-66106:
-  name: "星の降る刻 限定版"
+  name: "星の降る刻 [限定版]"
   name-sort: "ほしのふるとき [げんていばん]"
   name-en: "Hoshi no Furu Toki [Limited Edition]"
   region: "NTSC-J"
@@ -44796,8 +45098,8 @@ SLPM-66111:
   name: "Fushigi no Umi no Nadia - Dennou Battle - Miss Nautilus Contest"
   region: "NTSC-J"
 SLPM-66112:
-  name: "ふしぎの海のナディア 通常版"
-  name-sort: "ふしぎのうみのなでぃあ"
+  name: "ふしぎの海のナディア [通常版]"
+  name-sort: "ふしぎのうみのなでぃあ [つうじょうばん]"
   name-en: "Fushigi no Umi no Nadia - Inherit the Blue Water [Standard Edition]"
   region: "NTSC-J"
 SLPM-66113:
@@ -44812,7 +45114,7 @@ SLPM-66114:
   region: "NTSC-J"
 SLPM-66115:
   name: "水の旋律 [通常版]"
-  name-sort: "みずのせんりつ"
+  name-sort: "みずのせんりつ [つうじょうばん]"
   name-en: "Mizu no Senritsu [Standard Edition]"
   region: "NTSC-J"
 SLPM-66116:
@@ -44930,9 +45232,9 @@ SLPM-66130:
     halfPixelOffset: 4 # Aligns post effects.
     nativeScaling: 2 # Fixes post effects.
 SLPM-66131:
-  name: "ティム・バートン ナイトメアー・ビフォア・クリスマス ブギーの逆襲 プレミアムパック"
-  name-sort: "てぃむばーとん ないとめあー びふぉあ くりすます ぶぎーのぎゃくしゅう ぷれみあむぱっく"
-  name-en: "Tim Burton's The Nightmare Before Christmas [Premium Pack]"
+  name: "ティム・バートン ナイトメアー・ビフォア・クリスマス ブギーの逆襲 [プレミアムパック]"
+  name-sort: "てぃむばーとん ないとめあー びふぉあ くりすます ぶぎーのぎゃくしゅう [ぷれみあむぱっく]"
+  name-en: "Tim Burton's The Nightmare Before Christmas - Oogie no Gyakushuu [Premium Pack]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Aligns post Effect and bloom.
@@ -44947,12 +45249,12 @@ SLPM-66132:
     halfPixelOffset: 4 # Aligns post effects.
     nativeScaling: 1 # Fixes post effects.
 SLPM-66133:
-  name: "Shuffle! On the Stage [Deluxe Pack]"
+  name: "Shuffle！ On the Stage [Deluxe Pack]"
   region: "NTSC-J"
 SLPM-66134:
   name: "シャッフル！オン・ザ・ステージ"
   name-sort: "しゃっふる おん ざ すてーじ"
-  name-en: "Shuffle! On the Stage"
+  name-en: "Shuffle！ On the Stage"
   region: "NTSC-J"
 SLPM-66135:
   name: "WORLD TANK MUSEUM for GAME ワールド タンク ミュージアム フォー ゲーム"
@@ -44996,7 +45298,7 @@ SLPM-66141:
   name-en: "Matantei Loki Ragnarok - Mayouga Ushinawareta Hohoemi"
   region: "NTSC-J"
 SLPM-66142:
-  name: "リバース ムーン 限定版"
+  name: "リバース ムーン [限定版]"
   name-sort: "りばーす むーん [げんていばん]"
   name-en: "Rebirth Moon [Limited Edition]"
   region: "NTSC-J"
@@ -45048,13 +45350,13 @@ SLPM-66148:
     halfPixelOffset: 4 # Corrects post processing positioning.
     nativeScaling: 2 # Smooths post processing.
 SLPM-66149:
-  name: "しろがねの鳥籠 限定版"
+  name: "しろがねの鳥籠 [限定版]"
   name-sort: "しろがねのとりかご [げんていばん]"
   name-en: "Silver Birdcage [Limited Edition]"
   region: "NTSC-J"
 SLPM-66150:
-  name: "しろがねの鳥籠 通常版"
-  name-sort: "しろがねのとりかご"
+  name: "しろがねの鳥籠 [通常版]"
+  name-sort: "しろがねのとりかご [つうじょうばん]"
   name-en: "Silver Birdcage [Standard Edition]"
   region: "NTSC-J"
 SLPM-66151:
@@ -45080,7 +45382,7 @@ SLPM-66153:
 SLPM-66155:
   name: "アニメバトル 烈火の炎 FINAL BURNING [コナミ殿堂セレクション]"
   name-sort: "あにめばとる れっかのほのお FINAL BURNING [こなみでんどうせれくしょん]"
-  name-en: "Flame of Recca - Final Burning [Konami Palace Selection]"
+  name-en: "Flame of Recca - Final Burning [Konami Dendou Selection]"
   region: "NTSC-J"
 SLPM-66156:
   name: "メルヘヴン ARM FIGHT DREAM"
@@ -45229,8 +45531,8 @@ SLPM-66178:
   name-en: "Pop'n music 7 [KONAMI The BEST]"
   region: "NTSC-J"
 SLPM-66179:
-  name: "ポップンミュージック 8 コナミザベスト"
-  name-sort: "ぽっぷんみゅーじっく 8 こなみざ・べすと"
+  name: "ポップンミュージック 8 [KONAMI The BEST]"
+  name-sort: "ぽっぷんみゅーじっく 8 [KONAMI The BEST]"
   name-en: "Pop'n music 8 [KONAMI The BEST]"
   region: "NTSC-J"
 SLPM-66180:
@@ -45271,9 +45573,9 @@ SLPM-66184:
     halfPixelOffset: 4 # Fixes misaligned lighting and bloom.
     bilinearUpscale: 1 # Smooths out bloom.
 SLPM-66185:
-  name: "ゲームになったよ！ドクロちゃん～健康診断大作戦～ 限定版"
+  name: "ゲームになったよ！ドクロちゃん～健康診断大作戦～ [限定版]"
   name-sort: "げーむになったよ！どくろちゃん けんこうしんだんだいさくせん [げんていばん]"
-  name-en: "Game ni Nattayo! Dokuro-chan [Limited Edition]"
+  name-en: "Game ni Nattayo！ Dokuro-chan [Limited Edition]"
   region: "NTSC-J"
   patches:
     169099FC:
@@ -45285,7 +45587,7 @@ SLPM-66185:
 SLPM-66186:
   name: "ゲームになったよ！ドクロちゃん～健康診断大作戦～"
   name-sort: "げーむになったよ どくろちゃん けんこうしんだんだいさくせん"
-  name-en: "Game ni Nattayo! Dokuro-chan"
+  name-en: "Game ni Nattayo！ Dokuro-chan"
   region: "NTSC-J"
   patches:
     169099FC:
@@ -45375,7 +45677,7 @@ SLPM-66202:
   region: "NTSC-J"
 SLPM-66203:
   name: "フラグメンツ・ブルー [通常版]"
-  name-sort: "ふらぐめんつ・ぶるー"
+  name-sort: "ふらぐめんつ・ぶるー [つうじょうばん]"
   name-en: "Fragments Blue [Standard Edition]"
   region: "NTSC-J"
 SLPM-66204:
@@ -45387,7 +45689,7 @@ SLPM-66204:
     vuClampMode: 3 # Missing geometry with microVU.
 SLPM-66205:
   name: "フロントミッション5 ～Scars of the War～"
-  name-sort: "ふろんとみっしょん 5 ～Scars of the War～"
+  name-sort: "ふろんとみっしょん5 ～Scars of the War～"
   name-en: "Front Mission 5 - Scars of the War"
   region: "NTSC-J"
   compat: 5
@@ -45474,7 +45776,7 @@ SLPM-66217:
 SLPM-66218:
   name: "アイシールド21 ～アメフトやろうぜ！Ya-！Ha-！～"
   name-sort: "あいしーるど21 あめふとやろうぜYa-！Ha-！"
-  name-en: "Eyeshield 21 Amefoot Yarouze! Ya-!Ha-!"
+  name-en: "Eyeshield 21 Amefoot Yarouze！ Ya-！Ha-！"
   region: "NTSC-J"
 SLPM-66219:
   name: "テニスの王子様 ～学園祭の王子様～"
@@ -45633,12 +45935,12 @@ SLPM-66235:
 SLPM-66237:
   name: "乙女的恋革命★ラブレボ！！ラブレボックス"
   name-sort: "おとめてきこいかくめい らぶれぼ！！ [らぶれぼっくす]"
-  name-en: "Otometeki Koi Kakumei Rabu Rebo!! [Love Revo Box]"
+  name-en: "Otometeki Koi Kakumei Rabu Rebo！！ [Love Revo Box]"
   region: "NTSC-J"
 SLPM-66238:
   name: "乙女的恋革命★ラブレボ！！"
   name-sort: "おとめてきこいかくめい らぶれぼ！！"
-  name-en: "Otometeki Koi Kakumei Rabu Rebo!!"
+  name-en: "Otometeki Koi Kakumei Rabu Rebo！！"
   region: "NTSC-J"
 SLPM-66239:
   name: "レッスルエンジェルス SURVIVOR"
@@ -45651,12 +45953,12 @@ SLPM-66239:
 SLPM-66240:
   name: "実戦パチスロ必勝法！ アラジン2 エボリューション"
   name-sort: "じっせんぱちすろひっしょうほう！ あらじん2 えぼりゅーしょん"
-  name-en: "Jissen Pachi-Slot Hisshouhou! Aladdin 2 Evolution"
+  name-en: "Jissen Pachi-Slot Hisshouhou！ Aladdin 2 Evolution"
   region: "NTSC-J"
 SLPM-66241:
   name: "実戦パチンコ必勝法！ CR 北斗の拳"
   name-sort: "じっせんぱちんこひっしょうほう CR ほくとのけん"
-  name-en: "Jissen Pachinko Hisshouhou! CR Hokuto no Ken"
+  name-en: "Jissen Pachinko Hisshouhou！ CR Hokuto no Ken"
   region: "NTSC-J"
 SLPM-66242:
   name: "Dance Dance Revolution Strike"
@@ -45674,7 +45976,7 @@ SLPM-66243:
 SLPM-66244:
   name: "ダービー馬をつくろう！5"
   name-sort: "だーびーばをつくろう！5"
-  name-en: "Derby Tsuku 5 - Derby Uma o Tsukurou!"
+  name-en: "Derby Tsuku 5 - Derby Uma o Tsukurou！"
   region: "NTSC-J"
 SLPM-66245:
   name: "ジュエルスオーシャン Star of Sierra Leone"
@@ -45690,8 +45992,8 @@ SLPM-66246:
   gsHWFixes:
     minimumBlendingLevel: 3 # Fixes broken effect rendering.
 SLPM-66247:
-  name: "マイネリーベII ～誇りと正義と愛～"
-  name-sort: "まいねりーべII ほこりとせいぎとあい"
+  name: "マイネリーベⅡ ～誇りと正義と愛～"
+  name-sort: "まいねりーべ2 ほこりとせいぎとあい"
   name-en: "Meine Liebe II - Hokori to Seigi to Ai"
   region: "NTSC-J"
 SLPM-66248:
@@ -45712,9 +46014,9 @@ SLPM-66249:
   gsHWFixes:
     moveHandler: "MV_Growlanser" # Fixes precomputed depth buffer.
 SLPM-66250:
-  name: "ATLUS BEST COLLECTION チョロＱＨＧ4"
-  name-sort: "ATLUS BEST COLLECTION ちょろQHG4"
-  name-en: "Choro Q HG 4 [Takara Best]"
+  name: "チョロＱＨＧ4 [ATLUS BEST COLLECTION]"
+  name-sort: "ちょろQHG4 [ATLUS BEST COLLECTION]"
+  name-en: "Choro Q HG 4 [Atlus Best Collection]"
   region: "NTSC-J"
 SLPM-66251:
   name: "EX人生ゲームⅡ [ATLUS BEST COLLECTION]"
@@ -45732,13 +46034,13 @@ SLPM-66252:
     halfPixelOffset: 4 # Fixes bloom misalignment.
     nativeScaling: 2 # Fixes post effects.
 SLPM-66253:
-  name: "ふぁいなりすと 初回限定版"
-  name-sort: "ふぁいなりすと しょかいげんていばん"
+  name: "ふぁいなりすと [初回限定版]"
+  name-sort: "ふぁいなりすと [しょかいげんていばん]"
   name-en: "Finalist [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-66254:
-  name: "ふぁいなりすと 通常版"
-  name-sort: "ふぁいなりすと"
+  name: "ふぁいなりすと [通常版]"
+  name-sort: "ふぁいなりすと [つうじょうばん]"
   name-en: "Finalist [Standard Edition]"
   region: "NTSC-J"
 SLPM-66255:
@@ -45772,7 +46074,7 @@ SLPM-66258:
 SLPM-66259:
   name: "魔法先生ネギま！ 2時間目 戦う乙女たち！麻帆良大運動会SP！ [KONAM the Best]"
   name-sort: "まほうせんせいねぎま！ 2じかんめ たたかうおとめたち！まほらだいうんどうかいSP！ [KONAMI The BEST]"
-  name-en: "Mahou Sensei Negima! Silver Medal [KONAMI The BEST]"
+  name-en: "Mahou Sensei Negima！ Silver Medal [KONAMI The BEST]"
   region: "NTSC-J"
 SLPM-66260:
   name: "リモートコントロールダンディSF [KONAMI The BEST]"
@@ -45789,8 +46091,8 @@ SLPM-66261:
     autoFlush: 2 # Fixes misaligned bloom on sun.
     nativeScaling: 2 # Fixes post effects.
 SLPM-66262:
-  name: "トム・クランシーシリーズ レインボーシックス3 [ユービーアイソフトベスト]"
-  name-sort: "とむくらんしーしりーず れいんぼーしっくす3 [ゆーびーあいそふとべすと]"
+  name: "トム・クランシーシリーズ レインボーシックス3 [UBISOFT BEST]"
+  name-sort: "とむくらんしーしりーず れいんぼーしっくす3 [UBISOFT BEST]"
   name-en: "Tom Clancy's Rainbow Six 3 [Ubisoft The Best]"
   region: "NTSC-J"
 SLPM-66263:
@@ -45807,7 +46109,7 @@ SLPM-66264:
   region: "NTSC-J"
 SLPM-66265:
   name: "Canvas2 ～虹色のスケッチ～ [通常版]"
-  name-sort: "きゃんばす2 ～にじいろのすけっち～"
+  name-sort: "きゃんばす2 ～にじいろのすけっち～ [つうじょうばん]"
   name-en: "Canvas 2 - Nijiiro no Sketch [Standard Edition]"
   region: "NTSC-J"
 SLPM-66266:
@@ -45828,13 +46130,13 @@ SLPM-66268:
   gsHWFixes:
     textureInsideRT: 1 # Fixes Hollywood Hulk Hogan's entrance and slow-mo finisher.
 SLPM-66269:
-  name: "ブレイジング ソウルズ 限定版"
+  name: "ブレイジング ソウルズ [限定版]"
   name-sort: "ぶれいじんぐ そうるず [げんていばん]"
   name-en: "Blazing Souls [Limited Edition]"
   region: "NTSC-J"
 SLPM-66270:
-  name: "ブレイジング ソウルズ 通常版"
-  name-sort: "ぶれいじんぐ そうるず"
+  name: "ブレイジング ソウルズ [通常版]"
+  name-sort: "ぶれいじんぐ そうるず [つうじょうばん]"
   name-en: "Blazing Souls [Standard Edition]"
   region: "NTSC-J"
 SLPM-66271:
@@ -45949,7 +46251,7 @@ SLPM-66284:
   region: "NTSC-J"
 SLPM-66285:
   name: "プリンセスコンチェルト [通常版]"
-  name-sort: "ぷりんせすこんちぇると"
+  name-sort: "ぷりんせすこんちぇると [つうじょうばん]"
   name-en: "Princess Concerto [Standard Edition]"
   region: "NTSC-J"
 SLPM-66286:
@@ -45985,7 +46287,7 @@ SLPM-66291:
 SLPM-66292:
   name: "実戦パチスロ必勝法！ ウルトラマン倶楽部ST"
   name-sort: "じっせんぱちすろひっしょうほう！ うるとらまんくらぶST"
-  name-en: "Jissen Pachi-Slot Hisshouhou! Ultraman Club ST"
+  name-en: "Jissen Pachi-Slot Hisshouhou！ Ultraman Club ST"
   region: "NTSC-J"
 SLPM-66293:
   name: "学園アリス ～きらきら★メモリーキッス～"
@@ -46000,7 +46302,7 @@ SLPM-66294:
   name-en: "Sotsugyou 2nd Generation"
   region: "NTSC-J"
 SLPM-66295:
-  name: "闇夜にささやく ～探偵 相楽恭一郎～ 限定版"
+  name: "闇夜にささやく ～探偵 相楽恭一郎～ [限定版]"
   name-sort: "やみよにささやく ～たんてい さがらきょういちろう～ [げんていばん]"
   name-en: "Yamiyo ni Sasayaku - Tantei Sagara Kyouichirou [Limited Edition]"
   region: "NTSC-J"
@@ -46012,8 +46314,8 @@ SLPM-66295:
         // This patch skips over the stack code, allowing the game to boot.
         patch=1,EE,00156888,word,10000003
 SLPM-66296:
-  name: "闇夜にささやく ～探偵 相楽恭一郎～ 通常版"
-  name-sort: "やみよにささやく ～たんてい さがらきょういちろう～"
+  name: "闇夜にささやく ～探偵 相楽恭一郎～ [通常版]"
+  name-sort: "やみよにささやく ～たんてい さがらきょういちろう～ [つうじょうばん]"
   name-en: "Yamiyo ni Sasayaku - Tantei Sagara Kyouichirou [Standard Edition]"
   region: "NTSC-J"
   patches:
@@ -46024,13 +46326,13 @@ SLPM-66296:
         // This patch skips over the stack code, allowing the game to boot.
         patch=1,EE,00156888,word,10000003
 SLPM-66297:
-  name: "セパレイトハーツ 限定版"
+  name: "セパレイトハーツ [限定版]"
   name-sort: "せぱれいとはーつ [げんていばん]"
   name-en: "Separate Hearts [Limited Edition]"
   region: "NTSC-J"
 SLPM-66298:
-  name: "セパレイトハーツ 通常版"
-  name-sort: "せぱれいとはーつ"
+  name: "セパレイトハーツ [通常版]"
+  name-sort: "せぱれいとはーつ [つうじょうばん]"
   name-en: "Separate Hearts [Standard Edition]"
   region: "NTSC-J"
 SLPM-66299:
@@ -46127,7 +46429,7 @@ SLPM-66315:
 SLPM-66316:
   name: "プロサッカークラブをつくろう！ヨーロッパチャンピオンシップ"
   name-sort: "ぷろさっかーくらぶをつくろう！よーろっぱちゃんぴおんしっぷ"
-  name-en: "Pro Soccer Club o Tsukurou! Europe Championship"
+  name-en: "Pro Soccer Club o Tsukurou！ Europe Championship"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Makes the game to correctly register left and right Dpad button input.
@@ -46146,8 +46448,8 @@ SLPM-66318:
   name-en: "Haru no Ashioto - Step of Spring"
   region: "NTSC-J"
 SLPM-66319:
-  name: "新コンバットチョロQ アトラス・ベストコレクション"
-  name-sort: "しんこんばっとちょろQ [あとらす べすとこれくしょん]"
+  name: "新コンバットチョロQ [ATLUS BEST COLLECTION]"
+  name-sort: "しんこんばっとちょろQ [ATLUS BEST COLLECTION]"
   name-en: "New Choro Q [Atlus Best Collection]"
   region: "NTSC-J"
 SLPM-66320:
@@ -46189,7 +46491,7 @@ SLPM-66324:
 SLPM-66325:
   name: "キャッスルヴァニア [コナミ殿堂セレクション]"
   name-sort: "きゃっするゔぁにあ [こなみでんどうせれくしょん]"
-  name-en: "Castlevania [Konami Palace Selection]"
+  name-en: "Castlevania [Konami Dendou Selection]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 3 # Fixes cutscene freezes.
@@ -46220,13 +46522,13 @@ SLPM-66328:
 SLPM-66329:
   name: "魔法先生ネギま！ 課外授業 乙女のドキドキ・ビーチサイド"
   name-sort: "まほうせんせいねぎま！ かがいじゅぎょう おとめのどきどき びーちさいど"
-  name-en: "Mahou Sensei Negima! Kagai Jugyou"
+  name-en: "Mahou Sensei Negima！ Kagai Jugyou"
   region: "NTSC-J"
   compat: 5
   gameFixes:
     - XGKickHack # Fixes rendering problems.
 SLPM-66330:
-  name: "ときめきメモリアル Girl's Side 2nd Kiss 初回生産版"
+  name: "ときめきメモリアル Girl's Side 2nd Kiss [初回生産版]"
   name-sort: "ときめきめもりある がーるずさいど 2nd Kiss [しょかいせいさんばん]"
   name-en: "Tokimeki Memorial - Girl's Side - 2nd Kiss"
   region: "NTSC-J"
@@ -46236,8 +46538,8 @@ SLPM-66331:
   name-en: "Kouenji Onago Soccer [1st Stage Limited Edition]"
   region: "NTSC-J"
 SLPM-66332:
-  name: "高円寺女子サッカー 通常版"
-  name-sort: "こうえんじじょしさっかー"
+  name: "高円寺女子サッカー [通常版]"
+  name-sort: "こうえんじじょしさっかー [つうじょうばん]"
   name-en: "Kouenji Onago Soccer [Standard Edition]"
   region: "NTSC-J"
 SLPM-66333:
@@ -46271,12 +46573,12 @@ SLPM-66334:
   roundModes:
     eeRoundMode: 2 # Fixes rainbow highlighting on cars.
 SLPM-66335:
-  name: "いちご100% ストロベリーダイアリー  [トミコレベスト]"
-  name-sort: "いちご100ぱーせんと すとろべりーだいありー [とみこれべすと]"
+  name: "いちご100% ストロベリーダイアリー [TOMY Best Collection]"
+  name-sort: "いちご100ぱーせんと すとろべりーだいありー [TOMY Best Collection]"
   name-en: "Ichigo 100% Strawberry Diary [Tomy Best Collection]"
   region: "NTSC-J"
 SLPM-66336:
-  name: "新世紀エヴァンゲリオン 鋼鉄のガールフレンド<特別編>"
+  name: "新世紀エヴァンゲリオン 鋼鉄のガールフレンド [特別編]"
   name-sort: "しんせいきえゔぁんげりおん こうてつのがーるふれんど [とくべつへん]"
   name-en: "Shinseiki Evangelion - Koutetsu no Girlfriend [Special Edition]"
   region: "NTSC-J"
@@ -46451,7 +46753,7 @@ SLPM-66369:
 SLPM-66371:
   name: "Train Simulator＋電車でGO！東京急行編 [ONGAKUKAN Pocket Books]"
   name-sort: "とれいんしみゅれーたー＋でんしゃでごーとうきょうきゅうこうへん [ONGAKUKAN Pocket Books]"
-  name-en: "Train Simulator & Densha de Go! Tokyo Kyuukouhen [Ongakukan Pocket Books]"
+  name-en: "Train Simulator & Densha de Go！ Tokyo Kyuukouhen [Ongakukan Pocket Books]"
   region: "NTSC-J"
 SLPM-66372:
   name: "DIGITAL DEVIL SAGA ～アバタール・チューナー～ [ATLUS BEST COLLECTION]"
@@ -46516,7 +46818,7 @@ SLPM-66380:
   region: "NTSC-J"
 SLPM-66381:
   name: "蜜×蜜ドロップス LOVE×LOVE HONEY LIFE [通常版]"
-  name-sort: "みつみつどろっぷす LOVE×LOVE HONEY LIFE"
+  name-sort: "みつみつどろっぷす LOVE×LOVE HONEY LIFE [つうじょうばん]"
   name-en: "Mitsu x Mitsu Drops - Love x Love Honey Life [Standard Edition]"
   region: "NTSC-J"
   patches:
@@ -46793,7 +47095,7 @@ SLPM-66429:
 SLPM-66430:
   name: "デストロイ オール ヒューマンズ！"
   name-sort: "ですとろい おーる ひゅーまんず！"
-  name-en: "Destroy All Humans!"
+  name-en: "Destroy All Humans！"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves metal sheen and reflections.
@@ -46819,12 +47121,12 @@ SLPM-66433:
 SLPM-66434:
   name: "Festa！！HYPER GIRLS PARTY [限定版]"
   name-sort: "ふぇすた！！はいぱー がーるず ぱーてぃー [げんていばん]"
-  name-en: "Festa!! Hyper Girls Party [Limited Edition]"
+  name-en: "Festa！！ Hyper Girls Party [Limited Edition]"
   region: "NTSC-J"
 SLPM-66435:
   name: "Festa！！HYPER GIRLS PARTY [通常版]"
   name-sort: "ふぇすた！！はいぱー がーるず ぱーてぃー [つうじょうばん]"
-  name-en: "Festa!! Hyper Girls Party [Standard Edition]"
+  name-en: "Festa！！ Hyper Girls Party [Standard Edition]"
   region: "NTSC-J"
 SLPM-66436:
   name: "イリスのアトリエ グランファンタズム"
@@ -46972,7 +47274,7 @@ SLPM-66455:
 SLPM-66456:
   name: "あそびにいくヨ！ ～ちきゅうぴんちのこんやくせんげん～ [限定版]"
   name-sort: "あそびにいくよ！ ちきゅうぴんちのこんやくせんげん [げんていばん]"
-  name-en: "Asobi ni Iku yo! Chikyuu Pinch no Kon'yaku Sengen [Genteiban]"
+  name-en: "Asobi ni Iku yo！ Chikyuu Pinch no Kon'yaku Sengen [Genteiban]"
   region: "NTSC-J"
   patches:
     87FFC318:
@@ -46984,7 +47286,7 @@ SLPM-66456:
 SLPM-66457:
   name: "あそびにいくヨ！ ～ちきゅうぴんちのこんやくせんげん～"
   name-sort: "あそびにいくよ！ ちきゅうぴんちのこんやくせんげん"
-  name-en: "Asobi ni Iku yo! Chikyuu Pinch no Kon'yaku Sengen"
+  name-en: "Asobi ni Iku yo！ Chikyuu Pinch no Kon'yaku Sengen"
   region: "NTSC-J"
   patches:
     87FFC318:
@@ -47033,7 +47335,7 @@ SLPM-66462:
     halfPixelOffset: 4 # Aligns post effects.
     nativeScaling: 2 # Fixes post effects.
 SLPM-66463:
-  name: "デフジャム・ファイト・フォー・NY  [PlayStation2 the Best]"
+  name: "デフジャム・ファイト・フォー・NY [PlayStation2 the Best]"
   name-sort: "でふじゃむ・ふぁいと・ふぉー・NY [PlayStation2 the Best]"
   name-en: "Def Jam - Fight for NY [PlayStation2 the Best]"
   region: "NTSC-J"
@@ -47074,7 +47376,7 @@ SLPM-66469:
   region: "NTSC-J"
 SLPM-66470:
   name: "「ラブ★コン ～パンチDEコント～」[通常版]"
-  name-sort: "らぶこん ぱんちでこんと"
+  name-sort: "らぶこん ぱんちでこんと [つうじょうばん]"
   name-en: "Love-Com - Punch de Court [Standard Edition]"
   region: "NTSC-J"
   compat: 5
@@ -47113,12 +47415,12 @@ SLPM-66474:
 SLPM-66475:
   name: "実戦パチスロ必勝法！ 北斗の拳SE [通常版]"
   name-sort: "じっせんぱちすろひっしょうほう！ ほくとのけんSE [つうじょうばん]"
-  name-en: "Jissen Pachi-Slot Hisshouhou! Hokuto no Ken SE [Standard]"
+  name-en: "Jissen Pachi-Slot Hisshouhou！ Hokuto no Ken SE [Standard Edition]"
   region: "NTSC-J"
 SLPM-66476:
   name: "実戦パチンコ必勝法！ CR サラリーマン金太郎"
   name-sort: "じっせんぱちんこひっしょうほう CR さらりーまんきんたろう"
-  name-en: "Jissen Pachinko Hisshouhou! CR Salaryman Kintarou"
+  name-en: "Jissen Pachinko Hisshouhou！ CR Salaryman Kintarou"
   region: "NTSC-J"
 SLPM-66477:
   name: "神業"
@@ -47214,7 +47516,7 @@ SLPM-66489:
   region: "NTSC-J"
 SLPM-66491:
   name: "あやかしびと -幻妖異聞録- [通常版]"
-  name-sort: "あやかしびと げんよういぶんろく"
+  name-sort: "あやかしびと げんよういぶんろく [つうじょうばん]"
   name-en: "Ayakashi-bito - Gen'you Ibunroku [Standard Edition]"
   region: "NTSC-J"
   gsHWFixes:
@@ -47232,14 +47534,14 @@ SLPM-66493:
   name-en: "Shinten Makai - Generation of Chaos V [Idea Factory Collection]"
   region: "NTSC-J"
 SLPM-66494:
-  name: "女子高生 GAME'S-HIGH！ 限定版"
+  name: "女子高生 GAME'S-HIGH！ [限定版]"
   name-sort: "じょしこうせい GAME'S-HIGH！ [げんていばん]"
-  name-en: "Joshikousei Game's High! [Limited Edition]"
+  name-en: "Joshikousei Game's High！ [Limited Edition]"
   region: "NTSC-J"
 SLPM-66495:
   name: "女子高生 GAME'S-HIGH！"
   name-sort: "じょしこうせい GAME'S-HIGH！"
-  name-en: "Joshikousei Game's High!"
+  name-en: "Joshikousei Game's High！"
   region: "NTSC-J"
   patches:
     9FEA4A95:
@@ -47378,10 +47680,11 @@ SLPM-66514:
   name-en: "Medal of Honor - European Assault [EA Best Hits]"
   region: "NTSC-J"
   gsHWFixes:
-    recommendedBlendingLevel: 3 # Fixes banding and level lighting.
+    recommendedBlendingLevel: 2
     autoFlush: 1 # Fixes sun shinging through surfaces and graphical corruptions.
     halfPixelOffset: 2 # Fixes misaligned blur.
-    nativeScaling: 2 # Fixes bloom misaligment.
+    cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SLPM-66515:
   name: "スター・ウォーズ - エピソードⅢ シスの復讐 - [EA BEST HITS ]"
   name-sort: "すたーうぉーず えぴそーど3 しすのふくしゅう [EA BEST HITS]"
@@ -47412,11 +47715,11 @@ SLPM-66518:
 SLPM-66519:
   name: "学園ヘヴン BOY'S LOVE SCRAMBLE！ [ベスト版]"
   name-sort: "がくえんへゔん BOY'S LOVE SCRAMBLE！ [べすとばん]"
-  name-en: "Gakuen Heaven - Boy's Love Scramble! [Best Version]"
+  name-en: "Gakuen Heaven - Boy's Love Scramble！ [Best Version]"
   region: "NTSC-J"
 SLPM-66520:
-  name: "バイオハザード コード:ベロニカ 完全版 プレミアムパック"
-  name-sort: "ばいおはざーど こーど:べろにか かんぜんばん ぷれみあむぱっく"
+  name: "バイオハザード コード:ベロニカ 完全版 [プレミアムパック]"
+  name-sort: "ばいおはざーど こーど:べろにか かんぜんばん [ぷれみあむぱっく]"
   name-en: "BioHazard - Code Veronica [Premium Box]"
   region: "NTSC-J"
 SLPM-66521:
@@ -47471,7 +47774,7 @@ SLPM-66530:
   name-en: "Gift Prism [Standard Edition]"
   region: "NTSC-J"
 SLPM-66531:
-  name: "水の旋律2～緋の記憶～ 限定版"
+  name: "水の旋律2～緋の記憶～ [限定版]"
   name-sort: "みずのせんりつ2 ひのきおく [げんていばん]"
   name-en: "Mizu no Senritsu 2 [Limited Edition]"
   region: "NTSC-J"
@@ -47486,13 +47789,13 @@ SLPM-66533:
   name-en: "Pop'n music 13 Carnival"
   region: "NTSC-J"
 SLPM-66534:
-  name: "龍刻 Ryu-Koku 限定版"
+  name: "龍刻 Ryu-Koku [限定版]"
   name-sort: "りゅうこく [げんていばん]"
   name-en: "Ryu Koku [Limited Edition]"
   region: "NTSC-J"
 SLPM-66535:
-  name: "龍刻 Ryu-Koku 通常版"
-  name-sort: "りゅうこく"
+  name: "龍刻 Ryu-Koku [通常版]"
+  name-sort: "りゅうこく [つうじょうばん]"
   name-en: "Ryu Koku [Standard Edition]"
   region: "NTSC-J"
 SLPM-66536:
@@ -47501,8 +47804,8 @@ SLPM-66536:
   name-en: "Aria - The Natural - Tooi Yume no Mirage"
   region: "NTSC-J"
 SLPM-66537:
-  name: "ガスト ベスト プライス イリスのアトリエ エターナルマナ2"
-  name-sort: "いりすのあとりえ えたーなるまな2 [がすと べすと ぷらいす]"
+  name: "ガスト Best Price イリスのアトリエ エターナルマナ2"
+  name-sort: "いりすのあとりえ えたーなるまな2 [がすと Best Price]"
   name-en: "Iris no Atelier - Eternal Mana 2 [Gust Best Price]"
   region: "NTSC-J"
   gameFixes:
@@ -47603,7 +47906,7 @@ SLPM-66558:
     nativeScaling: 1 # Fixes post processing.
     halfPixelOffset: 4 # Fixes offset post processing.
 SLPM-66559:
-  name: "Winning Post6  [コーエー定番シリーズ]"
+  name: "Winning Post6 [コーエー定番シリーズ]"
   name-sort: "うぃにんぐぽすと6 [こーえーていばんしりーず]"
   name-en: "Winning Post 6 [KOEI Selection]"
   region: "NTSC-J"
@@ -47685,8 +47988,8 @@ SLPM-66568:
     halfPixelOffset: 2 # Reduces ghosting on objects though some still remains.
     recommendedBlendingLevel: 3 # Fixes ground shading.
 SLPM-66569:
-  name: "シークレット・オブ・エヴァンゲリオン 通常版"
-  name-sort: "しーくれっと おぶ えゔぁんげりおん"
+  name: "シークレット・オブ・エヴァンゲリオン [通常版]"
+  name-sort: "しーくれっと おぶ えゔぁんげりおん [つうじょうばん]"
   name-en: "Secret of Evangelion [Standard Edition]"
   region: "NTSC-J"
   gsHWFixes:
@@ -47707,8 +48010,8 @@ SLPM-66572:
   name-en: "LEGO Star Wars II - The Original Trilogy"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 1 # Aligns post processing.
-    nativeScaling: 2 # Fixes post processing smoothness and position.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
   memcardFilters:
     - "SLPM-66572"
     - "SLPS-20423"
@@ -47734,9 +48037,9 @@ SLPM-66576:
   region: "NTSC-J"
   compat: 5
 SLPM-66577:
-  name: "グラディエーター ～ロード トゥー フリーダム REMIX～ [アーテインベスト]"
-  name-sort: "ぐらでぃえーたー ～ろーど とぅー ふりーだむ りみっくす～ [あーていんべすと]"
-  name-en: "Gladiator - Road to Freedom Remix [ErtAin the Best]"
+  name: "グラディエーター ～ロード トゥー フリーダム REMIX～ [ERTAIN BEST]"
+  name-sort: "ぐらでぃえーたー ～ろーど とぅー ふりーだむ りみっくす～ [ERTAIN BEST]"
+  name-en: "Gladiator - Road to Freedom Remix [ErtAin Best]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 4 # Aligns post effects.
@@ -47747,7 +48050,7 @@ SLPM-66578:
   name-en: "Shin Sangoku Musou 3 - Empires [Shin Sangoku Musou Series Collection Gekan]"
   region: "NTSC-J"
 SLPM-66579:
-  name: "真・三國無双4  [真・三國無双シリーズコレクション 下巻]"
+  name: "真・三國無双4 [真・三國無双シリーズコレクション 下巻]"
   name-sort: "しんさんごくむそう4 [しんさんごくむそうしりーずこれくしょん 02 げかん]"
   name-en: "Shin Sangoku Musou 4 [Shin Sangoku Musou Series Collection Gekan]"
   region: "NTSC-J"
@@ -47762,9 +48065,9 @@ SLPM-66581:
   name-en: "Shin Sangoku Musou 4 - Empires [Shin Sangoku Musou Series Collection Gekan]"
   region: "NTSC-J"
 SLPM-66582:
-  name: "仔羊捕獲ケーカク！ スイートボーイズライフ 初回限定版"
-  name-sort: "こひつじほかくけーかく！ すいーとぼーいずらいふ しょかいげんていばん"
-  name-en: "Kohitsuji Hokaku Keikaku! Sweet Boys Life [Limited Edition]"
+  name: "仔羊捕獲ケーカク！ スイートボーイズライフ [初回限定版]"
+  name-sort: "こひつじほかくけーかく！ すいーとぼーいずらいふ [しょかいげんていばん]"
+  name-en: "Kohitsuji Hokaku Keikaku！ Sweet Boys Life [Limited Edition]"
   region: "NTSC-J"
   patches:
     9466CBA1:
@@ -47774,9 +48077,9 @@ SLPM-66582:
         // This patch skips over the stack code, allowing the game to boot.
         patch=1,EE,0014A148,word,10000003
 SLPM-66583:
-  name: "仔羊捕獲ケーカク！ スイートボーイズライフ 通常版"
-  name-sort: "こひつじほかくけーかく！ すいーとぼーいずらいふ"
-  name-en: "Kohitsuji Hokaku Keikaku! Sweet Boys Life [Standard Edition]"
+  name: "仔羊捕獲ケーカク！ スイートボーイズライフ [通常版]"
+  name-sort: "こひつじほかくけーかく！ すいーとぼーいずらいふ [つうじょうばん]"
+  name-en: "Kohitsuji Hokaku Keikaku！ Sweet Boys Life [Standard Edition]"
   region: "NTSC-J"
 SLPM-66584:
   name: "夜明け前より瑠璃色な ～Brighter than dawning blue～"
@@ -47831,12 +48134,12 @@ SLPM-66591:
 SLPM-66592:
   name: "ネギま！?3時間目～恋と魔法と世界樹伝説！～ 演劇版"
   name-sort: "ねぎま！?3じかんめ こいとまほうとせかいじゅでんせつ！ えんげきばん"
-  name-en: "Negima! 3-Jikanme [Theater Version]"
+  name-en: "Negima！ 3-Jikanme [Theater Version]"
   region: "NTSC-J"
 SLPM-66593:
   name: "ネギま！?3時間目～恋と魔法と世界樹伝説！～ ライブ版"
   name-sort: "ねぎま！?3じかんめ こいとまほうとせかいじゅでんせつ！ らいぶばん"
-  name-en: "Negima! 3-Jikanme [Live Version]"
+  name-en: "Negima！ 3-Jikanme [Live Version]"
   region: "NTSC-J"
   compat: 5
 SLPM-66594:
@@ -47855,8 +48158,8 @@ SLPM-66595:
   name-en: "J-League Winning Eleven 10 - Europa League '06-'07"
   region: "NTSC-J"
 SLPM-66596:
-  name: "テニスの王子様 学園祭の王子様 コナミザベスト"
-  name-sort: "てにすのおうじさま がくえんさいのおうじさま こなみざ・べすと"
+  name: "テニスの王子様 学園祭の王子様 [KONAMI The BEST]"
+  name-sort: "てにすのおうじさま がくえんさいのおうじさま [KONAMI The BEST]"
   name-en: "Prince of Tennis - Gakuensai no Oji-sama [KONAMI The BEST]"
   region: "NTSC-J"
 SLPM-66597:
@@ -47920,13 +48223,13 @@ SLPM-66605:
   name-en: "Castle Fantasia - Arihato Senki"
   region: "NTSC-J"
 SLPM-66606:
-  name: "ホワイトブレス～絆～ 限定版"
+  name: "ホワイトブレス～絆～ [限定版]"
   name-sort: "ほわいとぶれす～きずな～ [げんていばん]"
   name-en: "White Breath - Kizuna [First Print Limited Edition]"
   region: "NTSC-J"
 SLPM-66607:
-  name: "ホワイトブレス～絆～ 通常版"
-  name-sort: "ほわいとぶれす～きずな～"
+  name: "ホワイトブレス～絆～ [通常版]"
+  name-sort: "ほわいとぶれす～きずな～ [つうじょうばん]"
   name-en: "White Breath - Kizuna [Standard Edition]"
   region: "NTSC-J"
 SLPM-66608:
@@ -47952,9 +48255,9 @@ SLPM-66611:
   gsHWFixes:
     cpuCLUTRender: 1 # Fixes Colours.
 SLPM-66612:
-  name: "すくぅ～る らぶっ！～恋と希望のメトロノーム～ 初回限定版"
-  name-sort: "すくぅーる らぶっ！ こいときぼうのめとろのーむ しょかいげんていばん"
-  name-en: "School Love [Limited Edition]"
+  name: "すくぅ～る らぶっ！～恋と希望のメトロノーム～ [初回限定版]"
+  name-sort: "すくぅーる らぶっ！ こいときぼうのめとろのーむ [しょかいげんていばん]"
+  name-en: "School Love [First Limited Edition]"
   region: "NTSC-J"
 SLPM-66613:
   name: "メダル・オブ・オナー ～史上最大の作戦～ & メダル・オブ・オナー ～ライジングサン～ [EA BEST HITS]"
@@ -48004,8 +48307,8 @@ SLPM-66621:
   name-en: "Beatmania II DX 12 HAPPY SKY"
   region: "NTSC-J"
 SLPM-66622:
-  name: "トム・クランシーシリーズ ゴーストリコン2 [ユービーアイソフト ベスト ]"
-  name-sort: "とむくらんしーしりーず ごーすとりこん2 [ゆーびーあいそふと べすと]"
+  name: "トム・クランシーシリーズ ゴーストリコン2 [UBISOFT BEST]"
+  name-sort: "とむくらんしーしりーず ごーすとりこん2 [UBISOFT BEST]"
   name-en: "Tom Clancy's Ghost Recon 2 [Ubisoft Best]"
   region: "NTSC-J"
 SLPM-66623:
@@ -48021,7 +48324,7 @@ SLPM-66624:
 SLPM-66625:
   name: "とらぶるふぉうちゅん COMPANY★はぴCURE [初回限定版]"
   name-sort: "とらぶるふぉうちゅん COMPANY はぴCURE [しょかいげんていばん]"
-  name-en: "Trouble Fortune Company - HapiCure [Limited Edition]"
+  name-en: "Trouble Fortune Company - HapiCure [First Limited Edition]"
   region: "NTSC-J"
 SLPM-66626:
   name: "とらぶるふぉうちゅん COMPANY★はぴCURE [通常版]"
@@ -48031,14 +48334,14 @@ SLPM-66626:
 SLPM-66627:
   name: "WWE 2007 SmackDown(R) vs Raw(R)"
   name-sort: "WWE 2007 SmackDown(R) vs Raw(R)"
-  name-en: "WWE SmackDown! vs. RAW 2007"
+  name-en: "WWE SmackDown！ vs. RAW 2007"
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1 # Fixes Hollywood Hulk Hogan's entrance and slow-mo finisher.
 SLPM-66628:
   name: "OutRun2 SP - SPECIAL TOURS [初回限定版]"
   name-sort: "あうとらん2 SP すぺしゃる つあーず [しょかいげんていばん]"
-  name-en: "OutRun 2 SP - Special Tours [First Print Limited Edition]"
+  name-en: "OutRun 2 SP - Special Tours [First Limited Edition]"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -48111,7 +48414,7 @@ SLPM-66638:
     nativeScaling: 2 # Fixes post processing.
     beforeDraw: "OI_HauntingGround" # Fix bloom.
 SLPM-66639:
-  name: "ストリートファイターIII 3rd STRIKE Fight for the future [カプコレ]"
+  name: "ストリートファイターⅢ 3rd STRIKE Fight for the future [カプコレ]"
   name-sort: "すとりーとふぁいたー3 3rd STRIKE Fight for the future [かぷこれ]"
   name-en: "Street Fighter III - 3rd Strike [Capcom the Best]"
   region: "NTSC-J"
@@ -48128,7 +48431,7 @@ SLPM-66641:
 SLPM-66642:
   name: "テニスの王子様 CARD HUNTER [初回限定版]"
   name-sort: "てにすのおうじさま CARD HUNTER [しょかいげんていばん]"
-  name-en: "Prince of Tennis, The - Card Hunter [First Print Limited Edition]"
+  name-en: "Prince of Tennis, The - Card Hunter [First Limited Edition]"
   region: "NTSC-J"
 SLPM-66643:
   name: "OutRun2 SP - SPECIAL TOURS [通常版]"
@@ -48273,9 +48576,9 @@ SLPM-66664:
   name-en: "Full House Kiss 2 [CapColle]"
   region: "NTSC-J"
 SLPM-66667:
-  name: "マイネリーベII ～誇りと正義と愛～ コナミ殿堂セレクション"
+  name: "マイネリーベⅡ ～誇りと正義と愛～ コナミ殿堂セレクション"
   name-sort: "まいねりーべ2 ほこりとせいぎとあい こなみでんどうせれくしょん"
-  name-en: "Meine Liebe II [Konami Palace Selection]"
+  name-en: "Meine Liebe II [Konami Dendou Selection]"
   region: "NTSC-J"
 SLPM-66668:
   name: "悪魔城ドラキュラ 闇の呪印 [KONAM the Best]"
@@ -48319,8 +48622,8 @@ SLPM-66672:
     halfPixelOffset: 4 # Aligns post effects.
     nativeScaling: 2 # Fixes post effects.
 SLPM-66673:
-  name: "プリンス・オブ・ペルシャ ケンシ ノ ココロ [ユービーアイソフトベスト]"
-  name-sort: "ぷりんす おぶ ぺるしゃ けんし の こころ [ゆーびーあいそふとべすと]"
+  name: "プリンス・オブ・ペルシャ ケンシ ノ ココロ [UBISOFT BEST]"
+  name-sort: "ぷりんす おぶ ぺるしゃ けんし の こころ [UBISOFT BEST]"
   name-en: "Prince of Persia - Warrior Within [Ubisoft the Best]"
   region: "NTSC-J"
   gsHWFixes:
@@ -48405,9 +48708,9 @@ SLPM-66681:
   gsHWFixes:
     halfPixelOffset: 4 # Fixes bilinear on lighting effects.
 SLPM-66683:
-  name: "デビルサマナー 葛葉ライドウ 対 アバドン王 初回生産版"
-  name-sort: "でびるさまなー くずのはらいどう たい あばどんおう しょかいせいさんばん"
-  name-en: "Devil Summoner - Kuzunoha Raidou tai Abaddon Ou"
+  name: "デビルサマナー 葛葉ライドウ 対 アバドン王 [初回生産版]"
+  name-sort: "でびるさまなー くずのはらいどう たい あばどんおう [しょかいせいさんばん]"
+  name-en: "Devil Summoner - Kuzunoha Raidou tai Abaddon Ou [First Limited Edition]"
   region: "NTSC-J"
   memcardFilters:
     - "SLPM-66679"
@@ -48497,7 +48800,7 @@ SLPM-66696:
 SLPM-66697:
   name: "ティム・バートン ナイトメアー・ビフォア・クリスマス ブギーの逆襲 [カプコレ]"
   name-sort: "てぃむ・ばーとん ないとめあー・びふぉあ・くりすます ぶぎーのぎゃくしゅう [かぷこれ]"
-  name-en: "Nightmare Before Christmas, The [CapColle]"
+  name-en: "Tim Burton's The Nightmare Before Christmas - Oogie no Gyakushuu [CapColle]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Aligns post Effect and bloom.
@@ -48539,13 +48842,13 @@ SLPM-66703:
 SLPM-66704:
   name: "ネギま！? どりーむたくてぃっく 夢見る乙女はプリンセス 舞姫版"
   name-sort: "ねぎま！? どりーむたくてぃっく ゆめみるおとめはぷりんせす まいひめばん"
-  name-en: "Negima! Dream Tactic Yumemiru Otome Princess [Maihime Edition]"
+  name-en: "Negima！ Dream Tactic Yumemiru Otome Princess [Maihime Edition]"
   region: "NTSC-J"
   compat: 5
 SLPM-66705:
   name: "ネギま！? どりーむたくてぃっく 夢見る乙女はプリンセス 歌姫版"
   name-sort: "ねぎま！? どりーむたくてぃっく ゆめみるおとめはぷりんせす うたひめばん"
-  name-en: "Negima! Dream Tactic Yumemiru Otome Princess [Utahime Edition]"
+  name-en: "Negima！ Dream Tactic Yumemiru Otome Princess [Utahime Edition]"
   region: "NTSC-J"
   compat: 5
 SLPM-66707:
@@ -48554,8 +48857,8 @@ SLPM-66707:
   name-en: "Yukinko Daisenpuu - Sayuki to Koyuki no Hie Hie Daisoudou"
   region: "NTSC-J"
 SLPM-66708:
-  name: "ブラザー イン アームズ 名誉の代償 [ユービーアイソフトベスト]"
-  name-sort: "ぶらざー いん あーむず めいよのだいしょう [ゆーびーあいそふとべすと]"
+  name: "ブラザー イン アームズ 名誉の代償 [UBISOFT BEST]"
+  name-sort: "ぶらざー いん あーむず めいよのだいしょう [UBISOFT BEST]"
   name-en: "Brothers in Arms - Earned in Blood [Ubisoft Best]"
   region: "NTSC-J"
   gsHWFixes:
@@ -48638,27 +48941,27 @@ SLPM-66721:
 SLPM-66722:
   name: "実戦パチンコ必勝法！ CRアラジンデスティニーEX"
   name-sort: "じっせんぱちんこひっしょうほう CRあらじんですてぃにーEX"
-  name-en: "Jissen Pachinko Hisshouhou! CR Aladdin Destiny EX"
+  name-en: "Jissen Pachinko Hisshouhou！ CR Aladdin Destiny EX"
   region: "NTSC-J"
 SLPM-66723:
-  name: "ZOIDS INFINITY FUZORS [トミコレベスト]"
-  name-sort: "ぞいど いんふぃにてぃ ふゅーざーず [とみこれべすと]"
+  name: "ZOIDS INFINITY FUZORS [TOMY Best Collection]"
+  name-sort: "ぞいど いんふぃにてぃ ふゅーざーず [TOMY Best Collection]"
   name-en: "Zoids Infinity Fuzors [Tomy Best Collection]"
   region: "NTSC-J"
 SLPM-66724:
-  name: "ZOIDS TACTICS [トミコレベスト]"
-  name-sort: "ぞいど たくてぃくす [とみこれべすと]"
+  name: "ZOIDS TACTICS [TOMY Best Collection]"
+  name-sort: "ぞいど たくてぃくす [TOMY Best Collection]"
   name-en: "Zoids Tactics [Tomy Best Collection]"
   region: "NTSC-J"
 SLPM-66725:
-  name: "ZOIDS STRUGGLE [トミコレベスト]"
-  name-sort: "ぞいどす とらぐる [とみこれべすと]"
+  name: "ZOIDS STRUGGLE [TOMY Best Collection]"
+  name-sort: "ぞいどす とらぐる [TOMY Best Collection]"
   name-en: "Zoids Struggle [Tomy Best Collection]"
   region: "NTSC-J"
 SLPM-66726:
   name: "お嬢様組曲 -Sweet Concert- [通常版]"
-  name-sort: "おじょうさまくみきょく Sweet Concert"
-  name-en: "Ojousama Kumikyoku - Sweet Concert"
+  name-sort: "おじょうさまくみきょく Sweet Concert [つうじょうばん]"
+  name-en: "Ojousama Kumikyoku - Sweet Concert [Standard Edition]"
   region: "NTSC-J"
 SLPM-66727:
   name: "らぶ☆どろ～LoveDrops～"
@@ -48677,7 +48980,7 @@ SLPM-66729:
   region: "NTSC-J"
 SLPM-66730:
   name: "少年陰陽師 翼よいま、天へ還れ [通常版]"
-  name-sort: "しょうねんおんみょうじ つばさよいま てんへかえれ [通常版]"
+  name-sort: "しょうねんおんみょうじ つばさよいま てんへかえれ [つうじょうばん]"
   name-en: "Shounen Onmyouji - Tsubasa yo Ima, Ten he Kaere [Standard Edition]"
   region: "NTSC-J"
 SLPM-66731:
@@ -48697,7 +49000,7 @@ SLPM-66731:
 SLPM-66732:
   name: "許嫁 [初回限定版]"
   name-sort: "いいなずけ [しょかいげんていばん]"
-  name-en: "Iinazuke [Limited Edition]"
+  name-en: "Iinazuke [First Limited Edition]"
   region: "NTSC-J"
 SLPM-66733:
   name: "許嫁 [通常版]"
@@ -48707,7 +49010,7 @@ SLPM-66733:
 SLPM-66734:
   name: "きると ～貴方と紡ぐ夢と恋のドレス～ [初回限定版]"
   name-sort: "きると あなたとつむぐゆめとこいのどれす [しょかいげんていばん]"
-  name-en: "Kiruto - Anata to Tsumugu Yume to Koi no Dress [Limited Edition]"
+  name-en: "Kiruto - Anata to Tsumugu Yume to Koi no Dress [First Limited Edition]"
   region: "NTSC-J"
 SLPM-66735:
   name: "きると ～貴方と紡ぐ夢と恋のドレス～ [通常版]"
@@ -48772,7 +49075,7 @@ SLPM-66741:
 SLPM-66742:
   name: "ポップンミュージック 14 FEVER！"
   name-sort: "ぽっぷんみゅーじっく 14 FEVER！"
-  name-en: "Pop'n music 14 FEVER!"
+  name-en: "Pop'n music 14 FEVER！"
   region: "NTSC-J"
   compat: 5
 SLPM-66743:
@@ -48862,7 +49165,7 @@ SLPM-66755:
 SLPM-66756:
   name: "Que ～エンシェントリーフの妖精～ [初回限定版]"
   name-sort: "きゅー ～えんしぇんとりーふのようせい～ [しょかいげんていばん]"
-  name-en: "Que - Ancient Leaf no Yousei [Limited Edition]"
+  name-en: "Que - Ancient Leaf no Yousei [First Limited Edition]"
   region: "NTSC-J"
 SLPM-66757:
   name: "Que ～エンシェントリーフの妖精～ [通常版]"
@@ -48891,13 +49194,13 @@ SLPM-66761:
   region: "NTSC-J"
 SLPM-66762:
   name: "Panic Palette [通常版]"
-  name-sort: "Panic Palette"
-  name-en: "Panic Palette"
+  name-sort: "Panic Palette [つうじょうばん]"
+  name-en: "Panic Palette [Standard Edition]"
   region: "NTSC-J"
 SLPM-66763:
   name: "新世紀エヴァンゲリオン バトルオーケストラ [通常版]"
-  name-sort: "しんせいきえゔぁんげりおん ばとるおーけすとら"
-  name-en: "Neon Genesis Evangelion - Battle Orchestra"
+  name-sort: "しんせいきえゔぁんげりおん ばとるおーけすとら [つうじょうばん]"
+  name-en: "Neon Genesis Evangelion - Battle Orchestra [Standard Edition]"
   region: "NTSC-J"
   compat: 5
 SLPM-66764:
@@ -48907,13 +49210,13 @@ SLPM-66764:
   region: "NTSC-J"
 SLPM-66765:
   name: "十次元立方体サイファー ゲーム・オブ・サバイバル [初回限定版]"
-  name-sort: "じゅうじげんりっぽうたいさいふぁー げーむ・おぶ・さばいばる しょかいげんていばん"
-  name-en: "Juujigen Rippoutai Sypher - Game of Survival [Limited Edition]"
+  name-sort: "じゅうじげんりっぽうたいさいふぁー げーむ・おぶ・さばいばる [しょかいげんていばん]"
+  name-en: "Juujigen Rippoutai Sypher - Game of Survival [First Limited Edition]"
   region: "NTSC-J"
 SLPM-66766:
   name: "十次元立方体サイファー ゲーム・オブ・サバイバル [通常版]"
-  name-sort: "じゅうじげんりっぽうたいさいふぁー げーむ・おぶ・さばいばる"
-  name-en: "Juujigen Ripoutai Sypher - Game of Survival"
+  name-sort: "じゅうじげんりっぽうたいさいふぁー げーむ・おぶ・さばいばる [つうじょうばん]"
+  name-en: "Juujigen Ripoutai Sypher - Game of Survival [Standard Edition]"
   region: "NTSC-J"
 SLPM-66767:
   name: "アーバンカオス"
@@ -48942,17 +49245,17 @@ SLPM-66770:
 SLPM-66771:
   name: "電車でGO！新幹線 山陽新幹線編 [Eternal Hits]"
   name-sort: "でんしゃでごーさんようしんかんせんへん [Eternal Hits]"
-  name-en: "Densha de Go! Shinkansen Sanyou Shinkansen-hen [Eternal Hits]"
+  name-en: "Densha de Go！ Shinkansen Sanyou Shinkansen-hen [Eternal Hits]"
   region: "NTSC-J"
 SLPM-66772:
   name: "電車でGO！FINAL [Eternal Hits]"
   name-sort: "でんしゃでごーFINAL [Eternal Hits]"
-  name-en: "Densha de Go! Final [Eternal Hits]"
+  name-en: "Densha de Go！ Final [Eternal Hits]"
   region: "NTSC-J"
 SLPM-66773:
   name: "ジェットでGO！2 [Eternal Hits]"
   name-sort: "じぇっとでGO！2 [Eternal Hits]"
-  name-en: "Jet de Go! 2 [Eternal Hits]"
+  name-en: "Jet de Go！ 2 [Eternal Hits]"
   region: "NTSC-J"
 SLPM-66774:
   name: "エナジーエアーフォース [Eternal Hits]"
@@ -49029,8 +49332,8 @@ SLPM-66784:
   region: "NTSC-J"
 SLPM-66785:
   name: "アイドル雀士 スーチーパイⅣ [通常版]"
-  name-sort: "あいどるじゃんし すーちーぱい4"
-  name-en: "Idol Janshi Suchie-Pai 4"
+  name-sort: "あいどるじゃんし すーちーぱい4 [つうじょうばん]"
+  name-en: "Idol Janshi Suchie-Pai 4 [Standard Edition]"
   region: "NTSC-J"
 SLPM-66786:
   name: "gift -prism- [Sweets So Sweet Best]"
@@ -49154,18 +49457,18 @@ SLPM-66803:
   region: "NTSC-J"
 SLPM-66804:
   name: "カラフルアクアリウム～My Little Mermaid～ [初回限定版]"
-  name-sort: "からふるあくありうむ～My Little Mermaid～ しょかいげんていばん"
-  name-en: "Colorful Aquarium - My Little Mermaid [Limited Edition]"
+  name-sort: "からふるあくありうむ～My Little Mermaid～ [しょかいげんていばん]"
+  name-en: "Colorful Aquarium - My Little Mermaid [First Limited Edition]"
   region: "NTSC-J"
 SLPM-66805:
   name: "カラフルアクアリウム～My Little Mermaid～ [通常版]"
-  name-sort: "からふるあくありうむ～My Little Mermaid～"
-  name-en: "Colorful Aquarium - My Little Mermaid"
+  name-sort: "からふるあくありうむ～My Little Mermaid～ [つうじょうばん]"
+  name-en: "Colorful Aquarium - My Little Mermaid [Standard Edition]"
   region: "NTSC-J"
 SLPM-66806:
   name: "シャッフル！オン・ザ・ステージ KADOKAWA The BEST"
   name-sort: "しゃっふる！おん・ざ・すてーじ KADOKAWA The BEST"
-  name-en: "Shuffle! On the Stage [Kadokawa the Best]"
+  name-en: "Shuffle！ On the Stage [Kadokawa the Best]"
   region: "NTSC-J"
 SLPM-66807:
   name: "レミーのおいしいレストラン"
@@ -49180,8 +49483,8 @@ SLPM-66807:
     forceEvenSpritePosition: 1 # Reduces blooming misalignment.
     autoFlush: 2 # Fixes glows.
 SLPM-66808:
-  name: "ゴーストリコン アドバンスウォーファイター [ユービーアイソフトベスト]"
-  name-sort: "ごーすとりこん あどばんすうぉーふぁいたー [ゆーびーあいそふとべすと]"
+  name: "ゴーストリコン アドバンスウォーファイター [UBISOFT BEST]"
+  name-sort: "ごーすとりこん あどばんすうぉーふぁいたー [UBISOFT BEST]"
   name-en: "Tom Clancy's Ghost Recon - Advanced Warfighter [Ubisoft the Best]"
   region: "NTSC-J"
   gsHWFixes:
@@ -49244,7 +49547,7 @@ SLPM-66819:
 SLPM-66820:
   name: "実戦パチンコ必勝法！ CRサクラ大戦"
   name-sort: "じっせんぱちんこひっしょうほう CRさくらたいせん"
-  name-en: "Jissen Pachinko Hisshouhou! CR Sakura Taisen"
+  name-en: "Jissen Pachinko Hisshouhou！ CR Sakura Taisen"
   region: "NTSC-J"
 SLPM-66821:
   name: "戦国無双2 猛将伝"
@@ -49278,8 +49581,8 @@ SLPM-66826:
   region: "NTSC-J"
 SLPM-66827:
   name: "妖鬼姫伝 ～あやかし幻灯話～ [通常版]"
-  name-sort: "ようきひでん ～あやかしげんとうばなし～"
-  name-en: "Youki Hime Den"
+  name-sort: "ようきひでん ～あやかしげんとうばなし～ [つうじょうばん]"
+  name-en: "Youki Hime Den - Ayakashi Gentou-wa [Standard Edition]"
   region: "NTSC-J"
 SLPM-66828:
   name: "beatmania Ⅱ DX 13 DistorteD"
@@ -49363,8 +49666,8 @@ SLPM-66844:
   region: "NTSC-J"
 SLPM-66845:
   name: "悠久ノ桜 [通常版]"
-  name-sort: "ゆうきゅうのさくら"
-  name-en: "Yuukyuu no Sakura"
+  name-sort: "ゆうきゅうのさくら [つうじょうばん]"
+  name-en: "Yuukyuu no Sakura [Standard Edition]"
   region: "NTSC-J"
 SLPM-66846:
   name: "プリズム・アーク -AWAKE-"
@@ -49372,7 +49675,7 @@ SLPM-66846:
   name-en: "Prism Ark - Awake"
   region: "NTSC-J"
 SLPM-66847:
-  name: "アラビアンズ・ロスト～The engagement on desert～"
+  name: "アラビアンズ・ロスト ～The engagement on desert～"
   name-sort: "あらびあんず ろすと The engagement on desert"
   name-en: "Arabians Lost - The Engagement on Desert"
   region: "NTSC-J"
@@ -49382,8 +49685,8 @@ SLPM-66848:
   name-en: "Sengoku Basara 2 Heroes"
   region: "NTSC-J"
 SLPM-66849:
-  name: "イリスのアトリエ グランファンタズム [ガストベストプライス]"
-  name-sort: "いりすのあとりえ ぐらんふぁんたずむ [がすとべすとぷらいす]"
+  name: "イリスのアトリエ グランファンタズム [ガストBest Price]"
+  name-sort: "いりすのあとりえ ぐらんふぁんたずむ [がすとBest Price]"
   name-en: "Iris no Atelier - Grand Fantasm [Gust Best Price]"
   region: "NTSC-J"
   gsHWFixes:
@@ -49432,13 +49735,13 @@ SLPM-66856:
   region: "NTSC-J"
 SLPM-66857:
   name: "いつか、届く、あの空に。 ～陽の道と緋の昏と～ [初回限定版]"
-  name-sort: "いつかとどくあのそらに ようのみちとひのたそがれと しょかいげんていばん"
-  name-en: "Itsuka, Todoku, Ano Sora ni [Limited Edition]"
+  name-sort: "いつかとどくあのそらに ようのみちとひのたそがれと [しょかいげんていばん]"
+  name-en: "Itsuka, Todoku, Ano Sora ni [First Limited Edition]"
   region: "NTSC-J"
 SLPM-66858:
   name: "いつか、届く、あの空に。 ～陽の道と緋の昏と～ [通常版]"
-  name-sort: "いつかとどくあのそらに ようのみちとひのたそがれと"
-  name-en: "Itsuka, Todoku, Ano Sora ni"
+  name-sort: "いつかとどくあのそらに ようのみちとひのたそがれと [つうじょうばん]"
+  name-en: "Itsuka, Todoku, Ano Sora ni [Standard Edition]"
   region: "NTSC-J"
 SLPM-66859:
   name: "戦国BASARA [Best Price]"
@@ -49447,13 +49750,13 @@ SLPM-66859:
   region: "NTSC-J"
 SLPM-66860:
   name: "熱帯低気圧少女 [初回限定版]"
-  name-sort: "ねったいていきあつしょうじょ しょかいげんていばん"
-  name-en: "Nettai Teikiatsu Shoujo [Limited Edition]"
+  name-sort: "ねったいていきあつしょうじょ [しょかいげんていばん]"
+  name-en: "Nettai Teikiatsu Shoujo [First Limited Edition]"
   region: "NTSC-J"
 SLPM-66861:
   name: "熱帯低気圧少女 [通常版]"
-  name-sort: "ねったいていきあつしょうじょ"
-  name-en: "Nettai Teikiatsu Shoujo"
+  name-sort: "ねったいていきあつしょうじょ [つうじょうばん]"
+  name-en: "Nettai Teikiatsu Shoujo [Standard Edition]"
   region: "NTSC-J"
 SLPM-66862:
   name: "あやかしびとー幻妖異聞録ー [BestSelection]"
@@ -49461,9 +49764,9 @@ SLPM-66862:
   name-en: "Ayakashi Bito [Best Selection]"
   region: "NTSC-J"
 SLPM-66863:
-  name: "WWE2008 SmackDown! vs Raw"
-  name-sort: "WWE2008 SmackDown! vs Raw"
-  name-en: "WWE SmackDown! vs. Raw 2008"
+  name: "WWE2008 SmackDown！ vs Raw"
+  name-sort: "WWE2008 SmackDown！ vs Raw"
+  name-en: "WWE SmackDown！ vs. Raw 2008"
   region: "NTSC-J"
 SLPM-66864:
   name: "ウミショー"
@@ -49482,7 +49785,7 @@ SLPM-66865:
 SLPM-66866:
   name: "実戦パチスロ必勝法！ 北斗の拳2 乱世覇王伝 天覇の章"
   name-sort: "じっせんぱちすろひっしょうほう！ ほくとのけん2 らんせいはおうでん てんはのしょう"
-  name-en: "Jissen Pachi-Slot Hisshouhou! Hokuto no Ken 2"
+  name-en: "Jissen Pachi-Slot Hisshouhou！ Hokuto no Ken 2"
   region: "NTSC-J"
 SLPM-66867:
   name: "MotoGP'07"
@@ -49490,8 +49793,8 @@ SLPM-66867:
   name-en: "MotoGP '07"
   region: "NTSC-J"
 SLPM-66868:
-  name: "スプリンターセル 二重スパイ [ユービーアイソフトベスト]"
-  name-sort: "すぷりんたーせる にじゅうすぱい [ゆーびーあいそふとべすと]"
+  name: "スプリンターセル 二重スパイ [UBISOFT BEST]"
+  name-sort: "すぷりんたーせる にじゅうすぱい [UBISOFT BEST]"
   name-en: "Tom Clancy's Splinter Cell - Double Agent [Ubisoft the Best]"
   region: "NTSC-J"
   gsHWFixes:
@@ -49510,7 +49813,7 @@ SLPM-66869:
 SLPM-66870:
   name: "星色のおくりもの [初回スペシャル限定版]"
   name-sort: "ほしいろのおくりもの [しょかいすぺしゃるげんていばん]"
-  name-en: "Kuri no Okurimono [First Print Special Edition]"
+  name-en: "Kuri no Okurimono [First Special Limitred Edition]"
   region: "NTSC-J"
 SLPM-66871:
   name: "召喚少女-ElementalGirl Calling- [DXパック]"
@@ -49519,19 +49822,19 @@ SLPM-66871:
   region: "NTSC-J"
 SLPM-66872:
   name: "召喚少女-ElementalGirl Calling- [通常版]"
-  name-sort: "しょうかんしょうじょ ElementalGirl Calling"
-  name-en: "Shoukan Shoujo - Elemental Girl Calling"
+  name-sort: "しょうかんしょうじょ ElementalGirl Calling [つうじょうばん]"
+  name-en: "Shoukan Shoujo - Elemental Girl Calling [Standard Edition]"
   region: "NTSC-J"
   compat: 5
 SLPM-66873:
-  name: "らき☆すた ～陵桜学園 桜藤祭～ DXパック"
-  name-sort: "らきすた りょうおうがくえん おうとうさい DXぱっく"
-  name-en: "Lucky Star [DX Pack]"
+  name: "らき☆すた ～陵桜学園 桜藤祭～ [DXパック]"
+  name-sort: "らきすた りょうおうがくえん おうとうさい [DXぱっく]"
+  name-en: "Lucky Star - Ryouou Gakuen Outou-sai [DX Pack]"
   region: "NTSC-J"
 SLPM-66874:
-  name: "らき☆すた ～陵桜学園 桜藤祭～"
-  name-sort: "らきすた りょうおうがくえん おうとうさい"
-  name-en: "Lucky Star"
+  name: "らき☆すた ～陵桜学園 桜藤祭～ [通常版]"
+  name-sort: "らきすた りょうおうがくえん おうとうさい [つうじょうばん]"
+  name-en: "Lucky Star - Ryouou Gakuen Outou-sai [Standard Edition]"
   region: "NTSC-J"
 SLPM-66875:
   name: "実況パワフルメジャーリーグ 2"
@@ -49556,12 +49859,12 @@ SLPM-66878:
 SLPM-66879:
   name: "StarTRain -your past makes your future- [初回限定版]"
   name-sort: "すたーとれいん -ゆあ ぱすと めーくす ゆあ ふゅーちゃー- [しょかいげんていばん]"
-  name-en: "StarTRain - Your Past Makes Your Future [Limited Edition]"
+  name-en: "StarTRain - Your Past Makes Your Future [First Limited Edition]"
   region: "NTSC-J"
 SLPM-66880:
   name: "StarTRain -your past makes your future- [通常版]"
-  name-sort: "すたーとれいん -ゆあ ぱすと めーくす ゆあ ふゅーちゃー-"
-  name-en: "StarTRain - Your Past Makes Your Future"
+  name-sort: "すたーとれいん -ゆあ ぱすと めーくす ゆあ ふゅーちゃー- [つうじょうばん]"
+  name-en: "StarTRain - Your Past Makes Your Future [Standard Edition]"
   region: "NTSC-J"
 SLPM-66881:
   name: "TOCA RACE DRIVER 3 THE ULTIMATE RACING SIMULATOR"
@@ -49619,17 +49922,17 @@ SLPM-66888:
 SLPM-66889:
   name: "ぷりサガ～プリンセスをさがせ～ 初回限定版"
   name-sort: "ぷりさが ぷりんせすをさがせ [しょかいげんていばん]"
-  name-en: "Puri-Saga! Princess o Sagase! [Limited Edition]"
+  name-en: "Puri-Saga！ Princess o Sagase！ [First Limited Edition]"
   region: "NTSC-J"
 SLPM-66890:
   name: "ぷりサガ～プリンセスをさがせ～"
   name-sort: "ぷりさが ぷりんせすをさがせ"
-  name-en: "Puri-Saga! Princess o Sagase!"
+  name-en: "Puri-Saga！ Princess o Sagase！"
   region: "NTSC-J"
 SLPM-66891:
   name: "Myself;Yourself [初回限定版]"
   name-sort: "まいせるふ ゆあせるふ [しょかいげんていばん]"
-  name-en: "Myself, Yourself [Limited Edition]"
+  name-en: "Myself, Yourself [First Limited Edition]"
   region: "NTSC-J"
 SLPM-66892:
   name: "Myself;Yourself [通常版]"
@@ -49654,7 +49957,7 @@ SLPM-66895:
 SLPM-66896:
   name: "Piaキャロットへようこそ！！G.O. ～サマーフェア～"
   name-sort: "ぴあきゃろっとへようこそ！！ G.O. さまーふぇあ"
-  name-en: "Pia Carrot he Youkoso!! G.O. Summer Fair"
+  name-en: "Pia Carrot he Youkoso！！ G.O. Summer Fair"
   region: "NTSC-J"
 SLPM-66897:
   name: "XYANIDE：ザイナイド"
@@ -49712,8 +50015,8 @@ SLPM-66906:
   name-en: "Tenshou Gakuen Gekkouroku [Tokudane Price]"
   region: "NTSC-J"
 SLPM-66907:
-  name: "許婚 [プリンセスソフト・コレクション]"
-  name-sort: "いいなずけ [ぷりんせすそふと・これくしょん]"
+  name: "許婚 [プリンセスソフト コレクション]"
+  name-sort: "いいなずけ [ぷりんせすそふと これくしょん]"
   name-en: "Iinazuke [Princess Soft Collection]"
   region: "NTSC-J"
 SLPM-66908:
@@ -49736,8 +50039,8 @@ SLPM-66910:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misalignment.
 SLPM-66911:
-  name: "ふぁいなりすと [プリンセスソフト・コレクション]"
-  name-sort: "ふぁいなりすと [ぷりんせすそふと・これくしょん]"
+  name: "ふぁいなりすと [プリンセスソフト コレクション]"
+  name-sort: "ふぁいなりすと [ぷりんせすそふと これくしょん]"
   name-en: "Finalist [Princess Soft Collection]"
   region: "NTSC-J"
 SLPM-66912:
@@ -49856,9 +50159,9 @@ SLPM-66932:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth line.
 SLPM-66933:
-  name: "君が主で執事が俺で～お仕え日記～ 初回限定版"
-  name-sort: "きみがあるじでしつじがおれで おつかえにっき しょかいげんていばん"
-  name-en: "Kimi ga Aruji de Shitsuji ga Ore de - Oshie Nikki [Limited Edition]"
+  name: "君が主で執事が俺で～お仕え日記～ [初回限定版]"
+  name-sort: "きみがあるじでしつじがおれで おつかえにっき [しょかいげんていばん]"
+  name-en: "Kimi ga Aruji de Shitsuji ga Ore de - Oshie Nikki [First Limited Edition]"
   region: "NTSC-J"
 SLPM-66934:
   name: "君が主で執事が俺で～お仕え日記～"
@@ -49901,9 +50204,9 @@ SLPM-66941:
   name-en: "Hokuto no Ken [Sega the Best]"
   region: "NTSC-J"
 SLPM-66942:
-  name: "Φなる・あぷろーち 2 ～1st priority～ ＜初回限定版＞"
-  name-sort: "ふぁいなる・あぷろーち2 ～1st priority～ ＜しょかいげんていばん＞"
-  name-en: "Final Approach 2 - 1st Priority [First Print Limited Edition]"
+  name: "Φなる・あぷろーち 2 ～1st priority～ [初回限定版]"
+  name-sort: "ふぁいなる・あぷろーち2 ～1st priority～ [しょかいげんていばん]"
+  name-en: "Final Approach 2 - 1st Priority [First Limited Edition]"
   region: "NTSC-J"
 SLPM-66943:
   name: "Φなる・あぷろーち 2 ～1st priority～"
@@ -49911,7 +50214,7 @@ SLPM-66943:
   name-en: "Final Approach 2 - 1st Priority"
   region: "NTSC-J"
 SLPM-66944:
-  name: "プティフール 限定版"
+  name: "プティフール [限定版]"
   name-sort: "ぷてぃふーる [げんていばん]"
   name-en: "Petit Four [Limited Edition]"
   region: "NTSC-J"
@@ -49976,7 +50279,7 @@ SLPM-66957:
 SLPM-66958:
   name: "アオイシロ [初回限定版]"
   name-sort: "あおいしろ [しょかいげんていばん]"
-  name-en: "Aoi Shiro [Genteiban]"
+  name-en: "Aoi Shiro [First Limited Edition]"
   region: "NTSC-J"
 SLPM-66959:
   name: "アオイシロ [通常版]"
@@ -50123,7 +50426,7 @@ SLPM-66982:
 SLPM-66984:
   name: "学園ヘヴン BOY'S LOVE SCRAMBLE！ [Best版]"
   name-sort: "がくえんへゔん BOY'S LOVE SCRAMBLE！ [べすとばん]"
-  name-en: "Gakuen Heaven - Boy's Love Scramble! [Best Version]"
+  name-en: "Gakuen Heaven - Boy's Love Scramble！ [Best Version]"
   region: "NTSC-J"
 SLPM-66987:
   name: "九龍妖魔学園紀 再装填 -re:charge- [ATLUS BEST COLLECTION]"
@@ -50163,8 +50466,8 @@ SLPM-66993:
   name-en: "Rim Runners [Best Version]"
   region: "NTSC-J"
 SLPM-66994:
-  name: "マナケミア ～学園の錬金術士たち～ [ガストベストプライス]"
-  name-sort: "まなけみあ ～がくえんのれんきんじゅつしたち～ [がすとべすとぷらいす]"
+  name: "マナケミア ～学園の錬金術士たち～ [ガストBest Price]"
+  name-sort: "まなけみあ ～がくえんのれんきんじゅつしたち～ [がすとBest Price]"
   name-en: "Mana-Khemia - Gakuen no Renkinjutsu Shitachi [Best Version]"
   region: "NTSC-J"
   roundModes:
@@ -50180,7 +50483,7 @@ SLPM-66995:
 SLPM-66996:
   name: "終末少女幻想アリスマチック Apocalypse [初回限定版]"
   name-sort: "しゅうまつしょうじょげんそうありすまちっく あぽかりぷす [しょかいげんていばん]"
-  name-en: "Shuumatsu Shoujo Gensou Alicematic Apocalypse [Limited Edition]"
+  name-en: "Shuumatsu Shoujo Gensou Alicematic Apocalypse [First Limited Edition]"
   region: "NTSC-J"
 SLPM-66997:
   name: "終末少女幻想アリスマチック Apocalypse [通常版]"
@@ -50188,7 +50491,7 @@ SLPM-66997:
   name-en: "Shuumatsu Shoujo Gensou Alicematic Apocalypse [Standard Edition]"
   region: "NTSC-J"
 SLPM-66998:
-  name: "ふしぎ遊戯 朱雀異聞 限定版"
+  name: "ふしぎ遊戯 朱雀異聞 [限定版]"
   name-sort: "ふしぎゆうぎ すざくいぶん [げんていばん]"
   name-en: "Fushigi Yuugi - Suzaku Ibun [Limited Edition]"
   region: "NTSC-J"
@@ -50749,7 +51052,7 @@ SLPM-74002:
 SLPM-74003:
   name: "クラッシュ・バンディクー4 さくれつ！魔神パワー [PlayStation2 the Best]"
   name-sort: "くらっしゅばんでぃくー4 さくれつ！まじんぱわー [PlayStation2 the Best]"
-  name-en: "Crash Bandicoot 4 - Sakuretsu! Majin Power [PlayStation2 the Best]"
+  name-en: "Crash Bandicoot 4 - Sakuretsu！ Majin Power [PlayStation2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     nativePaletteDraw: 1
@@ -50785,7 +51088,7 @@ SLPM-74101:
 SLPM-74102:
   name: "桃太郎電鉄12 西日本編もありまっせー！ [PlayStation2 the Best]"
   name-sort: "ももたろうでんてつ12 にしにほんへんもありまっせー！ [PlayStation2 the Best]"
-  name-en: "Momotarou Dentetsu 12 [PlayStation2 the Best]"
+  name-en: "Momotarou Dentetsu 12 - Nishi Nihon hen mo Arimasse！ [PlayStation2 the Best]"
   region: "NTSC-J"
 SLPM-74103:
   name: "桃太郎電鉄USA [PlayStation2 the Best]"
@@ -50793,12 +51096,14 @@ SLPM-74103:
   name-en: "Momotarou Dentetsu USA [PlayStation2 the Best]"
   region: "NTSC-J"
 SLPM-74104:
-  name: "桃太郎電鉄15 [PlayStation2 the Best]"
-  name-sort: "ももたろうでんてつ15 [PlayStation2 the Best]"
-  name-en: "Momotarou Dentetsu 15 [PlayStation2 the Best]"
+  name: "桃太郎電鉄15 五大ボンビー登場！の巻 [PlayStation2 the Best]"
+  name-sort: "ももたろうでんてつ15 ごだいぼんびーとうじょう！のまき [PlayStation2 the Best]"
+  name-en: "Momotarou Dentetsu 15 Godai Bobii Toujo！ no Maki [PlayStation2 the Best]"
   region: "NTSC-J"
 SLPM-74105:
-  name: "Momotarou Dentetsu 16 - Hokkaido Daiidou no Maki!"
+  name: "桃太郎電鉄16 北海道大移動の巻 [PlayStation2 the Best]"
+  name-sort: "ももたろうでんてつ16 ほっかいどうだいいどうのまき [PlayStation2 the Best]"
+  name: "Momotarou Dentetsu 16 - Hokkaido Daiidou no Maki！ [PlayStation2 the Best]"
   region: "NTSC-J"
 SLPM-74201:
   name: "バイオハザード アウトブレイク [PlayStation2 the Best]"
@@ -50870,7 +51175,7 @@ SLPM-74213:
   name-en: "Gensou Suikoden IV"
   region: "NTSC-J"
 SLPM-74214:
-  name: "Densha de Go! Final"
+  name: "Densha de Go！ Final"
   region: "NTSC-J"
 SLPM-74215:
   name: "真・三國無双3 [PlayStation2 the Best]"
@@ -50930,7 +51235,7 @@ SLPM-74226:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes combat interface.
 SLPM-74227:
-  name: "戦神-いくさがみ- [PlayStation2 the Best]"
+  name: "戦神 -いくさがみ- [PlayStation2 the Best]"
   name-sort: "いくさがみ [PlayStation2 the Best]"
   name-en: "Ikusa Gami [PlayStation2 the Best]"
   region: "NTSC-J"
@@ -51388,9 +51693,9 @@ SLPM-74402:
   name-en: "Capcom vs. SNK 2 [PlayStation2 the Best]"
   region: "NTSC-J"
 SLPM-74403:
-  name: "電車でGO！新幹線 山陽新幹線編  [PlayStation2 the Best]"
+  name: "電車でGO！新幹線 山陽新幹線編 [PlayStation2 the Best]"
   name-sort: "でんしゃでごーしんかんせん さんようしんかんせんへん [PlayStation2 the Best]"
-  name-en: "Densha de Go! Shinkansen Sanyou Shinkansen hen  [PlayStation2 the Best]"
+  name-en: "Densha de Go！ Shinkansen Sanyou Shinkansen hen [PlayStation2 the Best]"
   region: "NTSC-J"
 SLPM-74404:
   name: "スペースチャンネル5 Part2 [PlayStation2 the Best]"
@@ -51416,7 +51721,7 @@ SLPM-74406:
 SLPM-74407:
   name: "ジェットでGO！2 [PlayStation2 the Best]"
   name-sort: "じぇっとでGO！2 [PlayStation2 the Best]"
-  name-en: "Jet de Go! 2 [PlayStation2 the Best]"
+  name-en: "Jet de Go！ 2 [PlayStation2 the Best]"
   region: "NTSC-J"
 SLPM-74408:
   name: "ガラクタ名作劇場 ラクガキ王国 [PlayStation2 the Best]"
@@ -51581,7 +51886,7 @@ SLPS-20009:
 SLPS-20010:
   name: "劇空間プロ野球 AT THE END OF THE CENTURY 1999"
   name-sort: "げきくうかんぷろやきゅう AT THE END OF THE CENTURY 1999"
-  name-en: "Pro Baseball Gekikuukan"
+  name-en: "Gekikuukan Pro Yakyuu At The End of The Century 1999"
   region: "NTSC-J"
 SLPS-20011:
   name: "アメリカン・アーケード"
@@ -51768,7 +52073,7 @@ SLPS-20044:
 SLPS-20045:
   name: "実戦パチスロ必勝法！ 獣王 [DXパック]"
   name-sort: "じっせんぱちすろひっしょうほう！ じゅうおう [DXぱっく]"
-  name-en: "Jissen Pachi-Slot Hisshouhou! Juuou [DX Pack]"
+  name-en: "Jissen Pachi-Slot Hisshouhou！ Juuou [DX Pack]"
   region: "NTSC-J"
 SLPS-20046:
   name: "空戦"
@@ -51788,7 +52093,7 @@ SLPS-20048:
 SLPS-20050:
   name: "ハッピー! ハッピー!! ボーダーズ in Hokkaido ルスツリゾート"
   name-sort: "はっぴー! はっぴー!! ぼーだーず in Hokkaido るすつりぞーと"
-  name-en: "Happy! Happy!! Boarders in Hokkaidou Rusutsu Resort"
+  name-en: "Happy！ Happy！！ Boarders in Hokkaidou Rusutsu Resort"
   region: "NTSC-J"
   speedHacks:
     mvuFlag: 0 # Fixes graphical issues.
@@ -51803,7 +52108,7 @@ SLPS-20052:
   name-en: "Global Folktale"
   region: "NTSC-J"
 SLPS-20053:
-  name: "天使のプレゼント マール王国物語 限定版"
+  name: "天使のプレゼント マール王国物語 [限定版]"
   name-sort: "てんしのぷれぜんと まーるおうこくものがたり [げんていばん]"
   name-en: "Tenshi no Present - Māru Oukoku Monogatari"
   region: "NTSC-J"
@@ -51888,7 +52193,7 @@ SLPS-20068:
 SLPS-20070:
   name: "ドナルドダック レスキュー大作戦！！"
   name-sort: "どなるどだっく れすきゅーだいさくせん！！"
-  name-en: "Disney's Donald Duck - Rescue Daisakusen!!"
+  name-en: "Disney's Donald Duck - Rescue Daisakusen！！"
   region: "NTSC-J"
 SLPS-20071:
   name: "GAME SELECT 5 洋"
@@ -51918,7 +52223,7 @@ SLPS-20075:
 SLPS-20077:
   name: "パイロットになろう！ 2"
   name-sort: "ぱいろっとになろう！ 2"
-  name-en: "Pilot ni Narou! 2"
+  name-en: "Pilot ni Narou！ 2"
   region: "NTSC-J"
 SLPS-20078:
   name: "シムピープル お茶の間劇場"
@@ -51970,8 +52275,8 @@ SLPS-20086:
   region: "NTSC-J"
 SLPS-20087:
   name: "Generation of Chaos [通常版]"
-  name-sort: "じぇねれーしょんおぶかおす [通常版]"
-  name-en: "Generation of Chaos"
+  name-sort: "じぇねれーしょんおぶかおす [つうじょうばん]"
+  name-en: "Generation of Chaos [Standard Edition]"
   region: "NTSC-J"
 SLPS-20089:
   name: "ガンハーツ [未発売]"
@@ -52086,12 +52391,12 @@ SLPS-20109:
 SLPS-20110:
   name: "めざせ！名門野球部2"
   name-sort: "めざせ！めいもんやきゅうぶ2"
-  name-en: "Mezase! Meimon Yakyuubu 2"
+  name-en: "Mezase！ Meimon Yakyuubu 2"
   region: "NTSC-J"
 SLPS-20111:
   name: "マジカルスポーツ 2001 プロ野球"
   name-sort: "まじかるすぽーつ 2001 ぷろやきゅう"
-  name-en: "Magical Sports - Pro Baseball 2001"
+  name-en: "Magical Sports - Pro Yakyuu 2001"
   region: "NTSC-J"
 SLPS-20112:
   name: "必殺パチンコステーションV2 天才バカボン"
@@ -52123,7 +52428,7 @@ SLPS-20116:
 SLPS-20117:
   name: "対局麻雀 ネットでロン！"
   name-sort: "たいきょくまーじゃん ねっとでろん！"
-  name-en: "Taikyoku Mahjong - Net de Ron!"
+  name-en: "Taikyoku Mahjong - Net de Ron！"
   region: "NTSC-J"
 SLPS-20120:
   name: "F1 2001"
@@ -52160,7 +52465,7 @@ SLPS-20127:
   name-en: "Chou! Tanoshii Internet Tomodachi no Wa [Type-OS]"
   region: "NTSC-J"
 SLPS-20128:
-  name: "マールDEジグソー 限定版"
+  name: "マールDEジグソー [限定版]"
   name-sort: "まーるDEじぐそー [げんていばん]"
   name-en: "Toshiyuki Morikawa Private Collection - Puppet Princess of Marl's Kingdom"
   region: "NTSC-J"
@@ -52178,7 +52483,7 @@ SLPS-20130:
 SLPS-20131:
   name: "実戦パチスロ必勝法！ 獣王"
   name-sort: "じっせんぱちすろひっしょうほう！ じゅうおう"
-  name-en: "Jissen Pachi-Slot Hisshouhou! Juuou"
+  name-en: "Jissen Pachi-Slot Hisshouhou！ Juuou"
   region: "NTSC-J"
 SLPS-20132:
   name: "鄭問之三國誌"
@@ -52321,10 +52626,10 @@ SLPS-20163:
   name-en: "Typing Kengo 634"
   region: "NTSC-J"
 SLPS-20164:
-  name: "Plarail - Yume ga Ippai! Plarail de Ikou!"
+  name: "Plarail - Yume ga Ippai！ Plarail de Ikou！"
   region: "NTSC-J"
 SLPS-20165:
-  name: "ラ・ピュセル 光の聖女伝説 限定版"
+  name: "ラ・ピュセル 光の聖女伝説 [限定版]"
   name-sort: "ら・ぴゅせる ひかりのせいじょでんせつ [げんていばん]"
   name-en: "La Pucelle - Hikari no Seijo Densetsu [Limited Edition]"
   region: "NTSC-J"
@@ -52417,7 +52722,7 @@ SLPS-20185:
 SLPS-20186:
   name: "パチンコで遊ぼう！ ～ フィーバードデカザウルス"
   name-sort: "ぱちんこであそぼう！ ～ ふぃーばーどでかざうるす"
-  name-en: "Pachinko de Asobou! Fever Dodeka Saurus"
+  name-en: "Pachinko de Asobou！ Fever Dodeka Saurus"
   region: "NTSC-J"
 SLPS-20187:
   name: "BLACK/MATRIX Ⅱ"
@@ -52428,7 +52733,7 @@ SLPS-20187:
 SLPS-20190:
   name: "熱チュー！プロ野球2002"
   name-sort: "ねっちゅー！ぷろやきゅう2002"
-  name-en: "Necchu! Pro Baseball 2002"
+  name-en: "Necchu！ Pro Proyakyuu 2002"
   region: "NTSC-J"
   patches:
     78E100AD:
@@ -52442,12 +52747,12 @@ SLPS-20191:
 SLPS-20192:
   name: "必殺パチンコステーションV3 出動！ミニスカポリス"
   name-sort: "ひっさつぱちんこすてーしょんV 3 しゅつどう！みにすかぽりす"
-  name-en: "Hissatsu Pachinko Station V3 - Shutsudou! みにすかぽりす"
+  name-en: "Hissatsu Pachinko Station V3 - Shutsudou！ みにすかぽりす"
   region: "NTSC-J"
 SLPS-20193:
   name: "実戦パチスロ必勝法！ Sammy's Collection"
   name-sort: "じっせんぱちすろひっしょうほう！ さみーずこれくしょん"
-  name-en: "Jissen Pachi-Slot Hisshouhou! Sammy's Collection"
+  name-en: "Jissen Pachi-Slot Hisshouhou！ Sammy's Collection"
   region: "NTSC-J"
 SLPS-20194:
   name: "U - underwater unit"
@@ -52519,8 +52824,8 @@ SLPS-20208:
   compat: 5
 SLPS-20209:
   name: "実戦パチスロ必勝法！ アラジンA [限定版]"
-  name-sort: "じっせんぱちすろひっしょうほう！ あらじんA げんていばん"
-  name-en: "Jissen Pachi-Slot Hisshouhou! Aladdin A [Limited Edition]"
+  name-sort: "じっせんぱちすろひっしょうほう！ あらじんA [げんていばん]"
+  name-en: "Jissen Pachi-Slot Hisshouhou！ Aladdin A [Limited Edition]"
   region: "NTSC-J"
 SLPS-20211:
   name: "山佐Digiワールド3"
@@ -52545,7 +52850,7 @@ SLPS-20214:
 SLPS-20215:
   name: "実戦パチスロ必勝法！ アラジンA"
   name-sort: "じっせんぱちすろひっしょうほう！ あらじんA"
-  name-en: "Jissen Pachi-Slot Hisshouhou! Aladdin A"
+  name-en: "Jissen Pachi-Slot Hisshouhou！ Aladdin A"
   region: "NTSC-J"
 SLPS-20216:
   name: "AIR RANGER -RESCUE HELICOPTER- [わくわくプライス]"
@@ -52569,7 +52874,7 @@ SLPS-20218:
 SLPS-20219:
   name: "エッグマニア つかんで！まわして！どっすんぱず～る！！"
   name-sort: "えっぐまにあ つかんで！まわして！どっすんぱずーる！！"
-  name-en: "Tsukande! Mawashite! Dossun Pazuru Egg Mania"
+  name-en: "Tsukande！ Mawashite！ Dossun Pazuru Egg Mania"
   region: "NTSC-J"
   patches:
     2A925A22:
@@ -52665,12 +52970,12 @@ SLPS-20238:
 SLPS-20239:
   name: "実戦パチスロ必勝法！ 猛獣王S [限定版]"
   name-sort: "じっせんぱちすろひっしょうほう！ もうじゅうおうS [げんていばん]"
-  name-en: "Jissen Pachi-Slot Hisshouhou! Moujuuou S [Limited Edition]"
+  name-en: "Jissen Pachi-Slot Hisshouhou！ Moujuuou S [Limited Edition]"
   region: "NTSC-J"
 SLPS-20240:
   name: "実戦パチスロ必勝法！ 猛獣王S"
   name-sort: "じっせんぱちすろひっしょうほう！ もうじゅうおうS"
-  name-en: "Jissen Pachi-Slot Hisshouhou! Moujuuou S"
+  name-en: "Jissen Pachi-Slot Hisshouhou！ Moujuuou S"
   region: "NTSC-J"
 SLPS-20241:
   name: "上海 ～三国牌闘儀～"
@@ -52722,8 +53027,8 @@ SLPS-20250:
   region: "NTSC-J"
 SLPS-20251:
   name: "魔界戦記 ディスガイア [通常版]"
-  name-sort: "まかいせんき でぃすがいあ"
-  name-en: "Makai Senki Disgaea"
+  name-sort: "まかいせんき でぃすがいあ [つうじょうばん]"
+  name-en: "Makai Senki Disgaea [Standard Edition]"
   region: "NTSC-J"
 SLPS-20253:
   name: "パチってちょんまげ達人2 ～ CRジュラシックパーク"
@@ -52759,7 +53064,7 @@ SLPS-20259:
 SLPS-20260:
   name: "魁！！ クロマティ高校"
   name-sort: "さきがけ！！ くろまてぃこうこう"
-  name-en: "Sakigake!! Kuromati Koukou"
+  name-en: "Sakigake！！ Kuromati Koukou"
   region: "NTSC-J"
 SLPS-20261:
   name: "三洋パチンコパラダイス8 ～新海物語～"
@@ -52769,7 +53074,7 @@ SLPS-20261:
 SLPS-20262:
   name: "SLOT！ PRO DX ～不二子2～"
   name-sort: "すろぷろ でらっくす ふじこ2"
-  name-en: "Slot! Pro DX - Fujiko 2 -"
+  name-en: "Slot！ Pro DX - Fujiko 2 -"
   region: "NTSC-J"
 SLPS-20263:
   name: "J.LEAGUE Tactics Manager"
@@ -52793,24 +53098,24 @@ SLPS-20266:
   region: "NTSC-J"
 SLPS-20267:
   name: "実戦パチスロ必勝法！ サラリーマン金太郎 [限定版]"
-  name-sort: "じっせんぱちすろひっしょうほう！ さらりーまんきんたろう げんていばん"
-  name-en: "Jissen Pachi-Slot Hisshouhou! Salaryman Kintarou [Limited Edition]"
+  name-sort: "じっせんぱちすろひっしょうほう！ さらりーまんきんたろう [げんていばん]"
+  name-en: "Jissen Pachi-Slot Hisshouhou！ Salaryman Kintarou [Limited Edition]"
   region: "NTSC-J"
 SLPS-20268:
   name: "実戦パチスロ必勝法！ サラリーマン金太郎"
   name-sort: "じっせんぱちすろひっしょうほう！ さらりーまんきんたろう"
-  name-en: "Jissen Pachi-Slot Hisshouhou! Salaryman Kintarou"
+  name-en: "Jissen Pachi-Slot Hisshouhou！ Salaryman Kintarou"
   region: "NTSC-J"
 SLPS-20272:
   name: "太鼓の達人 ドキッ！新曲だらけの春祭り"
   name-sort: "たいこのたつじん どきっ！しんきょくだらけのはるまつり"
-  name-en: "Taiko no Tatsujin - Doki! Shinkyoku Darake no Haru Matsuri"
+  name-en: "Taiko no Tatsujin - Doki！ Shinkyoku Darake no Haru Matsuri"
   region: "NTSC-J"
   compat: 5
 SLPS-20273:
   name: "熱チュー！プロ野球2003"
   name-sort: "ねっちゅー！ぷろやきゅう2003"
-  name-en: "Necchu! Pro Yakyuu 2003"
+  name-en: "Necchu！ Pro Yakyuu 2003"
   region: "NTSC-J"
   patches:
     34FB1FB7:
@@ -52856,7 +53161,7 @@ SLPS-20280:
 SLPS-20281:
   name: "モノポリー ～めざせっ！！大富豪人生！！～"
   name-sort: "ものぽりー ～めざせっ！！だいふごうじんせい！！～"
-  name-en: "Monopoly - Mezase!! Daifugou Jinsei!!"
+  name-en: "Monopoly - Mezase！！ Daifugou Jinsei！！"
   region: "NTSC-J"
   clampModes:
     vuClampMode: 0 # Fixes missing game board.
@@ -52888,7 +53193,7 @@ SLPS-20286:
 SLPS-20287:
   name: "焼肉奉行 ボンファイア！"
   name-sort: "やきにくぶぎょう ぼんふぁいあ！"
-  name-en: "Yakiniku Bugyou Bonfire!"
+  name-en: "Yakiniku Bugyou Bonfire！"
   region: "NTSC-J"
 SLPS-20288:
   name: "最強 東大将棋2003"
@@ -52908,12 +53213,12 @@ SLPS-20291:
 SLPS-20292:
   name: "実戦パチスロ必勝法！ サバンナパーク DX"
   name-sort: "じっせんぱちすろひっしょうほう！ さばんなぱーく DX"
-  name-en: "Jissen Pachi-Slot Hisshouhou! Savanna Park DX"
+  name-en: "Jissen Pachi-Slot Hisshouhou！ Savanna Park DX"
   region: "NTSC-J"
 SLPS-20293:
   name: "実戦パチスロ必勝法！ サバンナパーク"
   name-sort: "じっせんぱちすろひっしょうほう！ さばんなぱーく"
-  name-en: "Jissen Pachi-Slot Hisshouhou! Savanna Park"
+  name-en: "Jissen Pachi-Slot Hisshouhou！ Savanna Park"
   region: "NTSC-J"
   compat: 5
 SLPS-20294:
@@ -52959,8 +53264,8 @@ SLPS-20302:
   name-en: "Gokuraku-jong Premium"
   region: "NTSC-J"
 SLPS-20303:
-  name: "いなか暮らし～南の島の物語 ベストコレクション"
-  name-sort: "いなかぐらし みなみのしまのものがたり べすとこれくしょん"
+  name: "いなか暮らし～南の島の物語 [Best Collection]"
+  name-sort: "いなかぐらし みなみのしまのものがたり [Best Collection]"
   name-en: "Inaka Gurashi - Minami no Shima no Monogatari [Best Collection]"
   region: "NTSC-J"
 SLPS-20304:
@@ -52981,18 +53286,24 @@ SLPS-20306:
 SLPS-20307:
   name: "楽勝！ パチスロ宣言 - モグモグ風林火山・賞金首・BILLY THE BIG・Super Black Jack"
   name-sort: "らくしょう！ ぱちすろせんげん - もぐもぐふうりんかざん・しょうきんくび・びりーざびっぐ・すーぱーぶらっくじゃっく"
-  name-en: "Rakushou! Pachi-Slot Sengen - MoguMoguFuuRinKaZan,Shoukin Kubi,Billy the Big,Super Black Jack"
+  name-en: "Rakushou！ Pachi-Slot Sengen - MoguMoguFuuRinKaZan,Shoukin Kubi,Billy the Big,Super Black Jack"
   region: "NTSC-J"
 SLPS-20308:
   name: "花火百景 [特典版]"
   name-sort: "はなびひゃっけい [とくてんばん]"
   name-en: "Hanabi Hyakkei [Tokutenban]"
   region: "NTSC-J"
+  speedHacks:
+    instantVU1: 0 # Fixes working speed to correctly.
+    mtvu: 0 # Fixes working speed to correctly.
 SLPS-20309:
   name: "花火百景"
   name-sort: "はなびひゃっけい"
   name-en: "Hanabi Hyakkei"
   region: "NTSC-J"
+  speedHacks:
+    instantVU1: 0 # Fixes working speed to correctly.
+    mtvu: 0 # Fixes working speed to correctly.
 SLPS-20310:
   name: "麻雀飛龍伝説 天牌"
   name-sort: "まーじゃんひりゅうでんせつ てんぱい"
@@ -53031,7 +53342,7 @@ SLPS-20316:
 SLPS-20317:
   name: "実戦パチスロ必勝法！ キングキャメル"
   name-sort: "じっせんぱちすろひっしょうほう！ きんぐきゃめる"
-  name-en: "Jissen Pachi-Slot Hisshouhou! King Camel"
+  name-en: "Jissen Pachi-Slot Hisshouhou！ King Camel"
   region: "NTSC-J"
   compat: 5
 SLPS-20318:
@@ -53053,7 +53364,7 @@ SLPS-20321:
 SLPS-20322:
   name: "熱チュー！プロ野球2003 秋のナイター祭り"
   name-sort: "ねっちゅー！ぷろやきゅう2003 あきのないたーまつり"
-  name-en: "Necchu! Pro Yakyuu 2003 - Aki no Night Matsuri"
+  name-en: "Necchu！ Pro Yakyuu 2003 - Aki no Night Matsuri"
   region: "NTSC-J"
   patches:
     D3DAF7F4:
@@ -53142,12 +53453,12 @@ SLPS-20338:
 SLPS-20339:
   name: "実戦パチスロ必勝法！ Sammy's Collection2 DX"
   name-sort: "じっせんぱちすろひっしょうほう！ さみーずこれくしょん2 DX"
-  name-en: "Jissen Pachi-Slot Hisshouhou! Sammy's Collection 2 DX"
+  name-en: "Jissen Pachi-Slot Hisshouhou！ Sammy's Collection 2 DX"
   region: "NTSC-J"
 SLPS-20340:
   name: "実戦パチスロ必勝法！ Sammy's Collection2"
   name-sort: "じっせんぱちすろひっしょうほう！ さみーずこれくしょん2"
-  name-en: "Jissen Pachi-Slot Hisshouhou! Sammy's Collection 2"
+  name-en: "Jissen Pachi-Slot Hisshouhou！ Sammy's Collection 2"
   region: "NTSC-J"
 SLPS-20343:
   name: "ネットでボンバーマン"
@@ -53177,7 +53488,7 @@ SLPS-20349:
 SLPS-20350:
   name: "サッカーライフ！"
   name-sort: "さっかーらいふ！"
-  name-en: "Soccer Life! We are Challengers to Europe"
+  name-en: "Soccer Life！ We are Challengers to Europe"
   region: "NTSC-J"
 SLPS-20351:
   name: "スロッターUPマニア4 南国の香！スーパーハナハナ&シオマール&オアーゼ"
@@ -53195,23 +53506,23 @@ SLPS-20353:
   name-en: "Suki na Mono ha Sukidakara Shouganai FIRST LIMIT & TARGET†NIGHTS Sukisho! Episode ＃01+＃02 [Disc 2 of 2]"
   region: "NTSC-J"
 SLPS-20354:
-  name: "山佐Digiワールド3 [ベストオブベスト]"
-  name-sort: "やまさでじわーるど3 [べすとおぶべすと]"
+  name: "山佐Digiワールド3 [BEST OF BEST]"
+  name-sort: "やまさでじわーるど3 [BEST OF BEST]"
   name-en: "Yamasa Digi World 3 [Best of Best]"
   region: "NTSC-J"
 SLPS-20355:
-  name: "山佐DigiワールドSP ネオプラネットXX [ベストオブベスト]"
-  name-sort: "やまさでじわーるどSP ねおぷらねっとXX [べすとおぶべすと]"
+  name: "山佐DigiワールドSP ネオプラネットXX [BEST OF BEST]"
+  name-sort: "やまさでじわーるどSP ねおぷらねっとXX [BEST OF BEST]"
   name-en: "Yamasa Digi World SP - Neo Planett XX [Best of Best]"
   region: "NTSC-J"
 SLPS-20356:
-  name: "山佐Digiワールド4 [ベストオブベスト]"
-  name-sort: "やまさでじわーるど4 [べすとおぶべすと]"
+  name: "山佐Digiワールド4 [BEST OF BEST]"
+  name-sort: "やまさでじわーるど4 [BEST OF BEST]"
   name-en: "Yamasa Digi World 4 [Best of Best]"
   region: "NTSC-J"
 SLPS-20357:
-  name: "山佐DigiワールドSP 海一番R [ベストオブベスト]"
-  name-sort: "やまさでじわーるどSP うみいちばんR [べすとおぶべすと]"
+  name: "山佐DigiワールドSP 海一番R [BEST OF BEST]"
+  name-sort: "やまさでじわーるどSP うみいちばんR [BEST OF BEST]"
   name-en: "Yamasa Digi World SP - Umi Ichiban R [Best of Best]"
   region: "NTSC-J"
 SLPS-20361:
@@ -53222,7 +53533,7 @@ SLPS-20361:
 SLPS-20362:
   name: "かいけつゾロリ めざせ！いたずらキング EyeToy USBカメラ同梱版"
   name-sort: "かいけつぞろり めざせ！いたずらきんぐ あいとーいUSBかめらどうこんばん"
-  name-en: "Kaiketsu Zorro Mezase! Itazura King [Limited Edition]"
+  name-en: "Kaiketsu Zorro Mezase！ Itazura King [Limited Edition]"
   region: "NTSC-J"
 SLPS-20364:
   name: "世界最強銀星囲碁5"
@@ -53242,13 +53553,13 @@ SLPS-20366:
 SLPS-20367:
   name: "カレーハウスCoCo壱番屋 今日も元気だ！カレーがうまい！！"
   name-sort: "かれーはうすここいちばんや きょうもげんきだ！かれーがうまい！！"
-  name-en: "Curry House CoCo Ichiban'ya - Kyou mo Genki da! Curry ga Umai!!"
+  name-en: "Curry House CoCo Ichiban'ya - Kyou mo Genki da！ Curry ga Umai！！"
   region: "NTSC-J"
   compat: 5
 SLPS-20368:
   name: "かいけつゾロリ めざせ！いたずらキング [単体版]"
   name-sort: "かいけつぞろり めざせ！いたずらきんぐ [たんたいばん]"
-  name-en: "Kaiketsu Zorro Mezase! Itazura King"
+  name-en: "Kaiketsu Zorro Mezase！ Itazura King"
   region: "NTSC-J"
 SLPS-20369:
   name: "キン肉マン ジェネレーションズ"
@@ -53258,7 +53569,7 @@ SLPS-20369:
 SLPS-20370:
   name: "スロッターUPコア3 愉打！ドロンジョにおまかせ"
   name-sort: "すろったーUPこあ 3 ゆだ！どろんじょにおまかせ"
-  name-en: "Slotter Up Core 3 - Yuda! Doronjo ni Omakase!"
+  name-en: "Slotter Up Core 3 - Yuda! Doronjo ni Omakase！"
   region: "NTSC-J"
 SLPS-20371:
   name: "麻雀覇王 真剣バトル"
@@ -53268,14 +53579,14 @@ SLPS-20371:
 SLPS-20372:
   name: "実戦パチスロ必勝法！ 北斗の拳 [DXパック]"
   name-sort: "じっせんぱちすろひっしょうほう！ ほくとのけん [DXぱっく]"
-  name-en: "Jissen Pachi-Slot Hisshouhou! Hokuto no Ken [Limited Edition]"
+  name-en: "Jissen Pachi-Slot Hisshouhou！ Hokuto no Ken [Limited Edition]"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves the shine of the pachi slot machine.
 SLPS-20373:
   name: "実戦パチスロ必勝法！ 北斗の拳"
   name-sort: "じっせんぱちすろひっしょうほう！ ほくとのけん"
-  name-en: "Jissen Pachi-Slot Hisshouhou! Hokuto no Ken"
+  name-en: "Jissen Pachi-Slot Hisshouhou！ Hokuto no Ken"
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves the shine of the pachi slot machine.
@@ -53315,7 +53626,7 @@ SLPS-20379:
 SLPS-20380:
   name: "神魂合体ゴーダンナー！！"
   name-sort: "しんこんがったいごーだんなー！！"
-  name-en: "Shinkon Gattai Godannar!!"
+  name-en: "Shinkon Gattai Godannar！！"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 4 # Fixes ghosting.
@@ -53328,21 +53639,21 @@ SLPS-20381:
 SLPS-20382:
   name: "太鼓の達人 あつまれ！祭りだ！！四代目 タタコン同梱セット"
   name-sort: "たいこのたつじん あつまれ！まつりだ！！よんだいめ たたこんどうこんせっと"
-  name-en: "Taiko no Tatsujin - Atsumare! Matsuri da!! Yondaime [with Tatacon]"
+  name-en: "Taiko no Tatsujin - Atsumare！ Matsuri da！！ Yondaime [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20383:
   name: "太鼓の達人 あつまれ！祭りだ！！四代目"
   name-sort: "たいこのたつじん あつまれ！まつりだ！！よんだいめ"
-  name-en: "Taiko no Tatsujin - Atsumare! Matsuri da!! Yondaime"
+  name-en: "Taiko no Tatsujin - Atsumare！ Matsuri da！！ Yondaime"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20384:
-  name: "流行り神 警視庁怪異事件ファイル （初回限定版）"
+  name: "流行り神 警視庁怪異事件ファイル [初回限定版]"
   name-sort: "はやりがみ けいしちょうかいいじけんふぁいる [しょかいげんていばん]"
-  name-en: "Hayarigami - Keishichou Kaii Jiken File"
+  name-en: "Hayarigami - Keishichou Kaii Jiken File [First Limited Edition]"
   region: "NTSC-J"
 SLPS-20386:
   name: "バリュー2000シリーズ 囲碁4"
@@ -53382,7 +53693,7 @@ SLPS-20393:
 SLPS-20394:
   name: "好きなものは好きだからしょうがない！！ -RAIN- Sukisyo！ Episode #03"
   name-sort: "すきなものはすきだからしょうがない！！ 03 -れいん- すきしょ！ えぴそーど #03"
-  name-en: "Suki na Mono ha Sukida Rashouganai + White Flower + Sukisyo!"
+  name-en: "Suki na Mono ha Sukida Rashouganai + White Flower + Sukisyo！"
   region: "NTSC-J"
 SLPS-20396:
   name: "スロッターUPマニア5 爽快激打！マッハGoGoGo&だるま猫"
@@ -53402,14 +53713,14 @@ SLPS-20398:
 SLPS-20399:
   name: "太鼓の達人 ゴー！ゴー！五代目 [タタコン同梱セット]"
   name-sort: "たいこのたつじん ごー！ごー！ごだいめ [たたこんどうこんせっと]"
-  name-en: "Taiko no Tatsujin - Go! Go! Godaime [with Tatacon]"
+  name-en: "Taiko no Tatsujin - Go！ Go！ Godaime [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20400:
   name: "太鼓の達人 ゴー！ゴー！五代目 [ソフト単体]"
   name-sort: "たいこのたつじん ごー！ごー！ごだいめ [そふとたんたい]"
-  name-en: "Taiko no Tatsujin - Go! Go! Godaime"
+  name-en: "Taiko no Tatsujin - Go！ Go！ Godaime"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
@@ -53432,7 +53743,7 @@ SLPS-20403:
 SLPS-20404:
   name: "楽勝！ パチスロ宣言2 - ジュウジカ・デカダン"
   name-sort: "らくしょう！ ぱちすろせんげん2 - じゅうじか・でかだん"
-  name-en: "Rakushou! Pachi-Slot Sengen 2 - Juujika, Deka Dan"
+  name-en: "Rakushou！ Pachi-Slot Sengen 2 - Juujika, Deka Dan"
   region: "NTSC-J"
 SLPS-20405:
   name: "スロッターUPコア5 ルパン大好き！主役は銭形"
@@ -53452,13 +53763,13 @@ SLPS-20407:
 SLPS-20408:
   name: "カードキャプターさくら 「さくらちゃんとあそぼ！」"
   name-sort: "かーどきゃぷたーさくら さくらちゃんとあそぼ！"
-  name-en: "Card Captor Sakura - Sakura-Chan to Asobo!"
+  name-en: "Card Captor Sakura - Sakura-Chan to Asobo！"
   region: "NTSC-J"
   compat: 5
 SLPS-20409:
   name: "ファントム・キングダム [初回限定版]"
-  name-sort: "ふぁんとむ・きんぐだむ しょかいげんていばん"
-  name-en: "Phantom Kingdom [Limited Edition]"
+  name-sort: "ふぁんとむ・きんぐだむ [しょかいげんていばん]"
+  name-en: "Phantom Kingdom [First Limited Edition]"
   region: "NTSC-J"
 SLPS-20410:
   name: "ファントム・キングダム [通常版]"
@@ -53508,7 +53819,7 @@ SLPS-20418:
 SLPS-20419:
   name: "楽勝！ パチスロ宣言3 - リオデカーニバル・ジュウジカ600式"
   name-sort: "らくしょう！ ぱちすろせんげん3 - りおでかーにばる・じゅうじか600しき"
-  name-en: "Rakushou! Pachi-Slot Sengen 3 - Rio de Carnival, Juujika 600-shiki"
+  name-en: "Rakushou！ Pachi-Slot Sengen 3 - Rio de Carnival, Juujika 600-shiki"
   region: "NTSC-J"
 SLPS-20420:
   name: "ウルトラマンネクサス"
@@ -53535,14 +53846,14 @@ SLPS-20423:
 SLPS-20424:
   name: "太鼓の達人 とびっきり！アニメスペシャル [「タタコン」同梱版]"
   name-sort: "たいこのたつじん とびっきり！あにめすぺしゃる [「たたこん」どうこんばん]"
-  name-en: "Taiko no Tatsujin - Tobikkiri! Anime Special [with Tatacon]"
+  name-en: "Taiko no Tatsujin - Tobikkiri！ Anime Special [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20425:
   name: "太鼓の達人 とびっきり！アニメスペシャル [ソフト単体]"
   name-sort: "たいこのたつじん とびっきり！あにめすぺしゃる [そふとたんたい]"
-  name-en: "Taiko no Tatsujin - Tobikkiri! Anime Special"
+  name-en: "Taiko no Tatsujin - Tobikkiri！ Anime Special"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
@@ -53569,7 +53880,7 @@ SLPS-20428:
 SLPS-20429:
   name: "必殺パチスロエヴォリューション 忍者ハットリくんV"
   name-sort: "ひっさつぱちすろえゔぉりゅーしょん にんじゃはっとりくんV"
-  name-en: "Hissatsu Pachislot Ninja Hattori Kun V"
+  name-en: "Hissatsu Pachi-Slot Ninja Hattori Kun V"
   region: "NTSC-J"
 SLPS-20430:
   name: "SIMPLE2000シリーズ Vol.91 THE ALL★STAR格闘祭"
@@ -53587,7 +53898,7 @@ SLPS-20431:
 SLPS-20436:
   name: "魁！！男塾"
   name-sort: "さきがけ！！おとこじゅく"
-  name-en: "Sakigake!! Otokojuku"
+  name-en: "Sakigake！！ Otokojuku"
   region: "NTSC-J"
 SLPS-20439:
   name: "SIMPLE2000シリーズ Vol.79 アッコにおまかせ！ THE パーティークイズ"
@@ -53630,7 +53941,7 @@ SLPS-20444:
 SLPS-20445:
   name: "SIMPLE2000シリーズ Ultimate Vol.28 闘走！喧嘩グランプリ ～Drive to Survive～"
   name-sort: "しんぷる2000しりーず あるてぃめっと Vol.28 とうそう！けんかぐらんぷり ～Drive to Survive～"
-  name-en: "Simple 2000 Series Ultimate Vol. 28 - Tousou! Kenka Grand Prix - Drive to Survive"
+  name-en: "Simple 2000 Series Ultimate Vol. 28 - Tousou！ Kenka Grand Prix - Drive to Survive"
   region: "NTSC-J"
 SLPS-20446:
   name: "SIMPLE2000シリーズ Vol.89 THE パーティーゲーム2"
@@ -53640,7 +53951,7 @@ SLPS-20446:
 SLPS-20447:
   name: "仮面ライダー 響鬼 [初回生産版]"
   name-sort: "かめんらいだー ひびき [しょかいせいさんばん]"
-  name-en: "Kamen Rider Hibiki"
+  name-en: "Kamen Rider Hibiki [First Limited Edition]"
   region: "NTSC-J"
   compat: 5
 SLPS-20448:
@@ -53651,28 +53962,28 @@ SLPS-20448:
 SLPS-20450:
   name: "太鼓の達人 わいわいハッピー！六代目 タタコン同梱版"
   name-sort: "たいこのたつじん わいわいはっぴー！ろくだいめ たたこんどうこんばん"
-  name-en: "Taiko no Tatsujin - Wai Wai Happy! Rokudaime [with Tatacon]"
+  name-en: "Taiko no Tatsujin - Wai Wai Happy！ Rokudaime [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20451:
   name: "太鼓の達人 わいわいハッピー！六代目"
   name-sort: "たいこのたつじん わいわいはっぴー！ろくだいめ"
-  name-en: "Taiko no Tatsujin - Wai Wai Happy! Rokudaime"
+  name-en: "Taiko no Tatsujin - Wai Wai Happy！ Rokudaime"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20452:
   name: "SIMPLE2000シリーズ Ultimate Vol.30 降臨！族車ゴッド～仏恥義理★愛羅武勇～"
   name-sort: "しんぷる2000しりーず あるてぃめっと Vol.30 こうりん！ぞくしゃごっど ぶっちぎりあいらぶゆう"
-  name-en: "Simple 2000 Series Ultimate Vol. 30 - Kourin! Zokusha Goddo!"
+  name-en: "Simple 2000 Series Ultimate Vol. 30 - Kourin！ Zokusha Goddo！"
   region: "NTSC-J"
   gameFixes:
     - XGKickHack # Fixes car colours.
 SLPS-20453:
   name: "SIMPLE2000シリーズ Ultimate Vol.29 K-1 PREMIUM 2005 Dynamite！！"
   name-sort: "しんぷる2000しりーず あるてぃめっと Vol.29 K-1 PREMIUM 2005 Dynamite！！"
-  name-en: "Simple 2000 Series Ultimate Vol. 29 - K-1 Premium 2005 Dynamite!!"
+  name-en: "Simple 2000 Series Ultimate Vol. 29 - K-1 Premium 2005 Dynamite！！"
   region: "NTSC-J"
   compat: 5
   gameFixes:
@@ -53702,12 +54013,12 @@ SLPS-20456:
 SLPS-20457:
   name: "必殺パチスロエヴォリューション2 おそ松くん"
   name-sort: "ひっさつぱちすろえゔぉりゅーしょん2 おそまつくん"
-  name-en: "Hissatsu Pachislo Evolution 2 - Osomatsu-Kun"
+  name-en: "Hissatsu Pachi-Slot Evolution 2 - Osomatsu-Kun"
   region: "NTSC-J"
 SLPS-20458:
   name: "SIMPLE2000シリーズ Vol.96 THE 海賊 ～ガイコツいっぱいれーつ！～"
   name-sort: "しんぷる2000しりーず Vol.  96 THE かいぞく ～がいこついっぱいれーつ！～"
-  name-en: "Simple 2000 Series Vol. 96 - The Kaizoku - Gaikotsu Ippaire~tsu!"
+  name-en: "Simple 2000 Series Vol. 96 - The Kaizoku - Gaikotsu Ippaire~tsu！"
   region: "NTSC-J"
 SLPS-20459:
   name: "山佐DigiワールドSP 燃えよ！功夫淑女"
@@ -53717,7 +54028,7 @@ SLPS-20459:
 SLPS-20460:
   name: "楽勝！パチスロ宣言4 - 真モグモグ風林火山・リオデカーニバル"
   name-sort: "らくしょう！ぱちすろせんげん4 - しんもぐもぐふうりんかざん りおでかーにばる"
-  name-en: "Rakushou! Pachi-Slot Sengen 4 - Shin MoguMogu FuuRinKaZan,Rio de Carnival"
+  name-en: "Rakushou！ Pachi-Slot Sengen 4 - Shin MoguMogu FuuRinKaZan,Rio de Carnival"
   region: "NTSC-J"
 SLPS-20461:
   name: "SIMPLE2000シリーズ Vol.99 THE 原始人"
@@ -53726,14 +54037,14 @@ SLPS-20461:
   region: "NTSC-J"
   compat: 5
 SLPS-20462:
-  name: "黄金騎士 牙狼<GARO>[限定版]"
+  name: "黄金騎士 牙狼<GARO> [限定版]"
   name-sort: "おうごんきし がろう [げんていばん]"
   name-en: "Ougon Kishi Garo [Limited Edition]"
   region: "NTSC-J"
 SLPS-20463:
-  name: "黄金騎士 牙狼<GARO>[通常版]"
-  name-sort: "おうごんきし がろう つうじょうばん"
-  name-en: "Ougon Kishi Garo"
+  name: "黄金騎士 牙狼<GARO> [通常版]"
+  name-sort: "おうごんきし がろう [つうじょうばん]"
+  name-en: "Ougon Kishi Garo [Standard Edition]"
   region: "NTSC-J"
 SLPS-20464:
   name: "SIMPLE2000シリーズ Vol.105 THE メイド服と機関銃"
@@ -53790,7 +54101,7 @@ SLPS-20472:
 SLPS-20473:
   name: "SIMPLE2000シリーズ Vol.104 THE ロボットつくろうぜっ！ ～激闘！ロボットファイト～"
   name-sort: "しんぷる2000しりーず Vol.104 THE ろぼっとつくろうぜっ！ ～げきとう！ろぼっとふぁいと～"
-  name-en: "Simple 2000 Series Vol. 104 - The Robot Tsuku Rouze! - Gekitou! Robot Fight"
+  name-en: "Simple 2000 Series Vol. 104 - The Robot Tsuku Rouze！ - Gekitou！ Robot Fight"
   region: "NTSC-J"
 SLPS-20474:
   name: "SIMPLE2000シリーズ Vol.107 THE 炎の格闘番長"
@@ -53816,7 +54127,7 @@ SLPS-20477:
 SLPS-20478:
   name: "SIMPLE2000シリーズ Vol.109 THE タクシー2 ～運転手はやっぱり君だ！～"
   name-sort: "しんぷる2000しりーず Vol.109 THEたくしー2 ～うんてんしゅはやっぱりきみだ！～"
-  name-en: "Simple 2000 Series Vol. 109 - The Taxi 2 - Untenshu ha Yappari Kimi da!"
+  name-en: "Simple 2000 Series Vol. 109 - The Taxi 2 - Untenshu ha Yappari Kimi da！"
   region: "NTSC-J"
 SLPS-20479:
   name: "速読マスター"
@@ -53839,8 +54150,8 @@ SLPS-20482:
   name-en: "3D Mahjong + Janpai Tori"
   region: "NTSC-J"
 SLPS-20483:
-  name: "仮面ライダーカブト"
-  name-sort: "かめんらいだーかぶと"
+  name: "仮面ライダー カブト"
+  name-sort: "かめんらいだー かぶと"
   name-en: "Kamen Rider Kabuto"
   region: "NTSC-J"
   gsHWFixes:
@@ -53848,26 +54159,26 @@ SLPS-20483:
 SLPS-20484:
   name: "SIMPLE2000シリーズ Ultimate Vol.34 魁！！男塾"
   name-sort: "しんぷる2000しりーず あるてぃめっと Vol.34 さきがけ！！おとこじゅく"
-  name-en: "Simple 2000 Series Ultimate Vol. 34 - Sakigake!! Otokojuku"
+  name-en: "Simple 2000 Series Ultimate Vol. 34 - Sakigake！！ Otokojuku"
   region: "NTSC-J"
 SLPS-20485:
   name: "太鼓の達人 ドカッ！と大盛り七代目 [タタコン同梱]"
   name-sort: "たいこのたつじん どかっ！とおおもりななだいめ [たたこんどうこん]"
-  name-en: "Taiko no Tatsujin - Doka! to Oomori Nanadaime [with Tatacon]"
+  name-en: "Taiko no Tatsujin - Doka！ to Oomori Nanadaime [with Tatacon]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20486:
   name: "太鼓の達人 ドカッ！と大盛り七代目 [ソフト単体]"
   name-sort: "たいこのたつじん どかっ！とおおもりななだいめ [そふとたんたい]"
-  name-en: "Taiko no Tatsujin - Doka! to Oomori Nanadaime [Only Soft]"
+  name-en: "Taiko no Tatsujin - Doka！ to Oomori Nanadaime [Only Soft]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-20487:
   name: "パチスロキング！ 科学忍者隊ガッチャマン"
   name-sort: "ぱちすろきんぐ！ かがくにんじゃたいがっちゃまん"
-  name-en: "Pachi-Slot King! Kagaku Ninja-Tai Gatchaman"
+  name-en: "Pachi-Slot King！ Kagaku Ninja-Tai Gatchaman"
   region: "NTSC-J"
 SLPS-20488:
   name: "SIMPLE2000シリーズ Vol.113 THE 大量地獄"
@@ -53877,7 +54188,7 @@ SLPS-20488:
 SLPS-20489:
   name: "SIMPLE2000シリーズ Vol.114 THE 女岡っピチ捕物帳 ～お春ちゃんGOGOGO！～"
   name-sort: "しんぷる2000しりーず Vol.114 THEおんなおかっぴちとりものちょう ～おはるちゃんGOGOGO！～"
-  name-en: "Simple 2000 Series Vol. 114 - The Onna Okappichi Torimonochou - Oharu-chan GoGoGo!"
+  name-en: "Simple 2000 Series Vol. 114 - The Onna Okappichi Torimonochou - Oharu-chan GoGoGo！"
   region: "NTSC-J"
   gsHWFixes:
     getSkipCount: "GSC_Simple2000Vol114"
@@ -54020,7 +54331,7 @@ SLPS-25003:
 SLPS-25004:
   name: "建設重機喧嘩バトル ぶちギレ金剛！！"
   name-sort: "けんせつじゅうきけんかばとる ぶちぎれこんごう！！"
-  name-en: "Kensetsu Juuki Kenka Battle - Buchigire Kongou!!"
+  name-en: "Kensetsu Juuki Kenka Battle - Buchigire Kongou！！"
   region: "NTSC-J"
   compat: 5
 SLPS-25005:
@@ -54197,7 +54508,7 @@ SLPS-25032:
   name-en: "Golful Golf"
   region: "NTSC-J"
 SLPS-25033:
-  name: "風のクロノア2～世界が望んだ忘れもの～"
+  name: "風のクロノア2 ～世界が望んだ忘れもの～"
   name-sort: "かぜのくろのあ2 せかいがのぞんだわすれもの"
   name-en: "Kaze no Klonoa 2 - Sekai ga Nozonda Wasuremono"
   region: "NTSC-J"
@@ -54271,7 +54582,7 @@ SLPS-25041:
 SLPS-25042:
   name: "魔剣爻 -MAKEN SHAO-[初回限定版]"
   name-sort: "まけんしゃお [しょかいげんていばん]"
-  name-en: "Maken Shao [Limited Edition]"
+  name-en: "Maken Shao [First Limited Edition]"
   region: "NTSC-J"
   speedHacks:
     mvuFlag: 0
@@ -54353,7 +54664,7 @@ SLPS-25053:
   name-en: "Eikan ha Kimi ni - Koushien no Hasha"
   region: "NTSC-J"
 SLPS-25054:
-  name: "玉繭物語2～滅びの蟲～"
+  name: "玉繭物語2 ～滅びの蟲～"
   name-sort: "たままゆものがたり2 ほろびのむし"
   name-en: "Tamamayu Story 2"
   region: "NTSC-J"
@@ -54461,7 +54772,7 @@ SLPS-25073:
 SLPS-25074:
   name: "零 ～zero～"
   name-sort: "ぜろ"
-  name-en: "Fatal Frame"
+  name-en: "Zero"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
@@ -54509,7 +54820,7 @@ SLPS-25079:
 SLPS-25080:
   name: "宇宙戦艦ヤマト イスカンダルへの追憶 [初回生産限定版]"
   name-sort: "うちゅうせんかんやまと いすかんだるへのついおく [しょかいせいさんげんていばん]"
-  name-en: "Uchuu Senkan Yamato - Iscandar he no Tsuioku [Special Edition]"
+  name-en: "Uchuu Senkan Yamato - Iscandar he no Tsuioku [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25081:
   name: "最終電車"
@@ -54618,7 +54929,7 @@ SLPS-25102:
   name-en: "Project Arms"
   region: "NTSC-J"
 SLPS-25103:
-  name: "スーパーロボット大戦IMPACT 限定版"
+  name: "スーパーロボット大戦IMPACT [限定版]"
   name-sort: "すーぱーろぼっとたいせんIMPACT [げんていばん]"
   name-en: "Super Robot Taisen Impact [Limited Edition]"
   region: "NTSC-J"
@@ -54956,14 +55267,14 @@ SLPS-25160:
   name-en: "Final Fantasy XI 2002 [Special Art Box]"
   region: "NTSC-J"
 SLPS-25161:
-  name: "宇宙戦艦ヤマト 暗黒星団帝国の逆襲 [初回生産限定]"
+  name: "宇宙戦艦ヤマト 暗黒星団帝国の逆襲 [初回生産限定版]"
   name-sort: "うちゅうせんかんやまと あんこくせいだんていこくのぎゃくしゅう [しょかいせいさんげんてい]"
-  name-en: "Uchuu Senkan Yamato - Ankoku Seidan Teikoku no Gyakushuu [Special Edition]"
+  name-en: "Uchuu Senkan Yamato - Ankoku Seidan Teikoku no Gyakushuu [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25162:
-  name: "宇宙戦艦ヤマト 暗黒星団帝国の逆襲"
-  name-sort: "うちゅうせんかんやまと あんこくせいだんていこくのぎゃくしゅう"
-  name-en: "Uchuu Senkan Yamato - Ankoku Seidan Teikoku no Gyakushuu"
+  name: "宇宙戦艦ヤマト 暗黒星団帝国の逆襲 [通常版]"
+  name-sort: "うちゅうせんかんやまと あんこくせいだんていこくのぎゃくしゅう [つうじょうばん]"
+  name-en: "Uchuu Senkan Yamato - Ankoku Seidan Teikoku no Gyakushuu [Standard Edition]"
   region: "NTSC-J"
 SLPS-25164:
   name: "宇宙戦艦ヤマト 二重銀河の崩壊"
@@ -55012,7 +55323,7 @@ SLPS-25170:
 SLPS-25171:
   name: "ルパン三世 魔術王の遺産"
   name-sort: "るぱんさんせい まじゅつおうのいさん"
-  name-en: "Lupin III - Majutsu no Isan"
+  name-en: "Lupin III-sei - Majutsuou no Isan"
   region: "NTSC-J"
 SLPS-25172:
   name: "テイルズ オブ デスティニー2"
@@ -55108,7 +55419,7 @@ SLPS-25188:
 SLPS-25189:
   name: "闘魂 猪木道 ～ぱずるDEダァーッ！"
   name-sort: "とうこん いのきみち ～ぱずるでだぁーっ！～"
-  name-en: "Toukon Inoki-michi - Puzzle de Daaa!"
+  name-en: "Toukon Inoki-michi - Puzzle de Daaa！"
   region: "NTSC-J"
 SLPS-25190:
   name: "スイートレガシー ～ボクと彼女の名もないお菓子～"
@@ -55123,7 +55434,7 @@ SLPS-25191:
 SLPS-25192:
   name: "My Merry May [初回限定版]"
   name-sort: "まい めりー めい [しょかいげんていばん]"
-  name-en: "My Merry May [First print Limited Edition]"
+  name-en: "My Merry May [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25193:
   name: "My Merry May"
@@ -55134,8 +55445,8 @@ SLPS-25194:
   name: "Herdy Gerdy"
   region: "NTSC-J"
 SLPS-25195:
-  name: "ヴィーナス&ブレイブス ～魔女と女神と滅びの予言～ プレミアムボックス"
-  name-sort: "ゔぃーなす&ぶれいぶす まじょとめがみとほろびのよげん ぷれみあむぼっくす"
+  name: "ヴィーナス&ブレイブス ～魔女と女神と滅びの予言～ [プレミアムボックス]"
+  name-sort: "ゔぃーなす&ぶれいぶす まじょとめがみとほろびのよげん [ぷれみあむぼっくす]"
   name-en: "Venus & Braves [Premium Pack]"
   region: "NTSC-J"
   compat: 5
@@ -55263,7 +55574,7 @@ SLPS-25214:
 SLPS-25215:
   name: "Iris [初回限定版]"
   name-sort: "いりす [しょかいげんていばん]"
-  name-en: "Iris [Limited Edition]"
+  name-en: "Iris [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25216:
   name: "Iris"
@@ -55290,12 +55601,12 @@ SLPS-25220:
 SLPS-25221:
   name: "Piaキャロットへようこそ！！3 ～round summer～ [初回限定版]"
   name-sort: "ぴあきゃろっとへようこそ！！3 ～らうんど さまー～ [しょかいげんていばん]"
-  name-en: "Welcome to Pia Carrot!! 3 - eound summer - [Limited Edition]"
+  name-en: "Welcome to Pia Carrot！！ 3 - eound summer - [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25222:
   name: "Piaキャロットへようこそ！！3 ～round summer～ [通常版]"
   name-sort: "ぴあきゃろっとへようこそ！！3 ～らうんど さまー～ [つうじょうばん]"
-  name-en: "Pia Carrot he Youkoso!! 3 - eound summer - [Standard Edition]"
+  name-en: "Pia Carrot he Youkoso！！ 3 - eound summer - [Standard Edition]"
   region: "NTSC-J"
 SLPS-25223:
   name: "Canvas～セピア色のモチーフ～"
@@ -55305,7 +55616,7 @@ SLPS-25223:
 SLPS-25224:
   name: "藍より青し [初回限定版]"
   name-sort: "あいよりあおし [しょかいげんていばん]"
-  name-en: "Ai yori Aoshi [First Print Limited Edition]"
+  name-en: "Ai yori Aoshi [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25225:
   name: "藍より青し [通常版]"
@@ -55444,7 +55755,7 @@ SLPS-25248:
 SLPS-25249:
   name: "三洋パチンコパラダイス9 ～新海おかわり！～"
   name-sort: "さんようぱちんこぱらだいす 9 しんうみおかわり！"
-  name-en: "Sanyo Pachinko Paradise 9 - Shin Umi Okawari!"
+  name-en: "Sanyo Pachinko Paradise 9 - Shin Umi Okawari！"
   region: "NTSC-J"
 SLPS-25250:
   name: "ファイナルファンタジーⅩ-2"
@@ -55551,7 +55862,7 @@ SLPS-25264:
     autoFlush: 2 # Fixes DOF effect.
 SLPS-25265:
   name: "ラーゼフォン 蒼穹幻想曲 [通常版]"
-  name-sort: "らーぜふぉん そうきゅうげんそうきょく"
+  name-sort: "らーぜふぉん そうきゅうげんそうきょく [つうじょうばん]"
   name-en: "RAhXEPhON - Soukyuu Gensoukyoku [Standard Edition]"
   region: "NTSC-J"
   roundModes:
@@ -55629,7 +55940,7 @@ SLPS-25281:
 SLPS-25282:
   name: "学園ヘヴン BOY'S LOVE SCRAMBLE！"
   name-sort: "がくえんへゔん BOY'S LOVE SCRAMBLE！"
-  name-en: "Gakuen Heaven - Boy's Love Scramble!"
+  name-en: "Gakuen Heaven - Boy's Love Scramble！"
   region: "NTSC-J"
 SLPS-25283:
   name: "INTERLUDE"
@@ -55644,7 +55955,7 @@ SLPS-25287:
 SLPS-25288:
   name: "D→A:BLACK [初回限定版]"
   name-sort: "D→A:BLACK [しょかいげんていばん]"
-  name-en: "D-A - Black [Limited Edition]"
+  name-en: "D-A - Black [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25289:
   name: "タイムクライシス3 [ガンコン2同梱]"
@@ -55670,9 +55981,9 @@ SLPS-25291:
     texturePreloading: 1 # Performs much better with partial preload.
     estimateTextureRegion: 1 # Improves performance.
 SLPS-25292:
-  name: "D→A:BLACK"
-  name-sort: "D→A:BLACK"
-  name-en: "D-A - Black"
+  name: "D→A:BLACK [通常版]"
+  name-sort: "D→A:BLACK [つうじょうばん]"
+  name-en: "D-A - Black [Standard Edition]"
   region: "NTSC-J"
 SLPS-25293:
   name: "NARUTO-ナルト- ナルティメットヒーロー"
@@ -55738,7 +56049,7 @@ SLPS-25302:
 SLPS-25303:
   name: "零 ～紅い蝶～"
   name-sort: "ぜろ あかいちょう"
-  name-en: "Zero - Crimson Butterfly"
+  name-en: "Zero - Akai Chou"
   region: "NTSC-J"
   compat: 5
 SLPS-25304:
@@ -55759,7 +56070,7 @@ SLPS-25307:
 SLPS-25308:
   name: "クラウチングタイガー・ヒドゥンドラゴン"
   name-sort: "くらうちんぐたいがー ひどぅんどらごん"
-  name-en: "Crouching Tiger, Hidden Dragon"
+  name-en: "Crouching Tiger Hidden Dragon"
   region: "NTSC-J"
   gameFixes:
     - InstantDMAHack # Fixes FMVs to be visible.
@@ -55849,17 +56160,17 @@ SLPS-25323:
 SLPS-25324:
   name: "西風の狂詩曲 [初回限定版]"
   name-sort: "にしかぜのらぷそでぃ [しょかいげんていばん]"
-  name-en: "Rhapsody of Zephyr, The [First Print limited Edition]"
+  name-en: "Rhapsody of Zephyr, The [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25326:
   name: "エキサイティングプロレス 5 [限定版]"
   name-sort: "えきさいてぃんぐぷろれす5 [げんていばん]"
-  name-en: "WWE Smackdown! Here Comes the Pain - Exciting Pro Wrestling 5 [Limited Edition]"
+  name-en: "WWE Smackdown！ Here Comes the Pain - Exciting Pro Wrestling 5 [Limited Edition]"
   region: "NTSC-J"
 SLPS-25327:
   name: "エキサイティングプロレス 5"
   name-sort: "えきさいてぃんぐぷろれす5"
-  name-en: "WWE Smackdown! Here Comes the Pain - Exciting Pro Wrestling 5"
+  name-en: "WWE Smackdown！ Here Comes the Pain - Exciting Pro Wrestling 5"
   region: "NTSC-J"
 SLPS-25329:
   name: "九怨 -kuon-"
@@ -55898,7 +56209,7 @@ SLPS-25333:
 SLPS-25334:
   name: "シャドウハーツⅡ [通常版] [ディスク1/2]"
   name-sort: "しゃどうはーつ2 [つうじょうばん] [でぃすく1/2]"
-  name-en: "Shadow Hearts II [Disc 1 of 2]"
+  name-en: "Shadow Hearts II [Standard Edition] [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 4 # Fixes shadow positioning.
@@ -55906,7 +56217,7 @@ SLPS-25334:
 SLPS-25335:
   name: "シャドウハーツⅡ [通常版] [ディスク2/2]"
   name-sort: "しゃどうはーつ2 [つうじょうばん] [でぃすく2/2]"
-  name-en: "Shadow Hearts II [Disc 2 of 2]"
+  name-en: "Shadow Hearts II [Standard Edition] [Disc 2 of 2]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 4 # Fixes shadow positioning.
@@ -55998,9 +56309,9 @@ SLPS-25347:
   name-en: "King of Fighters 2002, The"
   region: "NTSC-J"
 SLPS-25348:
-  name: "こころの扉 初回限定版 コレクターズエディション"
-  name-sort: "こころのとびら しょかいげんていばん これくたーずえでぃしょん"
-  name-en: "Kokoro no Tobira [Limited Edition]"
+  name: "こころの扉 初回限定版 [コレクターズエディション]"
+  name-sort: "こころのとびら しょかいげんていばん [これくたーずえでぃしょん]"
+  name-en: "Kokoro no Tobira [Collector's Edition]"
   region: "NTSC-J"
 SLPS-25349:
   name: "こころの扉"
@@ -56010,7 +56321,7 @@ SLPS-25349:
 SLPS-25350:
   name: "熱チュー！プロ野球2004"
   name-sort: "ねっちゅー！ぷろやきゅう2004"
-  name-en: "Necchu! Pro Baseball 2004"
+  name-en: "Necchu！ Pro Proyakyuu 2004"
   region: "NTSC-J"
 SLPS-25351:
   name: "バーンアウト2 ポイント オブ インパクト"
@@ -56056,12 +56367,12 @@ SLPS-25356:
 SLPS-25357:
   name: "3年B組金八先生 伝説の教壇に立て！"
   name-sort: "3ねんBぐみきんぱちせんせい でんせつのきょうだんにたて！"
-  name-en: "3-nen B-gumi Kinpachi Sensei - Densetsu no Kyoudan ni Tate!"
+  name-en: "3-nen B-gumi Kinpachi Sensei - Densetsu no Kyoudan ni Tate！"
   region: "NTSC-J"
 SLPS-25358:
   name: "金色のガッシュベル！！ 友情タッグバトル"
   name-sort: "こんじきのがっしゅべる！！ ゆうじょうたっぐばとる"
-  name-en: "Gold Gasho Bell! - Friendship Tag Battle"
+  name-en: "Konjiki no Gashbell！！ - Yuujou Tag Battle"
   region: "NTSC-J"
 SLPS-25359:
   name: "シャーマンキング ふんばりスピリッツ"
@@ -56112,8 +56423,8 @@ SLPS-25365:
   name-en: "Missing Blue [Best Price]"
   region: "NTSC-J"
 SLPS-25366:
-  name: "ゼノサーガ エピソードⅡ [善悪の彼岸] プレミアムボックス [ディスク1/2]"
-  name-sort: "ぜのさーが えぴそーど2 ぜんあくのひがん ぷれみあむぼっくす [でぃすく1/2]"
+  name: "ゼノサーガ エピソードⅡ [善悪の彼岸] [プレミアムボックス] [ディスク1/2]"
+  name-sort: "ぜのさーが えぴそーど2 ぜんあくのひがん [ぷれみあむぼっくす] [でぃすく1/2]"
   name-en: "Xenosaga Episode II - Jenseits von Gut und Bose [Premium Box] [Disc 1 of 2]"
   region: "NTSC-J"
   gsHWFixes:
@@ -56129,8 +56440,8 @@ SLPS-25366:
     - "SLPS-25353"
     - "SLPS-73224"
 SLPS-25367:
-  name: "ゼノサーガ エピソードⅡ [善悪の彼岸] プレミアムボックス [ディスク2/2]"
-  name-sort: "ぜのさーが えぴそーど2 ぜんあくのひがん ぷれみあむぼっくす [でぃすく2/2]"
+  name: "ゼノサーガ エピソードⅡ [善悪の彼岸] [プレミアムボックス] [ディスク2/2]"
+  name-sort: "ぜのさーが えぴそーど2 ぜんあくのひがん [ぷれみあむぼっくす] [でぃすく2/2]"
   name-en: "Xenosaga Episode II - Jenseits von Gut und Bose [Premium Box] [Disc 2 of 2]"
   region: "NTSC-J"
   gsHWFixes:
@@ -56187,7 +56498,7 @@ SLPS-25370:
 SLPS-25371:
   name: "DearS [初回限定版]"
   name-sort: "でぃあーず [しょかいげんていばん]"
-  name-en: "DearS [Limited Edition]"
+  name-en: "DearS [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25372:
   name: "DearS"
@@ -56223,7 +56534,7 @@ SLPS-25377:
 SLPS-25378:
   name: "東京魔人學園外法帖血風録 [初回限定版]"
   name-sort: "とうきょうまじんがくえんげほうちょうけっぷうろく [しょかいげんていばん]"
-  name-en: "Tokyo Majin Gakuen - Kaihoujyou Kefurokou [Limited Edition]"
+  name-en: "Tokyo Majin Gakuen - Kaihoujyou Kefurokou [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25379:
   name: "東京魔人學園外法帖血風録"
@@ -56233,7 +56544,7 @@ SLPS-25379:
 SLPS-25381:
   name: "学園ヘヴン BOY'S LOVE SCRAMBLE！"
   name-sort: "がくえんへゔん ぼーいずらぶすくらんぶる！"
-  name-en: "Gakuen Heaven - Boy's Love Scramble! Type B"
+  name-en: "Gakuen Heaven - Boy's Love Scramble！ Type B"
   region: "NTSC-J"
 SLPS-25382:
   name: "ワンピース ランドランド！"
@@ -56280,7 +56591,7 @@ SLPS-25389:
 SLPS-25390:
   name: "クローバーハーツ ルッキングフォーハピネス [初回限定版]"
   name-sort: "くろーばーはーつ るっきんぐふぉーはぴねす [しょかいげんていばん]"
-  name-en: "Clover Heart's - Looking for Happiness [Limited Edition]"
+  name-en: "Clover Heart's - Looking for Happiness [First Limited Edition]"
   region: "NTSC-J"
   gsHWFixes:
     minimumBlendingLevel: 4 # Fixes transparancy.
@@ -56318,8 +56629,8 @@ SLPS-25396:
   region: "NTSC-J"
 SLPS-25397:
   name: "シンドバットアドベンチャーは榎本加奈子でどうですか [特典版]"
-  name-sort: "しんどばっどあどべんちゃーはえのもとかなこでどうですか とくてんばん"
-  name-en: "Golden Voyage - Sindbad Adventure"
+  name-sort: "しんどばっどあどべんちゃーはえのもとかなこでどうですか [とくてんばん]"
+  name-en: "Sindbad Adventure wa Enomoto Kanako de Doudesuka [Limiter Edition]"
   region: "NTSC-J"
 SLPS-25398:
   name: "NARUTO-ナルト- ナルティメットヒーロー2"
@@ -56416,9 +56727,9 @@ SLPS-25408:
       replacement:
         - { offset: 0x4, value: 0x3442CCE0 }
 SLPS-25409:
-  name: "双恋—フタコイ— 初回限定版"
-  name-sort: "ふたこい しょかいげんていばん"
-  name-en: "Futakoi [Limited Edition]"
+  name: "双恋—フタコイ— [初回限定版]"
+  name-sort: "ふたこい [しょかいげんていばん]"
+  name-en: "Futakoi [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25410:
   name: "双恋—フタコイ—"
@@ -56426,8 +56737,8 @@ SLPS-25410:
   name-en: "Futakoi"
   region: "NTSC-J"
 SLPS-25411:
-  name: "ToHeart & ToHeart2 限定デラックスパック"
-  name-sort: "とぅはーと & とぅはーと2 げんていでらっくすぱっく"
+  name: "ToHeart & ToHeart2 [限定デラックスパック]"
+  name-sort: "とぅはーと & とぅはーと2 [げんていでらっくすぱっく]"
   name-en: "To Heart 2 [Deluxe Edition]"
   region: "NTSC-J"
 SLPS-25412:
@@ -56435,9 +56746,9 @@ SLPS-25412:
   name-sort: "とぅはーと"
   region: "NTSC-J"
 SLPS-25413:
-  name: "ToHeart2 初回限定版"
-  name-sort: "とぅはーと2 しょかいげんていばん"
-  name-en: "ToHeart 2 [Limited Edition]"
+  name: "ToHeart2 [初回限定版]"
+  name-sort: "とぅはーと2 [しょかいげんていばん]"
+  name-en: "ToHeart 2 [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25414:
   name: "ToHeart2"
@@ -56445,14 +56756,14 @@ SLPS-25414:
   name-en: "ToHeart 2"
   region: "NTSC-J"
 SLPS-25415:
-  name: "ちゅ～かな雀士 てんほー牌娘 コレクターズエディション"
-  name-sort: "ちゅーかなじゃんし てんほーぱいにゃん これくたーずえでぃしょん"
+  name: "ちゅ～かな雀士 てんほー牌娘 [コレクターズエディション]"
+  name-sort: "ちゅーかなじゃんし てんほーぱいにゃん [これくたーずえでぃしょん]"
   name-en: "Chuuka na Janshi - Tenhoo Painyan [Collector's Edition]"
   region: "NTSC-J"
 SLPS-25416:
   name: "ちゅ～かな雀士 てんほー牌娘 [通常版]"
-  name-sort: "ちゅーかなじゃんし てんほーぱいにゃん"
-  name-en: "Chuuka na Janshi - Tenhoo Painyan"
+  name-sort: "ちゅーかなじゃんし てんほーぱいにゃん [つうじょうばん]"
+  name-en: "Chuuka na Janshi - Tenhoo Painyan [Standard Edition]"
   region: "NTSC-J"
 SLPS-25417:
   name: "PANZER FRONT Ausf.B [eb!コレ]"
@@ -56489,12 +56800,12 @@ SLPS-25419:
 SLPS-25420:
   name: "シンドバットアドベンチャーは榎本加奈子でどうですか"
   name-sort: "しんどばっどあどべんちゃーはえのもとかなこでどうですか"
-  name-en: "Golden Voyage - Sindbad Adventure"
+  name-en: "Sindbad Adventure wa Enomoto Kanako de Doudesuka"
   region: "NTSC-J"
 SLPS-25421:
   name: "牧場物語 Oh！ ワンダフルライフ [初回版]"
   name-sort: "ぼくじょうものがたり Oh わんだふるらいふ [しょかいばん]"
-  name-en: "Bokujou Monogatari - Oh! Wonderful Life [First Print Limited Edition]"
+  name-en: "Bokujou Monogatari - Oh！ Wonderful Life [First Limited Edition]"
   region: "NTSC-J"
   patches:
     D2F0DC73:
@@ -56525,7 +56836,7 @@ SLPS-25424:
 SLPS-25425:
   name: "SDガンダム - フォース 大決戦！次元海賊デ・スカール"
   name-sort: "SDがんだむふぉーす だいけっせん じげんかいぞくですかーる"
-  name-en: "SD Gundam Force Daikessen!"
+  name-en: "SD Gundam Force Daikessen！"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 2 # Needed for SPS on some characters.
@@ -56534,12 +56845,10 @@ SLPS-25426:
   name-sort: "めいたんていこなん だいえいていこくのいさん"
   name-en: "Detective Conan - Inheritance of Britain"
   region: "NTSC-J"
-  gsHWFixes:
-    halfPixelOffset: 2 # Fixes misaligned blur in game and on the UI.
 SLPS-25427:
   name: "レジェンズ 激闘！サーガバトル"
   name-sort: "れじぇんず げきとう さーがばとる"
-  name-en: "Legions Gekitou! Saga Battle"
+  name-en: "Legions Gekitou！ Saga Battle"
   region: "NTSC-J"
   compat: 5
 SLPS-25428:
@@ -56564,17 +56873,17 @@ SLPS-25430:
 SLPS-25431:
   name: "牧場物語 Oh！ ワンダフルライフ [通常版]"
   name-sort: "ぼくじょうものがたり Oh！ わんだふるらいふ [つうじょうばん]"
-  name-en: "Bokujou Monogatari - Oh! Wonderful Life [Standard Edition]"
+  name-en: "Bokujou Monogatari - Oh！ Wonderful Life [Standard Edition]"
   region: "NTSC-J"
 SLPS-25432:
   name: "魔女っ娘ア・ラ・モード 唱えて、恋の魔法！ [初回限定版]"
-  name-sort: "まじょっこあらもーど となえて こいのまほう！ しょかいげんていばん"
+  name-sort: "まじょっこあらもーど となえて こいのまほう！ [しょかいげんていばん]"
   name-en: "Majo-kko A La Mode [Magical Box]"
   region: "NTSC-J"
 SLPS-25433:
   name: "帝国千戦記 [初回限定版]"
-  name-sort: "ていこくせんせんき しょかいげんていばん"
-  name-en: "Teikoku Sensenki [Limited Edition]"
+  name-sort: "ていこくせんせんき [しょかいげんていばん]"
+  name-en: "Teikoku Sensenki [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25434:
   name: "西風の狂詩曲～The Rhapsody of Zephyr～ Best Collection"
@@ -56594,12 +56903,12 @@ SLPS-25436:
 SLPS-25437:
   name: "D→A:WHITE [初回限定版]"
   name-sort: "D→A:WHITE [しょかいげんていばん]"
-  name-en: "D A - White"
+  name-en: "D A - White [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25438:
-  name: "D→A:WHITE"
-  name-sort: "D→A:WHITE"
-  name-en: "D A - White [Limited Edition]"
+  name: "D→A:WHITE [通常版]"
+  name-sort: "D→A:WHITE [つうじょうばん]"
+  name-en: "D A - White [Stnadard Edition]"
   region: "NTSC-J"
 SLPS-25439:
   name: "はじめの一歩 ALL☆STARS"
@@ -56609,11 +56918,11 @@ SLPS-25439:
 SLPS-25440:
   name: "金色のガッシュベル！！ 激闘！最強の魔物達"
   name-sort: "こんじきのがっしゅべる げきとう さいきょうのまものたち"
-  name-en: "Gold Gashbell!! Gekitou! Saikyou no Mamonotachi"
+  name-en: "Konjiki no Gashbell！！ Gekitou！ Saikyou no Mamonotachi"
   region: "NTSC-J"
 SLPS-25441:
-  name: "ウルトラマン Fighting Evolution3"
-  name-sort: "うるとらまん Fighting Evolution3"
+  name: "ウルトラマン Fighting Evolution 3"
+  name-sort: "うるとらまん Fighting Evolution 3"
   name-en: "Ultraman Fighting Evolution 3"
   region: "NTSC-J"
 SLPS-25443:
@@ -56634,7 +56943,7 @@ SLPS-25445:
 SLPS-25447:
   name: "トップをねらえ！"
   name-sort: "とっぷをねらえ"
-  name-en: "Top wo Nerae! Gunbuster"
+  name-en: "Top wo Nerae！ Gunbuster"
   region: "NTSC-J"
 SLPS-25448:
   name: "THE KING OF FIGHTERS 94 RE-BOUT [スペシャル限定版]"
@@ -56662,9 +56971,9 @@ SLPS-25451:
   gsHWFixes:
     textureInsideRT: 1 # Fixes some of the many graphical issues.
 SLPS-25452:
-  name: "キノの旅 -the Beautiful World- 電撃SP"
-  name-sort: "きののたび the Beautiful World でんげきSP"
-  name-en: "Kino no Tabi - The Beautiful World [MediaWorks Best]"
+  name: "キノの旅 -the Beautiful World- [電撃SP]"
+  name-sort: "きののたび the Beautiful World [でんげきSP]"
+  name-en: "Kino no Tabi - The Beautiful World [Dengeki SP]"
   region: "NTSC-J"
 SLPS-25453:
   name: "デジモンワールドX"
@@ -56743,7 +57052,7 @@ SLPS-25462:
 SLPS-25463:
   name: "マイホームをつくろう2！匠"
   name-sort: "まいほーむをつくろう2 たくみ"
-  name-en: "My Home o Tsukurou 2! Takumi"
+  name-en: "My Home o Tsukurou 2！ Takumi"
   region: "NTSC-J"
 SLPS-25464:
   name: "大戦略Ⅶ エクシード"
@@ -56756,9 +57065,9 @@ SLPS-25465:
   name-en: "Azumi"
   region: "NTSC-J"
 SLPS-25466:
-  name: "永遠のアセリア -この大地の果てで- 初回限定版"
-  name-sort: "えいえんのあせりあ このだいちのはてで しょかいげんていばん"
-  name-en: "Eternal Aselia - The Spirit of Eternity Sword [Limited Edition]"
+  name: "永遠のアセリア -この大地の果てで- [初回限定版]"
+  name-sort: "えいえんのあせりあ このだいちのはてで [しょかいげんていばん]"
+  name-en: "Eternal Aselia - The Spirit of Eternity Sword [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25467:
   name: "みんな大好き塊魂"
@@ -56801,7 +57110,7 @@ SLPS-25470:
 SLPS-25471:
   name: "学校をつくろう Happy Days！！"
   name-sort: "がっこうをつくろう Happy Days！！"
-  name-en: "Gakkou o Tsukurou - Happy Days!!"
+  name-en: "Gakkou o Tsukurou - Happy Days！！"
   region: "NTSC-J"
 SLPS-25472:
   name: "XIII - サーティーン - 大統領を殺した男 [Best Collection]"
@@ -56811,7 +57120,7 @@ SLPS-25472:
 SLPS-25473:
   name: "ワンピース グラバト！RUSH"
   name-sort: "わんぴーす ぐらばと！らっしゅ"
-  name-en: "One Piece - Grand Battle! Combat Rush"
+  name-en: "One Piece - Grand Battle！ Combat Rush"
   region: "NTSC-J"
 SLPS-25474:
   name: "BECK THE GAME"
@@ -56834,7 +57143,7 @@ SLPS-25478:
 SLPS-25479:
   name: "金色のガッシュベル！！友情タッグバトル2"
   name-sort: "こんじきのがっしゅべる！！ゆうじょうたっぐばとる2"
-  name-en: "Gold Gashbell - Friendship Tag Battle 2"
+  name-en: "Konjiki no Gashbell！！ - Yuujou Tag Battle 2"
   region: "NTSC-J"
 SLPS-25480:
   name: "ジパング"
@@ -56844,8 +57153,11 @@ SLPS-25480:
 SLPS-25481:
   name: "ガッツだ！！森の石松"
   name-sort: "がっつだ もりのいしまつ"
-  name-en: "Gattsu Da!! Mori no Ishimatsu"
+  name-en: "Gattsu Da！！ Mori no Ishimatsu"
   region: "NTSC-J"
+  gsHWFixes:
+    instantVU1: 0 # Fixes Turbo mode Freeze.
+    mtvu: 0 # Fixes Turbo mode Freeze.
 SLPS-25482:
   name: "雪語り リニューアル版"
   name-sort: "ゆきがたり りにゅーあるばん"
@@ -56919,8 +57231,8 @@ SLPS-25496:
   region: "NTSC-J"
 SLPS-25497:
   name: "ティアリングサーガシリーズ ベルウィックサーガ [通常版]"
-  name-sort: "てぃありんぐさーがしりーず べるうぃっくさーが"
-  name-en: "TearRing Saga Series - Berwick Saga"
+  name-sort: "てぃありんぐさーがしりーず べるうぃっくさーが [つうじょうばん]"
+  name-en: "TearRing Saga Series - Berwick Saga [Standard Edition]"
   region: "NTSC-J"
 SLPS-25498:
   name: "時空冒険記 ゼントリックス"
@@ -57005,8 +57317,8 @@ SLPS-25511:
   region: "NTSC-J"
 SLPS-25513:
   name: "蒼い海のトリスティア ～ナノカ・フランカ発明工房記～ [初回限定版]"
-  name-sort: "あおいうみのとりすてぃあ なのか ふらんかはつめいこうぼうき しょかいげんていばん"
-  name-en: "Aoi Umi no Tristia - Nanoca Flanka Hatsumei Koubouki [First Print Limited Edition]"
+  name-sort: "あおいうみのとりすてぃあ なのか ふらんかはつめいこうぼうき [しょかいげんていばん]"
+  name-en: "Aoi Umi no Tristia - Nanoca Flanka Hatsumei Koubouki [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25514:
   name: "蒼い海のトリスティア ～ナノカ・フランカ発明工房記～"
@@ -57014,7 +57326,7 @@ SLPS-25514:
   name-en: "Aoi Umi no Tristia - Nanoca Flanka Hatsumei Koubouki"
   region: "NTSC-J"
 SLPS-25515:
-  name: "フタコイ オルタナティブ 恋と少女とマシンガン 限定版"
+  name: "フタコイ オルタナティブ 恋と少女とマシンガン [限定版]"
   name-sort: "ふたこい おるたなてぃぶ こいとしょうじょとましんがん [げんていばん]"
   name-en: "Futakoi Alternative [Limited Edition]"
   region: "NTSC-J"
@@ -57026,7 +57338,7 @@ SLPS-25516:
 SLPS-25517:
   name: "エンジョイゴルフ！"
   name-sort: "えんじょいごるふ！"
-  name-en: "Enjoy Golf!"
+  name-en: "Enjoy Golf！"
   region: "NTSC-J"
 SLPS-25518:
   name: "犬夜叉 奥義乱舞"
@@ -57049,8 +57361,8 @@ SLPS-25521:
   name-en: "Soccer Life 2"
   region: "NTSC-J"
 SLPS-25522:
-  name: "義経紀 限定版 豪華絢爛BOX"
-  name-sort: "よしつねき [げんていばん] ごうかけんらんBOX"
+  name: "義経紀 [限定版 豪華絢爛BOX]"
+  name-sort: "よしつねき [げんていばん ごうかけんらんBOX]"
   name-en: "Yoshitsuneki [Gouka Kenran Box]"
   region: "NTSC-J"
 SLPS-25523:
@@ -57170,7 +57482,7 @@ SLPS-25543:
 SLPS-25544:
   name: "零 ～刺青の聲～"
   name-sort: "ぜろ しせいのこえ"
-  name-en: "Fatal Frame III - The Tormented"
+  name-en: "Zero - Shisei no Koe"
   region: "NTSC-J"
   compat: 5
 SLPS-25545:
@@ -57180,9 +57492,9 @@ SLPS-25545:
   region: "NTSC-J"
   compat: 5
 SLPS-25546:
-  name: "苺ましまろ 初回限定版"
-  name-sort: "いちごましまろ しょかいげんていばん"
-  name-en: "Ichigo Mashimaro [Limited Edition]"
+  name: "苺ましまろ [初回限定版]"
+  name-sort: "いちごましまろ [しょかいげんていばん]"
+  name-en: "Ichigo Mashimaro [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25547:
   name: "苺ましまろ"
@@ -57202,7 +57514,7 @@ SLPS-25549:
 SLPS-25550:
   name: "カウボーイビバップ 追憶の夜曲 [初回生産限定版]"
   name-sort: "かうぼーいびばっぷ ついおくのせれなーで [しょかいせいさんげんていばん]"
-  name-en: "Cowboy Bebop - Tsuioku no Serenade [Limited Edition]"
+  name-en: "Cowboy Bebop - Tsuioku no Serenade [First Limited Edition]"
   region: "NTSC-J"
   clampModes:
     eeClampMode: 0 # Fixes HUD going black.
@@ -57262,7 +57574,7 @@ SLPS-25559:
 SLPS-25560:
   name: "ドラゴンボールZ スパーキング！"
   name-sort: "どらごんぼーるZ すぱーきんぐ！"
-  name-en: "Dragon Ball Z - Sparking!"
+  name-en: "Dragon Ball Z - Sparking！"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes lines when powering up.
@@ -57443,8 +57755,6 @@ SLPS-25588:
   name-sort: "めいたんていこなん だいえいていこくのいさん BANDAI THE BEST"
   name-en: "Meitantei Conan - Daiei Teikoku no Isan [Bandai The Best]"
   region: "NTSC-J"
-  gsHWFixes:
-    halfPixelOffset: 2 # Fixes misaligned blur in game and on the UI.
 SLPS-25589:
   name: "NARUTO-ナルト- ナルティメットヒーロー3"
   name-sort: "なると なるてぃめっとひーろー3"
@@ -57480,17 +57790,17 @@ SLPS-25593:
 SLPS-25594:
   name: "金色のガッシュベル！！ゴー！ゴー！魔物ファイト！！ [旧本体用マルチタップ同梱]"
   name-sort: "こんじきのがっしゅべる！！ごー！ごー！まものふぁいと！！ [旧本体用マルチタップ同梱]"
-  name-en: "Konjiki no Gashbell! - Go!Go! Mamono Fight [with Multi-Tap for Old ver.PS2]"
+  name-en: "Konjiki no Gashbell！！ - Go！Go！ Mamono Fight [with Multi-Tap for Old ver.PS2]"
   region: "NTSC-J"
 SLPS-25595:
   name: "金色のガッシュベル！！ゴー！ゴー！魔物ファイト！！ [Slim本体用マルチタップ同梱]"
   name-sort: "こんじきのがっしゅべる！！ごー！ごー！まものふぁいと！！ [Slim本体用マルチタップ同梱]"
-  name-en: "Konjiki no Gashbell! - Go!Go! Mamono Fight [with Multi-Tap for Slim ver.PS2]"
+  name-en: "Konjiki no Gashbell！！ - Go！Go！ Mamono Fight [with Multi-Tap for Slim ver.PS2]"
   region: "NTSC-J"
 SLPS-25596:
   name: "金色のガッシュベル！！ゴー！ゴー！魔物ファイト！！ [ソフト単体]"
   name-sort: "こんじきのがっしゅべる！！ごー！ごー！まものふぁいと！！ [そふとたんたい]"
-  name-en: "Konjiki no Gashbell! - Go!Go! Mamono Fight [Only Soft]"
+  name-en: "Konjiki no Gashbell！！ - Go！Go！ Mamono Fight [Only Soft]"
   region: "NTSC-J"
 SLPS-25597:
   name: "川のぬし釣り ワンダフルジャーニー Best Collection"
@@ -57500,7 +57810,7 @@ SLPS-25597:
 SLPS-25598:
   name: "学校をつくろう！！Happy Days Best Collection"
   name-sort: "がっこうをつくろう！！Happy Days Best Collection"
-  name-en: "Gakkou o Tsukurou - Happy Days!! [Best Collection]"
+  name-en: "Gakkou o Tsukurou - Happy Days！！ [Best Collection]"
   region: "NTSC-J"
 SLPS-25599:
   name: "灼眼のシャナ"
@@ -57515,7 +57825,7 @@ SLPS-25600:
 SLPS-25601:
   name: "うえきの法則 倒すぜロベルト十団！！"
   name-sort: "うえきのほうそく たおすぜろべるとじゅうだん！！"
-  name-en: "Ueki no Housoku - Taosu Ze Roberuto Juudan!!"
+  name-en: "Ueki no Housoku - Taosu Ze Roberuto Juudan！！"
   region: "NTSC-J"
 SLPS-25602:
   name: "必勝パチンコ★パチスロ攻略シリーズ Vol.2 ボンバーパワフル&夢夢ワールドDX"
@@ -57537,7 +57847,7 @@ SLPS-25604:
 SLPS-25605:
   name: "NEOGEOオンラインコレクション Vol.3 THE KING OF FIGHTERS ～オロチ編～ [通常版]"
   name-sort: "ねおじおおんらいんこれくしょん Vol. 3 ざ きんぐ おぶ ふぁいたーず おろちへん [つうじょうばん]"
-  name-en: "NeoGeo Online Collection Vol.3 - The King of Fighters - Orochi Collection"
+  name-en: "NeoGeo Online Collection Vol.3 - The King of Fighters - Orochi Collection [Standard Edition]"
   region: "NTSC-J"
 SLPS-25606:
   name: "絶体絶命都市2 -凍てついた記憶たち-"
@@ -57552,7 +57862,7 @@ SLPS-25606:
 SLPS-25607:
   name: "魔界戦記ディスガイア2 [初回限定版]"
   name-sort: "まかいせんきでぃすがいあ2 [しょかいげんていばん]"
-  name-en: "Makai Senki Disgaea 2 [Limited Edition]"
+  name-en: "Makai Senki Disgaea 2 [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25608:
   name: "魔界戦記ディスガイア2"
@@ -57563,7 +57873,7 @@ SLPS-25608:
 SLPS-25609:
   name: "KOF MAXIMUM IMPACT2 [初回限定DVD同梱版]"
   name-sort: "ざ きんぐ おぶ ふぁいたーず まきしまむ いんぱくと2 [しょかいげんていDVDどうこんばん]"
-  name-en: "King of Fighters, The - Maximum Impact 2 [with DVD Limited Edition]"
+  name-en: "King of Fighters, The - Maximum Impact 2 [with DVD / First Limited Edition]"
   region: "NTSC-J"
 SLPS-25610:
   name: "NEOGEOオンラインコレクション Vol.4 龍虎の拳 ～天・地・人～"
@@ -57573,17 +57883,17 @@ SLPS-25610:
 SLPS-25611:
   name: "Strawberry Panic！ [初回限定版]"
   name-sort: "すとろべりーぱにっく！ [しょかいげんていばん]"
-  name-en: "Strawberry Panic [Limited Edition]"
+  name-en: "Strawberry Panic [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25612:
   name: "Strawberry Panic！ [通常版]"
-  name-sort: "すとろべりーぱにっく！"
-  name-en: "Strawberry Panic"
+  name-sort: "すとろべりーぱにっく！ [つうじょうばん]"
+  name-en: "Strawberry Panic [Standard Edition]"
   region: "NTSC-J"
 SLPS-25613:
   name: "マイホームをつくろう2！ 匠 Best Collection"
   name-sort: "まいほーむをつくろう2！ たくみ Best Collection"
-  name-en: "My Home o Tsukurou 2! Takumi [Best Collection]"
+  name-en: "My Home o Tsukurou 2！ Takumi [Best Collection]"
   region: "NTSC-J"
 SLPS-25614:
   name: "舞-HiME 運命の系統樹 Best Collection"
@@ -57593,7 +57903,7 @@ SLPS-25614:
 SLPS-25615:
   name: "マイホームをつくろう2 充実！簡単設計！！"
   name-sort: "まいほーむをつくろう2 じゅうじつ！かんたんせっけい！！"
-  name-en: "My Home wo Tsukurou 2! Kantan Sekkei!!"
+  name-en: "My Home wo Tsukurou 2！ Kantan Sekkei！！"
   region: "NTSC-J"
 SLPS-25616:
   name: "スキージャンプ・ペア Reloaded"
@@ -57606,13 +57916,13 @@ SLPS-25617:
   name-en: "Etude Prologue - Yureugoku Kokoro no Katachi"
   region: "NTSC-J"
 SLPS-25618:
-  name: "D→A:BLACK [ベストプライス]"
-  name-sort: "D→A:BLACK [べすとぷらいす]"
+  name: "D→A:BLACK [Best Price]"
+  name-sort: "D→A:BLACK [Best Price]"
   name-en: "D-A - Black [Best Price]"
   region: "NTSC-J"
 SLPS-25619:
-  name: "D→A:WHITE [ベストプライス]"
-  name-sort: "D→A:WHITE [べすとぷらいす]"
+  name: "D→A:WHITE [Best Price]"
+  name-sort: "D→A:WHITE [Best Price]"
   name-en: "D-A - White [Best Price]"
   region: "NTSC-J"
 SLPS-25620:
@@ -57623,12 +57933,12 @@ SLPS-25620:
 SLPS-25621:
   name: "かしまし ～ガールミーツガール～「初めての夏物語。」限定版"
   name-sort: "かしまし がーるみーつがーる「はじめてのなつものがたり」げんていばん"
-  name-en: "Kashimashi! - Girl Meets Girl [Limited Edition]"
+  name-en: "Kashimashi！ - Girl Meets Girl [Limited Edition]"
   region: "NTSC-J"
 SLPS-25622:
   name: "かしまし ～ガールミーツガール～「初めての夏物語。」通常版"
   name-sort: "かしまし がーるみーつがーる「はじめてのなつものがたり」つうじょうばん"
-  name-en: "Kashimashi! - Girl Meets Girl"
+  name-en: "Kashimashi！ - Girl Meets Girl"
   region: "NTSC-J"
 SLPS-25623:
   name: "Another Century's Episode 2"
@@ -57849,9 +58159,9 @@ SLPS-25652:
   name-en: ".hack//G.U. Vol.1 - Rebirth [Terminal Disc - The End of the World]"
   region: "NTSC-J"
 SLPS-25653:
-  name: "クラスターエッジ 君を待つ未来への証 初回限定版"
-  name-sort: "くらすたーえっじ きみをまつみらいへのあかし しょかいげんていばん"
-  name-en: "Cluster Edge [Limited Edition]"
+  name: "クラスターエッジ 君を待つ未来への証 [初回限定版]"
+  name-sort: "くらすたーえっじ きみをまつみらいへのあかし [しょかいげんていばん]"
+  name-en: "Cluster Edge [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25654:
   name: "クラスターエッジ 君を待つ未来への証"
@@ -57913,13 +58223,13 @@ SLPS-25657:
     halfPixelOffset: 2 # Helps ghosting when upscaling.
 SLPS-25658:
   name: "びんちょうタン しあわせ暦 [初回限定版]"
-  name-sort: "びんちょうたん しあわせごよみ しょかいげんていばん"
-  name-en: "Binchou-Tan - Shiwase Goyomi [First Print Limited Edition]"
+  name-sort: "びんちょうたん しあわせごよみ [しょかいげんていばん]"
+  name-en: "Binchou-Tan - Shiwase Goyomi [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25659:
   name: "びんちょうタン しあわせ暦 [通常版]"
-  name-sort: "びんちょうたん しあわせごよみ"
-  name-en: "Binchou-Tan - Shiwase Koyomi"
+  name-sort: "びんちょうたん しあわせごよみ [つうじょうばん]"
+  name-en: "Binchou-Tan - Shiwase Koyomi [Standard Edition]"
   region: "NTSC-J"
 SLPS-25660:
   name: "THE KING OF FIGHTERS Ⅺ"
@@ -57935,12 +58245,12 @@ SLPS-25661:
 SLPS-25662:
   name: "今日からマ王！はじマりの旅 [プレミアムBOX]"
   name-sort: "きょうからまおう！はじまりのたび [ぷれみあむBOX]"
-  name-en: "Kyo Kara Maoh! The 1st trip of Maoh! [Premium Box]"
+  name-en: "Kyo Kara Maoh！ The 1st trip of Maoh！ [Premium Box]"
   region: "NTSC-J"
 SLPS-25663:
   name: "今日からマ王！はじマりの旅 [通常版]"
-  name-sort: "きょうからまおう！はじまりのたび"
-  name-en: "Kyo Kara Maoh! The 1st trip of Maoh!"
+  name-sort: "きょうからまおう！はじまりのたび [つうじょうばん]"
+  name-en: "Kyo Kara Maoh！ The 1st trip of Maoh！ [Standard Edition]"
   region: "NTSC-J"
 SLPS-25664:
   name: "NEOGEOオンラインコレクション Vol.5 餓狼伝説 バトルアーカイブズ1"
@@ -57970,8 +58280,8 @@ SLPS-25668:
   region: "NTSC-J"
 SLPS-25669:
   name: "スクールランブル二学期 恐怖の(?)夏合宿！ 洋館に幽霊現る！? お宝を巡って真っ向勝負!!!の巻 [初回限定版]"
-  name-sort: "すくーるらんぶるにがっき きょうふの(?)なつがっしゅく！ ようかんにゆうれいあらわる！? おたからをめぐってまっこうしょうぶ!!!のまき しょかいげんていばん"
-  name-en: "School Rumble 2nd Term [Limited Edition]"
+  name-sort: "すくーるらんぶるにがっき きょうふの(?)なつがっしゅく！ ようかんにゆうれいあらわる！? おたからをめぐってまっこうしょうぶ!!!のまき [しょかいげんていばん]"
+  name-en: "School Rumble 2nd Term [First Limited Edition]"
   region: "NTSC-J"
   compat: 5
 SLPS-25670:
@@ -58020,7 +58330,7 @@ SLPS-25677:
 SLPS-25678:
   name: "うたわれるもの 散りゆく者への子守唄 [初回限定版]"
   name-sort: "うたわれるもの ちりゆくものへのこもりうた [しょかいげんていばん]"
-  name-en: "Utawareru Mono - Chiriyukumono he no Komoriuta [Limited Edition]"
+  name-en: "Utawareru Mono - Chiriyukumono he no Komoriuta [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25679:
   name: "うたわれるもの 散りゆく者への子守唄 [通常版]"
@@ -58061,7 +58371,7 @@ SLPS-25684:
 SLPS-25685:
   name: "るろうに剣心-明治剣客浪漫譚- 炎上！京都輪廻"
   name-sort: "るろうにけんしん めいじけんかくろまんたん えんじょう！きょうとりんね"
-  name-en: "Rurouni Kenshin - Enjou! Kyoto Rinne"
+  name-en: "Rurouni Kenshin - Enjou！ Kyoto Rinne"
   region: "NTSC-J"
 SLPS-25686:
   name: "ジョジョの奇妙な冒険 ファントムブラッド"
@@ -58078,14 +58388,14 @@ SLPS-25687:
   region: "NTSC-J"
   compat: 5
 SLPS-25688:
-  name: "シムーン 異薔薇戦争 封印のリ・マージョン 初回限定版"
-  name-sort: "しむーん いばらせんそう ふういんのりまーじょん しょかいげんていばん"
-  name-en: "Simoun - Shoubi Sensou - Fuuin no Remersion [First Print Limited Edition]"
+  name: "シムーン 異薔薇戦争 封印のリ・マージョン [初回限定版]"
+  name-sort: "しむーん いばらせんそう ふういんのりまーじょん [しょかいげんていばん]"
+  name-en: "Simoun - Shoubi Sensou - Fuuin no Remersion [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25689:
-  name: "シムーン 異薔薇戦争 封印のリ・マージョン 通常版"
-  name-sort: "しむーん いばらせんそう ふういんのりまーじょん"
-  name-en: "Simoun - Shoubi Sensou - Fuuin no Remersion"
+  name: "シムーン 異薔薇戦争 封印のリ・マージョン [通常版]"
+  name-sort: "しむーん いばらせんそう ふういんのりまーじょん [つうじょうばん]"
+  name-en: "Simoun - Shoubi Sensou - Fuuin no Remersion [Standard Edition]"
   region: "NTSC-J"
 SLPS-25690:
   name: "ドラゴンボールZ スパーキング！ ネオ"
@@ -58107,7 +58417,7 @@ SLPS-25691:
 SLPS-25693:
   name: "プリンセス・プリンセス 姫たちのアブナい放課後 [初回限定版]"
   name-sort: "ぷりんせすぷりんせす ひめたちのあぶないほうかご [しょかいげんていばん]"
-  name-en: "Shinseiki GPX - Road to the Infinity 3 [Limited Edition]"
+  name-en: "Shinseiki GPX - Road to the Infinity 3 [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25694:
   name: "プリンセス・プリンセス 姫たちのアブナい放課後 [通常版]"
@@ -58185,7 +58495,7 @@ SLPS-25707:
 SLPS-25708:
   name: "ゼロの使い魔 小悪魔と春風の協奏曲 [初回限定版]"
   name-sort: "ぜろのつかいま こあくまとはるかぜのこんちぇると [しょかいげんていばん]"
-  name-en: "Zero no Tsukaima [Limited Edition]"
+  name-en: "Zero no Tsukaima [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25709:
   name: "ゼロの使い魔 小悪魔と春風の協奏曲 [通常版]"
@@ -58213,7 +58523,7 @@ SLPS-25710:
 SLPS-25711:
   name: "かしまし ～ガールミーツガール「初めての夏物語。」Best Collection"
   name-sort: "かしまし がーるみーつがーる はじめてのなつものがたり Best Collection"
-  name-en: "Kashimashi! Girl Meets Girl [Best Collection]"
+  name-en: "Kashimashi！ Girl Meets Girl [Best Collection]"
   region: "NTSC-J"
 SLPS-25712:
   name: "THE KING OF FIGHTERS NEOWAVE [SNK BEST COLLECTION]"
@@ -58270,12 +58580,12 @@ SLPS-25718:
 SLPS-25719:
   name: "はぴねす！でらっくす [初回限定版]"
   name-sort: "はぴねす！でらっくす [しょかいげんていばん]"
-  name-en: "Happiness! Deluxe [First Print Limited Edition]"
+  name-en: "Happiness！ Deluxe [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25720:
   name: "はぴねす！でらっくす [通常版]"
   name-sort: "はぴねす！でらっくす [つうじょうばん]"
-  name-en: "Happiness! Deluxe [Standard Edition]"
+  name-en: "Happiness！ Deluxe [Standard Edition]"
   region: "NTSC-J"
 SLPS-25721:
   name: "ひめひび -Princess Days-"
@@ -58285,7 +58595,7 @@ SLPS-25721:
 SLPS-25722:
   name: "Routes PE [初回限定版]"
   name-sort: "るーつ PE [しょかいげんていばん]"
-  name-en: "Routes PE [Limited Edition]"
+  name-en: "Routes PE [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25723:
   name: "令嬢探偵～オフィスラブ事件慕～"
@@ -58314,13 +58624,13 @@ SLPS-25727:
   region: "NTSC-J"
 SLPS-25728:
   name: "くじびき アンバランス 会長お願いすま～っしゅファイト☆ [初回限定版]"
-  name-sort: "くじびき あんばらんす かいちょうおねがいすまーっしゅふぁいと しょかいげんていばん"
-  name-en: "Kujibiki Ambulance [Limited Edition]"
+  name-sort: "くじびき あんばらんす かいちょうおねがいすまーっしゅふぁいと [しょかいげんていばん]"
+  name-en: "Kujibiki Ambulance [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25729:
   name: "くじびき アンバランス 会長お願いすま～っしゅファイト☆ [通常版]"
-  name-sort: "くじびき あんばらんす かいちょうおねがいすまーっしゅふぁいと"
-  name-en: "Kujibiki Unbalance"
+  name-sort: "くじびき あんばらんす かいちょうおねがいすまーっしゅふぁいと [つうじょうばん]"
+  name-en: "Kujibiki Unbalance [Standard Edition]"
   region: "NTSC-J"
 SLPS-25730:
   name: "アーマード・コア ラストレイブン [MACHINE SIDE BOX]"
@@ -58358,7 +58668,7 @@ SLPS-25733:
 SLPS-25734:
   name: "THE BATTLE OF 幽★遊★白書～死闘！暗黒武術会～120%"
   name-sort: "ざ ばとる おぶ ゆうゆうはくしょ しとう あんこくぶじゅつかい 120%"
-  name-en: "Battle of Yuu Yuu Hakusho, The - Shitou! Ankoku Bujutsukai - 120% Full Power"
+  name-en: "Battle of Yuu Yuu Hakusho, The - Shitou！ Ankoku Bujutsukai - 120% Full Power"
   region: "NTSC-J"
 SLPS-25735:
   name: "ドラゴンシャドウスペル"
@@ -58378,7 +58688,7 @@ SLPS-25737:
 SLPS-25738:
   name: "SOUL CRADLE 世界を喰らう者 [初回限定版]"
   name-sort: "そうるくれいどる せかいをくらうもの [しょかいげんていばん]"
-  name-en: "Soul Cradle Sekai o Kurau Mono [Limited Edition]"
+  name-en: "Soul Cradle Sekai o Kurau Mono [First Limited Edition]"
   region: "NTSC-J"
   compat: 5
 SLPS-25739:
@@ -58393,13 +58703,13 @@ SLPS-25740:
   region: "NTSC-J"
 SLPS-25742:
   name: "ああっ女神さまっ [初回限定版]"
-  name-sort: "ああっめがみさまっ しょかいげんていばん"
+  name-sort: "ああっめがみさまっ [しょかいげんていばん]"
   name-en: "Aa Megami-sama [Holy Box]"
   region: "NTSC-J"
 SLPS-25743:
   name: "ああっ女神さまっ [通常版]"
-  name-sort: "ああっめがみさまっ"
-  name-en: "Aa Megami-sama"
+  name-sort: "ああっめがみさまっ [つうじょうばん]"
+  name-en: "Aa Megami-sama [Standard Edition]"
   region: "NTSC-J"
 SLPS-25744:
   name: "聖闘士星矢 -冥王ハーデス十二宮編-"
@@ -58412,7 +58722,7 @@ SLPS-25744:
 SLPS-25745:
   name: "必勝パチンコ★パチスロ攻略シリーズ Vol.1 CR新世紀エヴァンゲリオン [スペシャルプライス版]"
   name-sort: "ひっしょうぱちんこぱちすろこうりゃくしりーず Vol. 1 CRしんせいきえゔぁんげりおん [すぺしゃるぷらいすばん]"
-  name-en: "Hisshou Pachinko-Pachislot Kouryaku Series Vol. 1 - CR Shinseiki Evangelion [Special Price Edition]"
+  name-en: "Hisshou Pachinko Pachi-Slot Kouryaku Series Vol. 1 - CR Shinseiki Evangelion [Special Price Edition]"
   region: "NTSC-J"
 SLPS-25746:
   name: "必勝パチンコ★パチスロ攻略シリーズ Vol.9 CRフィーバー キャプテンハーロック"
@@ -58425,14 +58735,14 @@ SLPS-25747:
   name-en: "Garouden Break Blow - Fist or Twist"
   region: "NTSC-J"
 SLPS-25748:
-  name: "蒼い空のネオスフィア～ナノカ・フランカ発明工房記2～ [初回限定版]"
-  name-sort: "あおいそらのねおすふぃあ なのかふらんかはつめいこうぼうき2 しょかいげんていばん"
-  name-en: "Aoi Sora no Neosphere - Nanoca Flanka Hatsumei Koubouki 2 [First Print Limited Edition]"
+  name: "蒼い空のネオスフィア ～ナノカ・フランカ発明工房記2～ [初回限定版]"
+  name-sort: "あおいそらのねおすふぃあ なのかふらんかはつめいこうぼうき2 [しょかいげんていばん]"
+  name-en: "Aoi Sora no Neosphere - Nanoca Flanka Hatsumei Koubouki 2 [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25749:
-  name: "蒼い空のネオスフィア～ナノカ・フランカ発明工房記2～ [通常版]"
-  name-sort: "あおいそらのねおすふぃあ なのかふらんかはつめいこうぼうき2"
-  name-en: "Aoi Sora no Neosphere - Nanoca Flanka Hatsumei Koubouki 2"
+  name: "蒼い空のネオスフィア ～ナノカ・フランカ発明工房記2～ [通常版]"
+  name-sort: "あおいそらのねおすふぃあ なのかふらんかはつめいこうぼうき2 [つうじょうばん]"
+  name-en: "Aoi Sora no Neosphere - Nanoca Flanka Hatsumei Koubouki 2 [Standard Edition]"
   region: "NTSC-J"
 SLPS-25750:
   name: "スーパーロボット大戦 Scramble Commander the 2nd"
@@ -58441,13 +58751,13 @@ SLPS-25750:
   region: "NTSC-J"
 SLPS-25751:
   name: "がくえんゆーとぴあ まなびストレート！ キラキラ☆ Happy Festa！ [初回限定版]"
-  name-sort: "がくえんゆーとぴあ まなびすとれーと！ きらきら Happy Festa！ しょかいげんていばん"
-  name-en: "Gakuen Utopia - Manabi Straight! KiraKira Happy Festa! [Limited Edition]"
+  name-sort: "がくえんゆーとぴあ まなびすとれーと！ きらきら Happy Festa！ [しょかいげんていばん]"
+  name-en: "Gakuen Utopia - Manabi Straight！ KiraKira Happy Festa！ [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25752:
   name: "がくえんゆーとぴあ まなびストレート！ キラキラ☆ Happy Festa！"
   name-sort: "がくえんゆーとぴあ まなびすとれーと！ きらきら Happy Festa！"
-  name-en: "Gakuen Utopia - Manabi Straight! KiraKira Happy Festa!"
+  name-en: "Gakuen Utopia - Manabi Straight！ KiraKira Happy Festa！"
   region: "NTSC-J"
 SLPS-25753:
   name: "苺ましまろ [電撃SP]"
@@ -58489,12 +58799,12 @@ SLPS-25756:
 SLPS-25757:
   name: "ななついろ★ドロップスPure！！ [初回限定版]"
   name-sort: "ななついろどろっぷす ぴゅあ！！ [しょかいげんていばん]"
-  name-en: "Nanatsu Iro - Drops Pure!! [First Print Limited Edition]"
+  name-en: "Nanatsu Iro - Drops Pure！！ [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25758:
   name: "ななついろ★ドロップス Pure！！ [通常版]"
   name-sort: "ななついろどろっぷす ぴゅあ！！ [つうじょうばん]"
-  name-en: "Nanatsu Iro - Drops Pure!! [Standard Edition]"
+  name-en: "Nanatsu Iro - Drops Pure！！ [Standard Edition]"
   region: "NTSC-J"
 SLPS-25759:
   name: "四八(仮)"
@@ -58535,13 +58845,13 @@ SLPS-25765:
   region: "NTSC-J"
 SLPS-25766:
   name: "オレンジハニー 僕はキミに恋してる [初回限定版]"
-  name-sort: "おれんじはにー ぼくはきみにこいしてる しょかいげんていばん"
-  name-en: "Orange Honey - Boku ha Kimi ni Koishiteru [Limited Edition]"
+  name-sort: "おれんじはにー ぼくはきみにこいしてる [しょかいげんていばん]"
+  name-en: "Orange Honey - Boku ha Kimi ni Koishiteru [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25767:
   name: "オレンジハニー 僕はキミに恋してる [通常版]"
-  name-sort: "おれんじはにー ぼくはきみにこいしてる"
-  name-en: "Orange Honey - Boku ha Kimi ni Koishiteru"
+  name-sort: "おれんじはにー ぼくはきみにこいしてる [つうじょうばん]"
+  name-en: "Orange Honey - Boku ha Kimi ni Koishiteru [Standard Edition]"
   region: "NTSC-J"
 SLPS-25768:
   name: "NARUTO-ナルト- 疾風伝 ナルティメットアクセル"
@@ -58564,12 +58874,12 @@ SLPS-25769:
 SLPS-25770:
   name: "楽勝！パチスロ宣言5 - リオパラダイス"
   name-sort: "らくしょう！ぱちすろせんげん5 - りおぱらだいす"
-  name-en: "Rakushou! Pachi-Slot Sengen 5 - Rio Paradise"
+  name-en: "Rakushou！ Pachi-Slot Sengen 5 - Rio Paradise"
   region: "NTSC-J"
 SLPS-25771:
   name: "グリムグリモア [初回生産版]"
   name-sort: "ぐりむぐりもあ [しょかいせいさんばん]"
-  name-en: "GrimGrimoire"
+  name-en: "GrimGrimoire [First Limited Edition]"
   region: "NTSC-J"
   compat: 5
 SLPS-25772:
@@ -58600,13 +58910,13 @@ SLPS-25776:
   region: "NTSC-J"
 SLPS-25777:
   name: "すもももももも ～地上最強のヨメ～ 継承しましょ！? 恋の花ムコ争奪戦！！ [初回限定版]"
-  name-sort: "すもももももも ちじょうさいきょうのよめ けいしょうしましょ！? こいのはなむこそうだつせん！！ しょかいげんていばん"
-  name-en: "Sumomomomomo - Chijou Saikyou no Yome [Limited Edition]"
+  name-sort: "すもももももも ちじょうさいきょうのよめ けいしょうしましょ！? こいのはなむこそうだつせん！！ [しょかいげんていばん]"
+  name-en: "Sumomomomomo - Chijou Saikyou no Yome [First Limited Edition]"
   region: "NTSC-J"
 SLPS-25778:
   name: "すもももももも ～地上最強のヨメ～ 継承しましょ！? 恋の花ムコ争奪戦！！ [通常版]"
-  name-sort: "すもももももも ちじょうさいきょうのよめ けいしょうしましょ！? こいのはなむこそうだつせん！！"
-  name-en: "Sumomomo Momomo - Chijou Saikyou no Yome - Keishou Shimasho! Koi no Hanamuko Soudatsu-sen!!"
+  name-sort: "すもももももも ちじょうさいきょうのよめ けいしょうしましょ！? こいのはなむこそうだつせん！！ [つうじょうばん]"
+  name-en: "Sumomomo Momomo - Chijou Saikyou no Yome - Keishou Shimasho！ Koi no Hanamuko Soudatsu-sen！！ [Standard Edition]"
   region: "NTSC-J"
 SLPS-25779:
   name: "KOF MAXIMUM IMPACT2 [SNK BEST COLLECTION]"
@@ -58658,8 +58968,8 @@ SLPS-25787:
     cpuSpriteRenderBW: 2 # Fixes broken minimap.
     cpuSpriteRenderLevel: 1 # Needed for above.
 SLPS-25788:
-  name: "メタルスラッグ  [SNK BEST COLLECTION]"
-  name-sort: "めたるすらっぐ  [SNK BEST COLLECTION]"
+  name: "メタルスラッグ [SNK BEST COLLECTION]"
+  name-sort: "めたるすらっぐ [SNK BEST COLLECTION]"
   name-en: "Metal Slug [SNK Best Collection]"
   region: "NTSC-J"
 SLPS-25789:
@@ -58711,20 +59021,20 @@ SLPS-25797:
     roundSprite: 1 # Aligns bloom effect.
 SLPS-25798:
   name: "一騎当千 Shining Dragon [通常版]"
-  name-sort: "いっきとうせん Shining Dragon"
-  name-en: "Ikki Tousen - Shining Dragon"
+  name-sort: "いっきとうせん Shining Dragon [つうじょうばん]"
+  name-en: "Ikki Tousen - Shining Dragon [Standard Edition]"
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
     roundSprite: 1 # Aligns bloom effect.
 SLPS-25799:
-  name: "ウルトラマン Fighting Evolution 3 バンプレストベスト"
-  name-sort: "うるとらまん Fighting Evolution 3 [ばんぷれすとべすと]"
+  name: "ウルトラマン Fighting Evolution 3 [BANPRESTO BEST]"
+  name-sort: "うるとらまん Fighting Evolution 3 [BANPRESTO BEST]"
   name-en: "Ultraman Fighting Evolution 3 [Banpresto Best]"
   region: "NTSC-J"
 SLPS-25800:
-  name: "ウルトラマン Fighting Evolution Rebirth バンプレストベスト"
-  name-sort: "うるとらまん Fighting Evolution Rebirth [ばんぷれすとべすと]"
+  name: "ウルトラマン Fighting Evolution Rebirth [BANPRESTO BEST]"
+  name-sort: "うるとらまん Fighting Evolution Rebirth [BANPRESTO BEST]"
   name-en: "Ultraman Fighting Evolution - Rebirth [Banpresto Best]"
   region: "NTSC-J"
   gsHWFixes:
@@ -58734,12 +59044,12 @@ SLPS-25800:
 SLPS-25801:
   name: "今日からマ王！ 眞マ国の休日"
   name-sort: "きょうからまおう しんまこくのきゅうじつ"
-  name-en: "Kyou Kara Maou! Shin Ma-Koku no Kyuujitsu [Limited Edition]"
+  name-en: "Kyou Kara Maou！ Shin Ma-Koku no Kyuujitsu [Limited Edition]"
   region: "NTSC-J"
 SLPS-25802:
   name: "今日からマ王！ 眞マ国の休日"
   name-sort: "きょうからまおう しんまこくのきゅうじつ"
-  name-en: "Kyou Kara Maou! Shin Ma-Koku no Kyuujitsu"
+  name-en: "Kyou Kara Maou！ Shin Ma-Koku no Kyuujitsu"
   region: "NTSC-J"
 SLPS-25803:
   name: "xxx HOLiC～四月一日の十六夜草話～"
@@ -58749,12 +59059,12 @@ SLPS-25803:
 SLPS-25804:
   name: "DEAR My SUN！！ ～ムスコ★育成★狂騒曲～ [限定版]"
   name-sort: "でぃあ まい さん！！ むすこいくせいきょうそうきょく [げんていばん]"
-  name-en: "Dear My Sun [Limited Edition]"
+  name-en: "Dear My Sun - Musuko Ikusei Kyousoukyoku [Limited Edition]"
   region: "NTSC-J"
 SLPS-25806:
   name: "家庭教師ヒットマンREBORN！ドリームハイパーバトル！死ぬ気の炎と黒き記憶"
   name-sort: "かてきょーひっとまんりぼーん！ どりーむはいぱーばとる！しぬきのほのおとくろききおく"
-  name-en: "Katekyoo Hitman Reborn! Dream Hyper Battle - Shinuki no Honoo to Kuroki Kioku"
+  name-en: "Katekyoo Hitman Reborn！ Dream Hyper Battle - Shinuki no Honoo to Kuroki Kioku"
   region: "NTSC-J"
   compat: 5
 SLPS-25807:
@@ -58764,23 +59074,23 @@ SLPS-25807:
   region: "NTSC-J"
 SLPS-25808:
   name: "セイント・ビースト ～螺旋の章～ [通常版]"
-  name-sort: "せいんと びーすと らせんのしょう"
-  name-en: "Saint Beast - Rasen no Shou"
+  name-sort: "せいんと びーすと らせんのしょう [つうじょうばん]"
+  name-en: "Saint Beast - Rasen no Shou [Standard Edition]"
   region: "NTSC-J"
 SLPS-25809:
   name: "銀魂 銀さんと一緒！ボクのかぶき町日記"
   name-sort: "ぎんたま ぎんさんといっしょ！ぼくのかぶきちょうちにっき"
-  name-en: "Gintama - Gin-san to Issho! Boku no Kabuki-chou Nikki"
+  name-en: "Gintama - Gin-san to Issho！ Boku no Kabuki-chou Nikki"
   region: "NTSC-J"
 SLPS-25810:
   name: "DEAR My SUN！！ ～ムスコ★育成★狂騒曲～ [通常版]"
-  name-sort: "でぃあ まい さん！！ むすこいくせいきょうそうきょく"
-  name-en: "Dear My Sun"
+  name-sort: "でぃあ まい さん！！ むすこいくせいきょうそうきょく [つうじょうばん]"
+  name-en: "Dear My Sun - Musuko Ikusei Kyousoukyoku [Standard Edition]"
   region: "NTSC-J"
 SLPS-25811:
   name: "はぴねす！ でらっくす Best Collection"
   name-sort: "はぴねす！ でらっくす Best Collection"
-  name-en: "Happiness! Deluxe [Best Collection]"
+  name-en: "Happiness！ Deluxe [Best Collection]"
   region: "NTSC-J"
 SLPS-25812:
   name: "トリノホシ ～Aerial Planet～"
@@ -58800,7 +59110,7 @@ SLPS-25814:
 SLPS-25815:
   name: "ドラゴンボールZ スパーキング！ メテオ"
   name-sort: "どらごんぼーるZ すぱーきんぐ めてお"
-  name-en: "Dragon Ball Z Sparking! Meteor"
+  name-en: "Dragon Ball Z Sparking！ Meteor"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 4 # Aligns post effects.
@@ -58837,7 +59147,7 @@ SLPS-25819:
 SLPS-25820:
   name: "家庭教師ヒットマンREBORN！ Let's暗殺！? 狙われた10代目！"
   name-sort: "かてきょーひっとまんりぼーん！ れっつあんさつ！? ねらわれた10だいめ！"
-  name-en: "Katekyoo Hitman Reborn!! Let's Ansatsu! Nerawareta 10 Daime!"
+  name-en: "Katekyoo Hitman Reborn！！ Let's Ansatsu！ Nerawareta 10 Daime！"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Reduces font artifacts but characters still have major artifacts.
@@ -58874,7 +59184,7 @@ SLPS-25825:
 SLPS-25826:
   name: "マイホームをつくろう2 充実！簡単設計！！ Best Collection"
   name-sort: "まいほーむをつくろう2 じゅうじつ！かんたんせっけい！！ Best Collection"
-  name-en: "My Home o Tsukurou 2! Easy Design [Best Collection]"
+  name-en: "My Home o Tsukurou 2！ Easy Design [Best Collection]"
   region: "NTSC-J"
 SLPS-25827:
   name: "装甲騎兵ボトムズ"
@@ -58972,7 +59282,7 @@ SLPS-25840:
     halfPixelOffset: 4 # Mostly aligns post processing.
     nativeScaling: 1 # Fixes post processing smoothness and position.
 SLPS-25841:
-  name: "テイルズ オブ デスティニー ディレクターズカット プレミアムBOX"
+  name: "テイルズ オブ デスティニー ディレクターズカット [プレミアムBOX]"
   name-sort: "ているず おぶ ですてぃにー でぃれくたーずかっと [ぷれみあむBOX]"
   name-en: "Tales of Destiny [Director's Cut] [Premium Box]"
   region: "NTSC-J"
@@ -59079,9 +59389,9 @@ SLPS-25856:
     autoFlush: 1 # Fixes bloom intensity.
     nativeScaling: 1 # Fixes post processing.
 SLPS-25858:
-  name: "電撃SP 灼眼のシャナ"
-  name-sort: "でんげきSP しゃくがんのしゃな"
-  name-en: "Dengeki SP - Shakugan no Shana"
+  name: "灼眼のシャナ [電撃SP]"
+  name-sort: "しゃくがんのしゃな [でんげきSP]"
+  name-en: "Dengeki SP - Shakugan no Shana [Dengeki SP]"
   region: "NTSC-J"
 SLPS-25859:
   name: "オレンジハニー 僕はキミに恋してる Best Collection"
@@ -59124,7 +59434,7 @@ SLPS-25866:
   name-en: "Fuuun Super Combo [SNK the Best]"
   region: "NTSC-J"
 SLPS-25867:
-  name: "花宵ロマネスク 愛と哀しみ−それは君のためのアリア 限定版"
+  name: "花宵ロマネスク 愛と哀しみ−それは君のためのアリア [限定版]"
   name-sort: "はなよいろまねすく あいとかなしみ-それはきみのためのありあ [げんていばん]"
   name-en: "Hanayoi Romanesque - Ai to Kanashimi [Limited Edition]"
   region: "NTSC-J"
@@ -59194,7 +59504,7 @@ SLPS-25882:
 SLPS-25883:
   name: "家庭教師ヒットマンREBORN！ 狙え！? リング×ボンゴレトレーナーズ"
   name-sort: "かてきょーひっとまんりぼーん！ ねらえ！? りんぐ×ぼんごれとれーなーず"
-  name-en: "Katekyoo Hitman Reborn! Nerae! Ring x Vongola Trainers"
+  name-en: "Katekyoo Hitman Reborn！ Nerae！ Ring x Vongola Trainers"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Reduces font artifacts but characters still have major artifacts.
@@ -59313,7 +59623,7 @@ SLPS-25898:
 SLPS-25899:
   name: "家庭教師ヒットマンREBORN！ Let's暗殺！? 狙われた10代目！ [Best Collection]"
   name-sort: "かてきょーひっとまんりぼーん！ れっつあんさつ！? ねらわれた10だいめ！ [Best Collection]"
-  name-en: "Katekyoo Hitman Reborn!! Let's Ansatsu! Nerawareta 10 Daime! [Best Collection]"
+  name-en: "Katekyoo Hitman Reborn！！ Let's Ansatsu！ Nerawareta 10 Daime！ [Best Collection]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Reduces font artifacts but characters still have major artifacts.
@@ -59340,7 +59650,7 @@ SLPS-25903:
 SLPS-25904:
   name: "家庭教師ヒットマンREBORN！禁断の闇のデルタ"
   name-sort: "かてきょーひっとまんりぼーん！ きんだんのやみのでるた"
-  name-en: "Katekyoo Hitman Reborn! Dream Hyper Battle - Kindan no Yami no Delta"
+  name-en: "Katekyoo Hitman Reborn！ Dream Hyper Battle - Kindan no Yami no Delta"
   region: "NTSC-J"
 SLPS-25905:
   name: "ドラゴンボールZ インフィニットワールド"
@@ -59374,7 +59684,7 @@ SLPS-25909:
 SLPS-25910:
   name: "家庭教師ヒットマンREBORN！ドリームハイパーバトル！死ぬ気の炎と黒き記憶 [Best Collection]"
   name-sort: "かてきょーひっとまんりぼーん！ どりーむはいぱーばとる！しぬきのほのおとくろききおく [Best Collection]"
-  name-en: "Katekyoo Hitman Reborn! Dream Hyper Battle - Shinuki no Honoo to Kuroki Kioku [Best Collection]"
+  name-en: "Katekyoo Hitman Reborn！ Dream Hyper Battle - Shinuki no Honoo to Kuroki Kioku [Best Collection]"
   region: "NTSC-J"
 SLPS-25911:
   name: "必勝パチンコ★パチスロ攻略シリーズ Vol.11 新世紀エヴァンゲリオン～まごころを、君に～ [スペシャルプライス版]"
@@ -59433,7 +59743,7 @@ SLPS-25920:
 SLPS-25921:
   name: "楽勝！ パチスロ宣言6 - リオ2 クルージング ヴァナディース"
   name-sort: "らくしょう！ ぱちすろせんげん6 - りお2 くるーじんぐ ヴぁなでぃーす"
-  name-en: "Rakushou! Pachi-Slot Sengen 6 - Rio 2 Cruising Vanadis"
+  name-en: "Rakushou！ Pachi-Slot Sengen 6 - Rio 2 Cruising Vanadis"
   region: "NTSC-J"
 SLPS-25922:
   name: "Vitamin Z [限定版]"
@@ -59495,7 +59805,7 @@ SLPS-25930:
 SLPS-25931:
   name: "家庭教師ヒットマンREBORN！ 狙え！? リング×ボンゴレトレーナーズ [Best Collection]"
   name-sort: "かてきょーひっとまんりぼーん！ ねらえ！? りんぐ×ぼんごれとれーなーず [Best Collection]"
-  name-en: "Katekyoo Hitman Reborn! Nerae! Ring x Vongola Trainers [Best Collection]"
+  name-en: "Katekyoo Hitman Reborn！ Nerae！ Ring x Vongola Trainers [Best Collection]"
   region: "NTSC-J"
   gsHWFixes:
     roundSprite: 2 # Reduces font artifacts but characters still have major artifacts.
@@ -59534,7 +59844,7 @@ SLPS-25938:
 SLPS-25939:
   name: "ひめひび - New Princess Days！！ 続！二学期"
   name-sort: "ひめひび - New Princess Days！！ ぞく！にがっき"
-  name-en: "Himehibi - New Princess Days!! Zoku! Nigakki"
+  name-en: "Himehibi - New Princess Days！！ Zoku！ Nigakki"
   region: "NTSC-J"
 SLPS-25940:
   name: "現代大戦略～一触即発・軍事バランス崩壊"
@@ -59724,8 +60034,8 @@ SLPS-25983:
   name-en: "King of Fighters 2002, The - Unlimited Match"
   region: "NTSC-J"
 SLPS-25986:
-  name: "トゥームレイダー アンダーワールド  [Spike The Best]"
-  name-sort: "とぅーむれいだー あんだーわーるど  [Spike The Best]"
+  name: "トゥームレイダー アンダーワールド [Spike The Best]"
+  name-sort: "とぅーむれいだー あんだーわーるど [Spike The Best]"
   name-en: "Tomb Raider - Underworld [Spike The Best]"
   region: "NTSC-J"
   gsHWFixes:
@@ -59743,7 +60053,7 @@ SLPS-25987:
 SLPS-25988:
   name: "カエル畑DEつかまえて・夏 千木良参戦！"
   name-sort: "かえるばたけでつかまえて なつ ちぎらさんせん！"
-  name-en: "Kaeru Batake de Tsukamaete - Natsu Chigira Sansen!"
+  name-en: "Kaeru Batake de Tsukamaete - Natsu Chigira Sansen！"
   region: "NTSC-J"
 SLPS-25989:
   name: "アマガミ [eb!コレ+] [限定版]"
@@ -59876,7 +60186,7 @@ SLPS-72502:
 SLPS-73001:
   name: "パイロットになろう！ 2"
   name-sort: "ぱいろっとになろう！ 2"
-  name-en: "Pilot ni Narou! 2"
+  name-en: "Pilot ni Narou！ 2"
   region: "NTSC-J"
 SLPS-73003:
   name: "牧場物語3 ハートに火をつけて [PlayStation2 the Best]"
@@ -59936,12 +60246,12 @@ SLPS-73105:
 SLPS-73106:
   name: "パイロットになろう！ 2 [PlayStation2 the Best]"
   name-sort: "ぱいろっとになろう！ 2 [PlayStation2 the Best]"
-  name-en: "Pilot Nina Rou! 2 [PlayStation2 the Best]"
+  name-en: "Pilot Nina Rou！ 2 [PlayStation2 the Best]"
   region: "NTSC-J"
 SLPS-73107:
   name: "太鼓の達人 ゴー！ゴー！五代目 [PlayStation2 the Best]"
   name-sort: "たいこのたつじん ごーごーごだいめ [PlayStation2 the Best]"
-  name-en: "Taiko no Tatsujin - Go! Go! Godaime [PlayStation2 the Best]"
+  name-en: "Taiko no Tatsujin - Go！ Go！ Godaime [PlayStation2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
@@ -59969,7 +60279,7 @@ SLPS-73111:
 SLPS-73201:
   name: "零 ～紅い蝶～ [PlayStation2 the Best]"
   name-sort: "ぜろ あかいちょう [PlayStation2 the Best]"
-  name-en: "Fatal Frame II - Crimson Butterfly [PlayStation2 the Best]"
+  name-en: "Zero - Akai Chou [PlayStation2 the Best]"
   region: "NTSC-J"
 SLPS-73202:
   name: "アーマード・コア ネクサス [DISC 1] [PlayStation2 the Best]"
@@ -60381,7 +60691,7 @@ SLPS-73244:
 SLPS-73245:
   name: "零 ～刺青の聲～ [PlayStation2 the Best]"
   name-sort: "ぜろ しせいのこえ [PlayStation2 the Best]"
-  name-en: "Fatal Frame III - The Tormented [PlayStation2 the Best]"
+  name-en: "Zero - Shisei no Koe [PlayStation2 the Best]"
   region: "NTSC-J"
 SLPS-73246:
   name: "ガンダム トゥルーオデッセイ ～失われしGの伝説～ [PlayStation2 the Best]"
@@ -60465,7 +60775,7 @@ SLPS-73252:
 SLPS-73253:
   name: "るろうに剣心-明治剣客浪漫譚- 炎上！京都輪廻 [PlayStation2 the Best]"
   name-sort: "るろうにけんしん めいじけんかくろまんたん えんじょう きょうとりんね [PlayStation2 the Best]"
-  name-en: "Rurouni Kenshin - Enjou! Kyoto Rinne [PlayStation2 the Best]"
+  name-en: "Rurouni Kenshin - Enjou！ Kyoto Rinne [PlayStation2 the Best]"
   region: "NTSC-J"
 SLPS-73254:
   name: "魔界戦記ディスガイア2 [PlayStation2 the Best]"
@@ -60477,7 +60787,7 @@ SLPS-73254:
 SLPS-73255:
   name: "零 ～zero～ [PlayStation2 the Best]"
   name-sort: "ぜろ [PlayStation2 the Best]"
-  name-en: "Fatal Frame [PlayStation 2 the Best - Reprint]"
+  name-en: "Zero [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blurriness.
@@ -60485,12 +60795,12 @@ SLPS-73255:
 SLPS-73256:
   name: "零 ～紅い蝶～ [PlayStation2 the Best]"
   name-sort: "ぜろ あかいちょう [PlayStation2 the Best]"
-  name-en: "Fatal Frame II - Crimson Butterfly [PlayStation 2 the Best - Reprint]"
+  name-en: "Zero - Akai Chou [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
 SLPS-73257:
   name: "零 ～刺青の聲～ [PlayStation2 the Best]"
   name-sort: "ぜろ しせいのこえ [PlayStation2 the Best]"
-  name-en: "Fatal Frame III - The Tormented [PlayStation 2 the Best - Reprint]"
+  name-en: "Zero - Shisei no Koe [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Reduces blurriness.
@@ -60569,7 +60879,7 @@ SLPS-73403:
     recommendedBlendingLevel: 3 # Improves sky rendering.
     textureInsideRT: 1 # Fixes texture corruption.
 SLPS-73404:
-  name: "風のクロノア2～世界が望んだ忘れもの～PlayStation 2 the Best"
+  name: "風のクロノア2 ～世界が望んだ忘れもの～PlayStation 2 the Best"
   name-sort: "かぜのくろのあ2 せかいがのぞんだわすれもの [PlayStation2 the Best]"
   name-en: "Klonoa 2 [PlayStation2 the Best]"
   region: "NTSC-J"
@@ -60583,7 +60893,7 @@ SLPS-73404:
 SLPS-73405:
   name: "零 ～zero～ [PlayStation2 the Best]"
   name-sort: "ぜろ [PlayStation2 the Best]"
-  name-en: "Fatal Frame [PlayStation2 the Best]"
+  name-en: "Zero [PlayStation2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Reduces blurriness.
@@ -60705,8 +61015,8 @@ SLPS-73421:
   name-en: "Tenchu 3 [PlayStation2 the Best]"
   region: "NTSC-J"
 SLPS-73422:
-  name: "ウルトラマン ファイティングエボリューション2 [PlayStation2 the Best]"
-  name-sort: "うるとらまん ふぁいてぃんぐえぼりゅーしょん2 [PlayStation2 the Best]"
+  name: "ウルトラマン Fighting Evolution 2 [PlayStation2 the Best]"
+  name-sort: "うるとらまん Fighting Evolution 2 [PlayStation2 the Best]"
   name-en: "Ultraman Fighting Evolution 2 [PlayStation2 the Best]"
   region: "NTSC-J"
 SLPS-73423:
@@ -62068,7 +62378,7 @@ SLUS-20315:
     recommendedBlendingLevel: 3 # Fixes gem reflections.
     nativeScaling: 1 # Fixes post effects.
 SLUS-20316:
-  name: "WWF SmackDown! - Just Bring It"
+  name: "WWF SmackDown！ - Just Bring It"
   region: "NTSC-U"
   compat: 5
 SLUS-20318:
@@ -62239,7 +62549,7 @@ SLUS-20347:
         patch=1,EE,00249e9c,word,48509000
         patch=1,EE,00249ea0,word,4BDD69FF
 SLUS-20348:
-  name: "Monopoly Party!"
+  name: "Monopoly Party！"
   region: "NTSC-U"
   compat: 4
   clampModes:
@@ -62247,7 +62557,7 @@ SLUS-20348:
   gsHWFixes:
     recommendedBlendingLevel: 2
 SLUS-20349:
-  name: "Scooby-Doo! Night of 100 Frights"
+  name: "Scooby-Doo！ Night of 100 Frights"
   region: "NTSC-U"
   compat: 5
 SLUS-20352:
@@ -62357,7 +62667,7 @@ SLUS-20375:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
 SLUS-20376:
-  name: "Mad Maestro!"
+  name: "Mad Maestro！"
   region: "NTSC-U"
   compat: 5
 SLUS-20377:
@@ -62923,7 +63233,7 @@ SLUS-20482:
   region: "NTSC-U"
   compat: 5
 SLUS-20483:
-  name: "WWE SmackDown! Shut Your Mouth"
+  name: "WWE SmackDown！ Shut Your Mouth"
   region: "NTSC-U"
   compat: 5
 SLUS-20484:
@@ -63084,7 +63394,7 @@ SLUS-20514:
   region: "NTSC-U"
   compat: 5
 SLUS-20515:
-  name: "Yu-Gi-Oh! The Duelists of the Roses"
+  name: "Yu-Gi-Oh！ The Duelists of the Roses"
   region: "NTSC-U"
   compat: 5
   roundModes:
@@ -63142,7 +63452,7 @@ SLUS-20526:
   name: "RockSteady ~~UNRELEASED~~"
   region: "NTSC-U"
 SLUS-20527:
-  name: "Butt Ugly Martians - Zoom or Doom!"
+  name: "Butt Ugly Martians - Zoom or Doom！"
   region: "NTSC-U"
   compat: 5
   clampModes:
@@ -63367,8 +63677,6 @@ SLUS-20567:
   name: "P.T.O. IV - Pacific Theater of Operations"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    minimumBlendingLevel: 3 # Fixes graphical flickering.
 SLUS-20568:
   name: "Hard Hitter Tennis"
   region: "NTSC-U"
@@ -63653,7 +63961,6 @@ SLUS-20622:
     - SoftwareRendererFMVHack # Fixes blackscreen when FMV.
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes menu transparancy effects and text.
-    deinterlace: 9 # Fixes incorrect field order in FMVs.
   memcardFilters: # Reads Silent Hill 2 for easter egg.
     - "SLUS-20622"
     - "SLUS-20228"
@@ -64069,7 +64376,7 @@ SLUS-20699:
   name: "Cowboy Bebop"
   region: "NTSC-U"
 SLUS-20701:
-  name: "Scooby-Doo! Mystery Mayhem"
+  name: "Scooby-Doo！ Mystery Mayhem"
   region: "NTSC-U"
   compat: 5
 SLUS-20702:
@@ -64275,7 +64582,7 @@ SLUS-20740:
   region: "NTSC-U"
   compat: 5
 SLUS-20741:
-  name: "Mojo!"
+  name: "Mojo！"
   region: "NTSC-U"
   compat: 5
 SLUS-20742:
@@ -64551,7 +64858,7 @@ SLUS-20786:
   speedHacks:
     mvuFlag: 0 # Fixes SPS.
 SLUS-20787:
-  name: "WWE SmackDown! Here Comes the Pain"
+  name: "WWE SmackDown！ Here Comes the Pain"
   region: "NTSC-U"
   compat: 5
 SLUS-20788:
@@ -64563,7 +64870,7 @@ SLUS-20788:
     halfPixelOffset: 4 # Aligns shadows.
     nativeScaling: 1 # Softens shadows.
 SLUS-20789:
-  name: "Jeopardy!"
+  name: "Jeopardy！"
   region: "NTSC-U"
   compat: 5
 SLUS-20790:
@@ -64744,7 +65051,7 @@ SLUS-20828:
   gsHWFixes:
     roundSprite: 1 # Fixes slight blur.
 SLUS-20830:
-  name: "Intellivision Lives!"
+  name: "Intellivision Lives！"
   region: "NTSC-U"
   compat: 5
 SLUS-20831:
@@ -65227,7 +65534,7 @@ SLUS-20913:
   region: "NTSC-U"
   compat: 5
 SLUS-20914:
-  name: "Ribbit King Plus! (Bonus Disc)"
+  name: "Ribbit King Plus！ (Bonus Disc)"
   region: "NTSC-U"
 SLUS-20915:
   name: "Metal Gear Solid 3 - Snake Eater"
@@ -65391,7 +65698,7 @@ SLUS-20939:
   name: "Viewtiful Joe 2"
   region: "NTSC-U"
 SLUS-20940:
-  name: "Yu-Gi-Oh! Capsule Monster Coliseum"
+  name: "Yu-Gi-Oh！ Capsule Monster Coliseum"
   region: "NTSC-U"
   compat: 5
 SLUS-20941:
@@ -65421,7 +65728,7 @@ SLUS-20944:
   region: "NTSC-U"
   compat: 5
 SLUS-20945:
-  name: "Destroy All Humans!"
+  name: "Destroy All Humans！"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
@@ -66162,7 +66469,7 @@ SLUS-21059:
     nativeScaling: 1 # Fixes depth of field effect.
     getSkipCount: "GSC_Tekken5"
 SLUS-21060:
-  name: "WWE SmackDown! vs. RAW"
+  name: "WWE SmackDown！ vs. RAW"
   region: "NTSC-U"
   compat: 5
 SLUS-21062:
@@ -66309,11 +66616,11 @@ SLUS-21090:
   region: "NTSC-U"
   compat: 5
 SLUS-21091:
-  name: "Scooby-Doo! Unmasked"
+  name: "Scooby-Doo！ Unmasked"
   region: "NTSC-U"
   compat: 5
 SLUS-21093:
-  name: "Worms Forts - Under Siege!"
+  name: "Worms Forts - Under Siege！"
   region: "NTSC-U"
   compat: 5
 SLUS-21094:
@@ -66637,7 +66944,7 @@ SLUS-21148:
     autoFlush: 2 # Fixes HUD blending.
     nativeScaling: 1 # Fixes post effects.
 SLUS-21149:
-  name: "Yourself! Fitness"
+  name: "Yourself！ Fitness"
   region: "NTSC-U"
 SLUS-21150:
   name: "Beat Down - Fists of Vengeance"
@@ -66918,10 +67225,11 @@ SLUS-21199:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    recommendedBlendingLevel: 3 # Fixes banding and level lighting.
+    recommendedBlendingLevel: 2
     autoFlush: 1 # Fixes sun shinging through surfaces and graphical corruptions.
     halfPixelOffset: 2 # Fixes misaligned blur.
-    nativeScaling: 2 # Fixes bloom misaligment.
+    cpuSpriteRenderBW: 2 # Fixes black spots appearing on some surfaces and massively reduces RP TC and TU count.
+    cpuSpriteRenderLevel: 2 # Needed for above.
 SLUS-21200:
   name: "Armored Core - Nine Breaker"
   region: "NTSC-U"
@@ -67279,7 +67587,7 @@ SLUS-21248:
     halfPixelOffset: 2 # Fixes misaligned bloom.
     autoFlush: 2 # Fixes glitchy black rectangles.
 SLUS-21249:
-  name: "Yourself! Fitness - Lifestyle"
+  name: "Yourself！ Fitness - Lifestyle"
   region: "NTSC-U"
 SLUS-21250:
   name: "Full Spectrum Warrior - Ten Hammers"
@@ -67294,7 +67602,7 @@ SLUS-21251:
   gsHWFixes:
     halfPixelOffset: 2 # Corrects most vertical lines.
 SLUS-21252:
-  name: "Nickelodeon SpongeBob SquarePants - Lights, Camera, Pants!"
+  name: "Nickelodeon SpongeBob SquarePants - Lights, Camera, Pants！"
   region: "NTSC-U"
   compat: 4
   gsHWFixes:
@@ -67310,7 +67618,7 @@ SLUS-21253:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes visible lines in water textures.
 SLUS-21254:
-  name: "Zatch Bell! Mamodo Battles"
+  name: "Zatch Bell！ Mamodo Battles"
   region: "NTSC-U"
   compat: 5
 SLUS-21255:
@@ -67556,7 +67864,7 @@ SLUS-21283:
     halfPixelOffset: 4 # Mostly aligns post processing.
     nativeScaling: 1 # Fixes post processing smoothness and position.
 SLUS-21284:
-  name: "Nicktoons Unite!"
+  name: "Nicktoons Unite！"
   region: "NTSC-U"
   gsHWFixes:
     autoFlush: 2 # Fixes glows. Also needed for recursive mipmap rendering.
@@ -67573,7 +67881,7 @@ SLUS-21285:
     autoFlush: 2 # Fixes shadow alignment along with HPO Special (Normal looks better but causes top left glitches).
     halfPixelOffset: 2
 SLUS-21286:
-  name: "WWE SmackDown! vs. RAW 2006"
+  name: "WWE SmackDown！ vs. RAW 2006"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
@@ -67906,7 +68214,7 @@ SLUS-21338:
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
     preloadFrameData: 1 # Fixes glowing emblems.
 SLUS-21339:
-  name: "Puzzle Collection - Crosswords & More!"
+  name: "Puzzle Collection - Crosswords & More！"
   region: "NTSC-U"
   compat: 5
 SLUS-21340:
@@ -68088,7 +68396,7 @@ SLUS-21362:
   memcardFilters:
     - "SLUS-21180"
 SLUS-21363:
-  name: "Zatch Bell! Mamodo Fury"
+  name: "Zatch Bell！ Mamodo Fury"
   region: "NTSC-U"
   compat: 5
 SLUS-21364:
@@ -68388,8 +68696,8 @@ SLUS-21409:
   name: "LEGO Star Wars II - The Original Trilogy"
   region: "NTSC-U"
   gsHWFixes:
-    halfPixelOffset: 1 # Aligns post processing.
-    nativeScaling: 2 # Fixes post processing smoothness and position.
+    halfPixelOffset: 4 # Mostly aligns post processing.
+    nativeScaling: 1 # Fixes post processing smoothness and position.
   memcardFilters:
     - "SLUS-21409"
     - "SLUS-21083"
@@ -68423,8 +68731,6 @@ SLUS-21415:
   name-sort: "Ant Bully, The"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    nativeScaling: 2 # Fixes misaligned post effects.
 SLUS-21416:
   name: "D1 Grand Prix Series - Professional Drift"
   region: "NTSC-U"
@@ -68524,7 +68830,7 @@ SLUS-21426:
     nativeScaling: 2 # Fixes post effects.
     cpuSpriteRenderBW: 1 # Fixes textures.
 SLUS-21427:
-  name: "WWE SmackDown! vs. RAW 2007"
+  name: "WWE SmackDown！ vs. RAW 2007"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
@@ -68589,7 +68895,7 @@ SLUS-21438:
   region: "NTSC-U"
   compat: 5
 SLUS-21439:
-  name: "Destroy All Humans! 2"
+  name: "Destroy All Humans！ 2"
   region: "NTSC-U"
   compat: 5
   clampModes:
@@ -69314,7 +69620,7 @@ SLUS-21598:
   region: "NTSC-U"
   compat: 5
 SLUS-21599:
-  name: "High School Musical - Sing It!"
+  name: "High School Musical - Sing It！"
   region: "NTSC-U"
 SLUS-21600:
   name: "Spider-Man - Friend or Foe"
@@ -69519,7 +69825,7 @@ SLUS-21627:
   gsHWFixes:
     halfPixelOffset: 1 # Fixes misaligned textures.
 SLUS-21628:
-  name: "Hot Wheels - Beat That!"
+  name: "Hot Wheels - Beat That！"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
@@ -69634,7 +69940,7 @@ SLUS-21644:
   gsHWFixes:
     halfPixelOffset: 4 # Fixes ghosting.
 SLUS-21645:
-  name: "WWE SmackDown! vs. Raw 2008"
+  name: "WWE SmackDown！ vs. Raw 2008"
   region: "NTSC-U"
   compat: 5
 SLUS-21646:
@@ -69815,7 +70121,7 @@ SLUS-21682:
   region: "NTSC-U"
   compat: 5
 SLUS-21683:
-  name: "Yu-Gi-Oh! GX - The Beginning of Destiny"
+  name: "Yu-Gi-Oh！ GX - The Beginning of Destiny"
   region: "NTSC-U"
   compat: 5
 SLUS-21684:
@@ -69944,7 +70250,7 @@ SLUS-21709:
   clampModes:
     vuClampMode: 3 # Fixes Lock picking pin.
 SLUS-21710:
-  name: "PopCap Hits! Volume 1"
+  name: "PopCap Hits！ Volume 1"
   region: "NTSC-U"
   compat: 5
   gameFixes:
@@ -69986,7 +70292,7 @@ SLUS-21717:
   name: "Dora the Explorer - Dora Saves the Mermaids"
   region: "NTSC-U"
 SLUS-21718:
-  name: "Go, Diego, Go! Safari Rescue"
+  name: "Go, Diego, Go！ Safari Rescue"
   region: "NTSC-U"
 SLUS-21719:
   name: "Karaoke Revolution Presents - American Idol Encore"
@@ -70273,7 +70579,7 @@ SLUS-21767:
   region: "NTSC-U"
   compat: 5
 SLUS-21768:
-  name: "PopCap Hits! Vol.2"
+  name: "PopCap Hits！ Vol.2"
   region: "NTSC-U"
   compat: 5
   gameFixes:
@@ -70389,7 +70695,7 @@ SLUS-21786:
   name: "Summer Athletics - The Ultimate Challenge"
   region: "NTSC-U"
 SLUS-21787:
-  name: "TNA Impact! Total Nonstop Action Wrestling"
+  name: "TNA Impact！ Total Nonstop Action Wrestling"
   region: "NTSC-U"
   compat: 5
   gameFixes:
@@ -70425,12 +70731,12 @@ SLUS-21793:
     gpuPaletteConversion: 2 # Improves performance and reduces hash cache size.
     autoFlush: 1 # Corrects shadows (Currently still broken even with this).
 SLUS-21794:
-  name: "Go, Diego, Go! Great Dinosaur Rescue"
+  name: "Go, Diego, Go！ Great Dinosaur Rescue"
   region: "NTSC-U"
   gsHWFixes:
     nativeScaling: 2 # Fixes shadow smoothness.
 SLUS-21795:
-  name: "Totally Spies! Totally Party"
+  name: "Totally Spies！ Totally Party"
   region: "NTSC-U"
   gameFixes:
     - VUSyncHack # Partially fixes graphical issues also needs EE+3 to be fully fixed.
@@ -70511,7 +70817,7 @@ SLUS-21809:
   region: "NTSC-U"
   compat: 5
 SLUS-21810:
-  name: "WWE SmackDown! vs. Raw 2009"
+  name: "WWE SmackDown！ vs. Raw 2009"
   region: "NTSC-U"
   compat: 5
 SLUS-21811:
@@ -70550,7 +70856,7 @@ SLUS-21818:
   region: "NTSC-U"
   compat: 5
 SLUS-21819:
-  name: "High School Musical 3 - Senior Year Dance!"
+  name: "High School Musical 3 - Senior Year Dance！"
   region: "NTSC-U"
   compat: 5
 SLUS-21820:
@@ -70713,7 +71019,7 @@ SLUS-21860:
   name-sort: "Bigs 2, The"
   region: "NTSC-U"
 SLUS-21861:
-  name: "Disney Sing It! High School Musical 3 - Senior Year"
+  name: "Disney Sing It！ High School Musical 3 - Senior Year"
   region: "NTSC-U"
 SLUS-21862:
   name: "Naruto Shippuden - Ultimate Ninja 4"
@@ -70935,13 +71241,13 @@ SLUS-21899:
     disablePartialInvalidation: 1 # Fixes missing graphics.
     halfPixelOffset: 2 # Fixes ghosting.
 SLUS-21900:
-  name: "Scooby-Doo! First Frights"
+  name: "Scooby-Doo！ First Frights"
   region: "NTSC-U"
   compat: 5
   roundModes:
     eeDivRoundMode: 3 # Fixes AI pathing.
 SLUS-21901:
-  name: "WWE SmackDown! vs. Raw 2010"
+  name: "WWE SmackDown！ vs. Raw 2010"
   region: "NTSC-U"
   compat: 5
 SLUS-21902:
@@ -71056,7 +71362,7 @@ SLUS-21927:
   gsHWFixes:
     getSkipCount: "GSC_SakuraWarsSoLongMyLove"
 SLUS-21928:
-  name: "Scooby-Doo! and the Spooky Swamp"
+  name: "Scooby-Doo！ and the Spooky Swamp"
   region: "NTSC-U"
 SLUS-21929:
   name: "Major League Baseball 2K10"
@@ -71110,7 +71416,7 @@ SLUS-21938:
   region: "NTSC-U"
   compat: 5
 SLUS-21939:
-  name: "WWE SmackDown! vs. Raw 2011"
+  name: "WWE SmackDown！ vs. Raw 2011"
   region: "NTSC-U"
   compat: 5
 SLUS-21940:
@@ -71184,16 +71490,16 @@ SLUS-21955:
   name: "Pro Evolution Soccer 2013"
   region: "NTSC-U"
 SLUS-27014:
-  name: "WWE SmackDown! vs Raw - Superstar Series [Bundle]"
+  name: "WWE SmackDown！ vs Raw - Superstar Series [Bundle]"
   region: "NTSC-U"
 SLUS-27029:
   name: "Disney Sing It [Bundle]"
   region: "NTSC-U"
 SLUS-27030:
-  name: "High School Musical 3 - Senior Year DANCE! [w-Mat]"
+  name: "High School Musical 3 - Senior Year DANCE！ [w-Mat]"
   region: "NTSC-U"
 SLUS-27034:
-  name: "Disney Sing It! High School Musical 3 - Senior Year"
+  name: "Disney Sing It！ High School Musical 3 - Senior Year"
   region: "NTSC-U"
 SLUS-27093:
   name: "FIFA 14"
@@ -71445,7 +71751,7 @@ SLUS-29010:
     nativePaletteDraw: 1
     autoFlush: 2 # Fixes refraction effect.
 SLUS-29011:
-  name: "WWF SmackDown! - Just Bring It [Demo]"
+  name: "WWF SmackDown！ - Just Bring It [Demo]"
   region: "NTSC-U"
 SLUS-29012:
   name: "Top Gun - Combat Zones [Demo]"
@@ -71784,7 +72090,7 @@ SLUS-29113:
     getSkipCount: "GSC_BurnoutGames"
     beforeDraw: "OI_BurnoutGames"
 SLUS-29116:
-  name: "WWE SmackDown! vs. RAW [Public Beta Vol.1.0]"
+  name: "WWE SmackDown！ vs. RAW [Public Beta Vol.1.0]"
   region: "NTSC-U"
 SLUS-29117:
   name: "Battlefield 2 - Modern Combat [Public Beta Vol.1.0]"
@@ -71928,7 +72234,7 @@ SLUS-29149:
   gsHWFixes:
     deinterlace: 9 # Fixes broken field order.
 SLUS-29150:
-  name: "Destroy All Humans! [Demo]"
+  name: "Destroy All Humans！ [Demo]"
   region: "NTSC-U"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves metal sheen and reflections.
@@ -72172,7 +72478,7 @@ SLUS-29195:
     alignSprite: 1 # Helps align bloom.
     nativeScaling: 2 # Fixes post processing and lighting smoothness.
 SLUS-29196:
-  name: "Destroy All Humans! 2 [Demo]"
+  name: "Destroy All Humans！ 2 [Demo]"
   region: "NTSC-U"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves metal sheen and reflections.
@@ -72246,7 +72552,6 @@ TCES-52033:
     autoFlush: 2 # Fixes lights going through walls.
     preloadFrameData: 1 # Fixes light flicker.
     halfPixelOffset: 2 # Corrects light position.
-    bilinearUpscale: 1 # Smooths out bloom on lights.
   gameFixes:
     - EETimingHack # Fixes random hangs.
   patches:
@@ -72313,12 +72618,12 @@ TCES-53286:
 TCPS-10058:
   name: "電車でGO！新幹線 山陽新幹線編 運転士セット [PlayStation2 the Best]"
   name-sort: "でんしゃでごーしんかんせん さんようしんかんせんへん うんてんしせっと [PlayStation2 the Best]"
-  name-en: "Densha de Go! Shinkansen Sanyou Shinkansen-hen [with Controller]"
+  name-en: "Densha de Go！ Shinkansen Sanyou Shinkansen-hen [with Controller]"
   region: "NTSC-J"
 TCPS-10068:
-  name: "電車でGO！ 旅情編コントローラ同梱セット"
-  name-sort: "でんしゃでごー りょじょうへんこんとろーらどうこんせっと"
-  name-en: "Densha de Go! Ryojou-hen [with Controller]"
+  name: "電車でGO！ 旅情編 [コントローラ同梱セット]"
+  name-sort: "でんしゃでごー りょじょうへん [こんとろーらどうこんせっと]"
+  name-en: "Densha de Go！ Ryojou-hen [with Controller]"
   region: "NTSC-J"
 TCPS-10074:
   name: "スペースインベーダー アニバーサリー [筐体型コントローラ同梱セット]"
@@ -72328,7 +72633,7 @@ TCPS-10074:
 TCPS-10075:
   name: "高橋尚子のマラソンしようよ！"
   name-sort: "たかはしなおこのまらそんしようよ"
-  name-en: "Takahashi Naoko no Marathon Shiyou yo!"
+  name-en: "Takahashi Naoko no Marathon Shiyou yo！"
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes missing text.
@@ -72340,12 +72645,12 @@ TCPS-10084:
 TCPS-10085:
   name: "電車でGO！FINAL"
   name-sort: "でんしゃでごーFINAL"
-  name-en: "Densha de Go! Final [Limited Edition]"
+  name-en: "Densha de Go！ Final [Limited Edition]"
   region: "NTSC-J"
   compat: 5
 TCPS-10086:
-  name: "ラクガキ王国 2 ～魔王城の戦い～"
-  name-sort: "らくがきおうこく 2 ～まおうじょうのたたかい～"
+  name: "ラクガキ王国2 ～魔王城の戦い～"
+  name-sort: "らくがきおうこく2 ～まおうじょうのたたかい～"
   name-en: "Rakugaki Oukoku 2 - Maoh jou no Tatakai"
   region: "NTSC-J"
   gsHWFixes:
@@ -72378,8 +72683,8 @@ TCPS-10107:
   region: "NTSC-J"
 TCPS-10109:
   name: "イースⅢ ～ワンダラーズ フロム イース～ [初回限定版]"
-  name-sort: "いーす3 わんだらーず ふろむ いーす しょかいげんていばん"
-  name-en: "Ys III - Wanderers from Ys [Limited Edition]"
+  name-sort: "いーす3 わんだらーず ふろむ いーす [しょかいげんていばん]"
+  name-en: "Ys III - Wanderers from Ys [First Limited Edition]"
   region: "NTSC-J"
 TCPS-10111:
   name: "エレメンタル ジェレイド -纏え、翠風の剣-"
@@ -72408,7 +72713,7 @@ TCPS-10115:
 TCPS-10117:
   name: "虫姫さま [初回限定版]"
   name-sort: "むしひめさま [しょかいげんていばん]"
-  name-en: "Mushihime-sama [Limited Edition]"
+  name-en: "Mushihime-sama [First Limited Edition]"
   region: "NTSC-J"
 TCPS-10123:
   name: "ラングリッサーⅢ"
@@ -72609,7 +72914,7 @@ TLES-52768:
   name: "Commandos - Strike Force"
   region: "PAL-Unk"
 TLES-52781:
-  name: "WWE SmackDown! vs. RAW Beta Trial Code"
+  name: "WWE SmackDown！ vs. RAW Beta Trial Code"
   region: "PAL-E"
 TLES-52940:
   name: "S.L.A.I. - Steel Lancer Arena International Beta Trial Code"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Fix Japanese Title (Trial,Demo Section)
Add 2titles gsHWFixes

SLPS-20308:
  name: "花火百景 [特典版]"
  name-sort: "はなびひゃっけい [とくてんばん]"
  name-en: "Hanabi Hyakkei [Tokutenban]"
  region: "NTSC-J"
  speedHacks:
    instantVU1: 0 # Fixes working speed to correctly.
    mtvu: 0 # Fixes working speed to correctly.

SLPS-20309:
  name: "花火百景"
  name-sort: "はなびひゃっけい"
  name-en: "Hanabi Hyakkei"
  region: "NTSC-J"
  speedHacks:
    instantVU1: 0 # Fixes working speed to correctly.
    mtvu: 0 # Fixes working speed to correctly.

These title must to turn off the options.
Becasue, If turn on the option then the game can't work correct speed.
*These title is same game means [Limited & Standard Edition]


SLPS-25481:
  name: "ガッツだ！！森の石松"
  name-sort: "がっつだ もりのいしまつ"
  name-en: "Gattsu Da！！ Mori no Ishimatsu"
  region: "NTSC-J"
  gsHWFixes:
    instantVU1: 0 # Fixes Turbo mode Freeze.
    mtvu: 0 # Fixes Turbo mode Freeze.

If turn on the options then the game will freeze by Turbo mode.
If turn off the options then Turbo mode wil work stable.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Japanese titles should appear by Japanese I think.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
See Above.