### PR TITLE
GameDB: Memory card filters for TOCA Race Driver 3 and NFS games

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -10418,15 +10418,6 @@ SCUS-21295:
     recommendedBlendingLevel: 3 # Fixes water and grass textures.
     halfPixelOffset: 4 # Mostly aligns post processing.
     nativeScaling: 1 # Fixes post processing smoothness and position.
-SCUS-21494:
-  name: "Need for Speed - Carbon Collector's Edition"
-  region: "NTSC-U"
-  compat: 5
-  clampModes:
-    eeClampMode: 3 # Fixes game hang after opening intro.
-  gsHWFixes:
-    halfPixelOffset: 2 # Fixes blurriness.
-    roundSprite: 2 # Fixes blurriness.
 SCUS-90174:
   name: "Disney/Pixar Toy Story 3 [PlayStation 2 Bundle]"
   region: "NTSC-U"
@@ -69491,6 +69482,7 @@ SLUS-21493:
 SLUS-21494:
   name: "Need for Speed - Carbon [Collector's Edition]"
   region: "NTSC-U"
+  compat: 5
   clampModes:
     eeClampMode: 3 # Fixes game hang after opening intro.
   gsHWFixes:

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -27402,26 +27402,132 @@ SLES-55002:
   region: "PAL-E"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth line.
+  memcardFilters:
+    - "SLES-55002"
+    - "SLES-55003"
+    - "SLES-55004"
+    - "SLES-55005"
+    - "SLES-55006"
+    # Carbon save grants extra money.
+    - "SLES-54321"
+    - "SLES-54322"
+    - "SLES-54323"
+    - "SLES-54324"
+    - "SLES-54402"
+    - "SLES-54492"
+    - "SLES-54493"
+    # Most Wanted save grants extra money.
+    - "SLES-53557"
+    - "SLES-53558"
+    - "SLES-53559"
+    - "SLES-53857" # Black Edition detection is bugged by default, can be fixed with a patch.
+    # UG2 saves can be detected, but the code is unused.
+    - "SLES-52725"
 SLES-55003:
   name: "Need for Speed - ProStreet"
   region: "PAL-F-G"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth line.
+  memcardFilters:
+    - "SLES-55002"
+    - "SLES-55003"
+    - "SLES-55004"
+    - "SLES-55005"
+    - "SLES-55006"
+    # Carbon save grants extra money.
+    - "SLES-54321"
+    - "SLES-54322"
+    - "SLES-54323"
+    - "SLES-54324"
+    - "SLES-54402"
+    - "SLES-54492"
+    - "SLES-54493"
+    # Most Wanted save grants extra money.
+    - "SLES-53557"
+    - "SLES-53558"
+    - "SLES-53559"
+    - "SLES-53857" # Black Edition detection is bugged by default, can be fixed with a patch.
+    # UG2 saves can be detected, but the code is unused.
+    - "SLES-52725"
 SLES-55004:
   name: "Need for Speed - ProStreet"
   region: "PAL-I-S"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth line.
+  memcardFilters:
+    - "SLES-55002"
+    - "SLES-55003"
+    - "SLES-55004"
+    - "SLES-55005"
+    - "SLES-55006"
+    # Carbon save grants extra money.
+    - "SLES-54321"
+    - "SLES-54322"
+    - "SLES-54323"
+    - "SLES-54324"
+    - "SLES-54402"
+    - "SLES-54492"
+    - "SLES-54493"
+    # Most Wanted save grants extra money.
+    - "SLES-53557"
+    - "SLES-53558"
+    - "SLES-53559"
+    - "SLES-53857" # Black Edition detection is bugged by default, can be fixed with a patch.
+    # UG2 saves can be detected, but the code is unused.
+    - "SLES-52725"
 SLES-55005:
   name: "Need for Speed - ProStreet"
   region: "PAL-M8"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth line.
+  memcardFilters:
+    - "SLES-55002"
+    - "SLES-55003"
+    - "SLES-55004"
+    - "SLES-55005"
+    - "SLES-55006"
+    # Carbon save grants extra money.
+    - "SLES-54321"
+    - "SLES-54322"
+    - "SLES-54323"
+    - "SLES-54324"
+    - "SLES-54402"
+    - "SLES-54492"
+    - "SLES-54493"
+    # Most Wanted save grants extra money.
+    - "SLES-53557"
+    - "SLES-53558"
+    - "SLES-53559"
+    - "SLES-53857" # Black Edition detection is bugged by default, can be fixed with a patch.
+    # UG2 saves can be detected, but the code is unused.
+    - "SLES-52725"
 SLES-55006:
   name: "Need for Speed - ProStreet"
   region: "PAL-R"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth line.
+  memcardFilters:
+    - "SLES-55002"
+    - "SLES-55003"
+    - "SLES-55004"
+    - "SLES-55005"
+    - "SLES-55006"
+    # Carbon save grants extra money. Detection is bugged by default, can be fixed with a patch.
+    - "SLES-54321"
+    - "SLES-54322"
+    - "SLES-54323"
+    - "SLES-54324"
+    - "SLES-54402"
+    - "SLES-54492"
+    - "SLES-54493"
+    # Most Wanted save grants extra money. Detection is bugged by default, can be fixed with a patch.
+    - "SLES-53557"
+    - "SLES-53558"
+    - "SLES-53559"
+    - "SLES-53857"
+    - "SLUS-21267" # Original wrong Most Wanted serial.
+    # UG2 saves can be detected, but the code is unused.
+    - "SLES-52725"
 SLES-55007:
   name: "Boogie"
   region: "PAL-M7"
@@ -31393,6 +31499,11 @@ SLKA-25411:
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth line.
+  memcardFilters:
+    - "SLKA-25411"
+    - "SLKA-25185" # Carbon save grants extra money.
+    - "SLKA-25334" # Most Wanted save grants extra money.
+    - "SLKA-25241" # UG2 saves can be detected, but the code is unused.
 SLKA-25412:
   name: "Sengoku Basara 2 - Heroes"
   region: "NTSC-K"
@@ -32496,6 +32607,16 @@ SLPM-55151:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth line.
+  memcardFilters:
+    - "SLPM-55151"
+    # Carbon save grants extra money.
+    - "SLPM-55061"
+    - "SLPM-66617"
+    - "SLPM-66869"
+    # Most Wanted save grants extra money.
+    - "SLPM-66232"
+    - "SLPM-66562"
+    - "SLPM-65766" # UG2 saves can be detected, but the code is unused.
 SLPM-55152:
   name: "スロッターUPコア11 巨人の星Ⅳ 青春群像編"
   name-sort: "すろったーUPこあ11 きょじんのほし4 せいしゅんぐんぞうへん"
@@ -50430,6 +50551,16 @@ SLPM-66932:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth line.
+  memcardFilters:
+    - "SLPM-66932"
+    # Carbon save grants extra money.
+    - "SLPM-55061"
+    - "SLPM-66617"
+    - "SLPM-66869"
+    # Most Wanted save grants extra money.
+    - "SLPM-66232"
+    - "SLPM-66562"
+    - "SLPM-65766" # UG2 saves can be detected, but the code is unused.
 SLPM-66933:
   name: "君が主で執事が俺で～お仕え日記～ [初回限定版]"
   name-sort: "きみがあるじでしつじがおれで おつかえにっき [しょかいげんていばん]"
@@ -70382,6 +70513,15 @@ SLUS-21658:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth line.
+  memcardFilters:
+    - "SLUS-21658"
+    # Carbon save grants extra money.
+    - "SLUS-21493"
+    - "SLUS-21494"
+    # Most Wanted save grants extra money.
+    - "SLUS-21267"
+    - "SLUS-21351"
+    - "SLUS-21065" # UG2 saves can be detected, but the code is unused.
 SLUS-21660:
   name: "Disney Princess - Enchanted Journey"
   region: "NTSC-U"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -28472,6 +28472,18 @@ SLES-55349:
     gpuTargetCLUT: 1 # Fixes sun penetration.
     nativeScaling: 2 # Fixes post alignment.
     getSkipCount: "GSC_NFSUndercover"
+  memcardFilters:
+    - "SLES-55349"
+    - "SLES-55350"
+    - "SLES-55351"
+    - "SLES-55352"
+    - "SLES-55353"
+    # Checks from Carbon are left in the code, unused.
+    - "SLES-53557"
+    - "SLES-53558"
+    - "SLES-53559"
+    - "SLES-53857"
+    - "SLES-52725"
 SLES-55350:
   name: "Need for Speed - Undercover"
   region: "PAL-F-G"
@@ -28482,6 +28494,18 @@ SLES-55350:
     gpuTargetCLUT: 1 # Fixes sun penetration.
     nativeScaling: 2 # Fixes post alignment.
     getSkipCount: "GSC_NFSUndercover"
+  memcardFilters:
+    - "SLES-55349"
+    - "SLES-55350"
+    - "SLES-55351"
+    - "SLES-55352"
+    - "SLES-55353"
+    # Checks from Carbon are left in the code, unused.
+    - "SLES-53557"
+    - "SLES-53558"
+    - "SLES-53559"
+    - "SLES-53857"
+    - "SLES-52725"
 SLES-55351:
   name: "Need for Speed - Undercover"
   region: "PAL-I-S"
@@ -28492,6 +28516,18 @@ SLES-55351:
     gpuTargetCLUT: 1 # Fixes sun penetration.
     nativeScaling: 2 # Fixes post alignment.
     getSkipCount: "GSC_NFSUndercover"
+  memcardFilters:
+    - "SLES-55349"
+    - "SLES-55350"
+    - "SLES-55351"
+    - "SLES-55352"
+    - "SLES-55353"
+    # Checks from Carbon are left in the code, unused.
+    - "SLES-53557"
+    - "SLES-53558"
+    - "SLES-53559"
+    - "SLES-53857"
+    - "SLES-52725"
 SLES-55352:
   name: "Need for Speed - Undercover"
   region: "PAL-SC"
@@ -28503,6 +28539,18 @@ SLES-55352:
     gpuTargetCLUT: 1 # Fixes sun penetration.
     nativeScaling: 2 # Fixes post alignment.
     getSkipCount: "GSC_NFSUndercover"
+  memcardFilters:
+    - "SLES-55349"
+    - "SLES-55350"
+    - "SLES-55351"
+    - "SLES-55352"
+    - "SLES-55353"
+    # Checks from Carbon are left in the code, unused.
+    - "SLES-53557"
+    - "SLES-53558"
+    - "SLES-53559"
+    - "SLES-53857"
+    - "SLES-52725"
 SLES-55353:
   name: "Need for Speed - Undercover"
   region: "PAL-M6"
@@ -28513,6 +28561,18 @@ SLES-55353:
     gpuTargetCLUT: 1 # Fixes sun penetration.
     nativeScaling: 2 # Fixes post alignment.
     getSkipCount: "GSC_NFSUndercover"
+  memcardFilters:
+    - "SLES-55349"
+    - "SLES-55350"
+    - "SLES-55351"
+    - "SLES-55352"
+    - "SLES-55353"
+    # Checks from Carbon are left in the code, unused.
+    - "SLES-53557"
+    - "SLES-53558"
+    - "SLES-53559"
+    - "SLES-53857"
+    - "SLES-52725"
 SLES-55354:
   name: "Shin Megami Tensei - Persona 3 FES"
   region: "PAL-E"
@@ -31620,6 +31680,13 @@ SLKA-25446:
     recommendedBlendingLevel: 3 # Improves car reflections.
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_NFSUndercover"
+  memcardFilters:
+    - "SLKA-25446"
+    # Checks from Carbon are left in the code, unused.
+    - "SLKA-25185"
+    - "SLKA-25334"
+    - "SLAJ-25075"
+    - "SLKA-25241"
 SLKA-25447:
   name: "FIFA 09"
   region: "NTSC-K"
@@ -32470,6 +32537,13 @@ SLPM-55127:
     gpuTargetCLUT: 1 # Fixes sun penetration.
     nativeScaling: 2 # Fixes post alignment.
     getSkipCount: "GSC_NFSUndercover"
+  memcardFilters:
+    - "SLPM-55127"
+    # Checks from Carbon are left in the code, unused.
+    - "SLPM-66232"
+    - "SLPM-66562"
+    - "SLAJ-25075"
+    - "SLPM-65766"
 SLPM-55128:
   name: "ラグビー08 [英語版] [EA:SY! 1980]"
   name-sort: "らぐびー08 [えいごばん] [EA:SY! 1980]"
@@ -33058,6 +33132,13 @@ SLPM-55244:
     gpuTargetCLUT: 1 # Fixes sun penetration.
     nativeScaling: 2 # Fixes post alignment.
     getSkipCount: "GSC_NFSUndercover"
+  memcardFilters:
+    - "SLPM-55244"
+    # Checks from Carbon are left in the code, unused.
+    - "SLPM-66232"
+    - "SLPM-66562"
+    - "SLAJ-25075"
+    - "SLPM-65766"
 SLPM-55245:
   name: "ひまわり -Pebble in the Sky-"
   name-sort: "ひまわり -Pebble in the Sky-"
@@ -71300,6 +71381,13 @@ SLUS-21801:
     gpuTargetCLUT: 1 # Fixes sun penetration.
     nativeScaling: 2 # Fixes post alignment.
     getSkipCount: "GSC_NFSUndercover"
+  memcardFilters:
+    - "SLUS-21801"
+    # Checks from Carbon are left in the code, unused.
+    - "SLUS-21267"
+    - "SLUS-21351"
+    - "SLAJ-25075"
+    - "SLUS-21065"
 SLUS-21802:
   name: "Naked Brothers Band - The Video Game"
   region: "NTSC-U"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -20077,7 +20077,7 @@ SLES-52636:
     autoFlush: 1 # Fixes incorrect colors.
     alignSprite: 1 # Fixes vertical lines such as in FMVs.
 SLES-52637:
-  name: "TOCA Racer Driver 2"
+  name: "TOCA Race Driver 2"
   region: "PAL-M5"
   gsHWFixes:
     alignSprite: 1 # Fixes lighting and vertical lines, also works with normal vertex.
@@ -21520,6 +21520,9 @@ SLES-53087:
     skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
     halfPixelOffset: 2 # Fixes depth of field alignment.
     nativeScaling: 1 # Fixes depth of field.
+  memcardFilters:
+    - "SLES-53087"
+    - "SLES-52637" # Race Driver 2 save unlocks 'Class A 4WD Track Challenge' in career early.
 SLES-53088:
   name: "DTM Race Driver 3"
   region: "PAL-M5"
@@ -21530,6 +21533,9 @@ SLES-53088:
     skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
     halfPixelOffset: 2 # Fixes depth of field alignment.
     nativeScaling: 1 # Fixes depth of field.
+  memcardFilters:
+    - "SLES-53088"
+    - "SLES-52638" # Race Driver 2 save unlocks 'Class A 4WD Track Challenge' in career early.
 SLES-53089:
   name: "V8 Supercars Australia 3"
   region: "PAL-E"
@@ -21540,6 +21546,9 @@ SLES-53089:
     skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
     halfPixelOffset: 2 # Fixes depth of field alignment.
     nativeScaling: 1 # Fixes depth of field.
+  memcardFilters:
+    - "SLES-53089"
+    - "SLES-52639" # Race Driver 2 save unlocks 'Class A 4WD Track Challenge' in career early.
 SLES-53090:
   name: "Circuit Blasters"
   region: "PAL-M5"
@@ -32138,6 +32147,9 @@ SLPM-55046:
     skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
     halfPixelOffset: 2 # Fixes depth of field alignment.
     nativeScaling: 1 # Fixes depth of field.
+  memcardFilters:
+    - "SLPM-55046"
+    - "SLPM-66498" # Race Driver 2 save unlocks 'Class A 4WD Track Challenge' in career early.
 SLPM-55047:
   name: "Sugar+Spice！ ～あの子のステキな何もかも～"
   name-sort: "しゅがーすぱいす あのこのすてきななにもかも"
@@ -50352,6 +50364,9 @@ SLPM-66881:
     skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
     halfPixelOffset: 2 # Fixes depth of field alignment.
     nativeScaling: 1 # Fixes depth of field.
+  memcardFilters:
+    - "SLPM-66881"
+    - "SLPM-66498" # Race Driver 2 save unlocks 'Class A 4WD Track Challenge' in career early.
 SLPM-66882:
   name: "はかれなはーと ～君がために輝きを～ [限定版・サントラボイスCD付]"
   name-sort: "はかれなはーと きみがためにかがやきを [げんていばん さんとらぼいすCDつき]"
@@ -67674,6 +67689,9 @@ SLUS-21182:
     skipDrawEnd: 1 # Removes large black box around player car till we properly emulate it.
     halfPixelOffset: 2 # Fixes depth of field alignment.
     nativeScaling: 1 # Fixes depth of field.
+  memcardFilters:
+    - "SLUS-21182"
+    - "SLUS-21039" # Race Driver 2 save unlocks 'Class A 4WD Track Challenge' in career early.
 SLUS-21183:
   name: "Teen Titans"
   region: "NTSC-U"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -12796,9 +12796,7 @@ SLAJ-25075:
     - "SLAJ-25075"
     - "SLPM-66232"
     - "SLPM-66562"
-    - "SLPM-65766"
-    - "SLPM-66051"
-    - "SLPM-66960"
+    - "SLAJ-25054" # Underground 2 save grants extra money.
 SLAJ-25076:
   name: "Harry Potter and the Goblet of Fire"
   region: "NTSC-Unk"
@@ -22914,12 +22912,12 @@ SLES-53557:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
-  memcardFilters: # Reads Underground 2 save for extra money.
+  memcardFilters:
     - "SLES-53557"
     - "SLES-53558"
     - "SLES-53559"
     - "SLES-53857"
-    - "SLES-52725"
+    - "SLES-52725" # Underground 2 save grants extra money.
 SLES-53558:
   name: "Need for Speed - Most Wanted"
   region: "PAL-M8"
@@ -22933,7 +22931,7 @@ SLES-53558:
     - "SLES-53558"
     - "SLES-53559"
     - "SLES-53857"
-    - "SLES-52725"
+    - "SLES-52725" # Underground 2 save grants extra money.
 SLES-53559:
   name: "Need for Speed - Most Wanted"
   region: "PAL-M7"
@@ -22947,7 +22945,7 @@ SLES-53559:
     - "SLES-53558"
     - "SLES-53559"
     - "SLES-53857"
-    - "SLES-52725"
+    - "SLES-52725" # Underground 2 save grants extra money.
 SLES-53560:
   name: "Sonic Riders"
   region: "PAL-M5"
@@ -23886,7 +23884,7 @@ SLES-53857:
     - "SLES-53558"
     - "SLES-53559"
     - "SLES-53857"
-    - "SLES-52725"
+    - "SLES-52725" # Underground 2 save grants extra money.
 SLES-53860:
   name: "Dynasty Warriors 5 - Xtreme Legends"
   region: "PAL-E"
@@ -30938,6 +30936,9 @@ SLKA-25334:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+  memcardFilters:
+    - "SLKA-25334"
+    - "SLKA-25241" # Underground 2 save grants extra money.
 SLKA-25335:
   name: "Shadow the Hedgehog"
   region: "NTSC-K"
@@ -31610,6 +31611,9 @@ SLPM-55003:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+  memcardFilters:
+    - "SLPM-55003"
+    - "SLPM-65766" # Underground 2 save grants extra money.
 SLPM-55004:
   name: "バーンアウト リベンジ [EA:SY! 1980]"
   name-sort: "ばーんあうと りべんじ [EA:SY! 1980])"
@@ -46054,7 +46058,8 @@ SLPM-66232:
     - "SLAJ-25075"
     - "SLPM-66232"
     - "SLPM-66562"
-    - "SLPM-65766"
+    - "SLPM-65766" # Underground 2 save grants extra money.
+    # Unconfirmed UG2 serials.
     - "SLPM-66051"
     - "SLPM-66960"
 SLPM-66233:
@@ -48085,7 +48090,8 @@ SLPM-66562:
     - "SLAJ-25075"
     - "SLPM-66232"
     - "SLPM-66562"
-    - "SLPM-65766"
+    - "SLPM-65766" # Underground 2 save grants extra money.
+    # Unconfirmed UG2 serials.
     - "SLPM-66051"
     - "SLPM-66960"
 SLPM-66563:
@@ -67860,6 +67866,9 @@ SLUS-21257:
     halfPixelOffset: 2 # Fixes blurriness.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+  memcardFilters:
+    - "SLUS-21257"
+    - "SLUS-21065" # Underground 2 save grants extra money.
 SLUS-21258:
   name: ".hack//G.U. Vol.1 - Rebirth"
   region: "NTSC-U"
@@ -67946,7 +67955,7 @@ SLUS-21267:
   memcardFilters:
     - "SLUS-21267"
     - "SLUS-21351"
-    - "SLUS-21065"
+    - "SLUS-21065" # Underground 2 save grants extra money.
 SLUS-21268:
   name: "24 - The Game"
   region: "NTSC-U"
@@ -68535,7 +68544,7 @@ SLUS-21351:
   memcardFilters:
     - "SLUS-21267"
     - "SLUS-21351"
-    - "SLUS-21065"
+    - "SLUS-21065" # Underground 2 save grants extra money.
 SLUS-21352:
   name: "Dai Senryaku VII Exceed"
   region: "NTSC-U"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -12868,6 +12868,13 @@ SLAJ-25091:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes car headlights.
     halfPixelOffset: 2 # Fixes depth line.
+  memcardFilters:
+    - "SLAJ-25091"
+    # Most Wanted save grants extra money.
+    - "SLAJ-25075"
+    - "SLPM-66232"
+    # UG2 saves can be detected, but the code is unused.
+    - "SLAJ-25054"
 SLAJ-25092:
   name: "Shin Sangoku Musou 4 [PlayStation2 the Best]"
   region: "NTSC-Unk"
@@ -25148,6 +25155,18 @@ SLES-54321:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes car headlights.
     halfPixelOffset: 2 # Fixes depth line.
+  memcardFilters:
+    - "SLES-54321"
+    - "SLES-54322"
+    - "SLES-54323"
+    - "SLES-54324"
+    # Most Wanted save grants extra money.
+    - "SLES-53557"
+    - "SLES-53558"
+    - "SLES-53559"
+    - "SLES-53857" # Black Edition detection is bugged by default, can be fixed with a patch.
+    # UG2 saves can be detected, but the code is unused.
+    - "SLES-52725"
 SLES-54322:
   name: "Need for Speed - Carbon"
   region: "PAL-M8"
@@ -25156,6 +25175,18 @@ SLES-54322:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes car headlights.
     halfPixelOffset: 2 # Fixes depth line.
+  memcardFilters:
+    - "SLES-54321"
+    - "SLES-54322"
+    - "SLES-54323"
+    - "SLES-54324"
+    # Most Wanted save grants extra money.
+    - "SLES-53557"
+    - "SLES-53558"
+    - "SLES-53559"
+    - "SLES-53857" # Black Edition detection is bugged by default, can be fixed with a patch.
+    # UG2 saves can be detected, but the code is unused.
+    - "SLES-52725"
 SLES-54323:
   name: "Need for Speed - Carbon"
   region: "PAL-I-S"
@@ -25164,6 +25195,18 @@ SLES-54323:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes car headlights.
     halfPixelOffset: 2 # Fixes depth line.
+  memcardFilters:
+    - "SLES-54321"
+    - "SLES-54322"
+    - "SLES-54323"
+    - "SLES-54324"
+    # Most Wanted save grants extra money.
+    - "SLES-53557"
+    - "SLES-53558"
+    - "SLES-53559"
+    - "SLES-53857" # Black Edition detection is bugged by default, can be fixed with a patch.
+    # UG2 saves can be detected, but the code is unused.
+    - "SLES-52725"
 SLES-54324:
   name: "Need for Speed - Carbon"
   region: "PAL-R"
@@ -25172,6 +25215,18 @@ SLES-54324:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes car headlights.
     halfPixelOffset: 2 # Fixes depth line.
+  memcardFilters:
+    - "SLES-54321"
+    - "SLES-54322"
+    - "SLES-54323"
+    - "SLES-54324"
+    # Most Wanted save grants extra money.
+    - "SLES-53557"
+    - "SLES-53558"
+    - "SLES-53559"
+    - "SLES-53857" # Black Edition detection is bugged by default, can be fixed with a patch.
+    # UG2 saves can be detected, but the code is unused.
+    - "SLES-52725"
 SLES-54326:
   name: "Raceway - Drag Stock Racing"
   region: "PAL-E"
@@ -25446,6 +25501,17 @@ SLES-54402:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes car headlights.
     halfPixelOffset: 2 # Fixes depth line.
+  memcardFilters:
+    - "SLES-54402"
+    - "SLES-54492"
+    - "SLES-54493"
+    # Most Wanted save grants extra money.
+    - "SLES-53557"
+    - "SLES-53558"
+    - "SLES-53559"
+    - "SLES-53857" # Black Edition detection is bugged by default, can be fixed with a patch.
+    # UG2 saves can be detected, but the code is unused.
+    - "SLES-52725"
 SLES-54410:
   name: "Monster Trux Arenas - Special Edition"
   region: "PAL-Unk"
@@ -25743,6 +25809,17 @@ SLES-54492:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes car headlights.
     halfPixelOffset: 2 # Fixes depth line.
+  memcardFilters:
+    - "SLES-54402"
+    - "SLES-54492"
+    - "SLES-54493"
+    # Most Wanted save grants extra money.
+    - "SLES-53557"
+    - "SLES-53558"
+    - "SLES-53559"
+    - "SLES-53857" # Black Edition detection is bugged by default, can be fixed with a patch.
+    # UG2 saves can be detected, but the code is unused.
+    - "SLES-52725"
 SLES-54493:
   name: "Need for Speed - Carbon [Collector's Edition]"
   region: "PAL-F-G"
@@ -25751,6 +25828,17 @@ SLES-54493:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes car headlights.
     halfPixelOffset: 2 # Fixes depth line.
+  memcardFilters:
+    - "SLES-54402"
+    - "SLES-54492"
+    - "SLES-54493"
+    # Most Wanted save grants extra money.
+    - "SLES-53557"
+    - "SLES-53558"
+    - "SLES-53559"
+    - "SLES-53857" # Black Edition detection is bugged by default, can be fixed with a patch.
+    # UG2 saves can be detected, but the code is unused.
+    - "SLES-52725"
 SLES-54494:
   name: "Little Britain - The Video Game"
   region: "PAL-E"
@@ -30250,6 +30338,11 @@ SLKA-25185:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes blurriness.
     roundSprite: 2 # Fixes blurriness.
+  memcardFilters:
+    - "SLKA-25185"
+    - "SLKA-25334" # Most Wanted save grants extra money.
+    - "SLAJ-25075" # Original wrong Black Edition serial.
+    - "SLKA-25241" # UG2 saves can be detected, but the code is unused.
 SLKA-25186:
   name: "The King of Fighters - Maximum Impact [Limited Edition]"
   name-sort: "King of Fighters, The - Maximum Impact [Limited Edition]"
@@ -31941,6 +32034,13 @@ SLPM-55061:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes car headlights.
     halfPixelOffset: 2 # Fixes depth line.
+  memcardFilters:
+    - "SLPM-55061"
+    # Most Wanted save grants extra money.
+    - "SLPM-66232"
+    - "SLPM-66562"
+    - "SLAJ-25075" # Original wrong Black Edition serial.
+    - "SLPM-65766" # UG2 saves can be detected, but the code is unused.
 SLPM-55062:
   name: "実況パワフルメジャーリーグ 3"
   name-sort: "じっきょうぱわふるめじゃーりーぐ 3"
@@ -48440,6 +48540,13 @@ SLPM-66617:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes car headlights.
     halfPixelOffset: 2 # Fixes depth line.
+  memcardFilters:
+    - "SLPM-66617"
+    # Most Wanted save grants extra money.
+    - "SLPM-66232"
+    - "SLPM-66562"
+    - "SLAJ-25075" # Original wrong Black Edition serial.
+    - "SLPM-65766" # UG2 saves can be detected, but the code is unused.
 SLPM-66618:
   name: "夢見師 [初回限定版]"
   name-sort: "ゆめみし [しょかいげんていばん]"
@@ -49968,6 +50075,13 @@ SLPM-66869:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes car headlights.
     halfPixelOffset: 2 # Fixes depth line.
+  memcardFilters:
+    - "SLPM-66869"
+    # Most Wanted save grants extra money.
+    - "SLPM-66232"
+    - "SLPM-66562"
+    - "SLAJ-25075" # Original wrong Black Edition serial.
+    - "SLPM-65766" # UG2 saves can be detected, but the code is unused.
 SLPM-66870:
   name: "星色のおくりもの [初回スペシャル限定版]"
   name-sort: "ほしいろのおくりもの [しょかいすぺしゃるげんていばん]"
@@ -69488,6 +69602,13 @@ SLUS-21493:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes car headlights.
     halfPixelOffset: 2 # Fixes depth line.
+  memcardFilters:
+    - "SLUS-21493"
+    # Most Wanted save grants extra money.
+    - "SLUS-21267"
+    - "SLUS-21351" # Black Edition detection is bugged by default, can be fixed with a patch.
+    - "SLAJ-25075" # Original wrong Black Edition serial.
+    - "SLUS-21065" # UG2 saves can be detected, but the code is unused.
 SLUS-21494:
   name: "Need for Speed - Carbon [Collector's Edition]"
   region: "NTSC-U"
@@ -69497,6 +69618,13 @@ SLUS-21494:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes car headlights.
     halfPixelOffset: 2 # Fixes depth line.
+  memcardFilters:
+    - "SLUS-21494"
+    # Most Wanted save grants extra money.
+    - "SLUS-21267"
+    - "SLUS-21351" # Black Edition detection is bugged by default, can be fixed with a patch.
+    - "SLAJ-25075" # Original wrong Black Edition serial.
+    - "SLUS-21065" # UG2 saves can be detected, but the code is unused.
 SLUS-21495:
   name: "Sudoku, Carol Vorderman's"
   region: "NTSC-U"


### PR DESCRIPTION
**Please merge together with https://github.com/PCSX2/pcsx2_patches/pull/499.**

### Description of Changes
Multiple NFS games and TOCA Race Driver 3 grant bonuses if they detect saves from the previous game in the series. This was previously set only for NFS Most Wanted (looking for saves from Underground 2), but even that was not exhaustive.

In this PR:
* Filters for Most Wanted have been improved.
* Filters for Carbon have been added. One of the checks in Carbon has a bug and checks for a wrong serial of MW Black Edition. **Both** wrong and correct serials have been added to the database, and a patch to correct the serial has been submitted to the patch repo. Filters for Underground 2 were also added, as the game has unused code referencing those.
* Filters for ProStreet have been added. Filters for Underground 2 were also added, as the game has unused code referencing those.
* Undercover copypastes the save scanning code from Carbon and leaves it unused, so I mirrored Carbon filters for that game too.
* Filters for TOCA Race Driver 3 looking for Race Driver 2 have been added (+ typo fix).

![image](https://github.com/user-attachments/assets/601dce69-76ea-489d-aa11-628abd099802)

### Rationale behind Changes
Making stock game functionality work properly.

### Suggested Testing Steps
Test starting new careers in:
* NFS Most Wanted
* NFS Carbon
* NFS ProStreet
* TOCA Race Driver 3

when you have saves from the previous games in your folder memcard.

**NOTE:** I was only able to test filters from the NTSC-U NFS games, the rest goes untested but based on the US binary files!
