### PR TITLE
GS: UV rounding method to grab enough of texture

### DIFF
--- a/pcsx2/pcsx2.vcxproj.filters
+++ b/pcsx2/pcsx2.vcxproj.filters
@@ -220,15 +220,6 @@
     <Filter Include="System\Ps2\GS\Shaders\Direct3D">
       <UniqueIdentifier>{eb697f5b-85f5-424a-a7e4-8d8b73d3426e}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Tools">
-      <UniqueIdentifier>{9153e32b-e1e3-49ac-b490-b56adfd1692f}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Tools\Input Recording">
-      <UniqueIdentifier>{03ba2aa7-2cd9-48cb-93c6-fc93d5bdc938}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Tools\Input Recording\Utilities">
-      <UniqueIdentifier>{78c9db9c-9c7c-4385-90e7-9fa71b922f60}</UniqueIdentifier>
-    </Filter>
     <Filter Include="System\Ps2\USB\qemu-usb">
       <UniqueIdentifier>{e068b724-9319-42e5-9ea7-63d80989ea1d}</UniqueIdentifier>
     </Filter>
@@ -283,11 +274,20 @@
     <Filter Include="System\Ps2\EmotionEngine\DMAC\Vif\Unpack\newVif\Dynarec\arm64">
       <UniqueIdentifier>{8aea3ae6-9722-463a-94ac-34f3738a3153}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Tools\arm64">
-      <UniqueIdentifier>{cf847f4e-744e-4c27-a7ac-8564726fb4e6}</UniqueIdentifier>
-    </Filter>
     <Filter Include="System\Ps2\EmotionEngine\EE\Dynarec\arm64">
       <UniqueIdentifier>{cd8ec519-2196-43f7-86de-7faced2d4296}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="System\Tools">
+      <UniqueIdentifier>{9153e32b-e1e3-49ac-b490-b56adfd1692f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="System\Tools\Input Recording">
+      <UniqueIdentifier>{03ba2aa7-2cd9-48cb-93c6-fc93d5bdc938}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="System\Tools\Input Recording\Utilities">
+      <UniqueIdentifier>{78c9db9c-9c7c-4385-90e7-9fa71b922f60}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="System\Tools\arm64">
+      <UniqueIdentifier>{cf847f4e-744e-4c27-a7ac-8564726fb4e6}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -1119,19 +1119,19 @@
       <Filter>System\Ps2\GS\Renderers\Direct3D12</Filter>
     </ClCompile>
     <ClCompile Include="Recording\InputRecording.cpp">
-      <Filter>Tools\Input Recording</Filter>
+      <Filter>System\Tools\Input Recording</Filter>
     </ClCompile>
     <ClCompile Include="Recording\InputRecordingControls.cpp">
-      <Filter>Tools\Input Recording</Filter>
+      <Filter>System\Tools\Input Recording</Filter>
     </ClCompile>
     <ClCompile Include="Recording\InputRecordingFile.cpp">
-      <Filter>Tools\Input Recording</Filter>
+      <Filter>System\Tools\Input Recording</Filter>
     </ClCompile>
     <ClCompile Include="Recording\PadData.cpp">
-      <Filter>Tools\Input Recording</Filter>
+      <Filter>System\Tools\Input Recording</Filter>
     </ClCompile>
     <ClCompile Include="Recording\Utilities\InputRecordingLogger.cpp">
-      <Filter>Tools\Input Recording\Utilities</Filter>
+      <Filter>System\Tools\Input Recording\Utilities</Filter>
     </ClCompile>
     <ClCompile Include="USB\USB.cpp">
       <Filter>System\Ps2\USB</Filter>
@@ -1233,7 +1233,7 @@
       <Filter>System\Ps2\SPU2</Filter>
     </ClCompile>
     <ClCompile Include="GSDumpReplayer.cpp">
-      <Filter>Tools</Filter>
+      <Filter>System\Tools</Filter>
     </ClCompile>
     <ClCompile Include="GS\Renderers\DX11\D3D11ShaderCache.cpp">
       <Filter>System\Ps2\GS\Renderers\Direct3D11</Filter>
@@ -1302,7 +1302,7 @@
       <Filter>Misc</Filter>
     </ClCompile>
     <ClCompile Include="PerformanceMetrics.cpp">
-      <Filter>Tools</Filter>
+      <Filter>System\Tools</Filter>
     </ClCompile>
     <ClCompile Include="Input\InputSource.cpp">
       <Filter>Misc\Input</Filter>
@@ -1329,7 +1329,7 @@
       <Filter>Misc</Filter>
     </ClCompile>
     <ClCompile Include="Achievements.cpp">
-      <Filter>Tools</Filter>
+      <Filter>System\Tools</Filter>
     </ClCompile>
     <ClCompile Include="Hotkeys.cpp">
       <Filter>Misc</Filter>
@@ -1432,7 +1432,7 @@
       <Filter>System\Ps2\EmotionEngine\DMAC\Vif\Unpack\newVif\Dynarec\arm64</Filter>
     </ClCompile>
     <ClCompile Include="arm64\AsmHelpers.cpp">
-      <Filter>Tools\arm64</Filter>
+      <Filter>System\Tools\arm64</Filter>
     </ClCompile>
     <ClCompile Include="arm64\RecStubs.cpp">
       <Filter>System\Ps2\EmotionEngine\EE\Dynarec\arm64</Filter>
@@ -2059,19 +2059,19 @@
       <Filter>System\Ps2\GS\Renderers\Direct3D12</Filter>
     </ClInclude>
     <ClInclude Include="Recording\InputRecording.h">
-      <Filter>Tools\Input Recording</Filter>
+      <Filter>System\Tools\Input Recording</Filter>
     </ClInclude>
     <ClInclude Include="Recording\InputRecordingControls.h">
-      <Filter>Tools\Input Recording</Filter>
+      <Filter>System\Tools\Input Recording</Filter>
     </ClInclude>
     <ClInclude Include="Recording\InputRecordingFile.h">
-      <Filter>Tools\Input Recording</Filter>
+      <Filter>System\Tools\Input Recording</Filter>
     </ClInclude>
     <ClInclude Include="Recording\PadData.h">
-      <Filter>Tools\Input Recording</Filter>
+      <Filter>System\Tools\Input Recording</Filter>
     </ClInclude>
     <ClInclude Include="Recording\Utilities\InputRecordingLogger.h">
-      <Filter>Tools\Input Recording\Utilities</Filter>
+      <Filter>System\Tools\Input Recording\Utilities</Filter>
     </ClInclude>
     <ClInclude Include="ShaderCacheVersion.h">
       <Filter>System\Include</Filter>
@@ -2191,7 +2191,7 @@
       <Filter>System\Ps2\IPU</Filter>
     </ClInclude>
     <ClInclude Include="GSDumpReplayer.h">
-      <Filter>Tools</Filter>
+      <Filter>System\Tools</Filter>
     </ClInclude>
     <ClInclude Include="GS.h">
       <Filter>System\Ps2\GS\GIF</Filter>
@@ -2391,7 +2391,7 @@
       <Filter>System\Ps2\EmotionEngine\DMAC\Vif\Unpack\newVif\Dynarec\arm64</Filter>
     </ClInclude>
     <ClInclude Include="arm64\AsmHelpers.h">
-      <Filter>Tools\arm64</Filter>
+      <Filter>System\Tools\arm64</Filter>
     </ClInclude>
     <ClInclude Include="SIO\Pad\PadJogcon.h">
       <Filter>System\Ps2\Iop\SIO\PAD</Filter>


### PR DESCRIPTION
EDIT: This is still broken except in special cases

### Description of Changes
This is in response to the issue https://github.com/PCSX2/pcsx2/issues/12100. The problem was that for certain draws, not enough of a texture was being read from memory, because the edge texels for bilinear filter was not being accounted for properly (which can be +/-1 more than for without the bilinear filter). To fix the issue, the code calculates the UV coordinates at the minimum/maximum pixel centers in the draw's bounding box, then computes the UV coordinates for the bilinear filter, then uses these to specify the area of the texture that needs to be read. I believe this is most useful when the draw is something that looks like a flat rectangle (either a sprite or triangles shaped like a rectangle, with constant depth). I'm not sure what would happen for 3d polys.

### Rationale behind Changes
The previous method for determining the proper bounds of the texture to read from memory used a heuristic that depended on ratio that the texture was being expanded/shrunk from texel space to pixel space. However, there are cases where this code cannot properly detect the bound of the texture being used when doing bilinear filtering.

### Suggested Testing Steps
I would recommend running the GS dump in the thread https://github.com/PCSX2/pcsx2/issues/12100 and running the game itself. If there are other games that have similar issues, it would be good to check those too.

PS. Any feedback/suggestions from devs/testers with more experience on these issues or help testing this is much appreciated. Currently the code is still rough, though I would plan to clean it up if it was accepted.
