### PR TITLE
Controllers: Make restore defaults restore controller LED

### DIFF
--- a/pcsx2/Input/SDLInputSource.cpp
+++ b/pcsx2/Input/SDLInputSource.cpp
@@ -247,6 +247,14 @@ u32 SDLInputSource::ParseRGBForPlayerId(const std::string_view str, u32 player_i
 	return color;
 }
 
+void SDLInputSource::ResetRGBForAllPlayers(SettingsInterface& si)
+{
+	for (u32 player_id = 0; player_id < MAX_LED_COLORS; player_id++)
+	{
+		si.DeleteValue("SDLExtra", fmt::format("Player{}LED", player_id).c_str());
+	}
+}
+
 void SDLInputSource::SetHints()
 {
 	if (const std::string upath = Path::Combine(EmuFolders::DataRoot, CONTROLLER_DB_FILENAME); FileSystem::FileExists(upath.c_str()))

--- a/pcsx2/Input/SDLInputSource.h
+++ b/pcsx2/Input/SDLInputSource.h
@@ -44,6 +44,7 @@ public:
 
 	static u32 GetRGBForPlayerId(SettingsInterface& si, u32 player_id);
 	static u32 ParseRGBForPlayerId(const std::string_view str, u32 player_id);
+	static void ResetRGBForAllPlayers(SettingsInterface& si);
 
 private:
 	struct ControllerData

--- a/pcsx2/SIO/Pad/Pad.cpp
+++ b/pcsx2/SIO/Pad/Pad.cpp
@@ -12,6 +12,8 @@
 #include "SIO/Pad/PadNotConnected.h"
 #include "SIO/Sio.h"
 
+#include "Input/SDLInputSource.h"
+
 #include "IconsFontAwesome5.h"
 
 #include "VMManager.h"
@@ -167,6 +169,7 @@ void Pad::SetDefaultControllerConfig(SettingsInterface& si)
 	si.SetBoolValue("Pad", "MultitapPort2", false);
 	si.SetFloatValue("Pad", "PointerXScale", 8.0f);
 	si.SetFloatValue("Pad", "PointerYScale", 8.0f);
+	SDLInputSource::ResetRGBForAllPlayers(si);
 
 	// PCSX2 Controller Settings - Default pad types and parameters.
 	for (u32 i = 0; i < Pad::NUM_CONTROLLER_PORTS; i++)


### PR DESCRIPTION
### Description of Changes
Makes it so that the `Restore Defaults` button in the `PCSX2 Controller Settings` restores the default LED colors for the four players. This takes effect immediately.

### Rationale behind Changes
`Restore Defaults` previously did not reset the controller LED colors set by the user, when it should reset all controller settings.

### Suggested Testing Steps
Go to `Settings` > `Controllers` and click the little lightbulb next to `DualShock 4 / DualSense Enhanced Mode`. Set all the ports to something obviously non-default. Then `Restore Defaults` either before you've exited out of PCSX2 or after reopening the application. If you have a DS4 or DS5 controller, check to ensure that this immediately changes the physical LED color on your controller.
