### PR TITLE
SDLInputSource: Halve default LED brightness

### DIFF
--- a/pcsx2/Input/SDLInputSource.cpp
+++ b/pcsx2/Input/SDLInputSource.cpp
@@ -119,10 +119,10 @@ static constexpr const char* s_sdl_hat_direction_names[] = {
 };
 
 static constexpr const char* s_sdl_default_led_colors[] = {
-	"0000ff", // SDL-0
-	"ff0000", // SDL-1
-	"00ff00", // SDL-2
-	"ffff00", // SDL-3
+	"000080", // SDL-0
+	"800000", // SDL-1
+	"008000", // SDL-2
+	"808000", // SDL-3
 };
 
 static void SetControllerRGBLED(SDL_GameController* gc, u32 color)


### PR DESCRIPTION
### Description of Changes
Adjusts the default DS4 and DS5 LED intensity to a more sane 50% as to not cause blindness in users. You can further adjust this down in the controller settings if you do not wish to experience a breach and clear at 3am courtesy of your DS4 or DS5.

Closes #12186 

### Rationale behind Changes
Getting flashbanged by a controller is unpleasant. 

### Suggested Testing Steps
Make sure the default colors are correct.
