### PR TITLE
Qt: Add Portable Mode launch argument

### DIFF
--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -2040,6 +2040,7 @@ void QtHost::PrintCommandLineHelp(const std::string_view progname)
 	std::fprintf(stderr, "  -version: Displays version information and exits.\n");
 	std::fprintf(stderr, "  -batch: Enables batch mode (exits after shutting down).\n");
 	std::fprintf(stderr, "  -nogui: Hides main window while running (implies batch mode).\n");
+	std::fprintf(stderr, "  -portable: Force enable portable mode to store data in local PCSX2 path instead of the default configuration path.\n");
 	std::fprintf(stderr, "  -elf <file>: Overrides the boot ELF with the specified filename.\n");
 	std::fprintf(stderr, "  -gameargs <string>: passes the specified quoted space-delimited string of launch arguments.\n");
 	std::fprintf(stderr, "  -disc <path>: Uses the specified host DVD drive as a source.\n");
@@ -2109,6 +2110,11 @@ bool QtHost::ParseCommandLineOptions(const QStringList& args, std::shared_ptr<VM
 			{
 				s_batch_mode = true;
 				s_nogui_mode = true;
+				continue;
+			}
+			else if (CHECK_ARG(QStringLiteral("-portable")))
+			{
+				EmuConfig.IsPortableMode = true;
 				continue;
 			}
 			else if (CHECK_ARG(QStringLiteral("-fastboot")))

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1328,6 +1328,7 @@ struct Pcsx2Config
 	std::string CurrentIRX;
 	std::string CurrentGameArgs;
 	AspectRatioType CurrentAspectRatio = AspectRatioType::RAuto4_3_3_2;
+	bool IsPortableMode = false;
 
 	Pcsx2Config();
 	void LoadSave(SettingsWrapper& wrap);


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
This PR adds in `-portable` launch arguments that forces PCSX2 to run in portable mode regardless of the presence of the `portable.ini/txt` file.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Feature parity with wxWidgets.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test windows and linux (appimage)
