### PR TITLE
Achievements: Fix leaderboard timers persisting

### DIFF
--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -1268,7 +1268,6 @@ void Achievements::HandleLeaderboardTrackerUpdateEvent(const rc_client_event_t* 
 		"Achievements: Updating leaderboard tracker: %u: %s", event->leaderboard_tracker->id, event->leaderboard_tracker->display);
 
 	it->text = event->leaderboard_tracker->display;
-	it->active = true;
 }
 
 void Achievements::HandleAchievementChallengeIndicatorShowEvent(const rc_client_event_t* event)


### PR DESCRIPTION
### Description of Changes
Remove setting indicator active state in `HandleLeaderboardTrackerUpdateEvent` per https://github.com/PCSX2/pcsx2/pull/12352#issuecomment-2679263223

Image showing the issue:
![image](https://github.com/user-attachments/assets/bc2a2c3b-9021-4a45-b9cf-5d538ff6879d)

Demo video showing the issue and before/after:
https://github.com/user-attachments/assets/f04ed5ce-5137-42e8-96be-f284766cdc0a

### Rationale behind Changes
Fix the timer being set if events come in out of order.

<details><summary>OLD PROPOSAL (outdated) </summary>

### Description of Changes
Drop `INDICATOR_FADE_IN_TIME` (0.1) / `INDICATOR_FADE_OUT_TIME` (0.5)
Replace with `INDICATOR_FADE_TIME` with value 0.1.
This makes it highly unlikely to experience a persistent timer.

### Rationale behind Changes
Depending on the rate that new timer/achievement (bottom right) indicators are added, it is possible to have indicators that never disappear until you end the emulation.
The new default of 0.1 does not look jarring, and avoids the issue.
</details> 

### Suggested Testing Steps
Use any version of PCSX2 that supports the Achievement UI feature. I used v2.3.171.
1. Load any game where you can rapidly start a leaderboard attempt that involves a timer. My demo video is using Spyro: A Hero's Tail.
2. Rapidly invoke leaderboard attempt end/starts. Best tested on high end hardware that can run a title at a fast rate; Recommend fast forward of 400% for testing to assist with invoking fast starts.
3. See demo video above of an example of before and after.
