### PR TITLE
Core: Accurate clip instruction

### DIFF
--- a/common/emitter/implement/simd_moremovs.h
+++ b/common/emitter/implement/simd_moremovs.h
@@ -119,6 +119,12 @@ namespace x86Emitter
 		xImplSimd_DestRegSSE VPD;
 	};
 
+	struct xImplSimd_PBlend
+	{
+		xImplSimd_DestRegImmSSE W;
+		xImplSimd_DestRegSSE VB;
+	};
+
 	// --------------------------------------------------------------------------------------
 	//  xImplSimd_PMove
 	// --------------------------------------------------------------------------------------

--- a/common/emitter/instructions.h
+++ b/common/emitter/instructions.h
@@ -500,6 +500,7 @@ namespace x86Emitter
 	extern const xImplSimd_MovHL_RtoR xMOVLH;
 	extern const xImplSimd_MovHL_RtoR xMOVHL;
 
+	extern const xImplSimd_PBlend xPBLEND;
 	extern const xImplSimd_Blend xBLEND;
 	extern const xImplSimd_PMove xPMOVSX;
 	extern const xImplSimd_PMove xPMOVZX;

--- a/common/emitter/simd.cpp
+++ b/common/emitter/simd.cpp
@@ -556,12 +556,18 @@ namespace x86Emitter
 	const xImplSimd_MovHL_RtoR xMOVLH = {0x16};
 	const xImplSimd_MovHL_RtoR xMOVHL = {0x12};
 
+	const xImplSimd_PBlend xPBLEND =
+	{
+		{0x66, 0x0e3a}, // W
+		{0x66, 0x1038}, // VB
+	};
+
 	const xImplSimd_Blend xBLEND =
-		{
-			{0x66, 0x0c3a}, // PS
-			{0x66, 0x0d3a}, // PD
-			{0x66, 0x1438}, // VPS
-			{0x66, 0x1538}, // VPD
+	{
+		{0x66, 0x0c3a}, // PS
+		{0x66, 0x0d3a}, // PD
+		{0x66, 0x1438}, // VPS
+		{0x66, 0x1538}, // VPD
 	};
 
 	const xImplSimd_PMove xPMOVSX = {0x2038};

--- a/pcsx2/VUops.cpp
+++ b/pcsx2/VUops.cpp
@@ -1703,15 +1703,19 @@ static __fi void _vuITOF15(VURegs* VU)
 
 static __fi void _vuCLIP(VURegs* VU)
 {
-	float value = fabs(vuDouble(VU->VF[_Ft_].i.w));
+	s32 value = VU->VF[_Ft_].i.w;
+	// If denormal, set to the highest possible denormal value so only non-denormals compare higher
+	value = (value & 0x7f800000) ? value & 0x7fffffff : 0x007fffff;
+	const u32 pos = 0x00000000;
+	const u32 neg = 0x80000000;
 
 	VU->clipflag <<= 6;
-	if ( vuDouble(VU->VF[_Fs_].i.x) > +value ) VU->clipflag|= 0x01;
-	if ( vuDouble(VU->VF[_Fs_].i.x) < -value ) VU->clipflag|= 0x02;
-	if ( vuDouble(VU->VF[_Fs_].i.y) > +value ) VU->clipflag|= 0x04;
-	if ( vuDouble(VU->VF[_Fs_].i.y) < -value ) VU->clipflag|= 0x08;
-	if ( vuDouble(VU->VF[_Fs_].i.z) > +value ) VU->clipflag|= 0x10;
-	if ( vuDouble(VU->VF[_Fs_].i.z) < -value ) VU->clipflag|= 0x20;
+	if (static_cast<s32>(VU->VF[_Fs_].i.x ^ pos) > value) VU->clipflag |= 0x01;
+	if (static_cast<s32>(VU->VF[_Fs_].i.x ^ neg) > value) VU->clipflag |= 0x02;
+	if (static_cast<s32>(VU->VF[_Fs_].i.y ^ pos) > value) VU->clipflag |= 0x04;
+	if (static_cast<s32>(VU->VF[_Fs_].i.y ^ neg) > value) VU->clipflag |= 0x08;
+	if (static_cast<s32>(VU->VF[_Fs_].i.z ^ pos) > value) VU->clipflag |= 0x10;
+	if (static_cast<s32>(VU->VF[_Fs_].i.z ^ neg) > value) VU->clipflag |= 0x20;
 	VU->clipflag = VU->clipflag & 0xFFFFFF;
 }
 

--- a/pcsx2/x86/microVU_Misc.h
+++ b/pcsx2/x86/microVU_Misc.h
@@ -21,6 +21,7 @@ struct mVU_Globals
 	u32   signbit [4] = __four(0x80000000);
 	u32   minvals [4] = __four(0xff7fffff);
 	u32   maxvals [4] = __four(0x7f7fffff);
+	u32   exponent[4] = __four(0x7f800000);
 	u32   one     [4] = __four(0x3f800000);
 	u32   Pi4     [4] = __four(0x3f490fdb);
 	u32   T1      [4] = __four(0x3f7ffff5);

--- a/pcsx2/x86/microVU_Misc.h
+++ b/pcsx2/x86/microVU_Misc.h
@@ -16,49 +16,41 @@ struct microVU;
 
 struct mVU_Globals
 {
-	u32   absclip[4], signbit[4], minvals[4], maxvals[4];
-	u32   one[4];
-	u32   Pi4[4];
-	u32   T1[4], T2[4], T3[4], T4[4], T5[4], T6[4], T7[4], T8[4];
-	u32   S2[4], S3[4], S4[4], S5[4];
-	u32   E1[4], E2[4], E3[4], E4[4], E5[4], E6[4];
-	float FTOI_4[4], FTOI_12[4], FTOI_15[4];
-	float ITOF_4[4], ITOF_12[4], ITOF_15[4];
+#define __four(val) { val, val, val, val }
+	u32   absclip [4] = __four(0x7fffffff);
+	u32   signbit [4] = __four(0x80000000);
+	u32   minvals [4] = __four(0xff7fffff);
+	u32   maxvals [4] = __four(0x7f7fffff);
+	u32   one     [4] = __four(0x3f800000);
+	u32   Pi4     [4] = __four(0x3f490fdb);
+	u32   T1      [4] = __four(0x3f7ffff5);
+	u32   T5      [4] = __four(0xbeaaa61c);
+	u32   T2      [4] = __four(0x3e4c40a6);
+	u32   T3      [4] = __four(0xbe0e6c63);
+	u32   T4      [4] = __four(0x3dc577df);
+	u32   T6      [4] = __four(0xbd6501c4);
+	u32   T7      [4] = __four(0x3cb31652);
+	u32   T8      [4] = __four(0xbb84d7e7);
+	u32   S2      [4] = __four(0xbe2aaaa4);
+	u32   S3      [4] = __four(0x3c08873e);
+	u32   S4      [4] = __four(0xb94fb21f);
+	u32   S5      [4] = __four(0x362e9c14);
+	u32   E1      [4] = __four(0x3e7fffa8);
+	u32   E2      [4] = __four(0x3d0007f4);
+	u32   E3      [4] = __four(0x3b29d3ff);
+	u32   E4      [4] = __four(0x3933e553);
+	u32   E5      [4] = __four(0x36b63510);
+	u32   E6      [4] = __four(0x353961ac);
+	float FTOI_4  [4] = __four(16.0);
+	float FTOI_12 [4] = __four(4096.0);
+	float FTOI_15 [4] = __four(32768.0);
+	float ITOF_4  [4] = __four(0.0625f);
+	float ITOF_12 [4] = __four(0.000244140625);
+	float ITOF_15 [4] = __four(0.000030517578125);
+#undef __four
 };
 
-#define __four(val) { val, val, val, val }
-alignas(32) static const mVU_Globals mVUglob = {
-	__four(0x7fffffff),       // absclip
-	__four(0x80000000),       // signbit
-	__four(0xff7fffff),       // minvals
-	__four(0x7f7fffff),       // maxvals
-	__four(0x3f800000),       // ONE!
-	__four(0x3f490fdb),       // PI4!
-	__four(0x3f7ffff5),       // T1
-	__four(0xbeaaa61c),       // T5
-	__four(0x3e4c40a6),       // T2
-	__four(0xbe0e6c63),       // T3
-	__four(0x3dc577df),       // T4
-	__four(0xbd6501c4),       // T6
-	__four(0x3cb31652),       // T7
-	__four(0xbb84d7e7),       // T8
-	__four(0xbe2aaaa4),       // S2
-	__four(0x3c08873e),       // S3
-	__four(0xb94fb21f),       // S4
-	__four(0x362e9c14),       // S5
-	__four(0x3e7fffa8),       // E1
-	__four(0x3d0007f4),       // E2
-	__four(0x3b29d3ff),       // E3
-	__four(0x3933e553),       // E4
-	__four(0x36b63510),       // E5
-	__four(0x353961ac),       // E6
-	__four(16.0),             // FTOI_4
-	__four(4096.0),           // FTOI_12
-	__four(32768.0),          // FTOI_15
-	__four(0.0625f),          // ITOF_4
-	__four(0.000244140625),   // ITOF_12
-	__four(0.000030517578125) // ITOF_15
-};
+alignas(32) static constexpr struct mVU_Globals mVUglob;
 
 static const uint _Ibit_ = 1 << 31;
 static const uint _Ebit_ = 1 << 30;

--- a/tests/ctest/common/x86emitter/codegen_tests_main.cpp
+++ b/tests/ctest/common/x86emitter/codegen_tests_main.cpp
@@ -153,6 +153,8 @@ TEST(CodegenTests, SSETest)
 	CODEGEN_TEST(xMOVAPS(ptr128[rax+r9], xmm8), "46 0f 29 04 08");
 	CODEGEN_TEST(xBLEND.PS(xmm0, xmm1, 0x55), "66 0f 3a 0c c1 55");
 	CODEGEN_TEST(xBLEND.PD(xmm8, xmm9, 0xaa), "66 45 0f 3a 0d c1 aa");
+	CODEGEN_TEST(xPBLEND.W(xmm0, xmm1, 0x55), "66 0f 3a 0e c1 55");
+	CODEGEN_TEST(xPBLEND.VB(xmm1, xmm2), "66 0f 38 10 ca");
 	CODEGEN_TEST(xEXTRACTPS(ptr32[base], xmm1, 2), "66 0f 3a 17 0d f6 ff ff ff 02");
 	CODEGEN_TEST(xMOVD(eax, xmm1), "66 0f 7e c8");
 	CODEGEN_TEST(xMOVD(eax, xmm10), "66 44 0f 7e d0");


### PR DESCRIPTION
### Description of Changes
Implements a version of CLIP that properly compares floats with max exponent

Also optimizes the flag extraction through the magic of SSE4.1

### Rationale behind Changes
In preparation for #12001, I'd like to maintain two code paths for as few instructions as possible.  So I'd like to see if any games break when just using an accurate version of CLIP at all times, even when all other ops are getting clamped.

### Suggested Testing Steps
See if any games break
See if I made anything slower