### PR TITLE
GameList: Allow recursive scans to be cancelled

### DIFF
--- a/common/FileSystem.h
+++ b/common/FileSystem.h
@@ -67,7 +67,7 @@ namespace FileSystem
 	std::vector<std::string> GetRootDirectoryList();
 
 	/// Search for files
-	bool FindFiles(const char* path, const char* pattern, u32 flags, FindResultsArray* results);
+	bool FindFiles(const char* path, const char* pattern, u32 flags, FindResultsArray* results, ProgressCallback* cancel = nullptr);
 
 	/// Stat file
 	bool StatFile(const char* path, struct stat* st);

--- a/pcsx2/GameList.cpp
+++ b/pcsx2/GameList.cpp
@@ -593,15 +593,14 @@ void GameList::ScanDirectory(const char* path, bool recursive, bool only_cache, 
 	progress->PushState();
 	progress->SetStatusText(fmt::format(
 		recursive ? TRANSLATE_FS("GameList", "Scanning directory {} (recursively)...") :
-					TRANSLATE_FS("GameList", "Scanning directory {}..."),
-		path)
-								.c_str());
+		            TRANSLATE_FS("GameList", "Scanning directory {}..."),
+		path).c_str());
 
 	FileSystem::FindResultsArray files;
 	FileSystem::FindFiles(path, "*",
 		recursive ? (FILESYSTEM_FIND_FILES | FILESYSTEM_FIND_HIDDEN_FILES | FILESYSTEM_FIND_RECURSIVE) :
-					(FILESYSTEM_FIND_FILES | FILESYSTEM_FIND_HIDDEN_FILES),
-		&files);
+		            (FILESYSTEM_FIND_FILES | FILESYSTEM_FIND_HIDDEN_FILES),
+		&files, progress);
 
 	u32 files_scanned = 0;
 	progress->SetProgressRange(static_cast<u32>(files.size()));


### PR DESCRIPTION
### Description of Changes
We get a lot of users that accidentally tell PCSX2 to recursively scan massive directories (e.g. home directory) and then complain about it freezing.  Looks like this is caused by gamelist scanning not being cancellable while it scans directories (only when scanning the files in those directories), so if anything asks the gamelist scan to cancel and then waits for it to finish, it ends up waiting for a long time.

### Rationale behind Changes
Less freezing, though it means people who do this won't come to us for help and will therefore never find out why PCSX2 spends tons of CPU scanning directories in the background whenever they open it.  Maybe we should add a warning if we notice a scan has been going on for some large amount of time asking the user if they want to set the directory to non-recursive...

### Suggested Testing Steps
- Set a massive directory to be scanned recursively
- Try to launch a game or quit PCSX2 while the directory is still being scanned