### PR TITLE
VMManager / vuJIT: Fix save state loading and saving on ARM64

### DIFF
--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -2561,6 +2561,11 @@ void VMManager::InitializeCPUProviders()
 
 	CpuMicroVU0.Reserve();
 	CpuMicroVU1.Reserve();
+#else
+	// Despite not having any VU recompilers on ARM64, therefore no MTVU,
+	// we still need the thread alive. Otherwise the read and write positions
+	// of the ring buffer wont match, and various systems in the emulator end up deadlocked.
+	vu1Thread.Open();
 #endif
 
 	VifUnpackSSE_Init();
@@ -2580,6 +2585,11 @@ void VMManager::ShutdownCPUProviders()
 
 	psxRec.Shutdown();
 	recCpu.Shutdown();
+#else
+	// See the comment in the InitializeCPUProviders for an explaination why we
+	// still need to manage the MTVU thread.
+	if(vu1Thread.IsOpen())
+		vu1Thread.WaitVU();
 #endif
 }
 

--- a/pcsx2/arm64/RecStubs.cpp
+++ b/pcsx2/arm64/RecStubs.cpp
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2002-2024 PCSX2 Dev Team
 // SPDX-License-Identifier: GPL-3.0
 
+#include "common/Console.h"
+#include "MTVU.h"
 #include "SaveState.h"
 #include "vtlb.h"
 
@@ -13,6 +15,16 @@ void vtlb_DynBackpatchLoadStore(uptr code_address, u32 code_size, u32 guest_pc, 
 
 bool SaveStateBase::vuJITFreeze()
 {
-  pxFailRel("Not implemented.");
-	return false;
+	if(IsSaving())
+		vu1Thread.WaitVU();
+
+	Console.Warning("recompiler state is stubbed in arm64!");
+
+	// HACK!!
+
+	// size of microRegInfo structure
+	std::array<u8,96> empty_data{};
+	Freeze(empty_data);
+	Freeze(empty_data);
+	return true;
 }


### PR DESCRIPTION
### Description of Changes
We still need to fire up the VU1 thread despite having no recompilers.
Adjusted the VU recompiler stub so save-states will save / reload, with 0 recompiler support.

### Rationale behind Changes
Trying to use ARM64 and I was sick of the VM deadlocking.

### Suggested Testing Steps
Test save-states, shutting down, resetting, etc on ARM64.