### PR TITLE
CI/Windows: Use Windows Server 2025

### DIFF
--- a/.github/workflows/windows_build_matrix.yml
+++ b/.github/workflows/windows_build_matrix.yml
@@ -13,7 +13,7 @@ jobs:
   lint_vs_proj_files:
     name: Lint VS Project Files
     if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
-    runs-on: windows-2019
+    runs-on: windows-2025
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/windows_build_qt.yml
+++ b/.github/workflows/windows_build_qt.yml
@@ -12,7 +12,7 @@ on:
       os:
         required: false
         type: string
-        default: windows-2022
+        default: windows-2025
       platform:
         required: false
         type: string
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: Tempfix Clang
         if: inputs.configuration == 'CMake'
-        run: choco uninstall llvm
+        run: choco upgrade llvm
         
       - name: Checkout Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
### Description of Changes
Updates the Windows runners to use Windows Server 2025 which gives us llvm 19 for our builds.

### Rationale behind Changes
Keeping our runners up to date is good.

### Suggested Testing Steps
See if the CI passes and everything within PCSX2 functions as normal as well as ideally testing on a non AVX2 CPU for any issues.
