### PR TITLE
Add mouse grab/lock feature when PCSX2 is in focus

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -107,7 +107,7 @@ MainWindow::MainWindow()
 #if !defined(_WIN32) && !defined(__APPLE__)
 	s_use_central_widget = DisplayContainer::isRunningOnWayland();
 #endif
-    createCheckMousePositionTimer();
+	createCheckMousePositionTimer();
 }
 
 MainWindow::~MainWindow()
@@ -1071,16 +1071,18 @@ bool MainWindow::shouldHideMainWindow() const
 }
 
 bool MainWindow::shouldMouseGrab() const
-{  
-    if (!s_vm_valid || s_vm_paused) return false;
+{
+	if (!s_vm_valid || s_vm_paused)
+		return false;
 
-    if (!Host::GetBoolSettingValue("EmuCore", "EnableMouseGrab", false)) return false;
+	if (!Host::GetBoolSettingValue("EmuCore", "EnableMouseGrab", false))
+		return false;
 
-    bool windowsHidden = (!m_debugger_window || m_debugger_window->isHidden()) &&
-                         (!m_controller_settings_window || m_controller_settings_window->isHidden()) &&
-                         (!m_settings_window || m_settings_window->isHidden());
+	bool windowsHidden = (!m_debugger_window || m_debugger_window->isHidden()) &&
+						 (!m_controller_settings_window || m_controller_settings_window->isHidden()) &&
+						 (!m_settings_window || m_settings_window->isHidden());
 
-    return windowsHidden && (isActiveWindow() || isRenderingFullscreen());
+	return windowsHidden && (isActiveWindow() || isRenderingFullscreen());
 }
 
 bool MainWindow::shouldAbortForMemcardBusy(const VMLock& lock)
@@ -2543,29 +2545,32 @@ QWidget* MainWindow::getDisplayContainer() const
 	return (m_display_container ? static_cast<QWidget*>(m_display_container) : static_cast<QWidget*>(m_display_widget));
 }
 
-void MainWindow::createCheckMousePositionTimer(){
-    m_mouse_check_timer = new QTimer(this);
-    connect(m_mouse_check_timer, &QTimer::timeout, this, &MainWindow::checkMousePosition);
-    m_mouse_check_timer->start(16);
+void MainWindow::createCheckMousePositionTimer()
+{
+	m_mouse_check_timer = new QTimer(this);
+	connect(m_mouse_check_timer, &QTimer::timeout, this, &MainWindow::checkMousePosition);
+	m_mouse_check_timer->start(16);
 }
 
-void MainWindow::checkMousePosition() {
-    if (!shouldMouseGrab()) return;
+void MainWindow::checkMousePosition()
+{
+	if (!shouldMouseGrab())
+		return;
 
-    QPoint globalCursorPos = QCursor::pos();
-    const QRect& windowBounds = isRenderingFullscreen() ? screen()->geometry() : geometry();
+	QPoint globalCursorPos = QCursor::pos();
+	const QRect& windowBounds = isRenderingFullscreen() ? screen()->geometry() : geometry();
 
-    if (windowBounds.contains(globalCursorPos)) return;
+	if (windowBounds.contains(globalCursorPos))
+		return;
 
-    QCursor::setPos(
-        std::clamp(globalCursorPos.x(), windowBounds.left(), windowBounds.right()),
-        std::clamp(globalCursorPos.y(), windowBounds.top(), windowBounds.bottom())
-    );
-    
+	QCursor::setPos(
+		std::clamp(globalCursorPos.x(), windowBounds.left(), windowBounds.right()),
+		std::clamp(globalCursorPos.y(), windowBounds.top(), windowBounds.bottom()));
 }
 
-void MainWindow::mouseMoveEvent(QMouseEvent *event){
-    QWidget::mouseMoveEvent(event);
+void MainWindow::mouseMoveEvent(QMouseEvent* event)
+{
+	QWidget::mouseMoveEvent(event);
 }
 
 

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -107,6 +107,7 @@ MainWindow::MainWindow()
 #if !defined(_WIN32) && !defined(__APPLE__)
 	s_use_central_widget = DisplayContainer::isRunningOnWayland();
 #endif
+    createCheckMousePositionTimer();
 }
 
 MainWindow::~MainWindow()
@@ -1067,6 +1068,19 @@ bool MainWindow::shouldHideMainWindow() const
 	return (Host::GetBoolSettingValue("UI", "HideMainWindowWhenRunning", false) && !g_emu_thread->shouldRenderToMain()) ||
 		   (g_emu_thread->shouldRenderToMain() && (isRenderingFullscreen() || m_is_temporarily_windowed)) ||
 		   QtHost::InNoGUIMode();
+}
+
+bool MainWindow::shouldMouseGrab() const
+{  
+    if (!s_vm_valid || s_vm_paused) return false;
+
+    if (!Host::GetBoolSettingValue("EmuCore", "EnableMouseGrab", false)) return false;
+
+    bool windowsHidden = (!m_debugger_window || m_debugger_window->isHidden()) &&
+                         (!m_controller_settings_window || m_controller_settings_window->isHidden()) &&
+                         (!m_settings_window || m_settings_window->isHidden());
+
+    return windowsHidden && (isActiveWindow() || isRenderingFullscreen());
 }
 
 bool MainWindow::shouldAbortForMemcardBusy(const VMLock& lock)
@@ -2528,6 +2542,32 @@ QWidget* MainWindow::getDisplayContainer() const
 {
 	return (m_display_container ? static_cast<QWidget*>(m_display_container) : static_cast<QWidget*>(m_display_widget));
 }
+
+void MainWindow::createCheckMousePositionTimer(){
+    m_mouse_check_timer = new QTimer(this);
+    connect(m_mouse_check_timer, &QTimer::timeout, this, &MainWindow::checkMousePosition);
+    m_mouse_check_timer->start(16);
+}
+
+void MainWindow::checkMousePosition() {
+    if (!shouldMouseGrab()) return;
+
+    QPoint globalCursorPos = QCursor::pos();
+    const QRect& windowBounds = isRenderingFullscreen() ? screen()->geometry() : geometry();
+
+    if (windowBounds.contains(globalCursorPos)) return;
+
+    QCursor::setPos(
+        std::clamp(globalCursorPos.x(), windowBounds.left(), windowBounds.right()),
+        std::clamp(globalCursorPos.y(), windowBounds.top(), windowBounds.bottom())
+    );
+    
+}
+
+void MainWindow::mouseMoveEvent(QMouseEvent *event){
+    QWidget::mouseMoveEvent(event);
+}
+
 
 void MainWindow::saveDisplayWindowGeometryToConfig()
 {

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -60,8 +60,8 @@ public:
 		/// Returns the parent widget, which can be used for any popup dialogs.
 		__fi QWidget* getDialogParent() const { return m_dialog_parent; }
 
-		/// Cancels any pending unpause/fullscreen transition.
-		/// Call when you're going to destroy the VM anyway.
+        /// Cancels any pending unpause/fullscreen transition.
+        /// Call when you're going to destroy the VM anyway.
 		void cancelResume();
 
 	private:
@@ -128,7 +128,7 @@ private Q_SLOTS:
 	void mouseModeRequested(bool relative_mode, bool hide_cursor);
 	void releaseRenderWindow();
 	void focusDisplayWidget();
-
+    void createCheckMousePositionTimer();
 	void onGameListRefreshComplete();
 	void onGameListRefreshProgress(const QString& status, int current, int total);
 	void onGameListSelectionChanged();
@@ -180,12 +180,13 @@ private Q_SLOTS:
 	void onInputRecPlayActionTriggered();
 	void onInputRecStopActionTriggered();
 	void onInputRecOpenViewer();
-
 	void onVMStarting();
 	void onVMStarted();
 	void onVMPaused();
 	void onVMResumed();
 	void onVMStopped();
+
+    void checkMousePosition();
 
 	void onGameChanged(const QString& title, const QString& elf_override, const QString& disc_path,
 		const QString& serial, quint32 disc_crc, quint32 crc);
@@ -204,6 +205,7 @@ protected:
 	void dropEvent(QDropEvent* event) override;
 	void moveEvent(QMoveEvent* event) override;
 	void resizeEvent(QResizeEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
 
 #ifdef _WIN32
 	bool nativeEvent(const QByteArray& eventType, void* message, qintptr* result) override;
@@ -238,6 +240,7 @@ private:
 	bool isRenderingToMain() const;
 	bool shouldHideMouseCursor() const;
 	bool shouldHideMainWindow() const;
+    bool shouldMouseGrab() const;
 	void switchToGameListView();
 	void switchToEmulationView();
 
@@ -307,8 +310,10 @@ private:
 	bool m_was_disc_change_request = false;
 	bool m_is_closing = false;
 	bool m_is_temporarily_windowed = false;
-
+    
 	QString m_last_fps_status;
+
+    QTimer* m_mouse_check_timer = nullptr;
 
 #ifdef _WIN32
 	void* m_device_notification_handle = nullptr;

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -60,8 +60,8 @@ public:
 		/// Returns the parent widget, which can be used for any popup dialogs.
 		__fi QWidget* getDialogParent() const { return m_dialog_parent; }
 
-        /// Cancels any pending unpause/fullscreen transition.
-        /// Call when you're going to destroy the VM anyway.
+		/// Cancels any pending unpause/fullscreen transition.
+		/// Call when you're going to destroy the VM anyway.
 		void cancelResume();
 
 	private:
@@ -128,7 +128,7 @@ private Q_SLOTS:
 	void mouseModeRequested(bool relative_mode, bool hide_cursor);
 	void releaseRenderWindow();
 	void focusDisplayWidget();
-    void createCheckMousePositionTimer();
+	void createCheckMousePositionTimer();
 	void onGameListRefreshComplete();
 	void onGameListRefreshProgress(const QString& status, int current, int total);
 	void onGameListSelectionChanged();
@@ -186,7 +186,7 @@ private Q_SLOTS:
 	void onVMResumed();
 	void onVMStopped();
 
-    void checkMousePosition();
+	void checkMousePosition();
 
 	void onGameChanged(const QString& title, const QString& elf_override, const QString& disc_path,
 		const QString& serial, quint32 disc_crc, quint32 crc);
@@ -205,7 +205,7 @@ protected:
 	void dropEvent(QDropEvent* event) override;
 	void moveEvent(QMoveEvent* event) override;
 	void resizeEvent(QResizeEvent* event) override;
-    void mouseMoveEvent(QMouseEvent* event) override;
+	void mouseMoveEvent(QMouseEvent* event) override;
 
 #ifdef _WIN32
 	bool nativeEvent(const QByteArray& eventType, void* message, qintptr* result) override;
@@ -240,7 +240,7 @@ private:
 	bool isRenderingToMain() const;
 	bool shouldHideMouseCursor() const;
 	bool shouldHideMainWindow() const;
-    bool shouldMouseGrab() const;
+	bool shouldMouseGrab() const;
 	void switchToGameListView();
 	void switchToEmulationView();
 
@@ -310,10 +310,10 @@ private:
 	bool m_was_disc_change_request = false;
 	bool m_is_closing = false;
 	bool m_is_temporarily_windowed = false;
-    
+
 	QString m_last_fps_status;
 
-    QTimer* m_mouse_check_timer = nullptr;
+	QTimer* m_mouse_check_timer = nullptr;
 
 #ifdef _WIN32
 	void* m_device_notification_handle = nullptr;

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -80,6 +80,8 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsWindow* dialog, QWidget
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.pauseOnControllerDisconnection, "UI", "PauseOnControllerDisconnection", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.discordPresence, "EmuCore", "EnableDiscordPresence", false);
 
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.mouseGrab, "EmuCore", "EnableMouseGrab", false);
+
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.startFullscreen, "UI", "StartFullscreen", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.doubleClickTogglesFullscreen, "UI", "DoubleClickTogglesFullscreen",
 		true);
@@ -161,6 +163,9 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsWindow* dialog, QWidget
 	dialog->registerWidgetHelp(
 		m_ui.discordPresence, tr("Enable Discord Presence"), tr("Unchecked"),
 		tr("Shows the game you are currently playing as part of your profile in Discord."));
+	dialog->registerWidgetHelp(
+		m_ui.mouseGrab, tr("Enable Mouse Grab"), tr("Unchecked"),
+		tr("Locks the mouse cursor to the windows when PCSX2 is in focus."));
 	dialog->registerWidgetHelp(
 		m_ui.doubleClickTogglesFullscreen, tr("Double-Click Toggles Fullscreen"), tr("Checked"),
 		tr("Allows switching in and out of fullscreen mode by double-clicking the game window."));

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
@@ -50,6 +50,13 @@
         </property>
        </widget>
       </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="mouseGrab">
+        <property name="text">
+         <string>Enable Mouse Grab</string>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="1">
        <widget class="QCheckBox" name="pauseOnStart">
         <property name="text">


### PR DESCRIPTION
### Description of Changes
This PR adds a new "Mouse Grab" feature to lock the mouse cursor within the PCSX2 window when it is in focus. This functionality is particularly useful for lightgun games that require shooting off the screen to reload, especially when PCSX2 is running in windowed mode or on multi-monitor setups.

The main changes include:

    1. Added a new option "Enable Mouse Grab" in the Settings/Interface menu to enable/disable mouse grab.

    2. Implemented a QTimer to check the mouse position and keep it within the window bounds when mouse grab is active.

    3. Logic to determine when the mouse should be grabbed based on the window state, emulation state, and user settings.

### Rationale behind Changes
This feature was requested in issue [#11902](https://github.com/PCSX2/PCSX2/issues/11902) to improve the experience for lightgun games, particularly in multi-monitor environments or when PCSX2 is running in windowed mode.

Mouse grab is a common feature in other emulators like RPCS3, Dolphin, and MAME. Implementing it in PCSX2 will provide users with a more consistent and accurate experience for games that rely on this mechanic.

### Key Logic for Mouse Grab

The mouse grab feature is enabled only under the following conditions:

    1. The "Enable Mouse Grab" setting (located in Settings/Interface) is turned on.

    2. PCSX2 is emulating a game.

    3. All auxiliary windows (debugger, controller settings, and settings windows) are either closed or hidden.

    4. The PCSX2 window is either active or rendering in fullscreen mode .

If any of these conditions are not met, the mouse grab feature is automatically disabled.

### Suggested Testing Steps
    1. Navigate to Settings/Interface and enable the "Enable Mouse Grab" option.

    2. Run PCSX2 in windowed mode and verify that the mouse cursor cannot leave the window bounds while emulation is active.

    3. Test it with several games and check that the cursor behaves as it should with the option enabled.
    
    4. Ensure that mouse grab is properly disabled in the following scenarios:

        · The emulator is paused or in an invalid state.

        · The "Enable Mouse Grab" setting is turned off.

        · Auxiliary windows (e.g., debugger, controller settings, or settings windows) are open.

        · The PCSX2 window loses focus or is minimized.

    5. Test in multi-monitor setups in fullscreen to confirm that the cursor does not escape to other monitors.
