### PR TITLE
Settings: Allow user to manually set RTC per-game

### DIFF
--- a/pcsx2-qt/SettingWidgetBinder.h
+++ b/pcsx2-qt/SettingWidgetBinder.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
+// SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
 // SPDX-License-Identifier: GPL-3.0+
 
 #pragma once
@@ -12,6 +12,7 @@
 #include <QtWidgets/QAbstractButton>
 #include <QtWidgets/QCheckBox>
 #include <QtWidgets/QComboBox>
+#include <QtWidgets/QDateTimeEdit>
 #include <QtWidgets/QDoubleSpinBox>
 #include <QtWidgets/QFileDialog>
 #include <QtWidgets/QLabel>
@@ -656,6 +657,26 @@ namespace SettingWidgetBinder
 		}
 	};
 
+	template <>
+	struct SettingAccessor<QDateTimeEdit>
+	{
+		static int getYear(const QDateTimeEdit* widget) { return widget->date().year(); }
+		static int getMonth(const QDateTimeEdit* widget) { return widget->date().month(); }
+		static int getDay(const QDateTimeEdit* widget) { return widget->date().day(); }
+
+		static int getHour(const QDateTimeEdit* widget) { return widget->time().hour(); }
+		static int getMinute(const QDateTimeEdit* widget) { return widget->time().minute(); }
+		static int getSecond(const QDateTimeEdit* widget) { return widget->time().second(); }
+
+		static void setDateTime(QDateTimeEdit* widget, const QDate date, const QTime time) { widget->setDateTime(QDateTime(date, time)); }
+
+		template <typename F>
+		static void connectValueChanged(QDateTimeEdit* widget, F func)
+		{
+			widget->connect(widget, &QDateTimeEdit::dateTimeChanged, func);
+		}
+	};
+
 	/// Binds a widget's value to a setting, updating it when the value changes.
 
 	template <typename WidgetType>
@@ -1238,5 +1259,106 @@ namespace SettingWidgetBinder
 		}
 
 		widget->connect(widget, &QLineEdit::editingFinished, widget, std::move(value_changed));
+	}
+
+	// No need to pass a section or key since this is only used once and has six keys associated with it
+	static inline void BindWidgetToDateTimeSetting(SettingsInterface* sif, QDateTimeEdit* widget, std::string section)
+	{
+		using Accessor = SettingAccessor<QDateTimeEdit>;
+
+		const int YEAR_OFFSET = 2000;
+		const int DEFAULT_YEAR = 0;
+		const int DEFAULT_MONTH = 1;
+		const int DEFAULT_DAY = 1;
+		const int DEFAULT_HOUR = 0;
+		const int DEFAULT_MINUTE = 0;
+		const int DEFAULT_SECOND = 0;
+
+		const char* YEAR_KEY = "RtcYear";
+		const char* MONTH_KEY = "RtcMonth";
+		const char* DAY_KEY = "RtcDay";
+		const char* HOUR_KEY = "RtcHour";
+		const char* MINUTE_KEY = "RtcMinute";
+		const char* SECOND_KEY = "RtcSecond";
+
+		// Fetch settings from .ini
+		const s32 year_value =
+			Host::GetBaseIntSettingValue(section.c_str(), YEAR_KEY, static_cast<s32>(DEFAULT_YEAR));
+		const s32 month_value =
+			Host::GetBaseIntSettingValue(section.c_str(), MONTH_KEY, static_cast<s32>(DEFAULT_MONTH));
+		const s32 day_value =
+			Host::GetBaseIntSettingValue(section.c_str(), DAY_KEY, static_cast<s32>(DEFAULT_DAY));
+		const s32 hour_value =
+			Host::GetBaseIntSettingValue(section.c_str(), HOUR_KEY, static_cast<s32>(DEFAULT_HOUR));
+		const s32 minute_value =
+			Host::GetBaseIntSettingValue(section.c_str(), MINUTE_KEY, static_cast<s32>(DEFAULT_MINUTE));
+		const s32 second_value =
+			Host::GetBaseIntSettingValue(section.c_str(), SECOND_KEY, static_cast<s32>(DEFAULT_SECOND));
+
+		if (sif)
+		{
+			int sif_year_value = DEFAULT_YEAR;
+			int sif_month_value = DEFAULT_MONTH;
+			int sif_day_value = DEFAULT_DAY;
+			int sif_hour_value = DEFAULT_HOUR;
+			int sif_minute_value = DEFAULT_MINUTE;
+			int sif_second_value = DEFAULT_SECOND;
+
+			// Get Settings Interface values or default if that fails
+			if (!sif->GetIntValue(section.c_str(), YEAR_KEY, &sif_year_value)) { sif_year_value = DEFAULT_YEAR; }
+			if (!sif->GetIntValue(section.c_str(), MONTH_KEY, &sif_month_value)) { sif_month_value = DEFAULT_MONTH; }
+			if (!sif->GetIntValue(section.c_str(), DAY_KEY, &sif_day_value)) { sif_day_value = DEFAULT_DAY; }
+			if (!sif->GetIntValue(section.c_str(), HOUR_KEY, &sif_hour_value)) { sif_hour_value = DEFAULT_HOUR; }
+			if (!sif->GetIntValue(section.c_str(), MINUTE_KEY, &sif_minute_value)) { sif_minute_value = DEFAULT_MINUTE; }
+			if (!sif->GetIntValue(section.c_str(), SECOND_KEY, &sif_second_value)) { sif_second_value = DEFAULT_SECOND; }
+
+			// No need to check for valid date since QDateTime resets to minimum upon becoming invalid
+			Accessor::setDateTime(widget, QDate(static_cast<int>(sif_year_value + YEAR_OFFSET), static_cast<int>(sif_month_value), static_cast<int>(sif_day_value)),
+				QTime(static_cast<int>(sif_hour_value), static_cast<int>(sif_minute_value), static_cast<int>(sif_second_value)));
+
+			// Update the settings interface and reload the game settings when changed
+			Accessor::connectValueChanged(widget, [sif, widget, section = std::move(section), YEAR_KEY = std::move(YEAR_KEY), MONTH_KEY = std::move(MONTH_KEY),
+				DAY_KEY = std::move(DAY_KEY), HOUR_KEY = std::move(HOUR_KEY), MINUTE_KEY = std::move(MINUTE_KEY), SECOND_KEY = std::move(SECOND_KEY), YEAR_OFFSET = std::move(YEAR_OFFSET)]() {
+
+				sif->SetIntValue(section.c_str(), YEAR_KEY, Accessor::getYear(widget) - YEAR_OFFSET);
+				sif->SetIntValue(section.c_str(), MONTH_KEY, Accessor::getMonth(widget));
+				sif->SetIntValue(section.c_str(), DAY_KEY, Accessor::getDay(widget));
+				sif->SetIntValue(section.c_str(), HOUR_KEY, Accessor::getHour(widget));
+				sif->SetIntValue(section.c_str(), MINUTE_KEY, Accessor::getMinute(widget));
+				sif->SetIntValue(section.c_str(), SECOND_KEY, Accessor::getSecond(widget));
+
+				QtHost::SaveGameSettings(sif, true);
+				g_emu_thread->reloadGameSettings();
+			});
+		}
+
+		else
+		{
+			// No need to check for valid date since QDateTime resets to minimum upon becoming invalid
+			Accessor::setDateTime(widget, QDate(static_cast<int>(year_value + YEAR_OFFSET), static_cast<int>(month_value), static_cast<int>(day_value)),
+				QTime(static_cast<int>(hour_value), static_cast<int>(minute_value), static_cast<int>(second_value)));
+
+			// Update and apply base settings with values from widget when user changes it in UI
+			Accessor::connectValueChanged(widget, [widget, section = std::move(section), YEAR_KEY = std::move(YEAR_KEY), MONTH_KEY = std::move(MONTH_KEY),
+				DAY_KEY = std::move(DAY_KEY), HOUR_KEY = std::move(HOUR_KEY), MINUTE_KEY = std::move(MINUTE_KEY), SECOND_KEY = std::move(SECOND_KEY), YEAR_OFFSET = std::move(YEAR_OFFSET)]() {
+
+				const int new_year_value = Accessor::getYear(widget);
+				const int new_month_value = Accessor::getMonth(widget);
+				const int new_day_value = Accessor::getDay(widget);
+				const int new_hour_value = Accessor::getHour(widget);
+				const int new_minute_value = Accessor::getMinute(widget);
+				const int new_second_value = Accessor::getSecond(widget);
+
+				Host::SetBaseIntSettingValue(section.c_str(), YEAR_KEY, new_year_value - YEAR_OFFSET);
+				Host::SetBaseIntSettingValue(section.c_str(), MONTH_KEY, new_month_value);
+				Host::SetBaseIntSettingValue(section.c_str(), DAY_KEY, new_day_value);
+				Host::SetBaseIntSettingValue(section.c_str(), HOUR_KEY, new_hour_value);
+				Host::SetBaseIntSettingValue(section.c_str(), MINUTE_KEY, new_minute_value);
+				Host::SetBaseIntSettingValue(section.c_str(), SECOND_KEY, new_second_value);
+				Host::CommitBaseSettingChanges();
+				g_emu_thread->applySettings();
+			});
+		}
+
 	}
 } // namespace SettingWidgetBinder

--- a/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
+// SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
 // SPDX-License-Identifier: GPL-3.0+
 
 #include <QtWidgets/QInputDialog>
@@ -48,6 +48,12 @@ EmulationSettingsWidget::EmulationSettingsWidget(SettingsWindow* dialog, QWidget
 
 	if (m_dialog->isPerGameSettings())
 	{
+		SettingWidgetBinder::BindWidgetToDateTimeSetting(sif, m_ui.rtcDateTime, "EmuCore");
+		m_ui.rtcDateTime->setDateRange(QDate(2000, 1, 1), QDate(2099, 12, 31));
+		SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.manuallySetRealTimeClock, "EmuCore", "ManuallySetRealTimeClock", false);
+		connect(m_ui.manuallySetRealTimeClock, &QCheckBox::checkStateChanged, this, &EmulationSettingsWidget::onManuallySetRealTimeClockChanged);
+		EmulationSettingsWidget::onManuallySetRealTimeClockChanged();
+
 		m_ui.eeCycleRate->insertItem(
 			0, tr("Use Global Setting [%1]")
 				   .arg(m_ui.eeCycleRate->itemText(
@@ -74,6 +80,8 @@ EmulationSettingsWidget::EmulationSettingsWidget(SettingsWindow* dialog, QWidget
 	}
 	else
 	{
+		m_ui.rtcGroup->hide();
+
 		SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.cheats, "EmuCore", "EnableCheats", false);
 
 		// Allow for FastCDVD for per-game settings only
@@ -146,6 +154,13 @@ EmulationSettingsWidget::EmulationSettingsWidget(SettingsWindow* dialog, QWidget
 	dialog->registerWidgetHelp(m_ui.useVSyncForTiming, tr("Use Host VSync Timing"), tr("Unchecked"),
 		tr("When synchronizing with the host refresh rate, this option disable's PCSX2's internal frame timing, and uses the host instead. "
 		   "Can result in smoother frame pacing, <strong>but at the cost of increased input latency</strong>."));
+	dialog->registerWidgetHelp(m_ui.manuallySetRealTimeClock, tr("Manually Set Real-Time Clock"), tr("Unchecked"),
+		tr("Manually set a real-time clock to use for the virtual PlayStation 2 instead of using your OS' system clock."));
+	dialog->registerWidgetHelp(m_ui.rtcDateTime, tr("Real-Time Clock"), tr("Current date and time"),
+		tr("Real-time clock (RTC) used by the virtual PlayStation 2. Date format is the same as the one used by your OS. "
+			"This time is only applied upon booting the PS2; changing it while in-game will have no effect. "
+			"NOTE: This assumes you have your PS2 set to the default timezone of GMT+0 and default DST of Summer Time. "
+			"Some games require an RTC date/time set after their release date."));
 
 	updateOptimalFramePacing();
 	updateUseVSyncForTimingEnabled();
@@ -291,4 +306,10 @@ void EmulationSettingsWidget::updateUseVSyncForTimingEnabled()
 	const bool vsync = m_dialog->getEffectiveBoolValue("EmuCore/GS", "VsyncEnable", false);
 	const bool sync_to_host_refresh = m_dialog->getEffectiveBoolValue("EmuCore/GS", "SyncToHostRefreshRate", false);
 	m_ui.useVSyncForTiming->setEnabled(vsync && sync_to_host_refresh);
+}
+
+void EmulationSettingsWidget::onManuallySetRealTimeClockChanged()
+{
+	const bool enabled = m_dialog->getEffectiveBoolValue("EmuCore", "ManuallySetRealTimeClock", false);
+	m_ui.rtcDateTime->setEnabled(enabled);
 }

--- a/pcsx2-qt/Settings/EmulationSettingsWidget.h
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
+// SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
 // SPDX-License-Identifier: GPL-3.0+
 
 #pragma once
@@ -25,6 +25,7 @@ private:
 	void handleSpeedComboChange(QComboBox* cb, const char* section, const char* key);
 	void updateOptimalFramePacing();
 	void updateUseVSyncForTimingEnabled();
+	void onManuallySetRealTimeClockChanged();
 
 	SettingsWindow* m_dialog;
 

--- a/pcsx2-qt/Settings/EmulationSettingsWidget.ui
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.ui
@@ -24,7 +24,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QGroupBox" name="groupBox_5">
+    <widget class="QGroupBox" name="speedGroup">
      <property name="title">
       <string>Speed Control</string>
      </property>
@@ -195,7 +195,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="basicGroupBox">
+    <widget class="QGroupBox" name="pacingGroup">
      <property name="title">
       <string>Frame Pacing / Latency Control</string>
      </property>
@@ -267,6 +267,26 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="rtcGroup">
+     <property name="title">
+      <string>Real-Time Clock</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayoutRTC">
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="manuallySetRealTimeClock">
+        <property name="text">
+         <string>Manually Set Real-Time Clock</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QDateTimeEdit" name="rtcDateTime">
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
+// SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
 // SPDX-License-Identifier: GPL-3.0+
 
 #include "CDVD/CDVD.h"
@@ -28,6 +28,9 @@
 
 #include <cctype>
 #include <ctime>
+#ifndef _WIN32
+#include <time.h>
+#endif
 #include <memory>
 
 cdvdStruct cdvd;
@@ -917,9 +920,38 @@ void cdvdReset()
 	cdvd.ReadTime = cdvdBlockReadTime(MODE_DVDROM);
 	cdvd.RotSpeed = cdvdRotationTime(MODE_DVDROM);
 
+	if (EmuConfig.ManuallySetRealTimeClock)
+	{
+		// Convert to GMT+9 (assumes GMT+0)
+		std::tm tm{};
+		tm.tm_sec = EmuConfig.RtcSecond;
+		tm.tm_min = EmuConfig.RtcMinute;
+		tm.tm_hour = EmuConfig.RtcHour;
+		tm.tm_mday = EmuConfig.RtcDay;
+		tm.tm_mon = EmuConfig.RtcMonth - 1;
+		tm.tm_year = EmuConfig.RtcYear + 100; // 2000 - 1900
+		tm.tm_isdst = 1;
+
+		// Need this instead of mktime for timezone independence
+		std::time_t t = 0;
+		#if defined(_WIN32)
+			t = _mkgmtime(&tm) + 32400; //60 * 60 * 9 for GMT+9
+			gmtime_s(&tm, &t);
+		#else
+			t = timegm(&tm) + 32400;
+			gmtime_r(&t, &tm);
+		#endif
+
+		cdvd.RTC.second = tm.tm_sec;
+		cdvd.RTC.minute = tm.tm_min;
+		cdvd.RTC.hour = tm.tm_hour;
+		cdvd.RTC.day = tm.tm_mday;
+		cdvd.RTC.month = tm.tm_mon + 1;
+		cdvd.RTC.year = tm.tm_year - 100;
+	}
 	// If we are recording, always use the same RTC setting
 	// for games that use the RTC to seed their RNG -- this is very important to be the same everytime!
-	if (g_InputRecording.isActive())
+	else if (g_InputRecording.isActive())
 	{
 		Console.WriteLn("Input Recording Active - Using Constant RTC of 04-03-2020 (DD-MM-YYYY)");
 		// Why not just 0 everything? Some games apparently require the date to be valid in terms of when

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
+// SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
 // SPDX-License-Identifier: GPL-3.0+
 
 #pragma once
@@ -1282,6 +1282,7 @@ struct Pcsx2Config
 		InhibitScreensaver : 1,
 		BackupSavestate : 1,
 		McdFolderAutoManage : 1,
+		ManuallySetRealTimeClock : 1,
 
 		HostFs : 1,
 
@@ -1314,6 +1315,13 @@ struct Pcsx2Config
 	std::string GzipIsoIndexTemplate; // for quick-access index with gzipped ISO
 
 	int PINESlot;
+
+	int RtcYear;
+	int RtcMonth;
+	int RtcDay;
+	int RtcHour;
+	int RtcMinute;
+	int RtcSecond;
 
 	// Set at runtime, not loaded from config.
 	std::string CurrentBlockdump;

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
+// SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
 // SPDX-License-Identifier: GPL-3.0+
 
 #include "common/CocoaTools.h"
@@ -1898,6 +1898,7 @@ Pcsx2Config::Pcsx2Config()
 	InhibitScreensaver = true;
 	BackupSavestate = true;
 	WarnAboutUnsafeSettings = true;
+	ManuallySetRealTimeClock = false;
 
 	// To be moved to FileMemoryCard pluign (someday)
 	for (uint slot = 0; slot < 8; ++slot)
@@ -1910,6 +1911,12 @@ Pcsx2Config::Pcsx2Config()
 
 	GzipIsoIndexTemplate = "$(f).pindex.tmp";
 	PINESlot = 28011;
+	RtcYear = 0;
+	RtcMonth = 1;
+	RtcDay = 1;
+	RtcHour = 0;
+	RtcMinute = 0;
+	RtcSecond = 0;
 }
 
 void Pcsx2Config::LoadSaveCore(SettingsWrapper& wrap)
@@ -1940,6 +1947,8 @@ void Pcsx2Config::LoadSaveCore(SettingsWrapper& wrap)
 
 	SettingsWrapBitBool(WarnAboutUnsafeSettings);
 
+	SettingsWrapBitBool(ManuallySetRealTimeClock);
+
 	// Process various sub-components:
 
 	Speedhacks.LoadSave(wrap);
@@ -1959,6 +1968,12 @@ void Pcsx2Config::LoadSaveCore(SettingsWrapper& wrap)
 
 	SettingsWrapEntry(GzipIsoIndexTemplate);
 	SettingsWrapEntry(PINESlot);
+	SettingsWrapEntry(RtcYear);
+	SettingsWrapEntry(RtcMonth);
+	SettingsWrapEntry(RtcDay);
+	SettingsWrapEntry(RtcHour);
+	SettingsWrapEntry(RtcMinute);
+	SettingsWrapEntry(RtcSecond);
 
 	// For now, this in the derived config for backwards ini compatibility.
 	SettingsWrapEntryEx(CurrentBlockdump, "BlockDumpSaveDirectory");


### PR DESCRIPTION
### Description of Changes
Allows the user the option to manually input a date and time for the PlayStation 2's real-time clock rather than 2020-04-03 00:00:00 for input recording and the OS' system clock otherwise. Only works if the BIOS is set to a region which is GMT+0 and DST is Summer Time (which is the default PCSX2 uses).

### Rationale behind Changes
Multiple games have mechanics that play with the real-time clock.
* Tool-assisted speedrunners may want the ability to designate an arbitrary start date and time for RNG purposes.
* Some games make use of the date for an in-game event, such as Scooby-Doo! Night of 100 Frights' multiple holidays.
* Some games make use of the advancement of real time for an in-game event, such as The End's boss fight in Metal Gear Solid 3.
* Some games make use of the time for an in-game event, for example Ratchet 2 and 3 which have a teleporter to the Insomniac Museum in the dead of night.
* Because we can.
* Closes #4491.

### Suggested Testing Steps
* Make sure you can't access this from the global settings, only per-game.
* Make sure this setting persists with reboots.
* Make sure you can't go beyond the bounds of 2000-01-01 and 2099-12-31.
* Make sure (using aforementioned BIOS defaults) that the date and time in games corresponds to the time you set on the clock. (I've tested this in the BIOS to confirm minutes and seconds work, but you might not be able to get that granular.)
* Make sure the tool tips are free of typos and adequately convey the information.

### Screenshots
Tested on 2005-03-09 03:04:05
![DreadZone Station](https://github.com/user-attachments/assets/b9292ceb-9c95-4736-95b1-f3914f0814c8)
![Insomniac Museum](https://github.com/user-attachments/assets/ae256da0-fc13-451d-94a0-243f034907c2)