### PR TITLE
Debugger: Add disassembler toggle to go to the PC address on pause

### DIFF
--- a/pcsx2-qt/Debugger/CpuWidget.cpp
+++ b/pcsx2-qt/Debugger/CpuWidget.cpp
@@ -336,7 +336,7 @@ void CpuWidget::onVMPaused()
 	}
 	else
 	{
-		m_ui.disassemblyWidget->gotoAddress(m_cpu.getPC(), false);
+		m_ui.disassemblyWidget->gotoProgramCounterOnPause();
 	}
 
 	reloadCPUWidgets();

--- a/pcsx2-qt/Debugger/DisassemblyWidget.cpp
+++ b/pcsx2-qt/Debugger/DisassemblyWidget.cpp
@@ -656,6 +656,12 @@ void DisassemblyWidget::customMenuRequested(QPoint pos)
 	connect(action, &QAction::triggered, this, &DisassemblyWidget::contextGoToAddress);
 	contextMenu->addAction(action = new QAction(tr("Go to in Memory View"), this));
 	connect(action, &QAction::triggered, this, [this]() { gotoInMemory(m_selectedAddressStart); });
+
+	contextMenu->addAction(action = new QAction(tr("Go to PC on Pause"), this));
+	action->setCheckable(true);
+	action->setChecked(m_goToProgramCounterOnPause);
+	connect(action, &QAction::triggered, this, [this](bool value) { m_goToProgramCounterOnPause = value; });
+
 	contextMenu->addSeparator();
 	contextMenu->addAction(action = new QAction(tr("Add Function"), this));
 	connect(action, &QAction::triggered, this, &DisassemblyWidget::contextAddFunction);
@@ -820,6 +826,12 @@ QString DisassemblyWidget::FetchSelectionInfo(SelectionInfo selInfo)
 void DisassemblyWidget::gotoAddressAndSetFocus(u32 address)
 {
 	gotoAddress(address, true);
+}
+
+void DisassemblyWidget::gotoProgramCounterOnPause()
+{
+	if (m_goToProgramCounterOnPause)
+		gotoAddress(m_cpu->getPC(), false);
 }
 
 void DisassemblyWidget::gotoAddress(u32 address, bool should_set_focus)

--- a/pcsx2-qt/Debugger/DisassemblyWidget.h
+++ b/pcsx2-qt/Debugger/DisassemblyWidget.h
@@ -59,6 +59,7 @@ public slots:
 	void contextShowOpcode();
 
 	void gotoAddressAndSetFocus(u32 address);
+	void gotoProgramCounterOnPause();
 	void gotoAddress(u32 address, bool should_set_focus);
 
 	void setDemangle(bool demangle) { m_demangleFunctions = demangle; };
@@ -82,6 +83,7 @@ private:
 
 	bool m_demangleFunctions = true;
 	bool m_showInstructionOpcode = true;
+	bool m_goToProgramCounterOnPause = true;
 	DisassemblyManager m_disassemblyManager;
 
 	inline QString DisassemblyStringFromAddress(u32 address, QFont font, u32 pc, bool selected);


### PR DESCRIPTION
### Description of Changes
Adds a context menu option to disable the behaviour of making the disassembler jump to the address stored in the program counter when the VM is paused.

### Rationale behind Changes
Implements/closes #12170. Seems like a reasonable suggestion.

### Suggested Testing Steps
Try the new context menu option and see if it still jumps.
