### PR TITLE
Memcard: Apply filtering when checking all possible memcard options

### DIFF
--- a/pcsx2/SIO/Memcard/MemoryCardFile.cpp
+++ b/pcsx2/SIO/Memcard/MemoryCardFile.cpp
@@ -869,7 +869,7 @@ std::vector<AvailableMcdInfo> FileMcd_GetAvailableCards(bool include_in_use_card
 			Pcsx2Config::McdOptions config;
 			config.Enabled = true;
 			config.Type = MemoryCardType::Folder;
-			sourceFolderMemoryCard.Open(fd.FileName, config, (8 * 1024 * 1024) / FolderMemoryCard::ClusterSize, false, "");
+			sourceFolderMemoryCard.Open(fd.FileName, config, (8 * 1024 * 1024) / FolderMemoryCard::ClusterSize, EmuConfig.McdFolderAutoManage, "");
 
 			mcds.push_back({std::move(basename), std::move(fd.FileName), fd.ModificationTime,
 				MemoryCardType::Folder, MemoryCardFileType::Unknown, 0u, sourceFolderMemoryCard.IsFormatted()});


### PR DESCRIPTION

### Description of Changes
This function is only called when the UI needs to know how many memcards you have for display purposes, but to do so needs to at least open them to see what they are. Switched enableFiltering from forced false to use whatever the automatically manage checkbox is set to.

### Rationale behind Changes
Prevents log being flooded with warnings when large folder memcards exceed 8 MB size and trying to open settings or run GS dumps.

### Suggested Testing Steps
Have a folder memcard containing more than 8 MB of data. Enable the log window. Open your settings menu. Verify that, if in your memory card settings the checkbox for automatically managing is ticked, you are no longer getting warnings for the folder memcard being full. Close PCSX2 and repeat for loading a GS dump.