### PR TITLE
Build/VS: Fix change in latest VS 2022 update with std::chrono

### DIFF
--- a/pcsx2/SIO/Memcard/MemoryCardFolder.cpp
+++ b/pcsx2/SIO/Memcard/MemoryCardFolder.cpp
@@ -24,6 +24,7 @@
 #include <sstream>
 #include <mutex>
 #include <optional>
+#include <chrono>
 
 // A helper function to parse the YAML file
 static std::optional<ryml::Tree> loadYamlFile(const char* filePath)


### PR DESCRIPTION
Fixes building in the latest Visual Studio 2022 update.

For more information see: https://learn.microsoft.com/en-us/cpp/overview/what-s-new-for-visual-cpp-in-visual-studio?view=msvc-170#:~:text=Moved%20system_clock%2C%20high_resolution_clock%2C%20and%20chrono_literals%20from%20a%20commonly%20included%20internal%20header%20to%20%3Cchrono%3E.%20If%20you%20see%20compiler%20errors%20that%20types%20like%20system_clock%20or%20user%2Ddefined%20literals%20like%201729ms%20aren%27t%20recognized%2C%20include%20%3Cchrono%3E.
