### PR TITLE
Memcard: Remove unnecessary FSeek64 for speed improvements

### DIFF
--- a/pcsx2/SIO/Memcard/MemoryCardFile.cpp
+++ b/pcsx2/SIO/Memcard/MemoryCardFile.cpp
@@ -360,24 +360,7 @@ void FileMemoryCard::Close()
 // Returns FALSE if the seek failed (is outside the bounds of the file).
 bool FileMemoryCard::Seek(std::FILE* f, u32 adr)
 {
-	const s64 size = FileSystem::FSize64(f);
-
-	// If anyone knows why this filesize logic is here (it appears to be related to legacy PSX
-	// cards, perhaps hacked support for some special emulator-specific memcard formats that
-	// had header info?), then please replace this comment with something useful.  Thanks!  -- air
-
-	u32 offset = 0;
-
-	if (size == MCD_SIZE + 64)
-		offset = 64;
-	else if (size == MCD_SIZE + 3904)
-		offset = 3904;
-	else
-	{
-		// perform sanity checks here?
-	}
-
-	return (FileSystem::FSeek64(f, adr + offset, SEEK_SET) == 0);
+	return (FileSystem::FSeek64(f, adr, SEEK_SET) == 0);
 }
 
 // returns FALSE if an error occurred (either permission denied or disk full)


### PR DESCRIPTION
### Description of Changes
Old memcard code was doing FSeek64 calls extremely often which was thrashing performance. One culprit was support for legacy PSX memcards with special headers, which I would argue are no longer used (or should no longer be used). The other was being used when fetching the card's size info, which is done on every sector change. FSeek64 is now called once upon card opening.

### Rationale behind Changes
Card size is static through PCSX2's lifecycle and only needs retrieved once. Doing so provides significant performance improvements as the IOP is no longer constantly performing unnecessary IO on the host file essentially every RPC call.

### Suggested Testing Steps
As always with memcard tests, make copies and use those for testing.

Boot all variety of games and test for data to load and save normally. Compare EE thread performance on master branch to this PR; mild to moderate reduction in EE thread utilization during load/save operations should be noted.

JRPGs among other games which use "save slots" and have in-game menus displaying them may be a prime test case, as such games are constantly making RPC calls to the memcard doing reads or otherwise checking card status to update the list. Check these games as well and see if EE utilization has decreased in these menus.