### PR TITLE
GS/HW: Maintain scale on subsequent downscale draws

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2750,7 +2750,7 @@ void GSRendererHW::Draw()
 
 		// Preserve downscaled target when copying directly from a downscaled target, or it's a normal draw using a downscaled target. Clears that are drawing to the target can also preserve size.
 		// Of course if this size is different (in width) or this is a shuffle happening, this will be bypassed.
-		const bool preserve_downscale_draw = scale_draw < 0 || (scale_draw == 0 && ((src && src->m_from_target && src->m_from_target->m_downscaled) || is_possible_mem_clear == ClearType::ClearWithDraw));
+		const bool preserve_downscale_draw = std::abs(scale_draw) == 1 || (scale_draw == 0 && ((src && src->m_from_target && src->m_from_target->m_downscaled) || is_possible_mem_clear == ClearType::ClearWithDraw));
 
 		rt = g_texture_cache->LookupTarget(FRAME_TEX0, t_size, ((src && src->m_scale != 1) && GSConfig.UserHacks_NativeScaling == GSNativeScaling::Normal && !possible_shuffle) ? GetTextureScaleFactor() : target_scale, GSTextureCache::RenderTarget, true,
 			fm, false, force_preload, preserve_rt_rgb, preserve_rt_alpha, unclamped_draw_rect, possible_shuffle, is_possible_mem_clear && FRAME_TEX0.TBP0 != m_cached_ctx.ZBUF.Block(), GSConfig.UserHacks_NativeScaling != GSNativeScaling::Off && preserve_downscale_draw && is_possible_mem_clear != ClearType::NormalClear);


### PR DESCRIPTION
### Description of Changes
maintains already downscaled targets on more downscaling.

### Rationale behind Changes
it was doing partial draws downscaled then upscaling it immediately in Onimusha 3 when using Normal NS, which is wrong.

### Suggested Testing Steps
test games which use native scaling, make sure they don't look more gross.

Changes which are technically better or different:
BBoy:
Master:
![image](https://github.com/user-attachments/assets/41b44423-e7b8-4fc0-a0ba-b5b9fcb77df9)

PR:
![image](https://github.com/user-attachments/assets/239eb2b9-48ec-4c4c-823e-97e55ac79822)

Spyro:
Master:
![image](https://github.com/user-attachments/assets/a251800a-9ff0-489b-864e-d193c7618ae1)
![image](https://github.com/user-attachments/assets/c24ffa9d-16d1-44dd-8117-03958f986161)

PR:
![image](https://github.com/user-attachments/assets/d3bed315-06ea-4cc7-be69-9be124adb630)
![image](https://github.com/user-attachments/assets/60627950-c6be-4ebf-a4c5-6f1dfed65db2)

Ratchet & Clank Up Your Arsenal:
Master:
![image](https://github.com/user-attachments/assets/dd1c2664-a7e3-4ed7-ad72-fce8165d10bc)

PR:
![image](https://github.com/user-attachments/assets/443fe2cc-37bf-4c35-8f33-5f524fff4206)

Tomb Raider Legends:
Master:
![image](https://github.com/user-attachments/assets/989b4a79-3319-415f-a834-34812ca4e3d1)

PR:
![image](https://github.com/user-attachments/assets/2e88ca50-66df-496d-aac5-8d76178391fe)
