### PR TITLE
GS/HW: Add CRC fixes for DT Carnage/Racer/Axel Impact

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -10365,9 +10365,14 @@ SCPS-56016:
   gameFixes:
     - GIFFIFOHack
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes post processing position.
+    nativeScaling: 2 # Fixes post effects.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
     gpuPaletteConversion: 2 # Improves performance and reduces hash cache size.
     autoFlush: 1 # Corrects shadows (Currently still broken even with this).
+    recommendedBlendingLevel: 4 # Fixes car shadows but addeds about 5000 barriers, might impact slower machines.
+    gpuTargetCLUT: 2 # Fixes light flicker.
+    getSkipCount: "GSC_DTGames"
 SCPS-72001:
   name: "GRAN TURISMO3 A-spec [MEGA HITS!]"
   name-sort: "ぐらんつーりすも3 A-spec [MEGA HITS!]"
@@ -23969,9 +23974,13 @@ SLES-53904:
   clampModes:
     vuClampMode: 0 # Fixes black artifacts on tracks
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes post processing position.
+    nativeScaling: 2 # Fixes post effects.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
     gpuPaletteConversion: 2 # Improves performance and reduces hash cache size.
     autoFlush: 1 # Corrects shadows (Currently still broken even with this).
+    gpuTargetCLUT: 2 # Fixes light flicker.
+    getSkipCount: "GSC_DTGames"
 SLES-53906:
   name: "50 Cent - Bulletproof"
   region: "PAL-F"
@@ -66754,9 +66763,13 @@ SLUS-21095:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
+    halfPixelOffset: 2 # Fixes post processing position.
+    nativeScaling: 2 # Fixes post effects.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
     gpuPaletteConversion: 2 # Improves performance and reduces hash cache size.
     autoFlush: 1 # Corrects shadows (Currently still broken even with this).
+    gpuTargetCLUT: 2 # Fixes light flicker.
+    getSkipCount: "GSC_DTGames"
 SLUS-21096:
   name: "Ape Escape - Pumped & Primed"
   region: "NTSC-U"
@@ -70873,10 +70886,12 @@ SLUS-21793:
   compat: 3
   gsHWFixes:
     halfPixelOffset: 2 # Fixes post processing position.
-    nativeScaling: 1 # Fixes post effects.
+    nativeScaling: 2 # Fixes post effects.
     estimateTextureRegion: 1 # Improves performance and reduces hash cache size.
     gpuPaletteConversion: 2 # Improves performance and reduces hash cache size.
     autoFlush: 1 # Corrects shadows (Currently still broken even with this).
+    gpuTargetCLUT: 2 # Fixes light flicker.
+    getSkipCount: "GSC_DTGames"
 SLUS-21794:
   name: "Go, Diego, Go! Great Dinosaur Rescue"
   region: "NTSC-U"

--- a/pcsx2/GS/Renderers/HW/GSHwHack.h
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.h
@@ -11,6 +11,7 @@ public:
 	static bool GSC_Manhunt2(GSRendererHW& r, int& skip);
 	static bool GSC_SacredBlaze(GSRendererHW& r, int& skip);
 	static bool GSC_SFEX3(GSRendererHW& r, int& skip);
+	static bool GSC_DTGames(GSRendererHW& r, int& skip);
 	static bool GSC_Tekken5(GSRendererHW& r, int& skip);
 	static bool GSC_BurnoutGames(GSRendererHW& r, int& skip);
 	static bool GSC_BlackAndBurnoutSky(GSRendererHW& r, int& skip);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -554,7 +554,7 @@ void GSRendererHW::ConvertSpriteTextureShuffle(u32& process_rg, u32& process_ba,
 		}
 		else
 		{
-			if ((floor(m_vt.m_max.p.y) <= rt->m_valid.w) && ((floor(m_vt.m_max.p.x) > (m_cached_ctx.FRAME.FBW * 64)) || (rt->m_TEX0.TBW != m_cached_ctx.FRAME.FBW)))
+			if (((m_r.width() + 8) & ~(GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].pgs.x - 1)) != GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].pgs.x && (floor(m_vt.m_max.p.y) <= rt->m_valid.w) && ((floor(m_vt.m_max.p.x) > (m_cached_ctx.FRAME.FBW * 64)) || (rt->m_TEX0.TBW < m_cached_ctx.FRAME.FBW)))
 			{
 				half_bottom_vert = false;
 				half_bottom_uv = false;


### PR DESCRIPTION
### Description of Changes
Adds a CRC and necessary fix to make Axel Impact/DT Racer/DT Carnage look mostly right and play at a decent speed.

It's not perfect with this PR, but with RT in RT #11461 it will be accurate. This still makes a huge improvement to playability.

### Rationale behind Changes
It was annoying me how broken they were and the game does an insane shuffle PCSX2 cannot handle, so this was the only real option.

### Suggested Testing Steps
Test said Games.

Axel Impact:

Master:
![image](https://github.com/user-attachments/assets/a16176ab-36c1-46d5-9131-18987443eb2a)
PR:
![image](https://github.com/user-attachments/assets/1e93c5f7-46ff-4fa8-a2b9-6ba70d735038)

DT Carnage:
Master:
![image](https://github.com/user-attachments/assets/ef83b750-b645-4bc4-a466-172cf57b7465)
PR:
![image](https://github.com/user-attachments/assets/b9055372-aa37-44da-ac65-0ebc1c8fa8e4)

DT Racer: (You can see noticeable glitches here, they are gone on RT in RT)
Master:
![image](https://github.com/user-attachments/assets/65277266-b24a-48da-97d9-b43ca106bcd7)
PR:
![image](https://github.com/user-attachments/assets/a3e6353f-74f7-42e5-86ee-969be73d699a)
