### PR TITLE
DebugInterface: isValidAddres on physical

### DIFF
--- a/pcsx2/DebugTools/DebugInterface.cpp
+++ b/pcsx2/DebugTools/DebugInterface.cpp
@@ -967,6 +967,7 @@ std::string R3000DebugInterface::disasm(u32 address, bool simplify)
 
 bool R3000DebugInterface::isValidAddress(u32 addr)
 {
+	addr &= 0x1fffffff;
 	if (addr >= 0x1D000000 && addr < 0x1E000000)
 	{
 		return true;


### PR DESCRIPTION
Mask off the segment bits so we don't show invalid address errors when in exception handling code.