### PR TITLE
Vif: Backup and restore used non-volatile SSE registers

### DIFF
--- a/pcsx2/x86/Vif_UnpackSSE.cpp
+++ b/pcsx2/x86/Vif_UnpackSSE.cpp
@@ -328,12 +328,12 @@ VifUnpackSSE_Simple::VifUnpackSSE_Simple(bool usn_, bool domask_, int curCycle_)
 
 void VifUnpackSSE_Simple::doMaskWrite(const xRegisterSSE& regX) const
 {
-	xMOVAPS(xmm7, ptr[dstIndirect]);
+	xMOVAPS(xmm3, ptr[dstIndirect]);
 	const int offX = std::min(curCycle, 3);
 	xPAND(regX, ptr32[nVifMask[0][offX]]);
-	xPAND(xmm7, ptr32[nVifMask[1][offX]]);
+	xPAND(xmm3, ptr32[nVifMask[1][offX]]);
 	xPOR (regX, ptr32[nVifMask[2][offX]]);
-	xPOR (regX, xmm7);
+	xPOR (regX, xmm3);
 	xMOVAPS(ptr[dstIndirect], regX);
 }
 

--- a/pcsx2/x86/Vif_UnpackSSE.h
+++ b/pcsx2/x86/Vif_UnpackSSE.h
@@ -102,6 +102,10 @@ protected:
 	const nVifBlock&  vB;  // some pre-collected data from VifStruct
 	int               vCL; // internal copy of vif->cl
 
+	std::array<xRegisterSSE, 4> colRegs;
+	xRegisterSSE rowReg;
+	xRegisterSSE tmpReg;
+
 public:
 	VifUnpackSSE_Dynarec(const nVifStruct& vif_, const nVifBlock& vifBlock_);
 	VifUnpackSSE_Dynarec(const VifUnpackSSE_Dynarec& src) // copy constructor

--- a/pcsx2/x86/newVif.h
+++ b/pcsx2/x86/newVif.h
@@ -17,9 +17,3 @@ extern void  mVUsaveReg(const xRegisterSSE& reg, xAddressVoid ptr, int xyzw, boo
 #define _v1 0x55
 #define _v2 0xaa
 #define _v3 0xff
-#define xmmCol0 xmm2
-#define xmmCol1 xmm3
-#define xmmCol2 xmm4
-#define xmmCol3 xmm5
-#define xmmRow  xmm6
-#define xmmTemp xmm7


### PR DESCRIPTION
### Description of Changes
Backup and restore the non-volatile registers used by compiled Vif code.

### Rationale behind Changes
XMM6-XMM15 are non-volatile on Windows, of which the Vif uses 3 of those.
These registers can be clobbered by JIT unpack code, while the calling code will expect these registers preserved.
This _appears_ to also cause https://github.com/PCSX2/pcsx2/issues/11549, at least with Jak X when testing with MTVU disabled.

Windows On Arm64 also has non-volatile fp registers, but the Arm vif code appears to not use these, so no changes for Arm.

### Suggested Testing Steps
Test to make sure I didn't blow up the core.