### PR TITLE
GS: Fix huge ST coordinates in input vertices.

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -1719,7 +1719,7 @@ void GSState::FlushPrim()
 		// Fix huge or nan ST coordinates
 		if (PRIM->TME && !PRIM->FST)
 		{
-			FixHugeSTCoords();	
+			FixHugeSTCoords();
 		}
 
 		// Round fractional parts of ST coords
@@ -4372,7 +4372,7 @@ void GSState::FixHugeSTCoordsImpl()
 			if (m_vertex.tail >= m_vertex.maxcount)
 				GrowVertexBuffer();
 		}
-		else if (new_index_tail < i) // If new_index_tail == i, don't update indices since no primitives have been culled
+		else if (new_index_tail < i) // If new_index_tail < i, update indices since primitives have been culled
 		{
 			// Keep the same primitive so shift indices down
 			for (u32 j = 0; j < n; j++)

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -4107,9 +4107,8 @@ GSState::TextureMinMaxResult GSState::GetTextureMinMax(GIFRegTEX0 TEX0, GIFRegCL
 
 		// Need to make sure we don't oversample, this can cause trouble in grabbing textures.
 		// This may be inaccurate depending on the draw, but adding 1 all the time is wrong too.
-		// FIXME: It breaks sw renderer so let's still use 1 for SW mode for now.
-		const int inclusive_x_req = GSIsHardwareRenderer() ? (((m_vt.m_primclass < GS_TRIANGLE_CLASS) || (grad.x < 1.0f || (grad.x == 1.0f && m_vt.m_max.p.x != floor(m_vt.m_max.p.x)))) ? 1 : 0) : 1;
-		const int inclusive_y_req = GSIsHardwareRenderer() ? (((m_vt.m_primclass < GS_TRIANGLE_CLASS) || (grad.y < 1.0f || (grad.y == 1.0f && m_vt.m_max.p.y != floor(m_vt.m_max.p.y)))) ? 1 : 0) : 1;
+		const int inclusive_x_req = ((m_vt.m_primclass < GS_TRIANGLE_CLASS) || (grad.x < 1.0f || (grad.x == 1.0f && m_vt.m_max.p.x != floor(m_vt.m_max.p.x)))) ? 1 : 0;
+		const int inclusive_y_req = ((m_vt.m_primclass < GS_TRIANGLE_CLASS) || (grad.y < 1.0f || (grad.y == 1.0f && m_vt.m_max.p.y != floor(m_vt.m_max.p.y)))) ? 1 : 0;
 	
 		// Roughly cut out the min/max of the read (Clamp)
 		switch (wms)

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -209,6 +209,9 @@ protected:
 	bool IsCoverageAlpha();
 	void CalcAlphaMinMax(const int tex_min, const int tex_max);
 	void CorrectATEAlphaMinMax(const u32 atst, const int aref);
+	void RoundSTCoords();
+	void FixHugeSTCoords();
+	template <u32 n, bool sprite> void FixHugeSTCoordsImpl();
 
 public:
 	struct GSUploadQueue

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -211,7 +211,8 @@ protected:
 	void CorrectATEAlphaMinMax(const u32 atst, const int aref);
 	void RoundSTCoords();
 	void FixHugeSTCoords();
-	template <u32 n, bool sprite> void FixHugeSTCoordsImpl();
+	template <u32 n, bool cull>
+	void FixHugeSTCoordsImpl();
 
 public:
 	struct GSUploadQueue

--- a/pcsx2/GS/GSVector4.h
+++ b/pcsx2/GS/GSVector4.h
@@ -267,6 +267,16 @@ public:
 		return round<Round_PosInf>();
 	}
 
+	__forceinline GSVector4 notnan() const
+	{
+		return GSVector4(_mm_cmpord_ps(m, m));
+	}
+
+	__forceinline GSVector4 isnan() const
+	{
+		return GSVector4(_mm_cmpunord_ps(m, m));
+	}
+
 	// http://jrfonseca.blogspot.com/2008/09/fast-sse2-pow-tables-or-polynomials.html
 
 #define LOG_POLY0(x, c0) GSVector4(c0)
@@ -654,6 +664,11 @@ public:
 	__forceinline GSVector4 operator-() const
 	{
 		return neg();
+	}
+
+	__forceinline GSVector4 operator~() const
+	{
+		return cast(~GSVector4i::cast(*this));
 	}
 
 	__forceinline void operator+=(const GSVector4& v)

--- a/pcsx2/GS/GSVector4_arm64.h
+++ b/pcsx2/GS/GSVector4_arm64.h
@@ -241,6 +241,16 @@ public:
 		return GSVector4(vrndpq_f32(v4s));
 	}
 
+	__forceinline GSVector4 notnan() const
+	{
+		return *this == *this;
+	}
+	
+	__forceinline GSVector4 isnan() const
+	{
+		return *this != *this;
+	}
+
 	// http://jrfonseca.blogspot.com/2008/09/fast-sse2-pow-tables-or-polynomials.html
 
 #define LOG_POLY0(x, c0) GSVector4(c0)
@@ -558,6 +568,11 @@ public:
 	__forceinline GSVector4 operator-() const
 	{
 		return neg();
+	}
+
+	__forceinline GSVector4 operator~() const
+	{
+		return cast(~GSVector4i::cast(*this));
 	}
 
 	__forceinline void operator+=(const GSVector4& v)

--- a/pcsx2/GS/Renderers/Common/GSVertexTrace.cpp
+++ b/pcsx2/GS/Renderers/Common/GSVertexTrace.cpp
@@ -25,6 +25,7 @@ void GSVertexTrace::Update(const void* vertex, const u16* index, int v_count, in
 	const u32 fst = m_state->PRIM->FST;
 	const u32 color = !(m_state->PRIM->TME && m_state->m_context->TEX0.TFX == TFX_DECAL && m_state->m_context->TEX0.TCC);
 
+	// Call the correct function to find the min/max values
 	m_fmm[color][fst][tme][iip][primclass](*this, vertex, index, i_count);
 
 	// Potential float overflow detected. Better uses the slower division instead


### PR DESCRIPTION
### Description of Changes
In the vertex trace, clamp floating point UV coordinates to valid UV ranges [-2047, 2047]. Add a pass to GSState::FlushPrims() that iterates through the primitivies about to be drawn and culls any that may be impossible to draw correctly (e.g., NaN values in ST coordinates) or replaces primitives with huge ST coordinates with a new primitive with clamped coordinates.

### Rationale behind Changes
The input texture ST coordinates can sometimes be huge or NaN (for reasons not totally clear, it might be emulation or game bugs) so they cause issues with calculating the vertex trace values, determining texture vounding boxes, etc. This can cause graphical glitches downstream. Also, based on hardware tests it was determined that for truly large floating points values in ST (after divided by Q), they appeart to be clamped to +/-2047 when converting to UV (before the clamping/wrapping determined by the CLAMP register operates).

### Suggested Testing Steps
Testing on GS dumps/games that are known to have huge ST coordinates as described above. I found a few examples of graphical issues that are caused in the SW renderer because of how the huge ST coords get clamped (first example below) . They were previously being masked because of the way the SW renderer it partially loads textures or cast floating point to integers in the rasterizer, which was being thrown off by the huge ST coordinates (so two problems were canceling each other out). Any help testing on more games/dumps or feedback on the changes would be greatly appreciated.

Currently these have been tested thouroughly on a large pack of GS dumps (provided by LightningTerror), with ta few of the more visible differences shown below. Some basic profiling was done on some of the GS dumps and the performance impact is similar to the GSVertexTraceFMM::FindMinMax(), since this is called once ever draw. It will have a larger impact on draws that have a large number of huge/infinite ST coordinates, which hopefully are not much.

In the example, before is left and after is right.

![counter-terror](https://github.com/user-attachments/assets/1c9c5562-a416-461e-a886-df3c5297631c)
Should be a slight blurring effect. Unfortunately, fixing this issue causes another issue with the black patches. This should be "accurate" on the GS side but the input coordinates from the EE may not be in this dump. (Counter_Terrorist_Special_Forces_-_Fire_for_Effect_SLES-53046_20230830195729.gs.xz).

![bakugan](https://github.com/user-attachments/assets/f2872d79-a341-4a68-80c7-4948e73b1f51)
Should not have double eyebrows (Bakugan_Battle_Brawlers_shadows.gs.xz).

![psychonauts](https://github.com/user-attachments/assets/a2acc349-252a-4753-a10b-0f174ae5a19d)
Should have a faint star-like patterns (Psychonauts_SLUS-21120_20231013005852.gs.xz).

![tomb_raider](https://github.com/user-attachments/assets/6b73b3be-e1da-4bfb-ab21-84ac052f5448)
Should have character's shadow (Tomb_Raider_-_Legend_SLUS-21203_20230905130255.gs.xz).

![testdrives](https://github.com/user-attachments/assets/5ab0176b-4694-4958-9813-3621a0cd3c02)
Should not have dark road (testdriveswminmax.gs.xz).
