### PR TITLE
Debugger: Fix AST node ownership confusion bug

### DIFF
--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeModel.cpp
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeModel.cpp
@@ -460,8 +460,8 @@ std::vector<std::unique_ptr<SymbolTreeNode>> SymbolTreeModel::populateChildren(
 
 			for (const ccc::ast::StructOrUnion::FlatField& field : fields)
 			{
-				if (symbol)
-					parent_handle = ccc::NodeHandle(*symbol, nullptr);
+				if (field.symbol)
+					parent_handle = ccc::NodeHandle(*field.symbol, nullptr);
 
 				SymbolTreeLocation field_location = location.addOffset(field.base_offset + field.node->offset_bytes);
 				if (field_location.type == SymbolTreeLocation::NONE)


### PR DESCRIPTION
### Description of Changes
Fixes a bug where the symbol tree model would think fields owned by a base class were instead owned by a subclass.

### Rationale behind Changes
In theory this could cause a crash if the base class was deleted. In practice the debugger provides no way to delete individual data types currently so it would never actually happen, but it may be helpful in the future.

### Suggested Testing Steps
Check a .mdebug game.