### PR TITLE
appimage: set WM_CLASS to AppRun.wrapped

### DIFF
--- a/.github/workflows/scripts/linux/appimage-qt.sh
+++ b/.github/workflows/scripts/linux/appimage-qt.sh
@@ -136,6 +136,7 @@ $LINUXDEPLOY --plugin qt --appdir="$OUTDIR" --executable="$BUILDDIR/bin/pcsx2-qt
 
 echo "Copying resources into AppDir..."
 cp -a "$BUILDDIR/bin/resources" "$OUTDIR/usr/bin"
+cp "$OUTDIR/PCSX2.png" "$OUTDIR/.DirIcon"
 
 # LinuxDeploy's Qt plugin doesn't include Wayland support. So manually copy in the additional Wayland libraries.
 echo "Copying Qt Wayland libraries..."

--- a/.github/workflows/scripts/linux/appimage-qt.sh
+++ b/.github/workflows/scripts/linux/appimage-qt.sh
@@ -122,6 +122,7 @@ done
 
 echo "Copying desktop file..."
 cp "$PCSX2DIR/.github/workflows/scripts/linux/pcsx2-qt.desktop" "net.pcsx2.PCSX2.desktop"
+sed -i "s/StartupWMClass=PCSX2/StartupWMClass=AppRun.wrapped/g" "net.pcsx2.PCSX2.desktop"
 cp "$PCSX2DIR/bin/resources/icons/AppIconLarge.png" "PCSX2.png"
 
 echo "Running linuxdeploy to create AppDir..."


### PR DESCRIPTION
This fixes an icon affiliation issue for appimages.

This closes https://github.com/PCSX2/pcsx2/issues/12289 .
