### PR TITLE
Patches: Load and list patches for ELFs with a Disc Path set

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1346,9 +1346,8 @@ void MainWindow::onGameListEntryContextMenuRequested(const QPoint& point)
 		if (action->isEnabled())
 		{
 			connect(action, &QAction::triggered, [entry]() {
-				SettingsWindow::openGamePropertiesDialog(entry, entry->title,
-					(entry->type != GameList::EntryType::ELF) ? entry->serial : std::string(),
-					entry->crc);
+				SettingsWindow::openGamePropertiesDialog(entry,
+					entry->title, entry->serial, entry->crc, entry->type == GameList::EntryType::ELF);
 			});
 		}
 
@@ -1564,7 +1563,7 @@ void MainWindow::onViewGamePropertiesActionTriggered()
 		if (entry)
 		{
 			SettingsWindow::openGamePropertiesDialog(
-				entry, entry->title, s_current_elf_override.isEmpty() ? entry->serial : std::string(), entry->crc);
+				entry, entry->title, entry->serial, entry->crc, !s_current_elf_override.isEmpty());
 			return;
 		}
 	}
@@ -1580,12 +1579,12 @@ void MainWindow::onViewGamePropertiesActionTriggered()
 	if (s_current_elf_override.isEmpty())
 	{
 		SettingsWindow::openGamePropertiesDialog(
-			nullptr, s_current_title.toStdString(), s_current_disc_serial.toStdString(), s_current_disc_crc);
+			nullptr, s_current_title.toStdString(), s_current_disc_serial.toStdString(), s_current_disc_crc, false);
 	}
 	else
 	{
 		SettingsWindow::openGamePropertiesDialog(
-			nullptr, s_current_title.toStdString(), std::string(), s_current_disc_crc);
+			nullptr, s_current_title.toStdString(), std::string(), s_current_disc_crc, true);
 	}
 }
 

--- a/pcsx2-qt/Settings/GameCheatSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GameCheatSettingsWidget.cpp
@@ -124,7 +124,7 @@ void GameCheatSettingsWidget::updateListEnabled()
 	m_ui.enableAll->setEnabled(cheats_enabled);
 	m_ui.disableAll->setEnabled(cheats_enabled);
 	m_ui.reloadCheats->setEnabled(cheats_enabled);
-	m_ui.allCRCsCheckbox->setEnabled(cheats_enabled);
+	m_ui.allCRCsCheckbox->setEnabled(cheats_enabled && !m_dialog->getSerial().empty());
 	m_ui.searchText->setEnabled(cheats_enabled);
 }
 
@@ -210,6 +210,7 @@ void GameCheatSettingsWidget::reloadList()
 
 	m_parent_map.clear();
 	m_model->removeRows(0, m_model->rowCount());
+	m_ui.allCRCsCheckbox->setEnabled(!m_dialog->getSerial().empty() && m_ui.cheatList->isEnabled());
 
 	for (const Patch::PatchInfo& pi : m_patches)
 	{

--- a/pcsx2-qt/Settings/GameCheatSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GameCheatSettingsWidget.cpp
@@ -56,6 +56,7 @@ GameCheatSettingsWidget::GameCheatSettingsWidget(SettingsWindow* dialog, QWidget
 		m_model_proxy->setFilterFixedString(text);
 		m_ui.cheatList->expandAll();
 	});
+	connect(m_dialog, &SettingsWindow::discSerialChanged, this, &GameCheatSettingsWidget::reloadList);
 
 	dialog->registerWidgetHelp(m_ui.allCRCsCheckbox, tr("Show Cheats For All CRCs"), tr("Checked"),
 		tr("Toggles scanning patch files for all CRCs of the game. With this enabled available patches for the game serial with different CRCs will also be loaded."));

--- a/pcsx2-qt/Settings/GamePatchSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GamePatchSettingsWidget.cpp
@@ -62,6 +62,7 @@ GamePatchSettingsWidget::GamePatchSettingsWidget(SettingsWindow* dialog, QWidget
 
 	connect(m_ui.reload, &QPushButton::clicked, this, &GamePatchSettingsWidget::onReloadClicked);
 	connect(m_ui.allCRCsCheckbox, &QCheckBox::checkStateChanged, this, &GamePatchSettingsWidget::reloadList);
+	connect(m_dialog, &SettingsWindow::discSerialChanged, this, &GamePatchSettingsWidget::reloadList);
 
 	dialog->registerWidgetHelp(m_ui.allCRCsCheckbox, tr("Show Patches For All CRCs"), tr("Checked"),
 		tr("Toggles scanning patch files for all CRCs of the game. With this enabled available patches for the game serial with different CRCs will also be loaded."));

--- a/pcsx2-qt/Settings/GamePatchSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GamePatchSettingsWidget.cpp
@@ -97,6 +97,7 @@ void GamePatchSettingsWidget::reloadList()
 
 	setUnlabeledPatchesWarningVisibility(number_of_unlabeled_patches > 0);
 	delete m_ui.scrollArea->takeWidget();
+	m_ui.allCRCsCheckbox->setEnabled(!m_dialog->getSerial().empty());
 
 	QWidget* container = new QWidget(m_ui.scrollArea);
 	QVBoxLayout* layout = new QVBoxLayout(container);

--- a/pcsx2-qt/Settings/GameSummaryWidget.cpp
+++ b/pcsx2-qt/Settings/GameSummaryWidget.cpp
@@ -156,7 +156,15 @@ void GameSummaryWidget::onDiscPathChanged(const QString& value)
 
 	// force rescan of elf to update the serial
 	g_main_window->rescanFile(m_entry_path);
-	repopulateCurrentDetails();
+	
+	auto lock = GameList::GetLock();
+	const GameList::Entry* entry = GameList::GetEntryForPath(m_entry_path.c_str());
+	if (entry)
+	{
+		populateDetails(entry);
+		m_dialog->setSerial(entry->serial);
+		m_ui.checkWiki->setEnabled(!entry->serial.empty());
+	}
 }
 
 void GameSummaryWidget::onDiscPathBrowseClicked()

--- a/pcsx2-qt/Settings/SettingsWindow.cpp
+++ b/pcsx2-qt/Settings/SettingsWindow.cpp
@@ -447,6 +447,12 @@ void SettingsWindow::setWindowTitle(const QString& title)
 		QWidget::setWindowTitle(QStringLiteral("%1 [%2]").arg(title, m_filename));
 }
 
+void SettingsWindow::setSerial(std::string serial)
+{
+	m_serial = std::move(serial);
+	emit discSerialChanged();
+}
+
 bool SettingsWindow::getEffectiveBoolValue(const char* section, const char* key, bool default_value) const
 {
 	bool value;

--- a/pcsx2-qt/Settings/SettingsWindow.cpp
+++ b/pcsx2-qt/Settings/SettingsWindow.cpp
@@ -649,9 +649,9 @@ void SettingsWindow::saveAndReloadGameSettings()
 	g_emu_thread->reloadGameSettings();
 }
 
-void SettingsWindow::openGamePropertiesDialog(const GameList::Entry* game, const std::string_view title, std::string serial, u32 disc_crc)
+void SettingsWindow::openGamePropertiesDialog(const GameList::Entry* game, const std::string_view title, std::string serial, u32 disc_crc, bool is_elf)
 {
-	std::string filename = VMManager::GetGameSettingsPath(serial, disc_crc);
+	std::string filename = VMManager::GetGameSettingsPath(!is_elf ? serial : std::string_view(), disc_crc);
 
 	// check for an existing dialog with this filename
 	for (SettingsWindow* dialog : s_open_game_properties_dialogs)

--- a/pcsx2-qt/Settings/SettingsWindow.h
+++ b/pcsx2-qt/Settings/SettingsWindow.h
@@ -45,7 +45,7 @@ public:
 		u32 disc_crc, QString filename = QString());
 	~SettingsWindow();
 
-	static void openGamePropertiesDialog(const GameList::Entry* game, const std::string_view title, std::string serial, u32 disc_crc);
+	static void openGamePropertiesDialog(const GameList::Entry* game, const std::string_view title, std::string serial, u32 disc_crc, bool is_elf);
 	static void closeGamePropertiesDialogs();
 
 	SettingsInterface* getSettingsInterface() const;

--- a/pcsx2-qt/Settings/SettingsWindow.h
+++ b/pcsx2-qt/Settings/SettingsWindow.h
@@ -72,6 +72,7 @@ public:
 	bool eventFilter(QObject* object, QEvent* event) override;
 
 	void setWindowTitle(const QString& title);
+	void setSerial(std::string serial);
 
 	QString getCategory() const;
 	void setCategory(const char* category);
@@ -96,7 +97,7 @@ public:
 	void saveAndReloadGameSettings();
 
 Q_SIGNALS:
-	void settingsResetToDefaults();
+	void discSerialChanged();
 
 private Q_SLOTS:
 	void onCategoryCurrentRowChanged(int row);

--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -362,12 +362,14 @@ bool Patch::OpenPatchesZip()
 std::string Patch::GetPnachTemplate(const std::string_view serial, u32 crc, bool include_serial, bool add_wildcard, bool all_crcs)
 {
 	pxAssert(!all_crcs || (include_serial && add_wildcard));
-	if (all_crcs)
-		return fmt::format("{}_*.pnach", serial);
-	else if (include_serial)
-		return fmt::format("{}_{:08X}{}.pnach", serial, crc, add_wildcard ? "*" : "");
-	else
-		return fmt::format("{:08X}{}.pnach", crc, add_wildcard ? "*" : "");
+	if (!serial.empty())
+	{
+		if (all_crcs)
+			return fmt::format("{}_*.pnach", serial);	
+		else if (include_serial)
+			return fmt::format("{}_{:08X}{}.pnach", serial, crc, add_wildcard ? "*" : "");
+	}
+	return fmt::format("{:08X}{}.pnach", crc, add_wildcard ? "*" : "");
 }
 
 std::vector<std::string> Patch::FindPatchFilesOnDisk(const std::string_view serial, u32 crc, bool cheats, bool all_crcs)


### PR DESCRIPTION
### Description of Changes

This PR improves the behaviour of the game list for ELFs loaded with the "backing" ISO set by the Disc Path. The following changes were made:
1. If the serial is not known, patches/cheats no longer try to use the empty serial. This previously resulted in PCSX2 attempting to load files with the filename format `_crc.pnach`, which, coincidentally, resulted in my "disabled" pnachs loading as I disabled some by prefixing them with an underscore.
2. If the serial is not known, `All CRCs` in Patches and Cheats is greyed out as it's meaningless.
3. If Disc Path is set, use the serial from that disc when populating the cheat and patch lists. This makes the UI behaviour match what PCSX2 was doing when loading the game - previously, these patches were loaded, but it was not possible to enable them from the UI. **This change does not change the INI file name for the ELF game settings!**
4. Additionally, changing the Disc Path now toggles the state of the `Check Wiki` button in the Game Summary.

![image](https://github.com/user-attachments/assets/b6f193b6-e8ec-4247-88d8-1dd2a7d23987)

Fixes #11533.

### Rationale behind Changes

Consistency between the UI behaviour and what happens when you load the game.

### Suggested Testing Steps

See #11533 for suggested steps.
