### PR TITLE
Debugger Assembler: BC1(t|f) 24 bit immediates to 16 bit immediates

### DIFF
--- a/pcsx2/DebugTools/ExpressionParser.cpp
+++ b/pcsx2/DebugTools/ExpressionParser.cpp
@@ -599,7 +599,11 @@ bool parsePostfixExpression(PostfixExpression& exp, IExpressionFunctions* funcs,
 		}
 	}
 
-	if (valueStack.size() != 1) return false;
+	if (valueStack.size() != 1)
+	{
+		error = TRANSLATE("ExpressionParser", "Invalid expression (Too many constants?)");
+		return false;
+	}
 	dest = valueStack[0];
 	return true;
 }

--- a/pcsx2/DebugTools/MipsAssembler.cpp
+++ b/pcsx2/DebugTools/MipsAssembler.cpp
@@ -637,14 +637,14 @@ bool CMipsInstruction::Validate()
 			immediate.value = (immediate.value >> 2) & 0x3FFFFFF;
 		} else if (Opcode.flags & MO_IPCR)	// relative 16 bit value
 		{
-			int num = (immediate.value-RamPos-4);
+			const int num = (immediate.value-RamPos-4) >> 2;
 
-			if (num > 0x20000 || num < (-0x20000))
+			if (num > std::numeric_limits<short>::max() || num < std::numeric_limits<short>::min())
 			{
 				Logger::queueError(Logger::Error,L"Branch target %08X out of range",immediate.value);
 				return false;
 			}
-			immediate.value = num >> 2;
+			immediate.value = num;
 		}
 
 		int immediateBits = getImmediateBits(immediateType);

--- a/pcsx2/DebugTools/MipsAssemblerTables.cpp
+++ b/pcsx2/DebugTools/MipsAssemblerTables.cpp
@@ -596,10 +596,10 @@ const tMipsOpcode MipsOpcodes[] = {
 //  10 |  ---  |  ---  |  ---  |  ---  |  ---  |  ---  |  ---  |  ---  | 10..17
 //  11 |  ---  |  ---  |  ---  |  ---  |  ---  |  ---  |  ---  |  ---  | 18..1F
 //  hi |-------|-------|-------|-------|-------|-------|-------|-------|
-	{ "bc1f",	"I",		MIPS_COP1BC(0x00),				MA_MIPS2,	MO_IPCR|MO_DELAY|MO_NODELAYSLOT },
-	{ "bc1t",	"I",		MIPS_COP1BC(0x01),				MA_MIPS2,	MO_IPCR|MO_DELAY|MO_NODELAYSLOT },
-	{ "bc1fl",	"I",		MIPS_COP1BC(0x02),				MA_MIPS2,	MO_IPCR|MO_DELAY|MO_NODELAYSLOT },
-	{ "bc1tl",	"I",		MIPS_COP1BC(0x03),				MA_MIPS2,	MO_IPCR|MO_DELAY|MO_NODELAYSLOT },
+	{ "bc1f",	"i",		MIPS_COP1BC(0x00),				MA_MIPS2,	MO_IPCR|MO_DELAY|MO_NODELAYSLOT },
+	{ "bc1t",	"i",		MIPS_COP1BC(0x01),				MA_MIPS2,	MO_IPCR|MO_DELAY|MO_NODELAYSLOT },
+	{ "bc1fl",	"i",		MIPS_COP1BC(0x02),				MA_MIPS2,	MO_IPCR|MO_DELAY|MO_NODELAYSLOT },
+	{ "bc1tl",	"i",		MIPS_COP1BC(0x03),				MA_MIPS2,	MO_IPCR|MO_DELAY|MO_NODELAYSLOT },
 
 //     31---------21------------------------------------------5--------0
 //     |=  COP1S  |                                          | function|


### PR DESCRIPTION
### Description of Changes
Fixes an invalid opcode form in the assembler table.
Also added an error message to an expression parser failure condition.

### Rationale behind Changes
This made assembling bc1f/bc1t bc1fl/bc1tl not possible as the immediate was clobbering the bits outside of the offset field.

The error message fixes a case where entering multiple constants failed, but didn't say why.

### Suggested Testing Steps
Try assembling the previously mentioned opcodes. The assembler uses absolute addressing (and internally converts it to be relative). Try assembling the maximum offset possible and beyond, make sure that there is no off-by-one errors.
