### PR TITLE
Input: Make macro chords work properly

### DIFF
--- a/pcsx2/Input/InputManager.h
+++ b/pcsx2/Input/InputManager.h
@@ -95,7 +95,7 @@ struct InputBindingKeyHash
 using InputButtonEventHandler = std::function<void(s32 value)>;
 
 /// Callback types for a normalized event. Usually used for pads.
-using InputAxisEventHandler = std::function<void(float value)>;
+using InputAxisEventHandler = std::function<void(InputBindingKey key, float value)>;
 
 /// Input monitoring for external access.
 struct InputInterceptHook
@@ -210,6 +210,9 @@ namespace InputManager
 
 	/// Represents a binding with icon fonts, if available.
 	bool PrettifyInputBinding(SmallStringBase& binding);
+
+	/// Splits a chord into individual bindings.
+	std::vector<std::string_view> SplitChord(const std::string_view binding);
 
 	/// Returns a list of all hotkeys.
 	std::vector<const HotkeyInfo*> GetHotkeyList();

--- a/pcsx2/SIO/Pad/Pad.h
+++ b/pcsx2/SIO/Pad/Pad.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "Config.h"
+#include "Input/InputManager.h"
 #include "SIO/Pad/PadTypes.h"
 
 #include <memory>
@@ -68,6 +69,6 @@ namespace Pad
 	bool Freeze(StateWrapper& sw);
 
 	// Sets the state of the specified macro button.
-	void SetMacroButtonState(u32 pad, u32 index, bool state);
+	void SetMacroButtonState(InputBindingKey& key, u32 pad, u32 index, bool state);
 	void UpdateMacroButtons();
 }; // namespace Pad


### PR DESCRIPTION
### Description of Changes
Macros don't trigger if you only press one key of a chord anymore, fixes #8192

`InputAxisEventHandler` has `InputBindingKey` as an argument now
`InputManager::SplitChord` was made public
`SetMacroButtonState` was changed to check if all triggers of a macro were pressed before proceeding with the input

### Rationale behind Changes
To make games that utilize pressure sensitive controls, like MGS3, playable on controllers that don't have it

### Suggested Testing Steps
Test this on a windows system, because I don't have one
