### PR TITLE
Qt: Properly disable all dumping options if draw dumping is disabled.

### DIFF
--- a/pcsx2-qt/Settings/DebugSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DebugSettingsWidget.cpp
@@ -151,6 +151,14 @@ void DebugSettingsWidget::onDrawDumpingChanged()
 	m_ui.saveFrame->setEnabled(enabled);
 	m_ui.saveTexture->setEnabled(enabled);
 	m_ui.saveDepth->setEnabled(enabled);
+	m_ui.startDraw->setEnabled(enabled);
+	m_ui.dumpCount->setEnabled(enabled);
+	m_ui.hwDumpDirectory->setEnabled(enabled);
+	m_ui.hwDumpBrowse->setEnabled(enabled);
+	m_ui.hwDumpOpen->setEnabled(enabled);
+	m_ui.swDumpDirectory->setEnabled(enabled);
+	m_ui.swDumpBrowse->setEnabled(enabled);
+	m_ui.swDumpOpen->setEnabled(enabled);
 }
 
 #ifdef PCSX2_DEVBUILD

--- a/pcsx2-qt/Settings/DebugSettingsWidget.ui
+++ b/pcsx2-qt/Settings/DebugSettingsWidget.ui
@@ -167,7 +167,7 @@
               </property>
              </widget>
             </item>
-            <item row="0" column="1">
+            <item row="1" column="1">
              <widget class="QCheckBox" name="saveRT">
               <property name="text">
                <string>Save RT</string>
@@ -181,7 +181,7 @@
               </property>
              </widget>
             </item>
-            <item row="1" column="1">
+            <item row="2" column="1">
              <widget class="QCheckBox" name="saveTexture">
               <property name="text">
                <string>Save Texture</string>


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Qt: Properly disable all dumping options if draw dumping is disabled.
Also move around sone options.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
UI improvements.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Make sure all draw dump options are disabled if draw dumping is disabled.
