### PR TITLE
Added 200% option for EE overclocking

### DIFF
--- a/pcsx2-qt/Settings/EmulationSettingsWidget.ui
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.ui
@@ -102,6 +102,11 @@
         </item>
         <item>
          <property name="text">
+          <string>200% (Overclock)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
           <string>300% (Overclock)</string>
          </property>
         </item>

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3349,6 +3349,7 @@ void FullscreenUI::DrawEmulationSettingsPage()
 		FSUI_NSTR("100% Speed (Default)"),
 		FSUI_NSTR("130% Speed"),
 		FSUI_NSTR("180% Speed"),
+		FSUI_NSTR("200% Speed"),
 		FSUI_NSTR("300% Speed"),
 	};
 	static constexpr const char* ee_cycle_skip_settings[] = {
@@ -7450,6 +7451,7 @@ TRANSLATE_NOOP("FullscreenUI", "75% Speed");
 TRANSLATE_NOOP("FullscreenUI", "100% Speed (Default)");
 TRANSLATE_NOOP("FullscreenUI", "130% Speed");
 TRANSLATE_NOOP("FullscreenUI", "180% Speed");
+TRANSLATE_NOOP("FullscreenUI", "200% Speed");
 TRANSLATE_NOOP("FullscreenUI", "300% Speed");
 TRANSLATE_NOOP("FullscreenUI", "Normal (Default)");
 TRANSLATE_NOOP("FullscreenUI", "Mild Underclock");

--- a/pcsx2/VU0microInterp.cpp
+++ b/pcsx2/VU0microInterp.cpp
@@ -293,7 +293,10 @@ void InterpVU0::Execute(u32 cycles)
 			case 2: // 180%
 				cycle_change /= 1.8f;
 				break;
-			case 3: // 300%
+			case 3: // 200%
+				cycle_change /= 2.0f;
+				break;
+			case 4: // 300%
 				cycle_change /= 3.0f;
 				break;
 			default:


### PR DESCRIPTION
### Description of Changes
Added 200% option for EE overclocking

### Rationale behind Changes
Some games may run unstably at 60fps with 180% overclock.

### Suggested Testing Steps
Shadow of the Colossus has variable FPS. With  CPU at 100%, it is 60 FPS in the open field,and 30 FPS in the initial palace and boss battle. When using EE overclocking to 180%, the game can be stable at 60% in the initial palace and boss battle scenes, but when interacting closely with the bosses, the game fluctuates violently between 30 and 60 FPS.
for example:
In close combat with the boss No. 2
![Wang Da Yu Ju Xiang_SCAJ-20146_20250223142224](https://github.com/user-attachments/assets/7ddf2ad6-fb92-4ac7-ad1e-fb7a8bf6cfb0)
Setting the EE overclock to 300% can also solve this problem. However, it will cause unnecessary computing overhead waste of the host, and excessive overclocking will also bring some unknown instability risks.
Maybe this PR also applies to some other cases where the 60FPS patch is used.