### PR TITLE
Qt: Add AMOLED Theme

### DIFF
--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -36,6 +36,8 @@ const char* InterfaceSettingsWidget::THEME_NAMES[] = {
 	//: Ignore what Crowdin says in this string about "[Light]/[Dark]" being untouchable here, these are not variables in this case and must be translated.
 	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Cobalt Sky (Blue) [Dark]"),
 	//: Ignore what Crowdin says in this string about "[Light]/[Dark]" being untouchable here, these are not variables in this case and must be translated.
+	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "AMOLED (Black) [Dark]"),
+	//: Ignore what Crowdin says in this string about "[Light]/[Dark]" being untouchable here, these are not variables in this case and must be translated.
 	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Ruby (Black/Red) [Dark]"),
 	//: Ignore what Crowdin says in this string about "[Light]/[Dark]" being untouchable here, these are not variables in this case and must be translated.
 	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Sapphire (Black/Blue) [Dark]"),
@@ -61,6 +63,7 @@ const char* InterfaceSettingsWidget::THEME_VALUES[] = {
 	"ScarletDevilRed",
 	"VioletAngelPurple",
 	"CobaltSky",
+	"AMOLED",
 	"Ruby",
 	"Sapphire",
 	"Emerald",

--- a/pcsx2-qt/Themes.cpp
+++ b/pcsx2-qt/Themes.cpp
@@ -280,7 +280,7 @@ void QtHost::SetStyleFromSettings()
 		pizzaPalette.setColor(QPalette::Link, highlight.darker());
 		pizzaPalette.setColor(QPalette::Highlight, highlight);
 		pizzaPalette.setColor(QPalette::HighlightedText, Qt::white);
-		
+
 		pizzaPalette.setColor(QPalette::Active, QPalette::Button, extr);
 		pizzaPalette.setColor(QPalette::Disabled, QPalette::ButtonText, gray.darker());
 		pizzaPalette.setColor(QPalette::Disabled, QPalette::WindowText, gray.darker());
@@ -426,6 +426,42 @@ void QtHost::SetStyleFromSettings()
 		cobaltSkyPalette.setColor(QPalette::Disabled, QPalette::Light, gray);
 
 		qApp->setPalette(cobaltSkyPalette);
+		qApp->setStyleSheet(QString());
+	}
+	else if (theme == "AMOLED")
+	{
+		// Custom palette by KamFretoZ, A pure concentrated darkness
+		// of a theme designed for maximum eye comfort and benefits
+		// OLED screens.
+		qApp->setStyle(QStyleFactory::create("Fusion"));
+
+		const QColor black(0, 0, 0);
+		const QColor gray(25, 25, 25);
+		const QColor lighterGray(75, 75, 75);
+		const QColor blue(198, 238, 255);
+
+		QPalette AMOLEDPalette;
+		AMOLEDPalette.setColor(QPalette::Window, black);
+		AMOLEDPalette.setColor(QPalette::WindowText, Qt::white);
+		AMOLEDPalette.setColor(QPalette::Base, gray);
+		AMOLEDPalette.setColor(QPalette::AlternateBase, black);
+		AMOLEDPalette.setColor(QPalette::ToolTipBase, gray);
+		AMOLEDPalette.setColor(QPalette::ToolTipText, Qt::white);
+		AMOLEDPalette.setColor(QPalette::Text, Qt::white);
+		AMOLEDPalette.setColor(QPalette::Button, gray);
+		AMOLEDPalette.setColor(QPalette::ButtonText, Qt::white);
+		AMOLEDPalette.setColor(QPalette::Link, blue);
+		AMOLEDPalette.setColor(QPalette::Highlight, lighterGray);
+		AMOLEDPalette.setColor(QPalette::HighlightedText, Qt::white);
+		AMOLEDPalette.setColor(QPalette::PlaceholderText, QColor(Qt::white).darker());
+
+		AMOLEDPalette.setColor(QPalette::Active, QPalette::Button, gray);
+		AMOLEDPalette.setColor(QPalette::Disabled, QPalette::ButtonText, QColor(Qt::white).darker());
+		AMOLEDPalette.setColor(QPalette::Disabled, QPalette::WindowText, QColor(Qt::white).darker());
+		AMOLEDPalette.setColor(QPalette::Disabled, QPalette::Text, QColor(Qt::white).darker());
+		AMOLEDPalette.setColor(QPalette::Disabled, QPalette::Light, QColor(Qt::white).darker());
+
+		qApp->setPalette(AMOLEDPalette);
 		qApp->setStyleSheet(QString());
 	}
 	else if (theme == "Ruby")


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
This PR adds a new pitch black theme.

Aiming for less eye-straining and flash-banging also helps with OLED screens.

Preview:
![image](https://github.com/user-attachments/assets/a45eb9f4-c0f7-46e4-b0d6-65e98b0e19e2)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
For those who wants darker than dark mode theme.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Check if it looks good and if usability isn't affected in a negative way.