### PR TITLE
GS/HW: Limit GetValidSize max height and width.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -949,6 +949,17 @@ GSVector2i GSRendererHW::GetValidSize(const GSTextureCache::Source* tex)
 		}
 	}
 
+	// Make sure sizes are within max limit of 2048,
+	// this shouldn't happen but if it does it needs to be addressed,
+	// clamp the size so at least it doesn't cause a crash.
+	constexpr int valid_max_size = 2048;
+	if ((width > valid_max_size) || (height > valid_max_size))
+	{
+		Console.Warning("Warning: GetValidSize out of bounds, X:%d Y:%d", width, height);
+		width = std::min(width, valid_max_size);
+		height = std::min(height, valid_max_size);
+	}
+
 	return  GSVector2i(width, height);
 }
 
@@ -2728,7 +2739,7 @@ void GSRendererHW::Draw()
 			}
 
 			rt = g_texture_cache->CreateTarget(FRAME_TEX0, t_size, GetValidSize(src), (scale_draw < 0 && is_possible_mem_clear != ClearType::NormalClear) ? src->m_from_target->GetScale() : target_scale, GSTextureCache::RenderTarget, true,
-				fm, false, force_preload, preserve_rt_color | possible_shuffle, m_r, src);
+				fm, false, force_preload, preserve_rt_color || possible_shuffle, m_r, src);
 			if (!rt) [[unlikely]]
 			{
 				GL_INS("ERROR: Failed to create FRAME target, skipping.");


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/HW: Limit GetValidSize height and width.

Max texture size limit is 2048.
This should never happen but if it does clamp it

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Prevent any crashes when target texture sizes are out of bounds.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Smoke test, I didn't find any dump that triggered it.
