### PR TITLE
Tools: Add additional options for dumping in GS runner.

### DIFF
--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -446,13 +446,14 @@ static void PrintCommandLineHelp(const char* progname)
 	std::fprintf(stderr, "  -dump [rt|tex|z|f|a|i]: Enabling dumping of render target, texture, z buffer, frame, "
 		"alphas, and info (context, vertices), respectively, per draw. Generates lots of data.\n");
 	std::fprintf(stderr, "  -dumprange N[,L,B]: Start dumping from draw N (base 0), stops after L draws, and only "
-		"those draws that are multiples of B (intersection of -dumprange and -dumrangef used)."
-		"Defaults to N=0,L=-1,B=1 (all draws). Only used if -dump used.\n");
+		"those draws that are multiples of B (intersection of -dumprange and -dumprangef used)."
+		"Defaults to 0,-1,1 (all draws). Only used if -dump used.\n");
 	std::fprintf(stderr, "  -dumprangef NF[,LF,BF]: Start dumping from frame NF (base 0), stops after LF frames, "
-		"and only those frames that are multiples of BF (intersection of -dumprange and -dumrangef used).\n"
-		"Defaults to NF=0,LF=-1,BF=1 (all frames). Only used if -dump is used.\n");
+		"and only those frames that are multiples of BF (intersection of -dumprange and -dumprangef used).\n"
+		"Defaults to 0,-1,1 (all frames). Only used if -dump is used.\n");
 	std::fprintf(stderr, "  -loop <count>: Loops dump playback N times. Defaults to 1. 0 will loop infinitely.\n");
 	std::fprintf(stderr, "  -renderer <renderer>: Sets the graphics renderer. Defaults to Auto.\n");
+	std::fprintf(stderr, "  -swthreads <threads>: Sets the number of threads for the software renderer.\n");
 	std::fprintf(stderr, "  -window: Forces a window to be displayed.\n");
 	std::fprintf(stderr, "  -surfaceless: Disables showing a window.\n");
 	std::fprintf(stderr, "  -logfile <filename>: Writes emu log to filename.\n");

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -745,6 +745,8 @@ struct Pcsx2Config
 					SaveFrame : 1,
 					SaveTexture : 1,
 					SaveDepth : 1,
+					SaveAlpha : 1,
+					SaveInfo : 1,
 					DumpReplaceableTextures : 1,
 					DumpReplaceableMipmaps : 1,
 					DumpTexturesWithFMVActive : 1,
@@ -822,6 +824,10 @@ struct Pcsx2Config
 
 		int SaveN = 0;
 		int SaveL = 5000;
+		int SaveB = 1;
+		int SaveNF = 0;
+		int SaveLF = -1;
+		int SaveBF = 1;
 
 		s8 ExclusiveFullscreenControl = -1;
 		GSScreenshotSize ScreenshotSize = GSScreenshotSize::WindowResolution;
@@ -865,6 +871,9 @@ struct Pcsx2Config
 
 		bool operator==(const GSOptions& right) const;
 		bool operator!=(const GSOptions& right) const;
+
+		// Should we dump this draw/frame?
+		bool ShouldDump(int draw, int frame) const;
 	};
 
 	struct SPU2Options

--- a/pcsx2/GS/GSDrawingContext.cpp
+++ b/pcsx2/GS/GSDrawingContext.cpp
@@ -203,16 +203,15 @@ void GSDrawingContext::Dump(const std::string& filename)
 		"\tTBW:%u\n"
 		"\tPSM:0x%x\n"
 		"\tTW:%u\n"
+		"\tTH:%u\n"
 		"\tTCC:%u\n"
 		"\tTFX:%u\n"
 		"\tCBP:0x%x\n"
 		"\tCPSM:0x%x\n"
 		"\tCSM:%u\n"
 		"\tCSA:%u\n"
-		"\tCLD:%u\n"
-		"\tTH:%u\n",
-		TEX0.TBP0, TEX0.TBW, TEX0.PSM, TEX0.TW, TEX0.TCC, TEX0.TFX, TEX0.CBP, TEX0.CPSM, TEX0.CSM, TEX0.CSA, TEX0.CLD,
-		static_cast<uint32_t>(TEX0.TH));
+		"\tCLD:%u\n\n",
+		TEX0.TBP0, TEX0.TBW, TEX0.PSM, TEX0.TW, static_cast<uint32_t>(TEX0.TH), TEX0.TCC, TEX0.TFX, TEX0.CBP, TEX0.CPSM, TEX0.CSM, TEX0.CSA, TEX0.CLD);
 
 	fprintf(fp,
 		"TEX1\n"

--- a/pcsx2/GS/GSDrawingEnvironment.h
+++ b/pcsx2/GS/GSDrawingEnvironment.h
@@ -87,7 +87,6 @@ public:
 
 		fprintf(fp, "SCANMSK\n"
 		            "\tMSK:%u\n\n"
-		            "\n"
 		        , SCANMSK.MSK);
 
 		fprintf(fp, "TEXA\n"

--- a/pcsx2/GS/GSLocalMemory.cpp
+++ b/pcsx2/GS/GSLocalMemory.cpp
@@ -662,11 +662,7 @@ void GSLocalMemory::SaveBMP(const std::string& fn, u32 bp, u32 bw, u32 psm, int 
 		}
 	}
 
-#ifdef PCSX2_DEVBUILD
-	GSPng::Save(GSPng::RGB_A_PNG, fn, static_cast<u8*>(bits), w, h, pitch, GSConfig.PNGCompressionLevel, false);
-#else
-	GSPng::Save(GSPng::RGB_PNG, fn, static_cast<u8*>(bits), w, h, pitch, GSConfig.PNGCompressionLevel, false);
-#endif
+	GSPng::Save((IsDevBuild || GSConfig.SaveAlpha) ? GSPng::RGB_A_PNG : GSPng::RGB_PNG, fn, static_cast<u8*>(bits), w, h, pitch, GSConfig.PNGCompressionLevel, false);
 
 	_aligned_free(bits);
 }

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -443,7 +443,7 @@ void GSState::DumpVertices(const std::string& filename)
 	file << std::fixed << std::setprecision(4);
 	for (u32 i = 0; i < count; ++i)
 	{
-		file << "\t" << "v" << i << ": ";
+		file << "\t" << std::dec << "v" << i << ": ";
 		GSVertex v = buffer[m_index.buff[i]];
 
 		const float x = (v.XYZ.X - (int)m_context->XYOFFSET.OFX) / 16.0f;
@@ -461,7 +461,7 @@ void GSState::DumpVertices(const std::string& filename)
 	file << std::fixed << std::setprecision(6);
 	for (u32 i = 0; i < count; ++i)
 	{
-		file << "\t" << "v" << i << ": ";
+		file << "\t" << std::dec << "v" << i << ": ";
 		GSVertex v = buffer[m_index.buff[i]];
 
 		file << std::setfill('0') << std::setw(3) << unsigned(v.RGBAQ.R) << DEL;
@@ -479,7 +479,7 @@ void GSState::DumpVertices(const std::string& filename)
 	file << "TEXTURE COORDS (" << qualifier << ")" << std::endl;;
 	for (u32 i = 0; i < count; ++i)
 	{
-		file << "\t" << "v" << i << ": ";
+		file << "\t" << "v" << std::dec << i << ": ";
 		const GSVertex v = buffer[m_index.buff[i]];
 
 		// note
@@ -1994,7 +1994,7 @@ void GSState::InitReadFIFO(u8* mem, int len)
 	// Read the image all in one go.
 	m_mem.ReadImageX(m_tr.x, m_tr.y, m_tr.buff, m_tr.total, m_env.BITBLTBUF, m_env.TRXPOS, m_env.TRXREG);
 
-	if (GSConfig.DumpGSData && GSConfig.SaveRT && s_n >= GSConfig.SaveN)
+	if (GSConfig.SaveRT && GSConfig.ShouldDump(s_n, g_perfmon.GetFrame()))
 	{
 		const std::string s(GetDrawDumpPath(
 			"%05d_read_%05x_%d_%d_%d_%d_%d_%d.bmp",
@@ -2742,7 +2742,7 @@ int GSState::Defrost(const freezeData* fd)
 	m_mem.m_clut.Reset();
 	(PRIM->CTXT == 0) ? ApplyTEX0<0>(m_context->TEX0) : ApplyTEX0<1>(m_context->TEX0);
 
-	g_perfmon.SetFrame(5000);
+	g_perfmon.SetFrame(0);
 
 	ResetPCRTC();
 

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -546,9 +546,9 @@ void GSRenderer::EndPresentFrame()
 
 void GSRenderer::VSync(u32 field, bool registers_written, bool idle_frame)
 {
-	if (GSConfig.DumpGSData && s_n >= GSConfig.SaveN)
+	if (GSConfig.SaveInfo && GSConfig.ShouldDump(s_n, g_perfmon.GetFrame()))
 	{
-		DumpGSPrivRegs(*m_regs, GetDrawDumpPath("vsync_%05d_f%lld_gs_reg.txt", s_n, g_perfmon.GetFrame()));
+		DumpGSPrivRegs(*m_regs, GetDrawDumpPath("%05d_f%05lld_vsync_gs_reg.txt", s_n, g_perfmon.GetFrame()));
 	}
 
 	const int fb_sprite_blits = g_perfmon.GetDisplayFramebufferSpriteBlits();

--- a/pcsx2/GS/Renderers/Common/GSTexture.cpp
+++ b/pcsx2/GS/Renderers/Common/GSTexture.cpp
@@ -35,11 +35,8 @@ bool GSTexture::Save(const std::string& fn)
 		return res;
 	}
 
-#ifdef PCSX2_DEVBUILD
-	GSPng::Format format = GSPng::RGB_A_PNG;
-#else
-	GSPng::Format format = GSPng::RGB_PNG;
-#endif
+	GSPng::Format format = (IsDevBuild || GSConfig.SaveAlpha) ? GSPng::RGB_A_PNG : GSPng::RGB_PNG;
+
 	switch (m_format)
 	{
 		case Format::UNorm8:

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -178,12 +178,10 @@ GSTexture* GSRendererHW::GetOutput(int i, float& scale, int& y_offset)
 			GL_CACHE("Frame y offset %d pixels, unit %d", y_offset, i);
 		}
 
-#ifdef ENABLE_OGL_DEBUG
 		if (GSConfig.SaveFrame && GSConfig.ShouldDump(s_n, g_perfmon.GetFrame()))
 		{
 			t->Save(GetDrawDumpPath("%05d_f%05lld_fr%d_%05x_%s.bmp", s_n, g_perfmon.GetFrame(), i, static_cast<int>(TEX0.TBP0), psm_str(TEX0.PSM)));
 		}
-#endif
 	}
 
 	return t;
@@ -207,10 +205,8 @@ GSTexture* GSRendererHW::GetFeedbackOutput(float& scale)
 	GSTexture* t = rt->m_texture;
 	scale = rt->m_scale;
 
-#ifdef ENABLE_OGL_DEBUG
 	if (GSConfig.SaveFrame && GSConfig.ShouldDump(s_n, g_perfmon.GetFrame()))
 		t->Save(GetDrawDumpPath("%05d_f%05lld_fr%d_%05x_%s.bmp", s_n, g_perfmon.GetFrame(), 3, static_cast<int>(TEX0.TBP0), psm_str(TEX0.PSM)));
-#endif
 
 	return t;
 }
@@ -3454,9 +3450,6 @@ void GSRendererHW::Draw()
 			GSTextureCache::RenderTarget, m_cached_ctx.ZBUF.Block(), m_cached_ctx.ZBUF.PSM, zm);
 	}
 
-	
-	//
-
 	if (GSConfig.ShouldDump(s_n, g_perfmon.GetFrame()))
 	{
 		const bool writeback_HDR_texture = g_gs_device->GetHDRTexture() != nullptr;
@@ -3473,14 +3466,14 @@ void GSRendererHW::Draw()
 
 		if (rt && GSConfig.SaveRT)
 		{
-			s = GetDrawDumpPath("%05d_f%05lld_rt1_(%05x)_%s.bmp", s_n, frame, m_cached_ctx.FRAME.Block(), psm_str(m_cached_ctx.FRAME.PSM));
+			s = GetDrawDumpPath("%05d_f%05lld_rt1_%05x_%s.bmp", s_n, frame, m_cached_ctx.FRAME.Block(), psm_str(m_cached_ctx.FRAME.PSM));
 
 			rt->m_texture->Save(s);
 		}
 
 		if (ds && GSConfig.SaveDepth)
 		{
-			s = GetDrawDumpPath("%05d_f%05lld_rz1_(%05x)_%s.bmp", s_n, frame, m_cached_ctx.ZBUF.Block(), psm_str(m_cached_ctx.ZBUF.PSM));
+			s = GetDrawDumpPath("%05d_f%05lld_rz1_%05x_%s.bmp", s_n, frame, m_cached_ctx.ZBUF.Block(), psm_str(m_cached_ctx.ZBUF.PSM));
 
 			ds->m_texture->Save(s);
 		}

--- a/pcsx2/GS/Renderers/SW/GSTextureCacheSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSTextureCacheSW.cpp
@@ -317,7 +317,7 @@ bool GSTextureCacheSW::Texture::Save(const std::string& fn) const
 	const u32 w = 1 << m_TEX0.TW;
 	const u32 h = 1 << m_TEX0.TH;
 
-	constexpr GSPng::Format format = IsDevBuild ? GSPng::RGB_A_PNG : GSPng::RGB_PNG;
+	const GSPng::Format format = (IsDevBuild || GSConfig.SaveAlpha) ? GSPng::RGB_A_PNG : GSPng::RGB_PNG;
 	const GSLocalMemory::psm_t& psm = GSLocalMemory::m_psm[m_TEX0.PSM];
 	const u8* RESTRICT src = (u8*)m_buff;
 	const u32 src_pitch = 1u << (m_tw + (psm.pal == 0 ? 2 : 0));

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -840,6 +840,10 @@ bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 		OpEqu(PNGCompressionLevel) &&
 		OpEqu(SaveN) &&
 		OpEqu(SaveL) &&
+		OpEqu(SaveB) &&
+		OpEqu(SaveNF) &&
+		OpEqu(SaveLF) &&
+		OpEqu(SaveBF) &&
 
 		OpEqu(ExclusiveFullscreenControl) &&
 		OpEqu(ScreenshotSize) &&
@@ -966,6 +970,8 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitBoolEx(SaveFrame, "savef");
 	SettingsWrapBitBoolEx(SaveTexture, "savet");
 	SettingsWrapBitBoolEx(SaveDepth, "savez");
+	SettingsWrapBitBoolEx(SaveAlpha, "savea");
+	SettingsWrapBitBoolEx(SaveInfo, "savei");
 	SettingsWrapBitBool(DumpReplaceableTextures);
 	SettingsWrapBitBool(DumpReplaceableMipmaps);
 	SettingsWrapBitBool(DumpTexturesWithFMVActive);
@@ -1026,6 +1032,10 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitfieldEx(PNGCompressionLevel, "png_compression_level");
 	SettingsWrapBitfieldEx(SaveN, "saven");
 	SettingsWrapBitfieldEx(SaveL, "savel");
+	SettingsWrapBitfieldEx(SaveB, "saveb");
+	SettingsWrapBitfieldEx(SaveNF, "savenf");
+	SettingsWrapBitfieldEx(SaveLF, "savelf");
+	SettingsWrapBitfieldEx(SaveBF, "savebf");
 
 	SettingsWrapEntryEx(CaptureContainer, "CaptureContainer");
 	SettingsWrapEntryEx(VideoCaptureCodec, "VideoCaptureCodec");
@@ -1108,6 +1118,13 @@ void Pcsx2Config::GSOptions::MaskUpscalingHacks()
 bool Pcsx2Config::GSOptions::UseHardwareRenderer() const
 {
 	return (Renderer != GSRendererType::Null && Renderer != GSRendererType::SW);
+}
+
+bool Pcsx2Config::GSOptions::ShouldDump(int draw, int frame) const
+{
+	return DumpGSData &&
+		(SaveN <= draw) && ((SaveL < 0) || (draw < SaveN + SaveL)) && (draw % SaveB == 0) &&
+		(SaveNF <= frame) && ((SaveLF < 0) || (frame < SaveNF + SaveLF)) && (frame % SaveBF == 0);
 }
 
 static constexpr const std::array s_spu2_sync_mode_names = {


### PR DESCRIPTION
### Description of Changes
Add additional options to GS dump runner to allow: dumping render target, textures, depth, alphas per draw; range of frames or draws to dump. Some miscellanous fixes to formatting of file names and dumping of GS context.

### Rationale behind Changes
To make it easier to debug large numbers of GS dumps. Example workflow: run a large number of GS dumps just outputting the frames, check which dumps/frames are different, rerun the dump runner on the differing dumps/frames while dumping all draws RTs to see which draw the change ocurred.

### Suggested Testing Steps
Run the GS dump runner with new options -dump [rt|tex|z|f|a|i], -dumprange, -dumprangef. Example:
`pcsx2-gsdumprunner-x64-dbg.exe <dump file> -renderer sw -dumpdir <output dir> -dump rttexfzai -dumprange 100,100,3`
to dump RTs, textures, frames, alphas,and info (context, vertex, vsync regs) from in draws 100 to 199 that are multiples of 3.
