### PR TITLE
Qt: End memcard conversion progress at 100% instead of 99%

### DIFF
--- a/pcsx2-qt/Settings/MemoryCardConvertWorker.cpp
+++ b/pcsx2-qt/Settings/MemoryCardConvertWorker.cpp
@@ -121,7 +121,7 @@ bool MemoryCardConvertWorker::ConvertToFolder(const std::string& srcFileName, co
 	// Set progress bar to the literal number of bytes in the memcard.
 	// Plus two because there is a lag period after the Save calls complete
 	// where the progress bar stalls out; this lets us stop the progress bar
-	// just shy of 50 and 100% so it seems like its still doing some work.
+	// just shy of 50 and 100% so it seems like it's still doing some work.
 	this->SetProgressRange((sourceBuffer.size() * 2) + 2);
 	this->SetProgressValue(0);
 
@@ -160,6 +160,8 @@ bool MemoryCardConvertWorker::ConvertToFolder(const std::string& srcFileName, co
 
 		this->IncrementProgressValue();
 	}
+
+	this->IncrementProgressValue();
 
 	return true;
 }


### PR DESCRIPTION
### Description of Changes
Makes the progress bar for File -> Folder conversion go from 0% to 100% instead of 0% to 99% (Folder -> File already worked as intended). This was purely an aesthetic issue.

### Rationale behind Changes
Resolves #12271.

### Suggested Testing Steps
Convert your file memcard to a folder memcard and look at the progress bar. Test on master to ensure this really was a problem.