### PR TITLE
UI: Add debug UI options for new GS dumping options.

### DIFF
--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -517,17 +517,17 @@ bool GSRunner::ParseCommandLineArgs(int argc, char* argv[], VMBootParameters& pa
 				s_settings_interface.SetBoolValue("EmuCore/GS", "dump", true);
 
 				if (str.find("rt") != std::string::npos)
-					s_settings_interface.SetBoolValue("EmuCore/GS", "save", true);
+					s_settings_interface.SetBoolValue("EmuCore/GS", "SaveRT", true);
 				if (str.find("f") != std::string::npos)
-					s_settings_interface.SetBoolValue("EmuCore/GS", "savef", true);
+					s_settings_interface.SetBoolValue("EmuCore/GS", "SaveFrame", true);
 				if (str.find("tex") != std::string::npos)
-					s_settings_interface.SetBoolValue("EmuCore/GS", "savet", true);
+					s_settings_interface.SetBoolValue("EmuCore/GS", "SaveTexture", true);
 				if (str.find("z") != std::string::npos)
-					s_settings_interface.SetBoolValue("EmuCore/GS", "savez", true);
+					s_settings_interface.SetBoolValue("EmuCore/GS", "SaveDepth", true);
 				if (str.find("a") != std::string::npos)
-					s_settings_interface.SetBoolValue("EmuCore/GS", "savea", true);
+					s_settings_interface.SetBoolValue("EmuCore/GS", "SaveAlpha", true);
 				if (str.find("i") != std::string::npos)
-					s_settings_interface.SetBoolValue("EmuCore/GS", "savei", true);
+					s_settings_interface.SetBoolValue("EmuCore/GS", "SaveInfo", true);
 				continue;
 			}
 			else if (CHECK_ARG_PARAM("-dumprange"))
@@ -550,9 +550,9 @@ bool GSRunner::ParseCommandLineArgs(int argc, char* argv[], VMBootParameters& pa
 				{
 					by = std::max(1, StringUtil::FromChars<int>(split[2]).value_or(1));
 				}
-				s_settings_interface.SetIntValue("EmuCore/GS", "saven", start);
-				s_settings_interface.SetIntValue("EmuCore/GS", "savel", num);
-				s_settings_interface.SetIntValue("EmuCore/GS", "saveb", by);
+				s_settings_interface.SetIntValue("EmuCore/GS", "SaveDrawStart", start);
+				s_settings_interface.SetIntValue("EmuCore/GS", "SaveDrawCount", num);
+				s_settings_interface.SetIntValue("EmuCore/GS", "SaveDrawBy", by);
 				continue;
 			}
 			else if (CHECK_ARG_PARAM("-dumprangef"))
@@ -575,9 +575,9 @@ bool GSRunner::ParseCommandLineArgs(int argc, char* argv[], VMBootParameters& pa
 				{
 					by = std::max(1, StringUtil::FromChars<int>(split[2]).value_or(1));
 				}
-				s_settings_interface.SetIntValue("EmuCore/GS", "savenf", start);
-				s_settings_interface.SetIntValue("EmuCore/GS", "savelf", num);
-				s_settings_interface.SetIntValue("EmuCore/GS", "savebf", by);
+				s_settings_interface.SetIntValue("EmuCore/GS", "SaveFrameStart", start);
+				s_settings_interface.SetIntValue("EmuCore/GS", "SaveFrameCount", num);
+				s_settings_interface.SetIntValue("EmuCore/GS", "SaveFrameBy", by);
 				continue;
 			}
 			else if (CHECK_ARG_PARAM("-dumpdirhw"))

--- a/pcsx2-qt/Settings/DebugSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DebugSettingsWidget.cpp
@@ -49,8 +49,12 @@ DebugSettingsWidget::DebugSettingsWidget(SettingsWindow* dialog, QWidget* parent
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.saveFrame, "EmuCore/GS", "savef", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.saveTexture, "EmuCore/GS", "savet", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.saveDepth, "EmuCore/GS", "savez", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.saveAlpha, "EmuCore/GS", "savea", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.saveInfo, "EmuCore/GS", "savei", false);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.startDraw, "EmuCore/GS", "saven", 0);
-	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.dumpCount, "EmuCore/GS", "savel", 5000);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.drawDumpCount, "EmuCore/GS", "savel", 5000);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.startFrame, "EmuCore/GS", "savenf", 0);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.frameDumpCount, "EmuCore/GS", "savelf", 5000);
 	SettingWidgetBinder::BindWidgetToFolderSetting(
 		sif, m_ui.hwDumpDirectory, m_ui.hwDumpBrowse, m_ui.hwDumpOpen, nullptr, "EmuCore/GS", "HWDumpDirectory", std::string(), false);
 	SettingWidgetBinder::BindWidgetToFolderSetting(
@@ -151,8 +155,12 @@ void DebugSettingsWidget::onDrawDumpingChanged()
 	m_ui.saveFrame->setEnabled(enabled);
 	m_ui.saveTexture->setEnabled(enabled);
 	m_ui.saveDepth->setEnabled(enabled);
+	m_ui.saveAlpha->setEnabled(enabled);
+	m_ui.saveInfo->setEnabled(enabled);
 	m_ui.startDraw->setEnabled(enabled);
-	m_ui.dumpCount->setEnabled(enabled);
+	m_ui.drawDumpCount->setEnabled(enabled);
+	m_ui.startFrame->setEnabled(enabled);
+	m_ui.frameDumpCount->setEnabled(enabled);
 	m_ui.hwDumpDirectory->setEnabled(enabled);
 	m_ui.hwDumpBrowse->setEnabled(enabled);
 	m_ui.hwDumpOpen->setEnabled(enabled);

--- a/pcsx2-qt/Settings/DebugSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DebugSettingsWidget.cpp
@@ -44,23 +44,23 @@ DebugSettingsWidget::DebugSettingsWidget(SettingsWindow* dialog, QWidget* parent
 	//////////////////////////////////////////////////////////////////////////
 	// GS Settings
 	//////////////////////////////////////////////////////////////////////////
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.dumpGSDraws, "EmuCore/GS", "dump", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.saveRT, "EmuCore/GS", "save", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.saveFrame, "EmuCore/GS", "savef", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.saveTexture, "EmuCore/GS", "savet", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.saveDepth, "EmuCore/GS", "savez", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.saveAlpha, "EmuCore/GS", "savea", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.saveInfo, "EmuCore/GS", "savei", false);
-	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.startDraw, "EmuCore/GS", "saven", 0);
-	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.drawDumpCount, "EmuCore/GS", "savel", 5000);
-	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.startFrame, "EmuCore/GS", "savenf", 0);
-	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.frameDumpCount, "EmuCore/GS", "savelf", 5000);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.dumpGSData, "EmuCore/GS", "DumpGSData", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.saveRT, "EmuCore/GS", "SaveRT", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.saveFrame, "EmuCore/GS", "SaveFrame", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.saveTexture, "EmuCore/GS", "SaveTexture", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.saveDepth, "EmuCore/GS", "SaveDepth", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.saveAlpha, "EmuCore/GS", "SaveAlpha", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.saveInfo, "EmuCore/GS", "SaveInfo", false);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.saveDrawStart, "EmuCore/GS", "SaveDrawStart", 0);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.saveDrawCount, "EmuCore/GS", "SaveDrawCount", 5000);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.saveFrameStart, "EmuCore/GS", "SaveFrameStart", 0);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.saveFrameCount, "EmuCore/GS", "SaveFrameCount", 999999);
 	SettingWidgetBinder::BindWidgetToFolderSetting(
 		sif, m_ui.hwDumpDirectory, m_ui.hwDumpBrowse, m_ui.hwDumpOpen, nullptr, "EmuCore/GS", "HWDumpDirectory", std::string(), false);
 	SettingWidgetBinder::BindWidgetToFolderSetting(
 		sif, m_ui.swDumpDirectory, m_ui.swDumpBrowse, m_ui.swDumpOpen, nullptr, "EmuCore/GS", "SWDumpDirectory", std::string(), false);
 
-	connect(m_ui.dumpGSDraws, &QCheckBox::checkStateChanged, this, &DebugSettingsWidget::onDrawDumpingChanged);
+	connect(m_ui.dumpGSData, &QCheckBox::checkStateChanged, this, &DebugSettingsWidget::onDrawDumpingChanged);
 	onDrawDumpingChanged();
 
 #ifdef PCSX2_DEVBUILD
@@ -150,17 +150,17 @@ DebugSettingsWidget::~DebugSettingsWidget() = default;
 
 void DebugSettingsWidget::onDrawDumpingChanged()
 {
-	const bool enabled = m_dialog->getEffectiveBoolValue("EmuCore/GS", "dump", false);
+	const bool enabled = m_dialog->getEffectiveBoolValue("EmuCore/GS", "DumpGSData", false);
 	m_ui.saveRT->setEnabled(enabled);
 	m_ui.saveFrame->setEnabled(enabled);
 	m_ui.saveTexture->setEnabled(enabled);
 	m_ui.saveDepth->setEnabled(enabled);
 	m_ui.saveAlpha->setEnabled(enabled);
 	m_ui.saveInfo->setEnabled(enabled);
-	m_ui.startDraw->setEnabled(enabled);
-	m_ui.drawDumpCount->setEnabled(enabled);
-	m_ui.startFrame->setEnabled(enabled);
-	m_ui.frameDumpCount->setEnabled(enabled);
+	m_ui.saveDrawStart->setEnabled(enabled);
+	m_ui.saveDrawCount->setEnabled(enabled);
+	m_ui.saveFrameStart->setEnabled(enabled);
+	m_ui.saveFrameCount->setEnabled(enabled);
 	m_ui.hwDumpDirectory->setEnabled(enabled);
 	m_ui.hwDumpBrowse->setEnabled(enabled);
 	m_ui.hwDumpOpen->setEnabled(enabled);

--- a/pcsx2-qt/Settings/DebugSettingsWidget.ui
+++ b/pcsx2-qt/Settings/DebugSettingsWidget.ui
@@ -161,7 +161,7 @@
           <item row="0" column="0" colspan="2">
            <layout class="QGridLayout" name="gridLayout">
             <item row="0" column="0">
-             <widget class="QCheckBox" name="dumpGSDraws">
+             <widget class="QCheckBox" name="dumpGSData">
               <property name="text">
                <string>Dump GS Draws</string>
               </property>
@@ -214,12 +214,12 @@
           <item row="1" column="0">
            <widget class="QLabel" name="label_1">
             <property name="text">
-             <string>Start Draw Number:</string>
+             <string>Save Draw Start:</string>
             </property>
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QSpinBox" name="startDraw">
+           <widget class="QSpinBox" name="saveDrawStart">
             <property name="maximum">
              <number>99999999</number>
             </property>
@@ -228,12 +228,12 @@
           <item row="2" column="0">
            <widget class="QLabel" name="label_2">
             <property name="text">
-             <string>Draw Dump Count:</string>
+             <string>Save Draw Count:</string>
             </property>
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QSpinBox" name="drawDumpCount">
+           <widget class="QSpinBox" name="saveDrawCount">
             <property name="minimum">
              <number>1</number>
             </property>
@@ -245,12 +245,12 @@
           <item row="3" column="0">
            <widget class="QLabel" name="label_3">
             <property name="text">
-             <string>Start Frame Number:</string>
+             <string>Save Frame Start:</string>
             </property>
            </widget>
           </item>
           <item row="3" column="1">
-           <widget class="QSpinBox" name="startFrame">
+           <widget class="QSpinBox" name="saveFrameStart">
             <property name="maximum">
              <number>99999999</number>
             </property>
@@ -259,12 +259,12 @@
           <item row="4" column="0">
            <widget class="QLabel" name="label_4">
             <property name="text">
-             <string>Frame Dump Count:</string>
+             <string>Save Frame Count:</string>
             </property>
            </widget>
           </item>
           <item row="4" column="1">
-           <widget class="QSpinBox" name="frameDumpCount">
+           <widget class="QSpinBox" name="saveFrameCount">
             <property name="minimum">
              <number>1</number>
             </property>

--- a/pcsx2-qt/Settings/DebugSettingsWidget.ui
+++ b/pcsx2-qt/Settings/DebugSettingsWidget.ui
@@ -195,10 +195,24 @@
               </property>
              </widget>
             </item>
+            <item row="3" column="0">
+              <widget class="QCheckBox" name="saveAlpha">
+                <property name="text">
+                 <string>Save Alpha</string>
+                </property>
+              </widget>
+            </item>
+            <item row="3" column="1">
+              <widget class="QCheckBox" name="saveInfo">
+                <property name="text">
+                 <string>Save Info</string>
+                </property>
+              </widget>
+            </item>
            </layout>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="label">
+           <widget class="QLabel" name="label_1">
             <property name="text">
              <string>Start Draw Number:</string>
             </property>
@@ -219,7 +233,7 @@
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QSpinBox" name="dumpCount">
+           <widget class="QSpinBox" name="drawDumpCount">
             <property name="minimum">
              <number>1</number>
             </property>
@@ -231,39 +245,49 @@
           <item row="3" column="0">
            <widget class="QLabel" name="label_3">
             <property name="text">
-             <string>Hardware Dump Directory:</string>
+             <string>Start Frame Number:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QSpinBox" name="startFrame">
+            <property name="maximum">
+             <number>99999999</number>
             </property>
            </widget>
           </item>
           <item row="4" column="0">
            <widget class="QLabel" name="label_4">
             <property name="text">
-             <string>Software Dump Directory:</string>
+             <string>Frame Dump Count:</string>
             </property>
            </widget>
           </item>
           <item row="4" column="1">
-           <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="1,0,0">
-            <item>
-             <widget class="QLineEdit" name="swDumpDirectory"/>
-            </item>
-            <item>
-             <widget class="QPushButton" name="swDumpBrowse">
-              <property name="text">
-               <string>Browse...</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="swDumpOpen">
-              <property name="text">
-               <string>Open...</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
+           <widget class="QSpinBox" name="frameDumpCount">
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>99999999</number>
+            </property>
+           </widget>
           </item>
-          <item row="3" column="1">
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Hardware Dump Directory:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>Software Dump Directory:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
            <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0,0">
             <item>
              <widget class="QLineEdit" name="hwDumpDirectory"/>
@@ -277,6 +301,27 @@
             </item>
             <item>
              <widget class="QPushButton" name="hwDumpOpen">
+              <property name="text">
+               <string>Open...</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="6" column="1">
+           <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="1,0,0">
+            <item>
+             <widget class="QLineEdit" name="swDumpDirectory"/>
+            </item>
+            <item>
+             <widget class="QPushButton" name="swDumpBrowse">
+              <property name="text">
+               <string>Browse...</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="swDumpOpen">
               <property name="text">
                <string>Open...</string>
               </property>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -822,12 +822,12 @@ struct Pcsx2Config
 		u16 SWExtraThreads = 2;
 		u16 SWExtraThreadsHeight = 4;
 
-		int SaveN = 0;
-		int SaveL = 5000;
-		int SaveB = 1;
-		int SaveNF = 0;
-		int SaveLF = -1;
-		int SaveBF = 1;
+		int SaveDrawStart = 0;
+		int SaveDrawCount = 5000;
+		int SaveDrawBy = 1;
+		int SaveFrameStart = 0;
+		int SaveFrameCount = -1;
+		int SaveFrameBy = 1;
 
 		s8 ExclusiveFullscreenControl = -1;
 		GSScreenshotSize ScreenshotSize = GSScreenshotSize::WindowResolution;

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -838,12 +838,12 @@ bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 		OpEqu(ShadeBoost_Contrast) &&
 		OpEqu(ShadeBoost_Saturation) &&
 		OpEqu(PNGCompressionLevel) &&
-		OpEqu(SaveN) &&
-		OpEqu(SaveL) &&
-		OpEqu(SaveB) &&
-		OpEqu(SaveNF) &&
-		OpEqu(SaveLF) &&
-		OpEqu(SaveBF) &&
+		OpEqu(SaveDrawStart) &&
+		OpEqu(SaveDrawCount) &&
+		OpEqu(SaveDrawBy) &&
+		OpEqu(SaveFrameStart) &&
+		OpEqu(SaveFrameCount) &&
+		OpEqu(SaveFrameBy) &&
 
 		OpEqu(ExclusiveFullscreenControl) &&
 		OpEqu(ScreenshotSize) &&
@@ -965,13 +965,13 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitBoolEx(UserHacks_EstimateTextureRegion, "UserHacks_EstimateTextureRegion");
 	SettingsWrapBitBoolEx(FXAA, "fxaa");
 	SettingsWrapBitBool(ShadeBoost);
-	SettingsWrapBitBoolEx(DumpGSData, "dump");
-	SettingsWrapBitBoolEx(SaveRT, "save");
-	SettingsWrapBitBoolEx(SaveFrame, "savef");
-	SettingsWrapBitBoolEx(SaveTexture, "savet");
-	SettingsWrapBitBoolEx(SaveDepth, "savez");
-	SettingsWrapBitBoolEx(SaveAlpha, "savea");
-	SettingsWrapBitBoolEx(SaveInfo, "savei");
+	SettingsWrapBitBoolEx(DumpGSData, "DumpGSData");
+	SettingsWrapBitBoolEx(SaveRT, "SaveRT");
+	SettingsWrapBitBoolEx(SaveFrame, "SaveFrame");
+	SettingsWrapBitBoolEx(SaveTexture, "SaveTexture");
+	SettingsWrapBitBoolEx(SaveDepth, "SaveDepth");
+	SettingsWrapBitBoolEx(SaveAlpha, "SaveAlpha");
+	SettingsWrapBitBoolEx(SaveInfo, "SaveInfo");
 	SettingsWrapBitBool(DumpReplaceableTextures);
 	SettingsWrapBitBool(DumpReplaceableMipmaps);
 	SettingsWrapBitBool(DumpTexturesWithFMVActive);
@@ -1030,12 +1030,12 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitfield(ShadeBoost_Saturation);
 	SettingsWrapBitfield(ExclusiveFullscreenControl);
 	SettingsWrapBitfieldEx(PNGCompressionLevel, "png_compression_level");
-	SettingsWrapBitfieldEx(SaveN, "saven");
-	SettingsWrapBitfieldEx(SaveL, "savel");
-	SettingsWrapBitfieldEx(SaveB, "saveb");
-	SettingsWrapBitfieldEx(SaveNF, "savenf");
-	SettingsWrapBitfieldEx(SaveLF, "savelf");
-	SettingsWrapBitfieldEx(SaveBF, "savebf");
+	SettingsWrapBitfieldEx(SaveDrawStart, "SaveDrawStart");
+	SettingsWrapBitfieldEx(SaveDrawCount, "SaveDrawCount");
+	SettingsWrapBitfieldEx(SaveDrawBy, "SaveDrawBy");
+	SettingsWrapBitfieldEx(SaveFrameStart, "SaveFrameStart");
+	SettingsWrapBitfieldEx(SaveFrameCount, "SaveFrameCount");
+	SettingsWrapBitfieldEx(SaveFrameBy, "SaveFrameBy");
 
 	SettingsWrapEntryEx(CaptureContainer, "CaptureContainer");
 	SettingsWrapEntryEx(VideoCaptureCodec, "VideoCaptureCodec");
@@ -1122,9 +1122,11 @@ bool Pcsx2Config::GSOptions::UseHardwareRenderer() const
 
 bool Pcsx2Config::GSOptions::ShouldDump(int draw, int frame) const
 {
+	int drawOffset = draw - SaveDrawStart;
+	int frameOffset = frame - SaveFrameStart;
 	return DumpGSData &&
-		(SaveN <= draw) && ((SaveL < 0) || (draw < SaveN + SaveL)) && (draw % SaveB == 0) &&
-		(SaveNF <= frame) && ((SaveLF < 0) || (frame < SaveNF + SaveLF)) && (frame % SaveBF == 0);
+		   (drawOffset >= 0) && ((SaveDrawCount < 0) || (drawOffset < SaveDrawCount)) && (drawOffset % SaveDrawBy == 0) &&
+		   (frameOffset >= 0) && ((SaveFrameCount < 0) || (frameOffset < SaveFrameCount)) && (frameOffset % SaveFrameBy == 0);
 }
 
 static constexpr const std::array s_spu2_sync_mode_names = {


### PR DESCRIPTION
### Description of Changes
Add UI elements for options to control dumping of GS data in the System/Settings/Debug/GS menu. Specifically: SaveInfo, SaveAlpha, Start Frame Number, Frame Dump Count. Note: This is a quick (but hopefully not dirty) PR to add the missing functionality that I intend to improve in a followup PR.

### Rationale behind Changes
I forgot to add these in a previous PR that added the said options.

### Suggested Testing Steps
Run any game and use the options mentioned above in the menubar System/Settings/Debug/GS (after enabling advanced settings in the menubar Tools/Show Advanced Settings).
