### PR TITLE
Build: Change AppImage WM_CLASS from AppRun.wrapped

### DIFF
--- a/.github/workflows/scripts/linux/appimage-qt.sh
+++ b/.github/workflows/scripts/linux/appimage-qt.sh
@@ -212,6 +212,11 @@ if [[ "${GIT_VERSION}" == "" ]]; then
 	fi
 fi
 
+# Changes WM_CLASS name to the correct one instead of AppRun.wrapped (helps GNOME)
+sed 's/Exec=AppRun.wrapped/Exec=net.pcsx2.PCSX2/g' $OUTDIR/usr/share/applications/net.pcsx2.PCSX2.desktop
+
 rm -f "$NAME.AppImage"
 ARCH=x86_64 VERSION="${GIT_VERSION}" "$APPIMAGETOOL" -s "$OUTDIR" && mv ./*.AppImage "$NAME.AppImage"
 
+# Changes WM_CLASS name to the correct one instead of AppRun.Wrapped (helps GNOME)
+sed 's/Exec=AppRun.wrapped/Exec=net.pcsx2.PCSX2/g' $OUTDIR/usr/share/applications/net.pcsx2.PCSX2.desktop


### PR DESCRIPTION
### Description of Changes
Changes the AppImage WM_CLASS attribute from AppRun.wrapped to net.pcsx2.PCSX2.

### Rationale behind Changes
Attempts to resolve #12289.

### Suggested Testing Steps
Try the AppImage on GNOME and see if the logo is correct.