### PR TITLE
Patch: Re-run PPT_ONCE_ON_LOAD patches when enabling them as the game is running

### DIFF
--- a/pcsx2/Patch.h
+++ b/pcsx2/Patch.h
@@ -88,7 +88,7 @@ namespace Patch
 	/// Reloads cheats/patches. If verbose is set, the number of patches loaded will be shown in the OSD.
 	extern void ReloadPatches(const std::string& serial, u32 crc, bool reload_files, bool reload_enabled_list, bool verbose, bool verbose_if_changed);
 
-	extern void UpdateActivePatches(bool reload_enabled_list, bool verbose, bool verbose_if_changed);
+	extern void UpdateActivePatches(bool reload_enabled_list, bool verbose, bool verbose_if_changed, bool apply_new_patches);
 	extern void ApplyPatchSettingOverrides();
 	extern bool ReloadPatchAffectingOptions();
 	extern void UnloadPatches();

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -760,7 +760,7 @@ bool VMManager::ReloadGameSettings()
 		return false;
 
 	// Patches must come first, because they can affect aspect ratio/interlacing.
-	Patch::UpdateActivePatches(true, false, true);
+	Patch::UpdateActivePatches(true, false, true, HasValidVM());
 	ApplySettings();
 	return true;
 }
@@ -2899,7 +2899,7 @@ void VMManager::CheckForPatchConfigChanges(const Pcsx2Config& old_config)
 		return;
 	}
 
-	Patch::UpdateActivePatches(true, false, true);
+	Patch::UpdateActivePatches(true, false, true, HasValidVM());
 
 	// This is a bit messy, because the patch config update happens after the settings are loaded,
 	// if we disable widescreen patches, we have to reload the original settings again.

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -2771,6 +2771,7 @@ void VMManager::Internal::EntryPointCompilingOnCPUThread()
 	HandleELFChange(true);
 
 	Patch::ApplyLoadedPatches(Patch::PPT_ONCE_ON_LOAD);
+	Patch::ApplyLoadedPatches(Patch::PPT_COMBINED_0_1);
 	// If the config changes at this point, it's a reset, so the game doesn't currently know about the memcard
 	// so there's no need to leave the eject running.
 	FileMcd_CancelEject();


### PR DESCRIPTION
### Description of Changes

This PR introduces two changes:
1. Patches of type `PPT_COMBINED_0_1` were erroneously working identical to the Type 1 patches, as they were not applying in the entrypoint, contrary to what the docs claimed.
2. Patches of type `PPT_ONCE_ON_LOAD` that are enabled while the game is running are now being applied immediately, without requiring a restart. Without this change, one-time patches were effectively at a disadvantage compared to the every-frame patches, as the user could not enable them on runtime, even if they were safe to do so.

### Rationale behind Changes

Stop punishing one-time patches for trying to be nice and not overwriting the code over and over every frame.

### Suggested Testing Steps

1. Run any game that has one-time patches, for example the 16:9 Widescreen fix for Tokyo Xtreme Racer Zero. Ensure the patch is disabled.
2. Enable the patch as the game is running.
3. Observe that the patch **does** apply.
