### PR TITLE
SDL Audio: Set app name hint

### DIFF
--- a/pcsx2/Host/SDLAudioStream.cpp
+++ b/pcsx2/Host/SDLAudioStream.cpp
@@ -37,6 +37,9 @@ static bool InitializeSDLAudio(Error* error)
 	if (initialized)
 		return true;
 
+	// Set the name that shows up in the audio mixers on some platforms
+	SDL_SetHint("SDL_AUDIO_DEVICE_APP_NAME", "PCSX2");
+
 	// May as well keep it alive until the process exits.
 	if (SDL_InitSubSystem(SDL_INIT_AUDIO) != 0)
 	{


### PR DESCRIPTION
### Description of Changes
Tells SDL to name our audio output stream "PCSX2".

### Rationale behind Changes
SDL and cubeb backends previously resulted in different names for the output which caused them be identified as different applications by the OS.

### Suggested Testing Steps
Check that the application name in the system volume mixer is as expected.
