### PR TITLE
CI/Windows: Use Windows Server 2025 and LLVM 19

### DIFF
--- a/.github/workflows/windows_build_matrix.yml
+++ b/.github/workflows/windows_build_matrix.yml
@@ -13,7 +13,7 @@ jobs:
   lint_vs_proj_files:
     name: Lint VS Project Files
     if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
-    runs-on: windows-2019
+    runs-on: windows-2025
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/windows_build_qt.yml
+++ b/.github/workflows/windows_build_qt.yml
@@ -12,7 +12,7 @@ on:
       os:
         required: false
         type: string
-        default: windows-2022
+        default: windows-2025
       platform:
         required: false
         type: string

--- a/.github/workflows/windows_build_qt.yml
+++ b/.github/workflows/windows_build_qt.yml
@@ -55,12 +55,30 @@ jobs:
       POWERSHELL_TELEMETRY_OPTOUT: 1
 
     steps:
-      - name: Tempfix Clang
-        if: inputs.configuration == 'CMake'
-        run: choco uninstall llvm
-        
       - name: Checkout Repository
         uses: actions/checkout@v4
+
+      - name: Configure MSBuild Clang Version
+        if: inputs.configuration != 'CMake'
+        shell: pwsh
+        run: |
+          [string[]] $clang_cl = &clang-cl.exe --version
+          
+          $version = [Regex]::Match($clang_cl[0], "(\d+\.\d+\.\d+)")
+          $path = $clang_cl[3].TrimStart("InstalledDir: ").TrimEnd("\bin")
+          
+          $output = @"
+          <Project>
+            <PropertyGroup>
+              <LLVMInstallDir>$path</LLVMInstallDir>
+              <LLVMToolsVersion>$version</LLVMToolsVersion>
+            </PropertyGroup>
+          </Project>
+          "@
+          
+          Write-Host $output
+          
+          $output | Out-File Directory.build.props
 
       # actions/checkout elides tags, fetch them primarily for releases
       - name: Fetch Tags


### PR DESCRIPTION
### Description of Changes
Takes https://github.com/PCSX2/pcsx2/pull/12129 and forces LLVM 19 to be used for both MSBuild (unlike the last PR) and CMake
Removes the `Tempfix Clang` step

### Rationale behind Changes
Hopefully resolves the issue with the Windows Clang runner dieing.

### Suggested Testing Steps
Span the CI for clang builds