### PR TITLE
A Little fix Raksuho Pachi-slot Sengen series glitch (issue #12022)

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -53333,6 +53333,8 @@ SLPS-20307:
   name-sort: "らくしょう！ ぱちすろせんげん - もぐもぐふうりんかざん・しょうきんくび・びりーざびっぐ・すーぱーぶらっくじゃっく"
   name-en: "Rakushou! Pachi-Slot Sengen - MoguMoguFuuRinKaZan,Shoukin Kubi,Billy the Big,Super Black Jack"
   region: "NTSC-J"
+  gsHWFixes:
+    cpuFramebufferConversion: 1 # A liitle fixes some graphic glitchs on upper screen (not Perfectly).
 SLPS-20308:
   name: "花火百景 [特典版]"
   name-sort: "はなびひゃっけい [とくてんばん]"
@@ -53790,6 +53792,8 @@ SLPS-20404:
   name-sort: "らくしょう！ ぱちすろせんげん2 - じゅうじか・でかだん"
   name-en: "Rakushou! Pachi-Slot Sengen 2 - Juujika, Deka Dan"
   region: "NTSC-J"
+  gsHWFixes:
+    cpuFramebufferConversion: 1 # A liitle fixes some graphic glitchs on upper screen (not Perfectly).
 SLPS-20405:
   name: "スロッターUPコア5 ルパン大好き！主役は銭形"
   name-sort: "すろったーUPこあ 5 るぱんだいすき！しゅやくはぜにがた"
@@ -53866,6 +53870,8 @@ SLPS-20419:
   name-sort: "らくしょう！ ぱちすろせんげん3 - りおでかーにばる・じゅうじか600しき"
   name-en: "Rakushou! Pachi-Slot Sengen 3 - Rio de Carnival, Juujika 600-shiki"
   region: "NTSC-J"
+  gsHWFixes:
+    cpuFramebufferConversion: 1 # A liitle fixes some graphic glitchs on upper screen (not Perfectly).
 SLPS-20420:
   name: "ウルトラマンネクサス"
   name-sort: "うるとらまんねくさす"
@@ -54075,6 +54081,8 @@ SLPS-20460:
   name-sort: "らくしょう！ ぱちすろせんげん4 - しんもぐもぐふうりんかざん りおでかーにばる"
   name-en: "Rakushou! Pachi-Slot Sengen 4 - Shin MoguMogu FuuRinKaZan,Rio de Carnival"
   region: "NTSC-J"
+  gsHWFixes:
+    cpuFramebufferConversion: 1 # A liitle fixes some graphic glitchs on upper screen (not Perfectly).
 SLPS-20461:
   name: "SIMPLE2000シリーズ Vol.99 THE 原始人"
   name-sort: "しんぷる2000しりーず Vol.  99 THE げんしじん"
@@ -58925,6 +58933,8 @@ SLPS-25770:
   name-sort: "らくしょう！ ぱちすろせんげん5 - りおぱらだいす"
   name-en: "Rakushou! Pachi-Slot Sengen 5 - Rio Paradise"
   region: "NTSC-J"
+  gsHWFixes:
+    cpuFramebufferConversion: 1 # A liitle fixes some graphic glitchs on upper screen (not Perfectly).
 SLPS-25771:
   name: "グリムグリモア [初回生産版]"
   name-sort: "ぐりむぐりもあ [しょかいせいさんばん]"
@@ -59794,6 +59804,8 @@ SLPS-25921:
   name-sort: "らくしょう！ ぱちすろせんげん6 - りお2 くるーじんぐ ヴぁなでぃーす"
   name-en: "Rakushou! Pachi-Slot Sengen 6 - Rio 2 Cruising Vanadis"
   region: "NTSC-J"
+  gsHWFixes:
+    cpuFramebufferConversion: 1 # A liitle fixes some graphic glitchs on upper screen (not Perfectly).
 SLPS-25922:
   name: "Vitamin Z [限定版]"
   name-sort: "びたみん Z [げんていばん]"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
SLPS-20307/20404/20419/20460/25770/25921 Rakusho ! Pachi-Slot Sengen Series has some graphic glitch.
Some of these glitch can be alleviated by  "Change CPU frame buffer" option .
Although it cannot fix some distortions in the drawing, it does improve critical problems such as objects that are not displayed at all being displayed, so I made a Pull Request for this.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
This allows you to play at least as much as possible.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Please, See issue #12022 