### PR TITLE
SIO: correctly report & check formatted status for conversion

### DIFF
--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
@@ -185,8 +185,6 @@ QString MemoryCardSettingsWidget::getSelectedCard() const
 
 bool MemoryCardSettingsWidget::isSelectedCardFormatted() const
 {
-	QString ret;
-
 	const QList<QTreeWidgetItem*> selection(m_ui.cardList->selectedItems());
 	if (!selection.empty())
 		return selection[0]->data(0, Qt::UserRole).toBool();
@@ -278,7 +276,6 @@ void MemoryCardSettingsWidget::convertCard()
 		QMessageBox::critical(this, tr("Error"), tr("Cannot convert an unformatted memory card."));
 		return;
 	}
-
 
 	MemoryCardConvertDialog dialog(QtUtils::GetRootWidget(this), selectedCard);
 

--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
@@ -183,6 +183,16 @@ QString MemoryCardSettingsWidget::getSelectedCard() const
 	return ret;
 }
 
+bool MemoryCardSettingsWidget::isSelectedCardFormatted() const
+{
+	QString ret;
+
+	const QList<QTreeWidgetItem*> selection(m_ui.cardList->selectedItems());
+	if (!selection.empty())
+		return selection[0]->data(0, Qt::UserRole).toBool();
+	return false;
+}
+
 void MemoryCardSettingsWidget::updateCardActions()
 {
 	QString selectedCard = getSelectedCard();
@@ -262,6 +272,13 @@ void MemoryCardSettingsWidget::convertCard()
 
 	if (selectedCard.isEmpty())
 		return;
+
+	if (!isSelectedCardFormatted())
+	{
+		QMessageBox::critical(this, tr("Error"), tr("Cannot convert an unformatted memory card."));
+		return;
+	}
+
 
 	MemoryCardConvertDialog dialog(QtUtils::GetRootWidget(this), selectedCard);
 
@@ -442,6 +459,10 @@ void MemoryCardListWidget::refresh(SettingsWindow* dialog)
 		item->setText(1, getSizeSummary(mcd));
 		item->setText(2, mcd.formatted ? tr("Yes") : tr("No"));
 		item->setText(3, mtime.toString(QLocale::system().dateTimeFormat(QLocale::ShortFormat)));
+
+		// store formatted metadata
+		item->setData(0, Qt::UserRole, mcd.formatted);
+
 		addTopLevelItem(item);
 	}
 }

--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.h
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.h
@@ -97,6 +97,7 @@ private:
 	void createCard();
 
 	QString getSelectedCard() const;
+	bool isSelectedCardFormatted() const;
 	void updateCardActions();
 	void deleteCard();
 	void renameCard();

--- a/pcsx2/SIO/Memcard/MemoryCardFile.cpp
+++ b/pcsx2/SIO/Memcard/MemoryCardFile.cpp
@@ -865,8 +865,15 @@ std::vector<AvailableMcdInfo> FileMcd_GetAvailableCards(bool include_in_use_card
 			if (!IsMemoryCardFolder(fd.FileName))
 				continue;
 
+			FolderMemoryCard sourceFolderMemoryCard;
+			Pcsx2Config::McdOptions config;
+			config.Enabled = true;
+			config.Type = MemoryCardType::Folder;
+			sourceFolderMemoryCard.Open(fd.FileName, config, (8 * 1024 * 1024) / FolderMemoryCard::ClusterSize, false, "");
+
 			mcds.push_back({std::move(basename), std::move(fd.FileName), fd.ModificationTime,
-				MemoryCardType::Folder, MemoryCardFileType::Unknown, 0u, true});
+				MemoryCardType::Folder, MemoryCardFileType::Unknown, 0u, sourceFolderMemoryCard.IsFormatted()});
+			sourceFolderMemoryCard.Close(false);
 		}
 		else
 		{

--- a/pcsx2/SIO/Memcard/MemoryCardFolder.h
+++ b/pcsx2/SIO/Memcard/MemoryCardFolder.h
@@ -318,6 +318,8 @@ public:
 	void Open(std::string fullPath, const Pcsx2Config::McdOptions& mcdOptions, const u32 sizeInClusters, const bool enableFiltering, std::string filter, bool simulateFileWrites = false);
 	// Close the memory card and flush changes to the file system. Set flush to false to not store changes.
 	void Close(bool flush = true);
+	// Checks whether the Memory Card is formatted.
+	bool IsFormatted() const;
 
 	// Closes and reopens card with given filter options if they differ from the current ones (returns true),
 	// or does nothing if they match already (returns false).
@@ -362,8 +364,6 @@ protected:
 
 	// initializes memory card data, as if it was fresh from the factory
 	void InitializeInternalData();
-
-	bool IsFormatted() const;
 
 	// returns the in-memory address of data the given memory card adr corresponds to
 	// returns nullptr if adr corresponds to a folder or file entry


### PR DESCRIPTION


### Description of Changes
Folder memcards always returned that they were formatted, whether or not that was the case. Additionally, we allowed to convert  unformatted memory cards which, in the case of folder memcards, lead to a crash because of the superblock being uninitialized.
This PR fixes that.

This fixes https://github.com/PCSX2/pcsx2/issues/12270

### Suggested Testing Steps
Check whether you can still convert memcards and particularly folder memcards.
