### PR TITLE
UV clipping hack for Tales of Rebirth screen tearing

### DIFF
--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -478,6 +478,7 @@ void GSRendererSW::Draw()
 			m_mem.SaveBMP(s, m_context->ZBUF.Block(), m_context->FRAME.FBW, m_context->ZBUF.PSM, r.z, r.w);
 		}
 
+		data.get()->global.t_bbox = m_vt.m_min.t.xyxy(m_vt.m_max.t); // Set min/max UV values for scanline function to clip
 		Queue(data);
 
 		Sync(3);
@@ -509,6 +510,7 @@ void GSRendererSW::Draw()
 	}
 	else
 	{
+		data.get()->global.t_bbox = m_vt.m_min.t.xyxy(m_vt.m_max.t); // Set min/max UV values for scanline function to clip
 		Queue(data);
 	}
 

--- a/pcsx2/GS/Renderers/SW/GSScanlineEnvironment.h
+++ b/pcsx2/GS/Renderers/SW/GSScanlineEnvironment.h
@@ -137,6 +137,8 @@ struct alignas(32) GSScanlineGlobalData // per batch variables, this is like a p
 	GSVector4i afix;
 	struct { GSVector4i min, max, minmax, mask, invmask; } t; // [u] x 4 [v] x 4
 
+	GSVector4 t_bbox = GSVector4(0.0f, 0.0f, 10000.0f, 10000.0f); // Min/max values of UV in verts.
+
 #if _M_SSE >= 0x501
 
 	u32 fm, zm;


### PR DESCRIPTION
### Description of Changes
This is a PR to address the screen tearing problem in https://github.com/PCSX2/pcsx2/issues/12100 for SW rendering. The main change is to clip UV values of individually rasterized pixels to the bounding box of the (rounded) UV) values of the poly. This is still very much for testing purposed as it only applies to SW renderers without the JIT recompiler (so it's very slow) and the code is hacky. This is for testing purposes at this point, but if it accepted I would add it to the JIT recompilers and clean it up. Also, the changes only apply to texture mapping in UV mode, though it might be able to be modifited to work with ST mode also.

### Rationale behind Changes
The problem is that some times bilinear interpolation causes interpolated UV values to go outside the area where they are expected to be. These edge UV values cause sampling from incorrect texels causing alpha tests to fail and leave tears in the poly. I don’t know if this is a game bug that is being correctly emulated or an emulation bug. Either way, the effect is not desirable.

The fix I suggest is to clip the UV values during rasterization against the min/max integer values of the UV values of the vertices of the poly. I don’t have enough experience to know if this is a viable solution or if it would cause worse issues elsewhere, so any help testing this on games or feedback would be much appreciated.

### Suggested Testing Steps
I have tested this on a GS dump of provided in the thread https://github.com/PCSX2/pcsx2/issues/12100 and it seems to fix that issue. I would suggest testing this on games to make sure it is not breaking other things. I anticipate it will be quite slow.

PS: I hope I made this PR correctly. Please let me know if I should change anything!