### PR TITLE
Debugger: Set default breakpoint size to 4

### DIFF
--- a/pcsx2-qt/Debugger/BreakpointDialog.ui
+++ b/pcsx2-qt/Debugger/BreakpointDialog.ui
@@ -212,7 +212,7 @@
          </size>
         </property>
         <property name="text">
-         <string>1</string>
+         <string>4</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
### Description of Changes
Title.
![image](https://github.com/user-attachments/assets/2a262a12-6d83-4d84-b1ab-6535abd90263)


### Rationale behind Changes
Size 4 is more inclusive than size 1. I was left scratching my head around the reason why I was unable to find the instructions manipulating a specific data in Yu-Gi-Oh! Duelists of the Roses, up until I changed the size to 4. 

This will help those using the debugger in finding the instructions they're looking for. If a person desires exclusionary sizes such as 1 or 2, which is unlikely, they can change it so. And considering size 8 is unlikely to be searched for, then no need to expand the number to that. However, given that size 4 is able to find most instructions, then size 4 it is. This lessens the burden of having to enter 4 every time I'm setting a breakpoint, and helps the inexperienced, unwary users out. Now every LB, LH, SB, OR SH instruction can be found when setting a breakpoint, not only a small number of them.

### Suggested Testing Steps
Not really needed. Besides, this size locates more instructions than it previously did.
