### PR TITLE
Qt: Add mouse grab/lock feature when PCSX2 is in focus

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -168,6 +168,7 @@ else()
 		${DBUS_LINK_LIBRARIES}
 		X11::X11
 		X11::Xrandr
+		X11::Xi
 	)
 	if(USE_BACKTRACE)
 		target_compile_definitions(common PRIVATE "HAS_LIBBACKTRACE=1")

--- a/common/HostSys.h
+++ b/common/HostSys.h
@@ -6,6 +6,7 @@
 #include "common/Pcsx2Defs.h"
 
 #include <atomic>
+#include <functional>
 #include <map>
 #include <memory>
 #include <string>
@@ -198,4 +199,8 @@ namespace Common
 	/// Abstracts platform-specific code for asynchronously playing a sound.
 	/// On Windows, this will use PlaySound(). On Linux, it will shell out to aplay. On MacOS, it uses NSSound.
 	bool PlaySoundAsync(const char* path);
+
+	void SetMousePosition(int x, int y);
+	bool AttachMousePositionCb(std::function<void(int,int)> cb);
+	void DetachMousePositionCb();
 } // namespace Common

--- a/common/Linux/LnxMisc.cpp
+++ b/common/Linux/LnxMisc.cpp
@@ -13,17 +13,20 @@
 
 #include "fmt/format.h"
 
-#include <ctype.h>
-#include <time.h>
-#include <unistd.h>
-#include <optional>
+#include <dbus/dbus.h>
 #include <spawn.h>
 #include <sys/time.h>
 #include <sys/wait.h>
 #include <unistd.h>
-#include <dbus/dbus.h>
+#include <X11/Xlib.h>
+#include <X11/extensions/XInput2.h>
+
 #include <cstdlib>
 #include <cstring>
+#include <ctime>
+#include <ctype.h>
+#include <optional>
+#include <thread>
 
 // Returns 0 on failure (not supported by the operating system).
 u64 GetPhysicalMemory()
@@ -175,6 +178,111 @@ static bool SetScreensaverInhibitDBus(const bool inhibit_requested, const char* 
 bool Common::InhibitScreensaver(bool inhibit)
 {
 	return SetScreensaverInhibitDBus(inhibit, "PCSX2", "PCSX2 VM is running.");
+}
+
+void Common::SetMousePosition(int x, int y)
+{
+	Display* display = XOpenDisplay(nullptr);
+	if (!display)
+		return;
+
+	Window root = DefaultRootWindow(display);
+	XWarpPointer(display, None, root, 0, 0, 0, 0, x, y);
+	XFlush(display);
+
+	XCloseDisplay(display);
+}
+
+static std::function<void(int, int)> fnMouseMoveCb;
+static std::atomic<bool> trackingMouse = false;
+static std::thread mouseThread;
+
+void mouseEventLoop()
+{
+	Threading::SetNameOfCurrentThread("X11 Mouse Thread");
+	Display* display = XOpenDisplay(nullptr);
+	if (!display)
+	{
+		return;
+	}
+
+	int opcode, eventcode, error;
+	if (!XQueryExtension(display, "XInputExtension", &opcode, &eventcode, &error))
+	{
+		XCloseDisplay(display);
+		return;
+	}
+
+	const Window root = DefaultRootWindow(display);
+	XIEventMask evmask;
+	unsigned char mask[(XI_LASTEVENT + 7) / 8] = {0};
+
+	evmask.deviceid = XIAllDevices;
+	evmask.mask_len = sizeof(mask);
+	evmask.mask = mask;
+	XISetMask(mask, XI_RawMotion);
+
+	XISelectEvents(display, root, &evmask, 1);
+	XSync(display, False);
+
+	XEvent event;
+	while (trackingMouse)
+	{
+		// XNextEvent is blocking, this is a zombie process risk if no events arrive
+		// while we are trying to shutdown.
+		// https://nrk.neocities.org/articles/x11-timeout-with-xsyncalarm might be
+		// a better solution than using XPending.
+		if (!XPending(display))
+		{
+			Threading::Sleep(1);
+			Threading::SpinWait();
+			continue;
+		}
+
+		XNextEvent(display, &event);
+		if (event.xcookie.type == GenericEvent &&
+			event.xcookie.extension == opcode &&
+			XGetEventData(display, &event.xcookie))
+		{
+			XIRawEvent* raw_event = reinterpret_cast<XIRawEvent*>(event.xcookie.data);
+			if (raw_event->evtype == XI_RawMotion)
+			{
+				Window w;
+				int root_x, root_y, win_x, win_y;
+				unsigned int mask;
+				XQueryPointer(display, root, &w, &w, &root_x, &root_y, &win_x, &win_y, &mask);
+
+				if (fnMouseMoveCb)
+					fnMouseMoveCb(root_x, root_y);
+			}
+			XFreeEventData(display, &event.xcookie);
+		}
+	}
+
+	XCloseDisplay(display);
+}
+
+bool Common::AttachMousePositionCb(std::function<void(int, int)> cb)
+{
+	fnMouseMoveCb = cb;
+
+	if (trackingMouse)
+		return true;
+
+	trackingMouse = true;
+	mouseThread = std::thread(mouseEventLoop);
+	mouseThread.detach();
+	return true;
+}
+
+void Common::DetachMousePositionCb()
+{
+	trackingMouse = false;
+	fnMouseMoveCb = nullptr;
+	if (mouseThread.joinable())
+	{
+		mouseThread.join();
+	}
 }
 
 bool Common::PlaySoundAsync(const char* path)

--- a/common/Windows/WinMisc.cpp
+++ b/common/Windows/WinMisc.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
 // SPDX-License-Identifier: GPL-3.0+
 
+#include "common/Console.h"
 #include "common/FileSystem.h"
 #include "common/HostSys.h"
 #include "common/RedtapeWindows.h"
@@ -84,6 +85,61 @@ bool Common::InhibitScreensaver(bool inhibit)
 		flags |= ES_DISPLAY_REQUIRED;
 	SetThreadExecutionState(flags);
 	return true;
+}
+
+void Common::SetMousePosition(int x, int y)
+{
+	SetCursorPos(x, y);
+}
+
+/*
+static HHOOK mouseHook = nullptr;
+static std::function<void(int, int)> fnMouseMoveCb;
+LRESULT CALLBACK Mousecb(int nCode, WPARAM wParam, LPARAM lParam)
+{
+	if (nCode >= 0 && wParam == WM_MOUSEMOVE)
+	{
+		MSLLHOOKSTRUCT* mouse = (MSLLHOOKSTRUCT*)lParam;
+		fnMouseMoveCb(mouse->pt.x, mouse->pt.y);
+	}
+	return CallNextHookEx(mouseHook, nCode, wParam, lParam);
+}
+*/
+
+// This (and the above) works, but is not recommended on Windows and is only here for consistency.
+// Defer to using raw input instead.
+bool Common::AttachMousePositionCb(std::function<void(int, int)> cb)
+{
+	/*
+		if (mouseHook)
+			Common::DetachMousePositionCb();
+
+		fnMouseMoveCb = cb;
+		mouseHook = SetWindowsHookEx(WH_MOUSE_LL, Mousecb, GetModuleHandle(NULL), 0);
+		if (!mouseHook)
+		{
+			Console.Warning("Failed to set mouse hook: %d", GetLastError());
+			return false;
+		}
+
+		#if defined(PCSX2_DEBUG) || defined(PCSX2_DEVBUILD)
+			static bool warned = false;
+			if (!warned)
+			{
+				Console.Warning("Mouse hooks are enabled, and this isn't a release build! Using a debugger, or loading symbols, _will_ stall the hook and cause global mouse lag.");
+				warned = true;
+			}
+		#endif
+	*/
+	return true;
+}
+
+void Common::DetachMousePositionCb()
+{
+	/*
+		UnhookWindowsHookEx(mouseHook);
+		mouseHook = nullptr;
+	*/
 }
 
 bool Common::PlaySoundAsync(const char* path)

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -128,7 +128,7 @@ private Q_SLOTS:
 	void mouseModeRequested(bool relative_mode, bool hide_cursor);
 	void releaseRenderWindow();
 	void focusDisplayWidget();
-
+	void createCheckMousePositionTimer();
 	void onGameListRefreshComplete();
 	void onGameListRefreshProgress(const QString& status, int current, int total);
 	void onGameListSelectionChanged();
@@ -180,12 +180,13 @@ private Q_SLOTS:
 	void onInputRecPlayActionTriggered();
 	void onInputRecStopActionTriggered();
 	void onInputRecOpenViewer();
-
 	void onVMStarting();
 	void onVMStarted();
 	void onVMPaused();
 	void onVMResumed();
 	void onVMStopped();
+
+	void checkMousePosition();
 
 	void onGameChanged(const QString& title, const QString& elf_override, const QString& disc_path,
 		const QString& serial, quint32 disc_crc, quint32 crc);
@@ -204,6 +205,7 @@ protected:
 	void dropEvent(QDropEvent* event) override;
 	void moveEvent(QMoveEvent* event) override;
 	void resizeEvent(QResizeEvent* event) override;
+	void mouseMoveEvent(QMouseEvent* event) override;
 
 #ifdef _WIN32
 	bool nativeEvent(const QByteArray& eventType, void* message, qintptr* result) override;
@@ -238,6 +240,7 @@ private:
 	bool isRenderingToMain() const;
 	bool shouldHideMouseCursor() const;
 	bool shouldHideMainWindow() const;
+	bool shouldMouseGrab() const;
 	void switchToGameListView();
 	void switchToEmulationView();
 
@@ -309,6 +312,8 @@ private:
 	bool m_is_temporarily_windowed = false;
 
 	QString m_last_fps_status;
+
+	QTimer* m_mouse_check_timer = nullptr;
 
 #ifdef _WIN32
 	void* m_device_notification_handle = nullptr;

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -104,7 +104,7 @@ public:
 	void rescanFile(const std::string& path);
 
 	void openDebugger();
-
+	void checkMousePosition(int x, int y);
 public Q_SLOTS:
 	void checkForUpdates(bool display_message, bool force_check);
 	void refreshGameList(bool invalidate_cache);
@@ -128,7 +128,7 @@ private Q_SLOTS:
 	void mouseModeRequested(bool relative_mode, bool hide_cursor);
 	void releaseRenderWindow();
 	void focusDisplayWidget();
-	void createCheckMousePositionTimer();
+	void setupMouseMoveHandler();
 	void onGameListRefreshComplete();
 	void onGameListRefreshProgress(const QString& status, int current, int total);
 	void onGameListSelectionChanged();
@@ -186,8 +186,6 @@ private Q_SLOTS:
 	void onVMResumed();
 	void onVMStopped();
 
-	void checkMousePosition();
-
 	void onGameChanged(const QString& title, const QString& elf_override, const QString& disc_path,
 		const QString& serial, quint32 disc_crc, quint32 crc);
 
@@ -205,7 +203,6 @@ protected:
 	void dropEvent(QDropEvent* event) override;
 	void moveEvent(QMoveEvent* event) override;
 	void resizeEvent(QResizeEvent* event) override;
-	void mouseMoveEvent(QMouseEvent* event) override;
 
 #ifdef _WIN32
 	bool nativeEvent(const QByteArray& eventType, void* message, qintptr* result) override;
@@ -240,7 +237,7 @@ private:
 	bool isRenderingToMain() const;
 	bool shouldHideMouseCursor() const;
 	bool shouldHideMainWindow() const;
-	bool shouldMouseGrab() const;
+	bool shouldMouseLock() const;
 	void switchToGameListView();
 	void switchToEmulationView();
 
@@ -312,8 +309,6 @@ private:
 	bool m_is_temporarily_windowed = false;
 
 	QString m_last_fps_status;
-
-	QTimer* m_mouse_check_timer = nullptr;
 
 #ifdef _WIN32
 	void* m_device_notification_handle = nullptr;

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -3,6 +3,7 @@
 
 #include "InterfaceSettingsWidget.h"
 #include "AutoUpdaterDialog.h"
+#include "Common.h"
 #include "MainWindow.h"
 #include "SettingWidgetBinder.h"
 #include "SettingsWindow.h"
@@ -80,8 +81,13 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsWindow* dialog, QWidget
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.pauseOnControllerDisconnection, "UI", "PauseOnControllerDisconnection", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.discordPresence, "EmuCore", "EnableDiscordPresence", false);
 
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.mouseGrab, "EmuCore", "EnableMouseGrab", false);
-
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.mouseLock, "EmuCore", "EnableMouseLock", false);
+	connect(m_ui.mouseLock, &QCheckBox::checkStateChanged, [](Qt::CheckState state) {
+		if (state == Qt::Checked)
+			Common::AttachMousePositionCb([](int x, int y) { g_main_window->checkMousePosition(x, y); });
+		else
+			Common::DetachMousePositionCb();
+	});
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.startFullscreen, "UI", "StartFullscreen", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.doubleClickTogglesFullscreen, "UI", "DoubleClickTogglesFullscreen",
 		true);
@@ -164,8 +170,13 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsWindow* dialog, QWidget
 		m_ui.discordPresence, tr("Enable Discord Presence"), tr("Unchecked"),
 		tr("Shows the game you are currently playing as part of your profile in Discord."));
 	dialog->registerWidgetHelp(
+<<<<<<< Updated upstream
 		m_ui.mouseGrab, tr("Enable Mouse Grab"), tr("Unchecked"),
 		tr("Locks the mouse cursor to the windows when PCSX2 is in focus."));
+=======
+		m_ui.mouseLock, tr("Enable Mouse Lock"), tr("Unchecked"),
+		tr("Locks the mouse cursor to the windows when PCSX2 is in focus and all other windows are closed.<br><b>Unavailable on Linux Wayland.</b><br><b>Requires accessibility permissions on macOS.</b>"));
+>>>>>>> Stashed changes
 	dialog->registerWidgetHelp(
 		m_ui.doubleClickTogglesFullscreen, tr("Double-Click Toggles Fullscreen"), tr("Checked"),
 		tr("Allows switching in and out of fullscreen mode by double-clicking the game window."));

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -80,6 +80,8 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsWindow* dialog, QWidget
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.pauseOnControllerDisconnection, "UI", "PauseOnControllerDisconnection", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.discordPresence, "EmuCore", "EnableDiscordPresence", false);
 
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.mouseGrab, "EmuCore", "EnableMouseGrab", false);
+
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.startFullscreen, "UI", "StartFullscreen", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.doubleClickTogglesFullscreen, "UI", "DoubleClickTogglesFullscreen",
 		true);
@@ -161,6 +163,9 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsWindow* dialog, QWidget
 	dialog->registerWidgetHelp(
 		m_ui.discordPresence, tr("Enable Discord Presence"), tr("Unchecked"),
 		tr("Shows the game you are currently playing as part of your profile in Discord."));
+	dialog->registerWidgetHelp(
+		m_ui.mouseGrab, tr("Enable Mouse Grab"), tr("Unchecked"),
+		tr("Locks the mouse cursor to the windows when PCSX2 is in focus."));
 	dialog->registerWidgetHelp(
 		m_ui.doubleClickTogglesFullscreen, tr("Double-Click Toggles Fullscreen"), tr("Checked"),
 		tr("Allows switching in and out of fullscreen mode by double-clicking the game window."));

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -170,13 +170,8 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsWindow* dialog, QWidget
 		m_ui.discordPresence, tr("Enable Discord Presence"), tr("Unchecked"),
 		tr("Shows the game you are currently playing as part of your profile in Discord."));
 	dialog->registerWidgetHelp(
-<<<<<<< Updated upstream
-		m_ui.mouseGrab, tr("Enable Mouse Grab"), tr("Unchecked"),
-		tr("Locks the mouse cursor to the windows when PCSX2 is in focus."));
-=======
 		m_ui.mouseLock, tr("Enable Mouse Lock"), tr("Unchecked"),
 		tr("Locks the mouse cursor to the windows when PCSX2 is in focus and all other windows are closed.<br><b>Unavailable on Linux Wayland.</b><br><b>Requires accessibility permissions on macOS.</b>"));
->>>>>>> Stashed changes
 	dialog->registerWidgetHelp(
 		m_ui.doubleClickTogglesFullscreen, tr("Double-Click Toggles Fullscreen"), tr("Checked"),
 		tr("Allows switching in and out of fullscreen mode by double-clicking the game window."));

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
@@ -50,6 +50,13 @@
         </property>
        </widget>
       </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="mouseGrab">
+        <property name="text">
+         <string>Enable Mouse Grab</string>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="1">
        <widget class="QCheckBox" name="pauseOnStart">
         <property name="text">

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
@@ -51,9 +51,9 @@
        </widget>
       </item>
       <item row="3" column="0">
-       <widget class="QCheckBox" name="mouseGrab">
+       <widget class="QCheckBox" name="mouseLock">
         <property name="text">
-         <string>Enable Mouse Grab</string>
+         <string>Enable Mouse Lock</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
### Description of Changes
Continuation of #12239 but instead if polling, use event based systems.

### Rationale behind Changes
See the original PR
Fixes: #11902

### Suggested Testing Steps
See the original PR

Note that this does not work on Wayland. Possibly myself or someone else can implement something regarding zwp_pointer_constraints_v1.