### PR TITLE
flatpak: misc additions to the metainfo

### DIFF
--- a/.github/workflows/scripts/linux/appimage-qt.sh
+++ b/.github/workflows/scripts/linux/appimage-qt.sh
@@ -63,9 +63,9 @@ declare -a REMOVE_LIBS=(
 
 set -e
 
-LINUXDEPLOY=./linuxdeploy-x86_64
-LINUXDEPLOY_PLUGIN_QT=./linuxdeploy-plugin-qt-x86_64
-APPIMAGETOOL=./appimagetool-x86_64
+LINUXDEPLOY=./linuxdeploy-x86_64.AppImage
+LINUXDEPLOY_PLUGIN_QT=./linuxdeploy-plugin-qt-x86_64.AppImage
+APPIMAGETOOL=./appimagetool-x86_64.AppImage
 PATCHELF=patchelf
 
 if [ ! -f "$LINUXDEPLOY" ]; then
@@ -78,11 +78,8 @@ if [ ! -f "$LINUXDEPLOY_PLUGIN_QT" ]; then
 	chmod +x "$LINUXDEPLOY_PLUGIN_QT"
 fi
 
-# Using go-appimage
-# Backported from https://github.com/stenzek/duckstation/pull/3251
 if [ ! -f "$APPIMAGETOOL" ]; then
-	APPIMAGETOOLURL=$(wget -q https://api.github.com/repos/probonopd/go-appimage/releases -O - | sed 's/[()",{} ]/\n/g' | grep -o 'https.*continuous.*tool.*86_64.*mage$' | head -1)
-	"$PCSX2DIR/tools/retry.sh" wget -O "$APPIMAGETOOL" "$APPIMAGETOOLURL"
+	"$PCSX2DIR/tools/retry.sh" wget -O "$APPIMAGETOOL" https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
 	chmod +x "$APPIMAGETOOL"
 fi
 
@@ -213,5 +210,4 @@ if [[ "${GIT_VERSION}" == "" ]]; then
 fi
 
 rm -f "$NAME.AppImage"
-ARCH=x86_64 VERSION="${GIT_VERSION}" "$APPIMAGETOOL" -s "$OUTDIR" && mv ./*.AppImage "$NAME.AppImage"
-
+$APPIMAGETOOL -v "$OUTDIR" "$NAME.AppImage"

--- a/.github/workflows/scripts/linux/pcsx2-qt.metainfo.xml.in
+++ b/.github/workflows/scripts/linux/pcsx2-qt.metainfo.xml.in
@@ -6,17 +6,21 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0+</project_license>
   <name>PCSX2</name>
-  <developer_name>PCSX2</developer_name>
+  <developer id="net.pcsx2">
+    <name>PCSX2 Team</name>
+  </developer>
   <summary>PlayStation 2 emulator</summary>
   <description>
     <p>PCSX2 is a free and open-source PlayStation 2 (PS2) emulator. Its purpose is to emulate the PS2's hardware, using a combination of MIPS CPU Interpreters, Recompilers, and a Virtual Machine which manages hardware states and PS2 system memory. This allows you to play PS2 games on your PC, with many additional features and benefits.</p>
     <p>PlayStation 2 and PS2 are registered trademarks of Sony Interactive Entertainment. This application is not affiliated in any way with Sony Interactive Entertainment.</p>
   </description>
   <url type="homepage">https://pcsx2.net/</url>
+  <url type="vcs-browser">https://github.com/PCSX2/pcsx2</url>
   <url type="bugtracker">https://github.com/PCSX2/pcsx2/issues</url>
   <url type="donation">https://github.com/sponsors/PCSX2</url>
   <url type="faq">https://pcsx2.net/docs/</url>
   <url type="help">https://pcsx2.net/discord</url>
+  <url type="contribute">https://github.com/PCSX2/pcsx2/blob/master/.github/CONTRIBUTING.md</url>
   <url type="translate">https://crowdin.com/project/pcsx2-emulator</url>
   <url type="contact">https://mastodon.social/@PCSX2</url>
   <screenshots>
@@ -37,10 +41,26 @@
       </caption>
     </screenshot>
   </screenshots>
+  <categories>
+    <category>Game</category>
+    <category>Emulator</category>
+  </categories>
   <branding>
     <color type="primary" scheme_preference="light">#3584e4</color>
     <color type="primary" scheme_preference="dark">#241f31</color>
   </branding>
+  <supports>
+    <control>keyboard</control>
+    <control>pointing</control>
+    <internet>offline-only</internet>
+  </supports>
+  <recommends>
+    <control>gamepad</control>
+    <memory>8192</memory>
+  </recommends>
+  <requires>
+    <display_length compare="ge">768</display_length>
+  </requires>
   <content_rating type="oars-1.1"/>
   <update_contact>pcsx2_AT_pcsx2.net</update_contact>
   <releases>


### PR DESCRIPTION
I actually went and read through the entire documentation of the metainfo format available here: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html

I found a few nitpicks:

* `developer_name` is deprecated in favour of `developer`
* Set categories to the same one we have set in our .desktop file for consistency
* Add github and contributing link
* Add support/recommends entries so flathub & co knows we are a desktop app and would recommend a gamepad/at least 8GB of ram
* Require a display that's at least a tablet/laptop and an input device: our UI is not made for phones

