### PR TITLE
wayland: fix and enable by default

### DIFF
--- a/.github/workflows/scripts/linux/appimage-qt.sh
+++ b/.github/workflows/scripts/linux/appimage-qt.sh
@@ -187,17 +187,6 @@ echo "Generating AppStream metainfo..."
 mkdir -p "$OUTDIR/usr/share/metainfo"
 "$SCRIPTDIR/generate-metainfo.sh" "$OUTDIR/usr/share/metainfo/net.pcsx2.PCSX2.appdata.xml"
 
-# Copy in AppRun hooks.
-# Unfortunately linuxdeploy is a bit lame and doesn't let us provide our own AppRun hooks, instead
-# they have to come from plugins.. and screw writing one of those just to disable Wayland.
-echo "Copying AppRun hooks..."
-mkdir -p "$OUTDIR/apprun-hooks"
-for hookpath in "$SCRIPTDIR/apprun-hooks"/*; do
-	hookname=$(basename "$hookpath")
-	cp -v "$hookpath" "$OUTDIR/apprun-hooks/$hookname"
-	sed -i -e 's/exec /source "$this_dir"\/apprun-hooks\/"'"$hookname"'"\nexec /' "$OUTDIR/AppRun"
-done
-
 echo "Generating AppImage..."
 GIT_VERSION=$(git tag --points-at HEAD)
 

--- a/.github/workflows/scripts/linux/apprun-hooks/default-to-x11.sh
+++ b/.github/workflows/scripts/linux/apprun-hooks/default-to-x11.sh
@@ -1,9 +1,0 @@
-if [[ -z "$I_WANT_A_BROKEN_WAYLAND_UI" ]]; then
-	echo "Forcing X11 instead of Wayland, due to various protocol limitations"
-	echo "and Qt issues. If you want to use Wayland, launch PCSX2 with"
-	echo "I_WANT_A_BROKEN_WAYLAND_UI=YES set."
-	export QT_QPA_PLATFORM=xcb
-else
-	echo "Wayland is not being disabled. Do not complain when things break."
-fi
-

--- a/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
+++ b/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
@@ -19,10 +19,10 @@
     "--device=all",
     "--share=network",
     "--share=ipc",
-    "--socket=x11",
+    "--socket=wayland",
+    "--socket=fallback-x11",
     "--socket=pulseaudio",
-    "--talk-name=org.freedesktop.ScreenSaver",
-    "--env=QT_QPA_PLATFORM=xcb"
+    "--talk-name=org.freedesktop.ScreenSaver"
   ],
   "modules": [
     "modules/10-libpcap.json",

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -104,6 +104,15 @@ MainWindow::MainWindow()
 	pxAssert(!g_main_window);
 	g_main_window = this;
 
+	//  Native window rendering is broken in wayland.
+	//  Let's work around it by disabling it for every widget besides
+	//  DisplayWidget.
+	//  Additionally, alien widget rendering is much more performant, so we
+	//  should have a nice responsiveness boost in our UI :)
+	//  QTBUG-133919, reported upstream by govanify 
+	QGuiApplication::setAttribute(Qt::AA_NativeWindows, false);
+	QGuiApplication::setAttribute(Qt::AA_DontCreateNativeWidgetSiblings, true);
+
 #if !defined(_WIN32) && !defined(__APPLE__)
 	s_use_central_widget = DisplayContainer::isRunningOnWayland();
 #endif


### PR DESCRIPTION
Following the original discovery that Qt's wl_surface lifetime were broken around 8 months ago, here's another upstream Qt bug!

Qt has two types of rendering for its widgets, alien and native. While alien is usually more efficient and allows Qt to handle its own refresh primitives, native window rendering is necessary if we want to paint to a widget ourselves (see [Qt::WA_PaintOnScreen](https://doc.qt.io/qt-6/qt.html#WidgetAttribute-enum) ).

Unfortunately, this comes with the side effect of letting the compositor decide how to deal with those surfaces.
Compositors that do not implement SSD, like GNOME (mutter) or weston do not by design, thus leading to pretty borked results on those OSes for some widgets, for example:

![image](https://github.com/user-attachments/assets/9f345fd7-6d9e-472f-a137-18c4c0434c29)


As such, let's disable native window rendering for everything but the DisplayWidget.

This bug is reported and tracked upstream: https://bugreports.qt.io/browse/QTBUG-133919  
POC: https://projects.govanify.com/govanify/qt-native-wayland-borked

~~NB: Do we want to enable alien rendering for every platform out of Wayland? Qt's documentation do mention that they are more efficient, but I only enabled it for wayland for now in fear of breakage.~~
EDIT: added alien widget rendering for all platforms as windows testing showed a performance boost

![image](https://github.com/user-attachments/assets/28875304-9857-4920-8e75-ef7c0909020b)


### Suggested Testing Steps

DO EVERYTHING YOU CAN TO MAKE IT BREAK!  
Be sure to test GNOME wayland in priority, and don't hesitate to do weird things with the window, like hide, unhide, rotate 33° idk.
