### PR TITLE
iR3000A/iR5900: Partial revert of 8c98f5d928 ("Remove mid block jumping")

### DIFF
--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -1597,6 +1597,14 @@ static void iopRecRecompile(const u32 startpc)
 
 	while (1)
 	{
+		BASEBLOCK* pblock = PSX_GETBLOCK(i);
+		if (i != startpc && pblock->GetFnptr() != (uptr)iopJITCompile)
+		{
+			// branch = 3
+			willbranch3 = 1;
+			s_nEndBlock = i;
+			break;
+		}
 
 		psxRegs.code = iopMemRead32(i);
 


### PR DESCRIPTION
### Description of Changes
Partially reverts #12056 since it causes the Jak games to trip the impossible block clear assert.

### Rationale behind Changes
I don't fully understand how our block caching works but it seems pretty clear that something broke. This probably does negate the perf changes seen by that PR, but someone needs to fully understand the cache and the block to figure out what the interactions are here if we want to make changes.

### Suggested Testing Steps
Probably stuff that dynamically load code was affected. (Jak games, probably SOTC, idk about others)
