### PR TITLE
iR5900: Reset manual protection counters on emulation reset

### DIFF
--- a/pcsx2/x86/ix86-32/iR5900.cpp
+++ b/pcsx2/x86/ix86-32/iR5900.cpp
@@ -594,6 +594,9 @@ static void recResetRaw()
 
 	g_branch = 0;
 	g_resetEeScalingStats = true;
+
+	memset(manual_page, 0, sizeof(manual_page));
+	memset(manual_counter, 0, sizeof(manual_counter));
 }
 
 void recShutdown()


### PR DESCRIPTION
### Description of Changes
Resets the manual protection counters on emulator reset

### Rationale behind Changes
This counters are used to avoid excessive recompilation of blocks that share a page with data see; https://github.com/PCSX2/pcsx2/blob/bf8693a7e8546f1ec3bcb8a71603d9e460430b5e/pcsx2/x86/ix86-32/iR5900.cpp#L2041-L2049

For some currently unknown reason, the initial value of these counters has an observable impact on TAS playback (at least with Jak X)
As these arrays weren't previously cleared, the sequential playback of the same TAS file will playback differently.

Ideally, we would investigate _why_ this has an effect on TAS playback (especially given that these values are not stored in savestates), but I believe these arrays should be reset regardless.

### Suggested Testing Steps
This might impact the performance on the second game launched in a PCSX2 session (or a relaunch of the same game)

For TAS playback testing, the following steps is what I've been testing with
Enable Pause on Start and Disable MTVU
Start a game, start input recording (from boot), then unpause
The second tutorial in Jak X is sensitive to this issue
Once recorded, close and reopen the emulator to get a clean state

Start a game, select the recording to play, then unpause
At the end of the recording, stop it and shutdown emulation
Relaunch the game, reselect the recording and unpause
Observe if any differences occur in playback between the 1st and 2nd run.
