### PR TITLE
SIO2: Set and clear first bit of ISTAT to signal transfer start/end

### DIFF
--- a/pcsx2/SIO/SioTypes.h
+++ b/pcsx2/SIO/SioTypes.h
@@ -118,6 +118,11 @@ namespace Sio2Ctrl
 	static constexpr u32 SIO2MAN_RESET = 0x000003bc;
 } // namespace Sio2Ctrl
 
+namespace Sio2IStat
+{
+	static constexpr u32 TRANSFER_STARTED = 0x1000;
+}
+
 // TODO: Remove deprecated options once memcards are no longer using them.
 namespace Recv1
 {


### PR DESCRIPTION
### Description of Changes
Sets bit 12 (zero indexed) of ISTAT upon transfer start, as signaled by CTRL. This is not hardware tested yet.

### Rationale behind Changes
Should allow modules that interact with MX4SIO to function, which actually checks if ISTAT is signaling a transfer in progress, unlike memory cards or pads which (seemingly) only check if the transfer is completed instead.

### Suggested Testing Steps
Boot games, verify normal memory card and controller operation. Please test with copies of memory cards to avoid any potential data loss.