### PR TITLE
GS/HW: Reduce number of copies for HDR

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -799,7 +799,8 @@ void ps_fbmask(inout float4 C, float2 pos_xy)
 {
 	if (PS_FBMASK)
 	{
-		float4 RT = trunc(RtTexture.Load(int3(pos_xy, 0)) * 255.0f + 0.1f);
+		float multi = PS_HDR ? 65535.0f : 255.0f;
+		float4 RT = trunc(RtTexture.Load(int3(pos_xy, 0)) * multi + 0.1f);
 		C = (float4)(((uint4)C & ~FbMask) | ((uint4)RT & FbMask));
 	}
 }
@@ -895,7 +896,8 @@ void ps_blend(inout float4 Color, inout float4 As_rgba, float2 pos_xy)
 		}
 		
 		float Ad = PS_RTA_CORRECTION ? trunc(RT.a * 128.0f + 0.1f) / 128.0f : trunc(RT.a * 255.0f + 0.1f) / 128.0f;
-		float3 Cd = trunc(RT.rgb * 255.0f + 0.1f);
+		float color_multi = PS_HDR ? 65535.0f : 255.0f;
+		float3 Cd = trunc(RT.rgb * color_multi + 0.1f);
 		float3 Cs = Color.rgb;
 
 		float3 A = (PS_BLEND_A == 0) ? Cs : ((PS_BLEND_A == 1) ? Cd : (float3)0.0f);

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -708,7 +708,11 @@ void ps_fbmask(inout vec4 C)
 {
 	// FIXME do I need special case for 16 bits
 #if PS_FBMASK
-	vec4 RT = trunc(fetch_rt() * 255.0f + 0.1f);
+	#if PS_HDR == 1
+		vec4 RT = trunc(fetch_rt() * 65535.0f);
+	#else
+		vec4 RT = trunc(fetch_rt() * 255.0f + 0.1f);
+	#endif
 	C = vec4((uvec4(C) & ~FbMask) | (uvec4(RT) & FbMask));
 #endif
 }
@@ -823,7 +827,11 @@ float As = As_rgba.a;
 	#endif
 		
 	// Let the compiler do its jobs !
-	vec3 Cd = trunc(RT.rgb * 255.0f + 0.1f);
+	#if PS_HDR == 1
+		vec3 Cd = trunc(RT.rgb * 65535.0f);
+	#else
+		vec3 Cd = trunc(RT.rgb * 255.0f + 0.1f);
+	#endif
 	vec3 Cs = Color.rgb;
 
 #if PS_BLEND_A == 0

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -972,7 +972,12 @@ vec4 ps_color()
 void ps_fbmask(inout vec4 C)
 {
 	#if PS_FBMASK
-		vec4 RT = trunc(sample_from_rt() * 255.0f + 0.1f);
+		
+		#if PS_HDR == 1
+			vec4 RT = trunc(sample_from_rt() * 65535.0f);
+		#else
+			vec4 RT = trunc(sample_from_rt() * 255.0f + 0.1f);
+		#endif
 		C = vec4((uvec4(C) & ~FbMask) | (uvec4(RT) & FbMask));
 	#endif
 }
@@ -1090,7 +1095,11 @@ void ps_blend(inout vec4 Color, inout vec4 As_rgba)
 		#endif
 
 			// Let the compiler do its jobs !
+			#if PS_HDR == 1
+			vec3 Cd = trunc(RT.rgb * 65535.0f);
+			#else
 			vec3 Cd = trunc(RT.rgb * 255.0f + 0.1f);
+			#endif
 			vec3 Cs = Color.rgb;
 
 		#if PS_BLEND_A == 0

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -111,7 +111,7 @@ private:
 	void EmulateATST(float& AREF, GSHWDrawConfig::PSSelector& ps, bool pass_2);
 
 	void SetTCOffset();
-
+	bool NextDrawHDR() const;
 	bool IsPossibleChannelShuffle() const;
 	bool NextDrawMatchesShuffle() const;
 	bool IsSplitTextureShuffle(GSTextureCache::Target* rt);

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -856,7 +856,10 @@ struct PSMain
 	void ps_fbmask(thread float4& C)
 	{
 		if (PS_FBMASK)
-			C = float4((uint4(int4(C)) & (cb.fbmask ^ 0xff)) | (uint4(current_color * 255.5) & cb.fbmask));
+		{
+			float multi = PS_HDR ? 65535.0 : 255.5;
+			C = float4((uint4(int4(C)) & (cb.fbmask ^ 0xff)) | (uint4(current_color * float4(multi, multi, multi, 255)) & cb.fbmask));
+		}
 	}
 
 	void ps_dither(thread float4& C, float As)
@@ -956,8 +959,8 @@ struct PSMain
 					current_color.a = float(denorm_rt.g & 0x80);
 				}
 			}
-
-			float3 Cd = trunc(current_color.rgb * 255.5f);
+			float multi = PS_HDR ? 65535.0 : 255.5;
+			float3 Cd = trunc(current_color.rgb * multi);
 			float3 Cs = Color.rgb;
 
 			float3 A = pick(PS_BLEND_A, Cs, Cd, float3(0.f));


### PR DESCRIPTION
### THIS WILL ONLY AFFECT SPECIFIC GAMES!

### Description of Changes
Tries to reduce the number of copies for HDR draws.

### Rationale behind Changes
Master would copy the render target to a new texture, draw, then copy back, every single time, but a lot of games do a lot of separate draws in a row to the same target, so it's better to keep it in one place until the end of the chain. This PR will keep it HDR as long as possible before converting back, hugely reducing copies and render passes in some cases.

TL;DR: Makes some games go brr more

### Suggested Testing Steps
Test the games listed below (sorry for the names)

Slightly Cherry Picked Reduction Results from Vulkan:

```
Ace Combat - Squadron Leader_SCES-52424 ['Draw Calls: -1 [620=>619]', 'Render Passes: -1 [44=>43]', 'Copies: -1 [8=>7]']
Big.Mutha.Truckers ['Draw Calls: -352 [903=>551]', 'Render Passes: -423 [440=>17]', 'Barriers: -127 [132=>5]', 'Copies: -352 [355=>3]']
DT_Carnage_SLUS-21793_20230908174547 ['Draw Calls: -29 [936=>907]', 'Render Passes: -32 [344=>312]', 'Copies: -30 [82=>52]']
Echo_Night_-_Beyond_SLUS-20928_20221019163851 ['Draw Calls: -2745 [6965=>4220]', 'Render Passes: -3384 [3456=>72]', 'Barriers: -1104 [1133=>29]', 'Copies: -2745 [2787=>42]']
evolution_colcliphdr ['Draw Calls: -142 [464=>322]', 'Render Passes: -179 [195=>16]', 'Barriers: -46 [50=>4]', 'Copies: -143 [149=>6]']
Full spectrum warrior ['Draw Calls: -3 [189=>186]', 'Render Passes: -3 [23=>20]', 'Copies: -3 [8=>5]']
JonnyMoseleydebug ['Draw Calls: -115 [211=>96]', 'Render Passes: -116 [128=>12]', 'Copies: -116 [118=>2]']
Kunoichi ['Draw Calls: -48 [1156=>1108]', 'Render Passes: -53 [168=>115]', 'Barriers: -1 [1=>0]', 'Copies: -48 [146=>98]']
Malice_SLES-52413_20240617171243 ['Draw Calls: -4 [453=>449]', 'Render Passes: -4 [232=>228]', 'Copies: -4 [23=>19]']
Mercenaries_-_Playground_of_Destruction_SLUS-20932 ['Draw Calls: -22 [780=>758]', 'Render Passes: -22 [86=>64]', 'Copies: -22 [51=>29]']
Nightshade_SLUS-20810_20231001162431 ['Draw Calls: -42 [1117=>1075]', 'Render Passes: -44 [131=>87]', 'Copies: -42 [119=>77]']
Pac-Man World Rally_SLUS-21328_20230127222927 ['Draw Calls: -57 [189=>132]', 'Render Passes: -64 [78=>14]', 'Barriers: -4 [4=>0]', 'Copies: -59 [64=>5]']
Pac-Man_World_2_SLUS-20224_20220816132032 ['Draw Calls: -2 [82=>80]', 'Render Passes: -2 [14=>12]', 'Copies: -2 [3=>1]']
sakura taisen shadows 1 (hw) ['Draw Calls: -96 [349=>253]', 'Render Passes: -111 [138=>27]', 'Barriers: -7 [7=>0]', 'Copies: -96 [116=>20]']
Sly 2 - Band of Thieves_SCUS-97316_20230422201628 ['Draw Calls: -173 [5962=>5789]', 'Render Passes: -152 [214=>62]', 'Barriers: -21 [546=>525]', 'Copies: -173 [178=>5]']
Snoopy vs Red Baron (snoopy) ['Draw Calls: -40 [198=>158]', 'Render Passes: -44 [60=>16]', 'Barriers: -2 [2=>0]', 'Copies: -40 [47=>7]']
Soul_Calibur_III_SLUS-21216_20231007100145 ['Draw Calls: -138 [526=>388]', 'Render Passes: -138 [156=>18]', 'Copies: -138 [143=>5]']
State_of_Emergency_2_SLUS-20966_20230921232225 ['Draw Calls: -2 [484=>482]', 'Render Passes: -2 [28=>26]', 'Copies: -2 [6=>4]']
Superman Returns - The Video Game_SLUS-21434_20221208170947 ['Render Passes: -1 [9=>8]']
Tekken_5_SLUS-21059_20240108195029 ['Draw Calls: -168 [641=>473]', 'Render Passes: -194 [244=>50]', 'Barriers: -45 [45=>0]', 'Copies: -168 [175=>7]']
tom_jerry_clear ['Draw Calls: -2 [93=>91]', 'Render Passes: -2 [13=>11]', 'Copies: -2 [3=>1]']
Virtua Quest _NTSC-U__SLUS-20977 ['Draw Calls: -2 [444=>442]', 'Render Passes: -2 [11=>9]', 'Copies: -2 [4=>2]']
```