### PR TITLE
GameDB: Add Namco CRC to Tales o.t. Abyss + Taiko no Tatsujin 9

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1270,6 +1270,7 @@ SCAJ-10015:
   region: "NTSC-Unk"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    getSkipCount: "GSC_Tekken5" # Fixes upscaling grid, same engine.
 SCAJ-20001:
   name: "Ratchet & Clank"
   region: "NTSC-Unk"
@@ -54350,6 +54351,7 @@ SLPS-20485:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    getSkipCount: "GSC_Tekken5" # Fixes upscaling grid, same engine.
 SLPS-20486:
   name: "太鼓の達人 ドカッ！と大盛り七代目 [ソフト単体]"
   name-sort: "たいこのたつじん どかっ！とおおもりななだいめ [そふとたんたい]"
@@ -54357,6 +54359,7 @@ SLPS-20486:
   region: "NTSC-J"
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
+    getSkipCount: "GSC_Tekken5" # Fixes upscaling grid, same engine.
 SLPS-20487:
   name: "パチスロキング！ 科学忍者隊ガッチャマン"
   name-sort: "ぱちすろきんぐ！ かがくにんじゃたいがっちゃまん"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -2236,6 +2236,7 @@ SCAJ-20163:
   gsHWFixes:
     halfPixelOffset: 2 # Fixes ghosting.
     autoFlush: 2 # Fixes post lighting.
+    getSkipCount: "GSC_Tekken5" # Fixes upscaling grid, same engine.
 SCAJ-20164:
   name: "Kingdom Hearts II"
   region: "NTSC-Unk"
@@ -57933,6 +57934,7 @@ SLPS-25586:
     halfPixelOffset: 4 # Fixes post positioning.
     nativeScaling: 1 # Fixes post effects.
     autoFlush: 2 # Fixes post lighting.
+    getSkipCount: "GSC_Tekken5" # Fixes upscaling grid, same engine.
 SLPS-25587:
   name: "シュガシュガルーン 恋もおしゃれもピックアップ！"
   name-sort: "しゅがしゅがるーん こいもおしゃれもぴっくあっぷ！"
@@ -60966,6 +60968,7 @@ SLPS-73252:
     halfPixelOffset: 4 # Fixes post positioning.
     nativeScaling: 1 # Fixes post effects.
     autoFlush: 2 # Fixes post lighting.
+    getSkipCount: "GSC_Tekken5" # Fixes upscaling grid, same engine.
 SLPS-73253:
   name: "るろうに剣心-明治剣客浪漫譚- 炎上！京都輪廻 [PlayStation2 the Best]"
   name-sort: "るろうにけんしん めいじけんかくろまんたん えんじょう きょうとりんね [PlayStation2 the Best]"
@@ -68793,6 +68796,7 @@ SLUS-21386:
     halfPixelOffset: 4 # Fixes post positioning.
     nativeScaling: 1 # Fixes post effects.
     autoFlush: 2 # Fixes post lighting.
+    getSkipCount: "GSC_Tekken5" # Fixes upscaling grid, same engine.
 SLUS-21387:
   name: "Warship Gunner 2"
   region: "NTSC-U"

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -212,10 +212,8 @@ bool GSHwHack::GSC_Tekken5(GSRendererHW& r, int& skip)
 {
 	if (skip == 0)
 	{
-		if (r.IsPossibleChannelShuffle())
+		if (r.IsPossibleChannelShuffle() && (RTBP0 & 31))
 		{
-			pxAssertMsg((RTBP0 & 31) == 0, "TEX0 should be page aligned");
-
 			GSVertex* v = &r.m_vertex.buff[0];
 
 			// Make sure we're detecting the right effect.


### PR DESCRIPTION
### Description of Changes
What happens when two idiots look at Tales of the Abyss and see the grid pattern that can't be fixed and go "hey, that looks like Tekken does without the CRC hack", that's right, the idiots slap the Tekken CRC on it, and it only goes and bloody works.

### Rationale behind Changes
Same engine as Tekken 5, same problems, same developer, different day.

### Suggested Testing Steps
Test Tales of the Abyss and Taiko no Tatsujin - Doka! to Oomori Nanadaime upscaled.

Fixes #6497

Tales of the Abyss:

Master:
![image](https://github.com/user-attachments/assets/d9c3469a-a6d2-43e2-89f1-8c4718ed56ca)

PR:
![image](https://github.com/user-attachments/assets/88f8e6c9-28f6-4d9c-93a3-367df9384e09)

Taiko no Tatsujin - Doka! to Oomori Nanadaime:

Master (actually RT in RT to get effects right):
![image](https://github.com/user-attachments/assets/6a9ed024-2602-46bf-8be0-112d4326d295)

PR:
![image](https://github.com/user-attachments/assets/93ece8f0-e62e-47f4-9422-88fecf9249bd)

