### PR TITLE
Debugger: Wait for the entry point to run before scanning from memory

### DIFF
--- a/pcsx2/DebugTools/SymbolImporter.h
+++ b/pcsx2/DebugTools/SymbolImporter.h
@@ -6,6 +6,8 @@
 #include "Config.h"
 #include "SymbolGuardian.h"
 
+#include <condition_variable>
+
 class DebugInterface;
 
 class SymbolImporter
@@ -17,6 +19,7 @@ public:
 	// that are used to determine when symbol tables should be loaded, and
 	// should be called from the CPU thread.
 	void OnElfChanged(std::vector<u8> elf, const std::string& elf_file_name);
+	void OnElfLoadedInMemory();
 	void OnDebuggerOpened();
 	void OnDebuggerClosed();
 
@@ -30,7 +33,11 @@ public:
 
 	// Import symbols from the ELF file, nocash symbols, and scan for functions.
 	// Should be called from the CPU thread.
-	void AnalyseElf(std::vector<u8> elf, const std::string& elf_file_name, Pcsx2Config::DebugAnalysisOptions options);
+	void AnalyseElf(
+		std::vector<u8> elf,
+		const std::string& elf_file_name,
+		Pcsx2Config::DebugAnalysisOptions options,
+		bool wait_until_elf_is_loaded);
 
 	// Interrupt the import thread. Should be called from the CPU thread.
 	void ShutdownWorkerThread();
@@ -76,6 +83,10 @@ protected:
 
 	std::thread m_import_thread;
 	std::atomic_bool m_interrupt_import_thread = false;
+
+	std::mutex m_elf_loaded_in_memory_mutex;
+	std::condition_variable m_elf_loaded_in_memory_condition_variable;
+	bool m_elf_loaded_in_memory = false;
 
 	std::map<std::string, ccc::DataTypeHandle> m_builtin_types;
 };

--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -9,6 +9,7 @@
 #include "Config.h"
 #include "Counters.h"
 #include "DebugTools/Breakpoints.h"
+#include "DebugTools/SymbolImporter.h"
 #include "Elfheader.h"
 #include "GS.h"
 #include "GS/GS.h"
@@ -80,6 +81,9 @@ static void PostLoadPrep()
 	CBreakPoints::SetSkipFirst(BREAKPOINT_IOP, 0);
 
 	UpdateVSyncRate(true);
+
+	if (VMManager::Internal::HasBootedELF())
+		R5900SymbolImporter.OnElfLoadedInMemory();
 }
 
 // --------------------------------------------------------------------------------------

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -2779,6 +2779,8 @@ void VMManager::Internal::EntryPointCompilingOnCPUThread()
 	// Toss all the recs, we're going to be executing new code.
 	mmap_ResetBlockTracking();
 	ClearCPUExecutionCaches();
+
+	R5900SymbolImporter.OnElfLoadedInMemory();
 }
 
 void VMManager::Internal::VSyncOnCPUThread()


### PR DESCRIPTION
### Description of Changes
The symbol importer thread will now wait for the entry point to run before scanning for functions from memory.

I've used `std::condition_variable` to implement it so hopefully there won't be any deadlock issues this time.

### Rationale behind Changes
When I modified the function scanner to scan the ELF file, I removed the code to sync the symbol importer thread with the CPU thread because it was broken, but when I reintroduced support for scanning from memory I forgot to reintroduce it.

Previously this meant that if the `Scan From Memory` option was selected from the global or per-game settings dialogs (not from the analysis options dialog in the debugger as that won't affect boot) the function scanner could run before the game's code was actually loaded in memory. This could be fixed by doing another analysis run, which if you've selected the `Scan From Memory` option is probably what you want to do anyway, but it's still good to fix this.

### Suggested Testing Steps
Perform a bunch of operations that change the VM state e.g. rebooting, loading/saving save states, etc.
