### PR TITLE
Settings/Log: Print advanced settings warning on the log

### DIFF
--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -300,7 +300,7 @@ std::string Achievements::GetGameHash(const std::string& elf_path)
 	Error error;
 	if (!cdvdLoadElf(&elfo, elf_path, false, &error))
 	{
-		Console.Error(fmt::format("(Achievements) Failed to read ELF '{}' on disc: {}", elf_path, error.GetDescription()));
+		Console.Error(fmt::format("Achievements: Failed to read ELF '{}' on disc: {}", elf_path, error.GetDescription()));
 		return {};
 	}
 
@@ -441,7 +441,7 @@ bool Achievements::Initialize()
 	const std::string api_token = Host::GetBaseStringSettingValue("Achievements", "Token");
 	if (!username.empty() && !api_token.empty())
 	{
-		Console.WriteLn("(Achievements) Attempting login with user '%s'...", username.c_str());
+		Console.WriteLn("Achievements: Attempting login with user '%s'...", username.c_str());
 		s_login_request =
 			rc_client_begin_login_with_token(s_client, username.c_str(), api_token.c_str(), ClientLoginWithTokenCallback, nullptr);
 	}
@@ -608,7 +608,7 @@ void Achievements::EnsureCacheDirectoriesExist()
 
 void Achievements::ClientMessageCallback(const char* message, const rc_client_t* client)
 {
-	Console.WriteLn("(Achievements) %s", message);
+	Console.WriteLn("Achievements: %s", message);
 }
 
 uint32_t Achievements::ClientReadMemory(uint32_t address, uint8_t* buffer, uint32_t num_bytes, rc_client_t* client)
@@ -865,7 +865,7 @@ void Achievements::IdentifyGame(u32 disc_crc, u32 crc)
 	// bail out if we're not logged in, just save the hash
 	if (!IsLoggedInOrLoggingIn())
 	{
-		Console.WriteLn(Color_StrongYellow, "(Achievements) Skipping load game because we're not logged in.");
+		Console.WriteLn(Color_StrongYellow, "Achievements: Skipping load game because we're not logged in.");
 		DisableHardcoreMode();
 		return;
 	}
@@ -908,7 +908,7 @@ void Achievements::ClientLoadGameCallback(int result, const char* error_message,
 	if (result == RC_NO_GAME_LOADED)
 	{
 		// Unknown game.
-		Console.WriteLn(Color_StrongYellow, "(Achievements) Unknown game '%s', disabling achievements.", s_game_hash.c_str());
+		Console.WriteLn(Color_StrongYellow, "Achievements: Unknown game '%s', disabling achievements.", s_game_hash.c_str());
 		DisableHardcoreMode();
 		return;
 	}
@@ -1083,7 +1083,7 @@ void Achievements::HandleUnlockEvent(const rc_client_event_t* event)
 	const rc_client_achievement_t* cheevo = event->achievement;
 	pxAssert(cheevo);
 
-	Console.WriteLn("(Achievements) Achievement %s (%u) for game %u unlocked", cheevo->title, cheevo->id, s_game_id);
+	Console.WriteLn("Achievements: Achievement %s (%u) for game %u unlocked", cheevo->title, cheevo->id, s_game_id);
 	UpdateGameSummary();
 
 	if (EmuConfig.Achievements.Notifications)
@@ -1109,7 +1109,7 @@ void Achievements::HandleUnlockEvent(const rc_client_event_t* event)
 
 void Achievements::HandleGameCompleteEvent(const rc_client_event_t* event)
 {
-	Console.WriteLn("(Achievements) Game %u complete", s_game_id);
+	Console.WriteLn("Achievements: Game %u complete", s_game_id);
 	UpdateGameSummary();
 
 	if (EmuConfig.Achievements.Notifications)
@@ -1133,7 +1133,7 @@ void Achievements::HandleGameCompleteEvent(const rc_client_event_t* event)
 
 void Achievements::HandleLeaderboardStartedEvent(const rc_client_event_t* event)
 {
-	DevCon.WriteLn("(Achievements) Leaderboard %u (%s) started", event->leaderboard->id, event->leaderboard->title);
+	DevCon.WriteLn("Achievements: Leaderboard %u (%s) started", event->leaderboard->id, event->leaderboard->title);
 
 	if (EmuConfig.Achievements.LeaderboardNotifications)
 	{
@@ -1152,7 +1152,7 @@ void Achievements::HandleLeaderboardStartedEvent(const rc_client_event_t* event)
 
 void Achievements::HandleLeaderboardFailedEvent(const rc_client_event_t* event)
 {
-	DevCon.WriteLn("(Achievements) Leaderboard %u (%s) failed", event->leaderboard->id, event->leaderboard->title);
+	DevCon.WriteLn("Achievements: Leaderboard %u (%s) failed", event->leaderboard->id, event->leaderboard->title);
 
 	if (EmuConfig.Achievements.LeaderboardNotifications)
 	{
@@ -1171,7 +1171,7 @@ void Achievements::HandleLeaderboardFailedEvent(const rc_client_event_t* event)
 
 void Achievements::HandleLeaderboardSubmittedEvent(const rc_client_event_t* event)
 {
-	Console.WriteLn("(Achievements) Leaderboard %u (%s) submitted", event->leaderboard->id, event->leaderboard->title);
+	Console.WriteLn("Achievements: Leaderboard %u (%s) submitted", event->leaderboard->id, event->leaderboard->title);
 
 	if (EmuConfig.Achievements.LeaderboardNotifications)
 	{
@@ -1203,7 +1203,7 @@ void Achievements::HandleLeaderboardSubmittedEvent(const rc_client_event_t* even
 
 void Achievements::HandleLeaderboardScoreboardEvent(const rc_client_event_t* event)
 {
-	Console.WriteLn("(Achievements) Leaderboard %u scoreboard rank %u of %u", event->leaderboard_scoreboard->leaderboard_id,
+	Console.WriteLn("Achievements: Leaderboard %u scoreboard rank %u of %u", event->leaderboard_scoreboard->leaderboard_id,
 		event->leaderboard_scoreboard->new_rank, event->leaderboard_scoreboard->num_entries);
 
 	if (EmuConfig.Achievements.LeaderboardNotifications)
@@ -1234,7 +1234,7 @@ void Achievements::HandleLeaderboardScoreboardEvent(const rc_client_event_t* eve
 void Achievements::HandleLeaderboardTrackerShowEvent(const rc_client_event_t* event)
 {
 	DevCon.WriteLn(
-		"(Achievements) Showing leaderboard tracker: %u: %s", event->leaderboard_tracker->id, event->leaderboard_tracker->display);
+		"Achievements: Showing leaderboard tracker: %u: %s", event->leaderboard_tracker->id, event->leaderboard_tracker->display);
 
 	LeaderboardTrackerIndicator indicator;
 	indicator.tracker_id = event->leaderboard_tracker->id;
@@ -1251,7 +1251,7 @@ void Achievements::HandleLeaderboardTrackerHideEvent(const rc_client_event_t* ev
 	if (it == s_active_leaderboard_trackers.end())
 		return;
 
-	DevCon.WriteLn("(Achievements) Hiding leaderboard tracker: %u", id);
+	DevCon.WriteLn("Achievements: Hiding leaderboard tracker: %u", id);
 	it->active = false;
 	it->show_hide_time.Reset();
 }
@@ -1265,7 +1265,7 @@ void Achievements::HandleLeaderboardTrackerUpdateEvent(const rc_client_event_t* 
 		return;
 
 	DevCon.WriteLn(
-		"(Achievements) Updating leaderboard tracker: %u: %s", event->leaderboard_tracker->id, event->leaderboard_tracker->display);
+		"Achievements: Updating leaderboard tracker: %u: %s", event->leaderboard_tracker->id, event->leaderboard_tracker->display);
 
 	it->text = event->leaderboard_tracker->display;
 	it->active = true;
@@ -1288,7 +1288,7 @@ void Achievements::HandleAchievementChallengeIndicatorShowEvent(const rc_client_
 	indicator.active = true;
 	s_active_challenge_indicators.push_back(std::move(indicator));
 
-	DevCon.WriteLn("(Achievements) Show challenge indicator for %u (%s)", event->achievement->id, event->achievement->title);
+	DevCon.WriteLn("Achievements: Show challenge indicator for %u (%s)", event->achievement->id, event->achievement->title);
 }
 
 void Achievements::HandleAchievementChallengeIndicatorHideEvent(const rc_client_event_t* event)
@@ -1298,14 +1298,14 @@ void Achievements::HandleAchievementChallengeIndicatorHideEvent(const rc_client_
 	if (it == s_active_challenge_indicators.end())
 		return;
 
-	DevCon.WriteLn("(Achievements) Hide challenge indicator for %u (%s)", event->achievement->id, event->achievement->title);
+	DevCon.WriteLn("Achievements: Hide challenge indicator for %u (%s)", event->achievement->id, event->achievement->title);
 	it->show_hide_time.Reset();
 	it->active = false;
 }
 
 void Achievements::HandleAchievementProgressIndicatorShowEvent(const rc_client_event_t* event)
 {
-	DevCon.WriteLn("(Achievements) Showing progress indicator: %u (%s): %s", event->achievement->id, event->achievement->title,
+	DevCon.WriteLn("Achievements: Showing progress indicator: %u (%s): %s", event->achievement->id, event->achievement->title,
 		event->achievement->measured_progress);
 
 	if (!s_active_progress_indicator.has_value())
@@ -1323,14 +1323,14 @@ void Achievements::HandleAchievementProgressIndicatorHideEvent(const rc_client_e
 	if (!s_active_progress_indicator.has_value())
 		return;
 
-	DevCon.WriteLn("(Achievements) Hiding progress indicator");
+	DevCon.WriteLn("Achievements: Hiding progress indicator");
 	s_active_progress_indicator->show_hide_time.Reset();
 	s_active_progress_indicator->active = false;
 }
 
 void Achievements::HandleAchievementProgressIndicatorUpdateEvent(const rc_client_event_t* event)
 {
-	DevCon.WriteLn("(Achievements) Updating progress indicator: %u (%s): %s", event->achievement->id, event->achievement->title,
+	DevCon.WriteLn("Achievements: Updating progress indicator: %u (%s): %s", event->achievement->id, event->achievement->title,
 		event->achievement->measured_progress);
 	s_active_progress_indicator->achievement = event->achievement;
 	s_active_progress_indicator->active = true;
@@ -1341,13 +1341,13 @@ void Achievements::HandleServerErrorEvent(const rc_client_event_t* event)
 	std::string message = fmt::format(TRANSLATE_FS("Achievements", "Server error in {0}:\n{1}"),
 		event->server_error->api ? event->server_error->api : "UNKNOWN",
 		event->server_error->error_message ? event->server_error->error_message : "UNKNOWN");
-	Console.Error("(Achievements) %s", message.c_str());
+	Console.Error("Achievements: %s", message.c_str());
 	Host::AddOSDMessage(std::move(message), Host::OSD_ERROR_DURATION);
 }
 
 void Achievements::HandleServerDisconnectedEvent(const rc_client_event_t* event)
 {
-	Console.Warning("(Achievements) Server disconnected.");
+	Console.Warning("Achievements: Server disconnected.");
 
 	MTGS::RunOnGSThread([]() {
 		if (ImGuiManager::InitializeFullscreenUI())
@@ -1360,7 +1360,7 @@ void Achievements::HandleServerDisconnectedEvent(const rc_client_event_t* event)
 
 void Achievements::HandleServerReconnectedEvent(const rc_client_event_t* event)
 {
-	Console.Warning("(Achievements) Server reconnected.");
+	Console.Warning("Achievements: Server reconnected.");
 
 	MTGS::RunOnGSThread([]() {
 		if (ImGuiManager::InitializeFullscreenUI())
@@ -1385,7 +1385,7 @@ void Achievements::ResetClient()
 	if (!IsActive())
 		return;
 
-	Console.WriteLn("(Achievements) Reset client");
+	Console.WriteLn("Achievements: Reset client");
 	rc_client_reset(s_client);
 }
 
@@ -1811,11 +1811,11 @@ void Achievements::Logout()
 		if (HasActiveGame())
 			ClearGameInfo();
 
-		Console.WriteLn("(Achievements) Logging out...");
+		Console.WriteLn("Achievements: Logging out...");
 		rc_client_logout(s_client);
 	}
 
-	Console.WriteLn("(Achievements) Clearing credentials...");
+	Console.WriteLn("Achievements: Clearing credentials...");
 	Host::RemoveBaseSettingValue("Achievements", "Username");
 	Host::RemoveBaseSettingValue("Achievements", "Token");
 	Host::RemoveBaseSettingValue("Achievements", "LoginTimestamp");
@@ -1961,7 +1961,7 @@ void Achievements::DrawGameOverlays()
 
 			if (!indicator.active && opacity <= 0.01f)
 			{
-				DevCon.WriteLn("(Achievements) Remove challenge indicator");
+				DevCon.WriteLn("Achievements: Remove challenge indicator");
 				it = s_active_challenge_indicators.erase(it);
 			}
 			else
@@ -2004,7 +2004,7 @@ void Achievements::DrawGameOverlays()
 
 		if (!indicator.active && opacity <= 0.01f)
 		{
-			DevCon.WriteLn("(Achievements) Remove progress indicator");
+			DevCon.WriteLn("Achievements: Remove progress indicator");
 			s_active_progress_indicator.reset();
 		}
 
@@ -2046,7 +2046,7 @@ void Achievements::DrawGameOverlays()
 
 			if (!indicator.active && opacity <= 0.01f)
 			{
-				DevCon.WriteLn("(Achievements) Remove tracker indicator");
+				DevCon.WriteLn("Achievements: Remove tracker indicator");
 				it = s_active_leaderboard_trackers.erase(it);
 			}
 			else
@@ -2151,7 +2151,7 @@ bool Achievements::PrepareAchievementsWindow()
 		RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_PROGRESS /*RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_LOCK_STATE*/);
 	if (!s_achievement_list)
 	{
-		Console.Error("(Achievements) rc_client_create_achievement_list() returned null");
+		Console.Error("Achievements: rc_client_create_achievement_list() returned null");
 		return false;
 	}
 
@@ -2489,7 +2489,7 @@ bool Achievements::PrepareLeaderboardsWindow()
 	s_leaderboard_list = rc_client_create_leaderboard_list(client, RC_CLIENT_LEADERBOARD_LIST_GROUPING_NONE);
 	if (!s_leaderboard_list)
 	{
-		Console.Error("(Achievements) rc_client_create_leaderboard_list() returned null");
+		Console.Error("Achievements: rc_client_create_leaderboard_list() returned null");
 		return false;
 	}
 
@@ -2920,7 +2920,7 @@ void Achievements::DrawLeaderboardListEntry(const rc_client_leaderboard_t* lboar
 
 void Achievements::OpenLeaderboard(const rc_client_leaderboard_t* lboard)
 {
-	Console.WriteLn("(Achievements) Opening leaderboard '%s' (%u)", lboard->title, lboard->id);
+	Console.WriteLn("Achievements: Opening leaderboard '%s' (%u)", lboard->title, lboard->id);
 
 	CloseLeaderboard();
 
@@ -2974,7 +2974,7 @@ void Achievements::FetchNextLeaderboardEntries()
 	for (rc_client_leaderboard_entry_list_t* list : s_leaderboard_entry_lists)
 		start += list->num_entries;
 
-	Console.WriteLn("(Achievements) Fetching entries %u to %u", start, start + LEADERBOARD_ALL_FETCH_SIZE);
+	Console.WriteLn("Achievements: Fetching entries %u to %u", start, start + LEADERBOARD_ALL_FETCH_SIZE);
 
 	if (s_leaderboard_fetch_handle)
 		rc_client_abort_async(s_client, s_leaderboard_fetch_handle);

--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -403,7 +403,7 @@ void UpdateVSyncRate(bool force)
 		vSyncInfoCalc(&vSyncInfo, frames_per_second, total_scanlines);
 
 		if (video_mode_initialized)
-			Console.WriteLn(Color_Green, "(UpdateVSyncRate) Mode Changed to %s.", ReportVideoMode());
+			Console.WriteLn(Color_Green, "UpdateVSyncRate: Mode Changed to %s.", ReportVideoMode());
 
 		if (custom && video_mode_initialized)
 			Console.WriteLn(Color_StrongGreen, "  ... with user configured refresh rate: %.02f Hz", vertical_frequency);

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -118,7 +118,7 @@ void GameDatabase::parseAndInsert(const std::string_view serial, const c4::yml::
 			if (eeVal >= 0 && eeVal < static_cast<int>(FPRoundMode::MaxCount))
 				gameEntry.eeRoundMode = static_cast<FPRoundMode>(eeVal);
 			else
-				Console.Error(fmt::format("[GameDB] Invalid EE round mode '{}', specified for serial: '{}'.", eeVal, serial));
+				Console.Error(fmt::format("GameDB: Invalid EE round mode '{}', specified for serial: '{}'.", eeVal, serial));
 		}
 		if (node["roundModes"].has_child("eeDivRoundMode"))
 		{
@@ -127,7 +127,7 @@ void GameDatabase::parseAndInsert(const std::string_view serial, const c4::yml::
 			if (eeVal >= 0 && eeVal < static_cast<int>(FPRoundMode::MaxCount))
 				gameEntry.eeDivRoundMode = static_cast<FPRoundMode>(eeVal);
 			else
-				Console.Error(fmt::format("[GameDB] Invalid EE division round mode '{}', specified for serial: '{}'.", eeVal, serial));
+				Console.Error(fmt::format("GameDB: Invalid EE division round mode '{}', specified for serial: '{}'.", eeVal, serial));
 		}
 		if (node["roundModes"].has_child("vuRoundMode"))
 		{
@@ -140,7 +140,7 @@ void GameDatabase::parseAndInsert(const std::string_view serial, const c4::yml::
 			}
 			else
 			{
-				Console.Error(fmt::format("[GameDB] Invalid VU round mode '{}', specified for serial: '{}'.", vuVal, serial));
+				Console.Error(fmt::format("GameDB: Invalid VU round mode '{}', specified for serial: '{}'.", vuVal, serial));
 			}
 		}
 		if (node["roundModes"].has_child("vu0RoundMode"))
@@ -150,7 +150,7 @@ void GameDatabase::parseAndInsert(const std::string_view serial, const c4::yml::
 			if (vuVal >= 0 && vuVal < static_cast<int>(FPRoundMode::MaxCount))
 				gameEntry.vu0RoundMode = static_cast<FPRoundMode>(vuVal);
 			else
-				Console.Error(fmt::format("[GameDB] Invalid VU0 round mode '{}', specified for serial: '{}'.", vuVal, serial));
+				Console.Error(fmt::format("GameDB: Invalid VU0 round mode '{}', specified for serial: '{}'.", vuVal, serial));
 		}
 		if (node["roundModes"].has_child("vu1RoundMode"))
 		{
@@ -159,7 +159,7 @@ void GameDatabase::parseAndInsert(const std::string_view serial, const c4::yml::
 			if (vuVal >= 0 && vuVal < static_cast<int>(FPRoundMode::MaxCount))
 				gameEntry.vu1RoundMode = static_cast<FPRoundMode>(vuVal);
 			else
-				Console.Error(fmt::format("[GameDB] Invalid VU1 round mode '{}', specified for serial: '{}'.", vuVal, serial));
+				Console.Error(fmt::format("GameDB: Invalid VU1 round mode '{}', specified for serial: '{}'.", vuVal, serial));
 		}
 	}
 	if (node.has_child("clampModes"))
@@ -217,7 +217,7 @@ void GameDatabase::parseAndInsert(const std::string_view serial, const c4::yml::
 
 			if (!fixValidated)
 			{
-				Console.Error(fmt::format("[GameDB] Invalid gamefix: '{}', specified for serial: '{}'. Dropping!", fix, serial));
+				Console.Error(fmt::format("GameDB: Invalid gamefix: '{}', specified for serial: '{}'. Dropping!", fix, serial));
 			}
 		}
 	}
@@ -239,7 +239,7 @@ void GameDatabase::parseAndInsert(const std::string_view serial, const c4::yml::
 			}
 			else
 			{
-				Console.Error(fmt::format("[GameDB] Invalid speedhack: '{}={}', specified for serial: '{}'. Dropping!",
+				Console.Error(fmt::format("GameDB: Invalid speedhack: '{}={}', specified for serial: '{}'. Dropping!",
 					id_view, value_view, serial));
 			}
 		}
@@ -266,7 +266,7 @@ void GameDatabase::parseAndInsert(const std::string_view serial, const c4::yml::
 
 				if (value.value_or(-1) < 0)
 				{
-					Console.Error(fmt::format("[GameDB] Invalid GS HW Fix Value for '{}' in '{}': '{}'", id_name, serial, str_value));
+					Console.Error(fmt::format("GameDB: Invalid GS HW Fix Value for '{}' in '{}': '{}'", id_name, serial, str_value));
 					continue;
 				}
 			}
@@ -276,7 +276,7 @@ void GameDatabase::parseAndInsert(const std::string_view serial, const c4::yml::
 			}
 			if (!id.has_value() || !value.has_value())
 			{
-				Console.Error(fmt::format("[GameDB] Invalid GS HW Fix: '{}' specified for serial '{}'. Dropping!", id_name, serial));
+				Console.Error(fmt::format("GameDB: Invalid GS HW Fix: '{}' specified for serial '{}'. Dropping!", id_name, serial));
 				continue;
 			}
 
@@ -305,12 +305,12 @@ void GameDatabase::parseAndInsert(const std::string_view serial, const c4::yml::
 			const std::optional<u32> crc = (StringUtil::compareNoCase(crc_str, "default")) ? std::optional<u32>(0) : StringUtil::FromChars<u32>(crc_str, 16);
 			if (!crc.has_value())
 			{
-				Console.Error(fmt::format("[GameDB] Invalid CRC '{}' found for serial: '{}'. Skipping!", crc_str, serial));
+				Console.Error(fmt::format("GameDB: Invalid CRC '{}' found for serial: '{}'. Skipping!", crc_str, serial));
 				continue;
 			}
 			if (gameEntry.patches.find(crc.value()) != gameEntry.patches.end())
 			{
-				Console.Error(fmt::format("[GameDB] Duplicate CRC '{}' found for serial: '{}'. Skipping, CRCs are case-insensitive!", crc_str, serial));
+				Console.Error(fmt::format("GameDB: Duplicate CRC '{}' found for serial: '{}'. Skipping, CRCs are case-insensitive!", crc_str, serial));
 				continue;
 			}
 
@@ -442,18 +442,18 @@ void GameDatabaseSchema::GameEntry::applyGameFixes(Pcsx2Config& config, bool app
 {
 	// Only apply core game fixes if the user has enabled them.
 	if (!applyAuto)
-		Console.Warning("[GameDB] Game Fixes are disabled");
+		Console.Warning("GameDB: Game Fixes are disabled");
 
 	if (eeRoundMode < FPRoundMode::MaxCount)
 	{
 		if (applyAuto)
 		{
-			Console.WriteLn("(GameDB) Changing EE/FPU roundmode to %d [%s]", eeRoundMode, s_round_modes[static_cast<u8>(eeRoundMode)]);
+			Console.WriteLn("GameDB: Changing EE/FPU roundmode to %d [%s]", eeRoundMode, s_round_modes[static_cast<u8>(eeRoundMode)]);
 			config.Cpu.FPUFPCR.SetRoundMode(eeRoundMode);
 		}
 		else
 		{
-			Console.Warning("[GameDB] Skipping changing EE/FPU roundmode to %d [%s]", eeRoundMode, s_round_modes[static_cast<u8>(eeRoundMode)]);
+			Console.Warning("GameDB: Skipping changing EE/FPU roundmode to %d [%s]", eeRoundMode, s_round_modes[static_cast<u8>(eeRoundMode)]);
 		}
 	}
 
@@ -461,12 +461,12 @@ void GameDatabaseSchema::GameEntry::applyGameFixes(Pcsx2Config& config, bool app
 	{
 		if (applyAuto)
 		{
-			Console.WriteLn("(GameDB) Changing EE/FPU divison roundmode to %d [%s]", eeRoundMode, s_round_modes[static_cast<u8>(eeDivRoundMode)]);
+			Console.WriteLn("GameDB: Changing EE/FPU divison roundmode to %d [%s]", eeRoundMode, s_round_modes[static_cast<u8>(eeDivRoundMode)]);
 			config.Cpu.FPUDivFPCR.SetRoundMode(eeDivRoundMode);
 		}
 		else
 		{
-			Console.Warning("[GameDB] Skipping changing EE/FPU roundmode to %d [%s]", eeRoundMode, s_round_modes[static_cast<u8>(eeRoundMode)]);
+			Console.Warning("GameDB: Skipping changing EE/FPU roundmode to %d [%s]", eeRoundMode, s_round_modes[static_cast<u8>(eeRoundMode)]);
 		}
 	}
 
@@ -474,12 +474,12 @@ void GameDatabaseSchema::GameEntry::applyGameFixes(Pcsx2Config& config, bool app
 	{
 		if (applyAuto)
 		{
-			Console.WriteLn("(GameDB) Changing VU0 roundmode to %d [%s]", vu0RoundMode, s_round_modes[static_cast<u8>(vu0RoundMode)]);
+			Console.WriteLn("GameDB: Changing VU0 roundmode to %d [%s]", vu0RoundMode, s_round_modes[static_cast<u8>(vu0RoundMode)]);
 			config.Cpu.VU0FPCR.SetRoundMode(vu0RoundMode);
 		}
 		else
 		{
-			Console.Warning("[GameDB] Skipping changing VU0 roundmode to %d [%s]", vu0RoundMode, s_round_modes[static_cast<u8>(vu0RoundMode)]);
+			Console.Warning("GameDB: Skipping changing VU0 roundmode to %d [%s]", vu0RoundMode, s_round_modes[static_cast<u8>(vu0RoundMode)]);
 		}
 	}
 
@@ -487,12 +487,12 @@ void GameDatabaseSchema::GameEntry::applyGameFixes(Pcsx2Config& config, bool app
 	{
 		if (applyAuto)
 		{
-			Console.WriteLn("(GameDB) Changing VU1 roundmode to %d [%s]", vu1RoundMode, s_round_modes[static_cast<u8>(vu1RoundMode)]);
+			Console.WriteLn("GameDB: Changing VU1 roundmode to %d [%s]", vu1RoundMode, s_round_modes[static_cast<u8>(vu1RoundMode)]);
 			config.Cpu.VU1FPCR.SetRoundMode(vu1RoundMode);
 		}
 		else
 		{
-			Console.Warning("[GameDB] Skipping changing VU1 roundmode to %d [%s]", vu1RoundMode, s_round_modes[static_cast<u8>(vu1RoundMode)]);
+			Console.Warning("GameDB: Skipping changing VU1 roundmode to %d [%s]", vu1RoundMode, s_round_modes[static_cast<u8>(vu1RoundMode)]);
 		}
 	}
 
@@ -501,13 +501,13 @@ void GameDatabaseSchema::GameEntry::applyGameFixes(Pcsx2Config& config, bool app
 		const int clampMode = enum_cast(eeClampMode);
 		if (applyAuto)
 		{
-			Console.WriteLn("(GameDB) Changing EE/FPU clamp mode [mode=%d]", clampMode);
+			Console.WriteLn("GameDB: Changing EE/FPU clamp mode [mode=%d]", clampMode);
 			config.Cpu.Recompiler.fpuOverflow = (clampMode >= 1);
 			config.Cpu.Recompiler.fpuExtraOverflow = (clampMode >= 2);
 			config.Cpu.Recompiler.fpuFullMode = (clampMode >= 3);
 		}
 		else
-			Console.Warning("[GameDB] Skipping changing EE/FPU clamp mode [mode=%d]", clampMode);
+			Console.Warning("GameDB: Skipping changing EE/FPU clamp mode [mode=%d]", clampMode);
 	}
 
 	if (vu0ClampMode != GameDatabaseSchema::ClampMode::Undefined)
@@ -515,13 +515,13 @@ void GameDatabaseSchema::GameEntry::applyGameFixes(Pcsx2Config& config, bool app
 		const int clampMode = enum_cast(vu0ClampMode);
 		if (applyAuto)
 		{
-			Console.WriteLn("(GameDB) Changing VU0 clamp mode [mode=%d]", clampMode);
+			Console.WriteLn("GameDB: Changing VU0 clamp mode [mode=%d]", clampMode);
 			config.Cpu.Recompiler.vu0Overflow = (clampMode >= 1);
 			config.Cpu.Recompiler.vu0ExtraOverflow = (clampMode >= 2);
 			config.Cpu.Recompiler.vu0SignOverflow = (clampMode >= 3);
 		}
 		else
-			Console.Warning("[GameDB] Skipping changing VU0 clamp mode [mode=%d]", clampMode);
+			Console.Warning("GameDB: Skipping changing VU0 clamp mode [mode=%d]", clampMode);
 	}
 
 	if (vu1ClampMode != GameDatabaseSchema::ClampMode::Undefined)
@@ -529,13 +529,13 @@ void GameDatabaseSchema::GameEntry::applyGameFixes(Pcsx2Config& config, bool app
 		const int clampMode = enum_cast(vu1ClampMode);
 		if (applyAuto)
 		{
-			Console.WriteLn("(GameDB) Changing VU1 clamp mode [mode=%d]", clampMode);
+			Console.WriteLn("GameDB: Changing VU1 clamp mode [mode=%d]", clampMode);
 			config.Cpu.Recompiler.vu1Overflow = (clampMode >= 1);
 			config.Cpu.Recompiler.vu1ExtraOverflow = (clampMode >= 2);
 			config.Cpu.Recompiler.vu1SignOverflow = (clampMode >= 3);
 		}
 		else
-			Console.Warning("[GameDB] Skipping changing VU1 clamp mode [mode=%d]", clampMode);
+			Console.Warning("GameDB: Skipping changing VU1 clamp mode [mode=%d]", clampMode);
 	}
 
 	// TODO - config - this could be simplified with maps instead of bitfields and enums
@@ -543,14 +543,14 @@ void GameDatabaseSchema::GameEntry::applyGameFixes(Pcsx2Config& config, bool app
 	{
 		if (!applyAuto)
 		{
-			Console.Warning("[GameDB] Skipping setting Speedhack '%s' to [mode=%d]",
+			Console.Warning("GameDB: Skipping setting Speedhack '%s' to [mode=%d]",
 				Pcsx2Config::SpeedhackOptions::GetSpeedHackName(it.first), it.second);
 			continue;
 		}
 		// Legacy note - speedhacks are setup in the GameDB as integer values, but
 		// are effectively booleans like the gamefixes
 		config.Speedhacks.Set(it.first, it.second);
-		Console.WriteLn("(GameDB) Setting Speedhack '%s' to [mode=%d]",
+		Console.WriteLn("GameDB: Setting Speedhack '%s' to [mode=%d]",
 			Pcsx2Config::SpeedhackOptions::GetSpeedHackName(it.first), it.second);
 	}
 
@@ -559,12 +559,12 @@ void GameDatabaseSchema::GameEntry::applyGameFixes(Pcsx2Config& config, bool app
 	{
 		if (!applyAuto)
 		{
-			Console.Warning("[GameDB] Skipping Gamefix: %s", Pcsx2Config::GamefixOptions::GetGameFixName(id));
+			Console.Warning("GameDB: Skipping Gamefix: %s", Pcsx2Config::GamefixOptions::GetGameFixName(id));
 			continue;
 		}
 		// if the fix is present, it is said to be enabled
 		config.Gamefixes.Set(id, true);
-		Console.WriteLn("(GameDB) Enabled Gamefix: %s", Pcsx2Config::GamefixOptions::GetGameFixName(id));
+		Console.WriteLn("GameDB: Enabled Gamefix: %s", Pcsx2Config::GamefixOptions::GetGameFixName(id));
 
 		// The LUT is only used for 1 game so we allocate it only when the gamefix is enabled (save 4MB)
 		if (id == Fix_GoemonTlbMiss && true)
@@ -694,7 +694,7 @@ void GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions&
 	const bool apply_auto_fixes = !config.ManualUserHacks;
 	const bool is_sw_renderer = EmuConfig.GS.Renderer == GSRendererType::SW;
 	if (!apply_auto_fixes)
-		Console.Warning("[GameDB] Manual GS hardware renderer fixes are enabled, not using automatic hardware renderer fixes from GameDB.");
+		Console.Warning("GameDB: Manual GS hardware renderer fixes are enabled, not using automatic hardware renderer fixes from GameDB.");
 
 	for (const auto& [id, value] : gsHWFixes)
 	{
@@ -703,7 +703,7 @@ void GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions&
 			if (configMatchesHWFix(config, id, value))
 				continue;
 
-			Console.Warning("[GameDB] Skipping GS Hardware Fix: %s to [mode=%d]", getHWFixName(id), value);
+			Console.Warning("GameDB: Skipping GS Hardware Fix: %s to [mode=%d]", getHWFixName(id), value);
 			fmt::format_to(std::back_inserter(disabled_fixes), "{} {} = {}", disabled_fixes.empty() ? "  " : "\n  ", getHWFixName(id), value);
 			continue;
 		}
@@ -790,7 +790,7 @@ void GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions&
 					if (config.TriFilter == TriFiltering::Automatic)
 						config.TriFilter = static_cast<TriFiltering>(value);
 					else if (config.TriFilter > TriFiltering::Off)
-						Console.Warning("[GameDB] Game requires trilinear filtering to be disabled.");
+						Console.Warning("GameDB: Game requires trilinear filtering to be disabled.");
 				}
 			}
 			break;
@@ -832,7 +832,7 @@ void GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions&
 					if (config.InterlaceMode == GSInterlaceMode::Automatic)
 						config.InterlaceMode = static_cast<GSInterlaceMode>(value);
 					else
-						Console.Warning("[GameDB] Game requires different deinterlace mode but it has been overridden by user setting.");
+						Console.Warning("GameDB: Game requires different deinterlace mode but it has been overridden by user setting.");
 				}
 			}
 			break;
@@ -919,7 +919,7 @@ void GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions&
 				break;
 		}
 
-		Console.WriteLn("[GameDB] Enabled GS Hardware Fix: %s to [mode=%d]", getHWFixName(id), value);
+		Console.WriteLn("GameDB: Enabled GS Hardware Fix: %s to [mode=%d]", getHWFixName(id), value);
 	}
 
 	// fixup skipdraw range just in case the db has a bad range (but the linter should catch this)
@@ -954,7 +954,7 @@ void GameDatabase::initDatabase()
 	auto buf = FileSystem::ReadFileToString(Path::Combine(EmuFolders::Resources, GAMEDB_YAML_FILE_NAME).c_str());
 	if (!buf.has_value())
 	{
-		Console.Error("[GameDB] Unable to open GameDB file, file does not exist.");
+		Console.Error("GameDB: Unable to open GameDB file, file does not exist.");
 		return;
 	}
 
@@ -971,7 +971,7 @@ void GameDatabase::initDatabase()
 		// However, YAML's keys are as expected case-sensitive, so we have to explicitly do our own duplicate checking
 		if (s_game_db.count(serial) == 1)
 		{
-			Console.Error(fmt::format("[GameDB] Duplicate serial '{}' found in GameDB. Skipping, Serials are case-insensitive!", serial));
+			Console.Error(fmt::format("GameDB: Duplicate serial '{}' found in GameDB. Skipping, Serials are case-insensitive!", serial));
 			continue;
 		}
 
@@ -988,9 +988,9 @@ void GameDatabase::ensureLoaded()
 {
 	std::call_once(s_load_once_flag, []() {
 		Common::Timer timer;
-		Console.WriteLn(fmt::format("[GameDB] Has not been initialized yet, initializing..."));
+		Console.WriteLn(fmt::format("GameDB: Has not been initialized yet, initializing..."));
 		initDatabase();
-		Console.WriteLn("[GameDB] %zu games on record (loaded in %.2fms)", s_game_db.size(), timer.GetTimeMilliseconds());
+		Console.WriteLn("GameDB: %zu games on record (loaded in %.2fms)", s_game_db.size(), timer.GetTimeMilliseconds());
 	});
 }
 
@@ -1115,7 +1115,7 @@ bool GameDatabase::loadHashDatabase()
 	auto buf = FileSystem::ReadFileToString(Path::Combine(EmuFolders::Resources, HASHDB_YAML_FILE_NAME).c_str());
 	if (!buf.has_value())
 	{
-		Console.Error("[GameDB] Unable to open hash database file, file does not exist.");
+		Console.Error("GameDB: Unable to open hash database file, file does not exist.");
 		return false;
 	}
 

--- a/pcsx2/Input/SDLInputSource.cpp
+++ b/pcsx2/Input/SDLInputSource.cpp
@@ -540,14 +540,14 @@ bool SDLInputSource::ProcessSDLEvent(const SDL_Event* event)
 	{
 		case SDL_CONTROLLERDEVICEADDED:
 		{
-			Console.WriteLn("(SDLInputSource) Controller %d inserted", event->cdevice.which);
+			Console.WriteLn("SDLInputSource: Controller %d inserted", event->cdevice.which);
 			OpenDevice(event->cdevice.which, true);
 			return true;
 		}
 
 		case SDL_CONTROLLERDEVICEREMOVED:
 		{
-			Console.WriteLn("(SDLInputSource) Controller %d removed", event->cdevice.which);
+			Console.WriteLn("SDLInputSource: Controller %d removed", event->cdevice.which);
 			CloseDevice(event->cdevice.which);
 			return true;
 		}
@@ -558,7 +558,7 @@ bool SDLInputSource::ProcessSDLEvent(const SDL_Event* event)
 			if (SDL_IsGameController(event->jdevice.which))
 				return false;
 
-			Console.WriteLn("(SDLInputSource) Joystick %d inserted", event->jdevice.which);
+			Console.WriteLn("SDLInputSource: Joystick %d inserted", event->jdevice.which);
 			OpenDevice(event->cdevice.which, false);
 			return true;
 		}
@@ -569,7 +569,7 @@ bool SDLInputSource::ProcessSDLEvent(const SDL_Event* event)
 			if (auto it = GetControllerDataForJoystickId(event->cdevice.which); it != m_controllers.end() && it->game_controller)
 				return false;
 
-			Console.WriteLn("(SDLInputSource) Joystick %d removed", event->jdevice.which);
+			Console.WriteLn("SDLInputSource: Joystick %d removed", event->jdevice.which);
 			CloseDevice(event->cdevice.which);
 			return true;
 		}
@@ -657,7 +657,7 @@ bool SDLInputSource::OpenDevice(int index, bool is_gamecontroller)
 
 	if (!gcontroller && !joystick)
 	{
-		ERROR_LOG("(SDLInputSource) Failed to open controller {}", index);
+		ERROR_LOG("SDLInputSource: Failed to open controller {}", index);
 		return false;
 	}
 
@@ -667,7 +667,7 @@ bool SDLInputSource::OpenDevice(int index, bool is_gamecontroller)
 	{
 		if (it->joystick_id == joystick_id)
 		{
-			ERROR_LOG("(SDLInputSource) Controller {}, instance {}, player {} already connected, ignoring.", index, joystick_id, player_id);
+			ERROR_LOG("SDLInputSource: Controller {}, instance {}, player {} already connected, ignoring.", index, joystick_id, player_id);
 			if (gcontroller)
 				SDL_GameControllerClose(gcontroller);
 			else
@@ -680,7 +680,7 @@ bool SDLInputSource::OpenDevice(int index, bool is_gamecontroller)
 	if (player_id < 0 || GetControllerDataForPlayerId(player_id) != m_controllers.end())
 	{
 		const int free_player_id = GetFreePlayerId();
-		WARNING_LOG("(SDLInputSource) Controller {} (joystick {}) returned player ID {}, which is invalid or in "
+		WARNING_LOG("SDLInputSource: Controller {} (joystick {}) returned player ID {}, which is invalid or in "
 					"use. Using ID {} instead.",
 			index, joystick_id, player_id, free_player_id);
 		player_id = free_player_id;
@@ -690,7 +690,7 @@ bool SDLInputSource::OpenDevice(int index, bool is_gamecontroller)
 	if (!name)
 		name = "Unknown Device";
 
-	INFO_LOG("(SDLInputSource) Opened {} {} (instance id {}, player id {}): {}", is_gamecontroller ? "game controller" : "joystick",
+	INFO_LOG("SDLInputSource: Opened {} {} (instance id {}, player id {}): {}", is_gamecontroller ? "game controller" : "joystick",
 		index, joystick_id, player_id, name);
 
 	ControllerData cd = {};
@@ -717,7 +717,7 @@ bool SDLInputSource::OpenDevice(int index, bool is_gamecontroller)
 		for (size_t i = 0; i < std::size(s_sdl_button_names); i++)
 			mark_bind(SDL_GameControllerGetBindForButton(gcontroller, static_cast<SDL_GameControllerButton>(i)));
 
-		INFO_LOG("(SDLInputSource) Controller {} has {} axes and {} buttons", player_id, num_axes, num_buttons);
+		INFO_LOG("SDLInputSource: Controller {} has {} axes and {} buttons", player_id, num_axes, num_buttons);
 	}
 	else
 	{
@@ -726,14 +726,14 @@ bool SDLInputSource::OpenDevice(int index, bool is_gamecontroller)
 		if (num_hats > 0)
 			cd.last_hat_state.resize(static_cast<size_t>(num_hats), u8(0));
 
-		INFO_LOG("(SDLInputSource) Joystick {} has {} axes, {} buttons and {} hats", player_id,
+		INFO_LOG("SDLInputSource: Joystick {} has {} axes, {} buttons and {} hats", player_id,
 			SDL_JoystickNumAxes(joystick), SDL_JoystickNumButtons(joystick), num_hats);
 	}
 
 	cd.use_game_controller_rumble = (gcontroller && SDL_GameControllerRumble(gcontroller, 0, 0, 0) == 0);
 	if (cd.use_game_controller_rumble)
 	{
-		INFO_LOG("(SDLInputSource) Rumble is supported on '{}' via gamecontroller", name);
+		INFO_LOG("SDLInputSource: Rumble is supported on '{}' via gamecontroller", name);
 	}
 	else
 	{
@@ -752,25 +752,25 @@ bool SDLInputSource::OpenDevice(int index, bool is_gamecontroller)
 			}
 			else
 			{
-				ERROR_LOG("(SDLInputSource) Failed to create haptic left/right effect: {}", SDL_GetError());
+				ERROR_LOG("SDLInputSource: Failed to create haptic left/right effect: {}", SDL_GetError());
 				if (SDL_HapticRumbleSupported(haptic) && SDL_HapticRumbleInit(haptic) != 0)
 				{
 					cd.haptic = haptic;
 				}
 				else
 				{
-					ERROR_LOG("(SDLInputSource) No haptic rumble supported: {}", SDL_GetError());
+					ERROR_LOG("SDLInputSource: No haptic rumble supported: {}", SDL_GetError());
 					SDL_HapticClose(haptic);
 				}
 			}
 		}
 
 		if (cd.haptic)
-			INFO_LOG("(SDLInputSource) Rumble is supported on '{}' via haptic", name);
+			INFO_LOG("SDLInputSource: Rumble is supported on '{}' via haptic", name);
 	}
 
 	if (!cd.haptic && !cd.use_game_controller_rumble)
-		WARNING_LOG("(SDLInputSource) Rumble is not supported on '{}'", name);
+		WARNING_LOG("SDLInputSource: Rumble is not supported on '{}'", name);
 
 	if (player_id >= 0 && static_cast<u32>(player_id) < MAX_LED_COLORS && gcontroller && SDL_GameControllerHasLED(gcontroller))
 	{

--- a/pcsx2/R3000AInterpreter.cpp
+++ b/pcsx2/R3000AInterpreter.cpp
@@ -237,7 +237,7 @@ static void doBranch(s32 tar) {
 	// This detects when SYSMEM is called and clears the modules then
 	if(tar == 0x890)
 	{
-		DevCon.WriteLn(Color_Gray, "[R3000 Debugger] Branch to 0x890 (SYSMEM). Clearing modules.");
+		DevCon.WriteLn(Color_Gray, "R3000 Debugger: Branch to 0x890 (SYSMEM). Clearing modules.");
 		R3000SymbolGuardian.ClearIrxModules();
 	}
 

--- a/pcsx2/SIO/Memcard/MemoryCardFolder.cpp
+++ b/pcsx2/SIO/Memcard/MemoryCardFolder.cpp
@@ -260,11 +260,11 @@ void FolderMemoryCard::LoadMemoryCardData(const u32 sizeInClusters, const bool e
 	{
 		if (enableFiltering)
 		{
-			Console.WriteLn(Color_Green, "(FolderMcd) Indexing slot %u with filter \"%s\".", m_slot, filter.c_str());
+			Console.WriteLn(Color_Green, "FolderMcd: Indexing slot %u with filter \"%s\".", m_slot, filter.c_str());
 		}
 		else
 		{
-			Console.WriteLn(Color_Green, "(FolderMcd) Indexing slot %u without filter.", m_slot);
+			Console.WriteLn(Color_Green, "FolderMcd: Indexing slot %u without filter.", m_slot);
 		}
 
 		CreateFat();
@@ -636,7 +636,7 @@ bool FolderMemoryCard::AddFile(MemoryCardFileEntry* const dirEntry, const std::s
 	}
 	else
 	{
-		Console.WriteLn("(FolderMcd) Could not open file: %s", relativeFilePath.c_str());
+		Console.WriteLn("FolderMcd: Could not open file: %s", relativeFilePath.c_str());
 		return false;
 	}
 }
@@ -1082,7 +1082,7 @@ void FolderMemoryCard::Flush()
 	WriteToFile(m_folderName.GetFullPath().RemoveLast() + L"-debug_" + wxDateTime::Now().Format(L"%Y-%m-%d-%H-%M-%S") + L"_pre-flush.ps2");
 #endif
 
-	Console.WriteLn("(FolderMcd) Writing data for slot %u to file system...", m_slot);
+	Console.WriteLn("FolderMcd: Writing data for slot %u to file system...", m_slot);
 	Common::Timer timeFlushStart;
 
 	// Keep a copy of the old file entries so we can figure out which files and directories, if any, have been deleted from the memory card.
@@ -1104,7 +1104,7 @@ void FolderMemoryCard::Flush()
 	FlushBlock(m_superBlock.data.backup_block2);
 	if (m_backupBlock2.programmedBlock != 0xFFFFFFFFu)
 	{
-		Console.Warning("(FolderMcd) Aborting flush of slot %u, emulation was interrupted during save process!", m_slot);
+		Console.Warning("FolderMcd: Aborting flush of slot %u, emulation was interrupted during save process!", m_slot);
 		return;
 	}
 
@@ -1150,7 +1150,7 @@ void FolderMemoryCard::Flush()
 	m_lastAccessedFile.ClearMetadataWriteState();
 	m_oldDataCache.clear();
 
-	Console.WriteLn("(FolderMcd) Done! Took %.2f ms.", timeFlushStart.GetTimeMilliseconds());
+	Console.WriteLn("FolderMcd: Done! Took %.2f ms.", timeFlushStart.GetTimeMilliseconds());
 
 #ifdef DEBUG_WRITE_FOLDER_CARD_IN_MEMORY_TO_FILE_ON_CHANGE
 	WriteToFile(m_folderName.GetFullPath().RemoveLast() + L"-debug_" + wxDateTime::Now().Format(L"%Y-%m-%d-%H-%M-%S") + L"_post-flush.ps2");
@@ -1763,7 +1763,7 @@ std::string FolderMemoryCard::GetDisabledMessage(uint slot) const
 
 std::string FolderMemoryCard::GetCardFullMessage(const std::string& filePath) const
 {
-	return fmt::format("(FolderMcd) Memory Card is full, could not add: {}", filePath);
+	return fmt::format("FolderMcd: Memory Card is full, could not add: {}", filePath);
 }
 
 std::vector<FolderMemoryCard::EnumeratedFileEntry> FolderMemoryCard::GetOrderedFiles(const std::string& dirPath) const

--- a/pcsx2/SIO/Pad/PadDualshock2.cpp
+++ b/pcsx2/SIO/Pad/PadDualshock2.cpp
@@ -145,7 +145,7 @@ void PadDualshock2::ConfigLog()
 	// VS: Vibration Small (how is the small vibration motor mapped)
 	// VL: Vibration Large (how is the large vibration motor mapped)
 	// RB: Response Bytes (what data is included in the controller's responses - D = Digital, A = Analog, P = Pressure)
-	Console.WriteLn(fmt::format("[Pad] DS2 Config Finished - P{0}/S{1} - AL: {2} - AB: {3} - VS: {4} - VL: {5} - RB: {6} (0x{7:08X})",
+	Console.WriteLn(fmt::format("Pad: DS2 Config Finished - P{0}/S{1} - AL: {2} - AB: {3} - VS: {4} - VL: {5} - RB: {6} (0x{7:08X})",
 		port + 1,
 		slot + 1,
 		(this->analogLight ? "On" : "Off"),

--- a/pcsx2/SIO/Pad/PadGuitar.cpp
+++ b/pcsx2/SIO/Pad/PadGuitar.cpp
@@ -47,7 +47,7 @@ void PadGuitar::ConfigLog()
 
 	// AL: Analog Light (is it turned on right now)
 	// AB: Analog Button (is it useable or is it locked in its current state)
-	Console.WriteLn(fmt::format("[Pad] Guitar Config Finished - P{0}/S{1} - AL: {2} - AB: {3}",
+	Console.WriteLn(fmt::format("Pad: Guitar Config Finished - P{0}/S{1} - AL: {2} - AB: {3}",
 		port + 1,
 		slot + 1,
 		(this->analogLight ? "On" : "Off"),

--- a/pcsx2/SIO/Pad/PadJogcon.cpp
+++ b/pcsx2/SIO/Pad/PadJogcon.cpp
@@ -53,7 +53,7 @@ void PadJogcon::ConfigLog()
 
 	// AL: Analog Light (is it turned on right now)
 	// AB: Analog Button (is it useable or is it locked in its current state)
-	Console.WriteLn(fmt::format("[Pad] Jogcon Config Finished - P{0}/S{1} - AL: {2} - AB: {3}",
+	Console.WriteLn(fmt::format("Pad: Jogcon Config Finished - P{0}/S{1} - AL: {2} - AB: {3}",
 		port + 1,
 		slot + 1,
 		(this->analogLight ? "On" : "Off"),

--- a/pcsx2/SIO/Pad/PadNegcon.cpp
+++ b/pcsx2/SIO/Pad/PadNegcon.cpp
@@ -50,7 +50,7 @@ void PadNegcon::ConfigLog()
 
 	// AL: Analog Light (is it turned on right now)
 	// AB: Analog Button (is it useable or is it locked in its current state)
-	Console.WriteLn(fmt::format("[Pad] Negcon Config Finished - P{0}/S{1} - AL: {2} - AB: {3}",
+	Console.WriteLn(fmt::format("Pad: Negcon Config Finished - P{0}/S{1} - AL: {2} - AB: {3}",
 		port + 1,
 		slot + 1,
 		(this->analogLight ? "On" : "Off"),

--- a/pcsx2/SIO/Pad/PadPopn.cpp
+++ b/pcsx2/SIO/Pad/PadPopn.cpp
@@ -56,7 +56,7 @@ void PadPopn::ConfigLog()
 	// AL: Analog Light (is it turned on right now)
 	// AB: Analog Button (is it useable or is it locked in its current state)
 	// RB: Response Bytes (what data is included in the controller's responses - D = Digital, A = Analog, P = Pressure)
-	Console.WriteLn(fmt::format("[Pad] Pop'n Config Finished - P{0}/S{1} - AL: {2} - AB: {3} - RB: {4} (0x{5:08X})",
+	Console.WriteLn(fmt::format("Pad: Pop'n Config Finished - P{0}/S{1} - AL: {2} - AB: {3} - RB: {4} (0x{5:08X})",
 		port + 1,
 		slot + 1,
 		(this->analogLight ? "On" : "Off"),

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -415,6 +415,10 @@ bool VMManager::Internal::CPUThreadInitialize()
 	if (EmuConfig.EnableDiscordPresence)
 		InitializeDiscordPresence();
 
+	// Check for advanced settings status and warn the user if its enabled
+	if (Host::GetBaseBoolSettingValue("UI", "ShowAdvancedSettings", false))
+		Console.Warning("Settings: Advanced Settings are enabled; only proceed if you know what you're doing! No support will be provided if you have the option enabled.");
+
 	return true;
 }
 

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -1543,7 +1543,7 @@ static void iopRecRecompile(const u32 startpc)
 	// This detects when SYSMEM is called and clears the modules then
 	if(startpc == 0x890)
 	{
-		DevCon.WriteLn(Color_Gray, "[R3000 Debugger] Branch to 0x890 (SYSMEM). Clearing modules.");
+		DevCon.WriteLn(Color_Gray, "R3000 Debugger: Branch to 0x890 (SYSMEM). Clearing modules.");
 		R3000SymbolGuardian.ClearIrxModules();
 	}
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
This PR adds a log entry that warns the user through the log if they have advanced options enabled.
Preview:
![image](https://github.com/user-attachments/assets/b230d211-5192-4fac-8c4f-4fee8bfeb01c)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Helps with user support in the event a user has messed around with the advanced settings.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
See if the warning shows up correctly if the advanced settings are enabled. Also checks when its off too, or when the value is absent from the ini file.