### PR TITLE
SIO: Fix save state OSD warning formatting

### DIFF
--- a/pcsx2/SIO/Sio.cpp
+++ b/pcsx2/SIO/Sio.cpp
@@ -162,6 +162,6 @@ void MemcardBusy::CheckSaveStateDependency()
 	if (g_FrameCount - sioLastFrameMcdBusy > NUM_FRAMES_BEFORE_SAVESTATE_DEPENDENCY_WARNING)
 	{
 		Host::AddIconOSDMessage("MemcardBusy", ICON_PF_MEMORY_CARD,
-			TRANSLATE_SV("MemoryCard", "The virtual console hasn't saved to your memory card for quite some time. Savestates should not be used in place of in-game saves."), Host::OSD_INFO_DURATION);
+			TRANSLATE_SV("MemoryCard", "The virtual console hasn't saved to your memory card in a long time.\nSavestates should not be used in place of in-game saves."), Host::OSD_INFO_DURATION);
 	}
 }


### PR DESCRIPTION
### Description of Changes
Adds a line break in the recently added OSD message that warns you about the use of save states after an hour of not saving. Additionally changes "for quite some time" to "in a long time".

### Rationale behind Changes
The line break was used because this message is already so long that it wraps to a second one. The message makes extremely inefficient use of its space, having around 3/5 of an entire row blank. The deliberate line break also makes the second sentence (which would otherwise get cut in half) less awkard to read. Finally, the line break substantially cuts down on the overall horizontal length of the message with no effect on the vertical.

"for quite some time" to "in a long time" because it 1) more heavily emphasizes the length ("quite some time" is very gentle wording; "a long time" is very direct and 'plain English') and 2) cuts down on the length slightly.

### Suggested Testing Steps
In order to test this like a sane person, you'll probably want to build it yourself and change the `constexpr u32 NUM_FRAMES_BEFORE_SAVESTATE_DEPENDENCY_WARNING` in `Sio.h` from one hour (60 * 60 * 60) to something like one second (60) so you can easily see this. Otherwise, you'll just have to take my word that this is the way it's formatted.

### Images
Before:
![Before](https://github.com/user-attachments/assets/04fa051e-800e-4f08-886d-f3040723f547)
After:
![After](https://github.com/user-attachments/assets/c942591b-bb89-4927-9a4b-31b62ba71224)