### PR TITLE
Debugger: Memory search changes

### DIFF
--- a/pcsx2-qt/Debugger/MemorySearchWidget.cpp
+++ b/pcsx2-qt/Debugger/MemorySearchWidget.cpp
@@ -512,56 +512,59 @@ void MemorySearchWidget::onSearchButtonClicked()
 
 	if(searchComparison != SearchComparison::UnknownValue)
 	{
-		switch (searchType)
+		if(doesSearchComparisonTakeInput(searchComparison))
 		{
-			case SearchType::ByteType:
-			case SearchType::Int16Type:
-			case SearchType::Int32Type:
-			case SearchType::Int64Type:
-				value = searchValue.toULongLong(&ok, searchHex ? 16 : 10);
-				break;
-			case SearchType::FloatType:
-			case SearchType::DoubleType:
-				searchValue.toDouble(&ok);
-				break;
-			case SearchType::StringType:
-				ok = !searchValue.isEmpty();
-				break;
-			case SearchType::ArrayType:
-				ok = !searchValue.trimmed().isEmpty();
-				break;
-		}
-		
-		if (!ok)
-		{
-			QMessageBox::critical(this, tr("Debugger"), tr("Invalid search value"));
-			return;
-		}
-		
-		switch (searchType)
-		{
-			case SearchType::ArrayType:
-			case SearchType::StringType:
-			case SearchType::DoubleType:
-			case SearchType::FloatType:
-				break;
-			case SearchType::Int64Type:
-				if (value <= std::numeric_limits<unsigned long long>::max())
+			switch (searchType)
+			{
+				case SearchType::ByteType:
+				case SearchType::Int16Type:
+				case SearchType::Int32Type:
+				case SearchType::Int64Type:
+					value = searchValue.toULongLong(&ok, searchHex ? 16 : 10);
 					break;
-			case SearchType::Int32Type:
-				if (value <= std::numeric_limits<unsigned long>::max())
+				case SearchType::FloatType:
+				case SearchType::DoubleType:
+					searchValue.toDouble(&ok);
 					break;
-			case SearchType::Int16Type:
-				if (value <= std::numeric_limits<unsigned short>::max())
+				case SearchType::StringType:
+					ok = !searchValue.isEmpty();
 					break;
-			case SearchType::ByteType:
-				if (value <= std::numeric_limits<unsigned char>::max())
+				case SearchType::ArrayType:
+					ok = !searchValue.trimmed().isEmpty();
 					break;
-			default:
-				QMessageBox::critical(this, tr("Debugger"), tr("Value is larger than type"));
+			}
+
+			if (!ok)
+			{
+				QMessageBox::critical(this, tr("Debugger"), tr("Invalid search value"));
 				return;
+			}
+
+			switch (searchType)
+			{
+				case SearchType::ArrayType:
+				case SearchType::StringType:
+				case SearchType::DoubleType:
+				case SearchType::FloatType:
+					break;
+				case SearchType::Int64Type:
+					if (value <= std::numeric_limits<unsigned long long>::max())
+						break;
+				case SearchType::Int32Type:
+					if (value <= std::numeric_limits<unsigned long>::max())
+						break;
+				case SearchType::Int16Type:
+					if (value <= std::numeric_limits<unsigned short>::max())
+						break;
+				case SearchType::ByteType:
+					if (value <= std::numeric_limits<unsigned char>::max())
+						break;
+				default:
+					QMessageBox::critical(this, tr("Debugger"), tr("Value is larger than type"));
+					return;
+			}
 		}
-		
+
 		if (!isFilterSearch && (searchComparison == SearchComparison::Changed || searchComparison == SearchComparison::ChangedBy
 								|| searchComparison == SearchComparison::Decreased || searchComparison == SearchComparison::DecreasedBy
 								|| searchComparison == SearchComparison::Increased || searchComparison == SearchComparison::IncreasedBy
@@ -642,6 +645,23 @@ SearchComparison MemorySearchWidget::getCurrentSearchComparison()
 {
 	// Note: The index can't be converted directly to the enum value since we change what comparisons are shown.
 	return m_searchComparisonLabelMap.labelToEnum(m_ui.cmbSearchComparison->currentText());
+}
+
+bool MemorySearchWidget::doesSearchComparisonTakeInput(const SearchComparison comparison)
+{
+	switch (comparison) {
+		case SearchComparison::Equals:
+		case SearchComparison::NotEquals:
+		case SearchComparison::GreaterThan:
+		case SearchComparison::GreaterThanOrEqual:
+		case SearchComparison::LessThan:
+		case SearchComparison::LessThanOrEqual:
+		case SearchComparison::IncreasedBy:
+		case SearchComparison::DecreasedBy:
+			return true;
+		default:
+			return false;
+	}
 }
 
 void MemorySearchWidget::onSearchTypeChanged(int newIndex)

--- a/pcsx2-qt/Debugger/MemorySearchWidget.h
+++ b/pcsx2-qt/Debugger/MemorySearchWidget.h
@@ -48,6 +48,7 @@ public:
 		Changed,
 		ChangedBy,
 		NotChanged,
+		UnknownValue,
 		Invalid
 	};
 
@@ -69,6 +70,7 @@ public:
 			insert(SearchComparison::Changed, tr("Changed"));
 			insert(SearchComparison::ChangedBy, tr("Changed By"));
 			insert(SearchComparison::NotChanged, tr("Not Changed"));
+			insert(SearchComparison::UnknownValue, tr("Unknown Initial Value"));
 			insert(SearchComparison::Invalid, "");
 		}
 		SearchComparison labelToEnum(QString comparisonLabel)
@@ -120,6 +122,7 @@ public slots:
 	void onSearchButtonClicked();
 	void onSearchResultsListScroll(u32 value);
 	void onSearchTypeChanged(int newIndex);
+	void onSearchComparisonChanged(int newIndex);
 	void loadSearchResults();
 	void contextSearchResultGoToDisassembly();
 	void contextRemoveSearchResult();

--- a/pcsx2-qt/Debugger/MemorySearchWidget.h
+++ b/pcsx2-qt/Debugger/MemorySearchWidget.h
@@ -149,4 +149,5 @@ private:
 	std::vector<SearchComparison> getValidSearchComparisonsForState(SearchType type, std::vector<SearchResult> &existingResults);
 	SearchType getCurrentSearchType();
 	SearchComparison getCurrentSearchComparison();
+	bool doesSearchComparisonTakeInput(SearchComparison comparison);
 };

--- a/pcsx2-qt/Debugger/MemorySearchWidget.ui
+++ b/pcsx2-qt/Debugger/MemorySearchWidget.ui
@@ -148,6 +148,11 @@
          <string>Less Than Or Equal</string>
         </property>
        </item>
+       <item>
+        <property name="text">
+         <string>Unknown Initial Value</string>
+        </property>
+       </item>
       </widget>
      </item>
      <item row="1" column="0">


### PR DESCRIPTION
### Description of Changes
Adds an 'unknown initial value' comparison to the memory searcher (fixes #12276)
Made it so we only validate the search value input when the comparison uses the value.

### Rationale behind Changes
Better ergonomics and improves the utility of the debugger. 

### Suggested Testing Steps
Try doing a filter search with 'decreased by', 'unchanged', etc with the search value text-box being empty
Try filtering down a value using the 'unknown initial value' comparison.
