### PR TITLE
EE Cache: Make the SIMD path x86 only to support ARM interpreters

### DIFF
--- a/pcsx2/vtlb.cpp
+++ b/pcsx2/vtlb.cpp
@@ -30,7 +30,9 @@
 #include "fmt/core.h"
 
 #include <bit>
+#ifdef _M_X86
 #include <immintrin.h>
+#endif
 #include <map>
 #include <unordered_set>
 #include <unordered_map>
@@ -118,12 +120,13 @@ __inline int CheckCache(u32 addr)
 		return false;
 	}
 
+	size_t i = 0;
 	const size_t size = cachedTlbs.count;
+
+#ifdef _M_X86
 	const int stride = 4;
 
-	__m128i addr_vec = _mm_set1_epi32(addr);
-
-	size_t i = 0;
+	const __m128i addr_vec = _mm_set1_epi32(addr);
 
 	for (; i + stride <= size; i += stride)
 	{
@@ -170,7 +173,7 @@ __inline int CheckCache(u32 addr)
 			return true;
 		}
 	}
-
+#endif
 	for (; i < size; i++)
 	{
 		const u32 mask = cachedTlbs.PageMasks[i];


### PR DESCRIPTION
### Description of Changes
When introducing x86 intrinsics into the cache lookup, I completely forgot that we technically support ARM interpreters.

### Rationale behind Changes
This would have broke any ARM building.

### Suggested Testing Steps
I tested locally by checking for a non-existing define (to not compile the SIMD code) and it worked fine. I guess try and build ARM?