### PR TITLE
FSUI: Add automatic mode to "Swap OK/Cancel" option

### DIFF
--- a/pcsx2-qt/Translations.cpp
+++ b/pcsx2-qt/Translations.cpp
@@ -11,6 +11,7 @@
 #include "common/SmallString.h"
 #include "common/StringUtil.h"
 
+#include "pcsx2/ImGui/FullscreenUI.h"
 #include "pcsx2/ImGui/ImGuiManager.h"
 #include "pcsx2/MTGS.h"
 
@@ -191,6 +192,13 @@ void QtHost::InstallTranslator(QWidget* dialog_parent)
 	}
 
 	UpdateGlyphRangesAndClearCache(dialog_parent, language.toStdString());
+
+	if (FullscreenUI::IsInitialized())
+	{
+		MTGS::RunOnGSThread([]() mutable {
+			FullscreenUI::LocaleChanged();
+		});
+	}
 }
 
 const char* QtHost::GetDefaultLanguage()
@@ -218,6 +226,12 @@ s32 Host::Internal::GetTranslatedStringImpl(
 std::string Host::TranslatePluralToString(const char* context, const char* msg, const char* disambiguation, int count)
 {
 	return qApp->translate(context, msg, disambiguation, count).toStdString();
+}
+
+bool Host::LocaleCircleConfirm()
+{
+	QLocale& loc = QtHost::s_current_locale;
+	return (loc.language() == QLocale::Japanese) || (loc.language() == QLocale::Chinese) || (loc.language() == QLocale::Korean);
 }
 
 std::vector<std::pair<QString, QString>> QtHost::GetAvailableLanguageList()

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -1383,8 +1383,7 @@ void FullscreenUI::DrawLandingWindow()
 			std::make_pair(ICON_PF_BUTTON_TRIANGLE, FSUI_VSTR("Game List")),
 			std::make_pair(ICON_PF_BUTTON_SQUARE, FSUI_VSTR("Toggle Fullscreen")),
 			std::make_pair(circleOK ? ICON_PF_BUTTON_CIRCLE : ICON_PF_BUTTON_CROSS, FSUI_VSTR("Select")),
-			std::make_pair(circleOK ? ICON_PF_BUTTON_CROSS : ICON_PF_BUTTON_CIRCLE, FSUI_VSTR("Exit"))
-		});
+			std::make_pair(circleOK ? ICON_PF_BUTTON_CROSS : ICON_PF_BUTTON_CIRCLE, FSUI_VSTR("Exit"))});
 	}
 	else
 	{
@@ -1394,8 +1393,7 @@ void FullscreenUI::DrawLandingWindow()
 			std::make_pair(ICON_PF_ARROW_LEFT ICON_PF_ARROW_RIGHT, FSUI_VSTR("Navigate")),
 			std::make_pair(ICON_PF_SPACE, FSUI_VSTR("Game List")),
 			std::make_pair(ICON_PF_ENTER, FSUI_VSTR("Select")),
-			std::make_pair(ICON_PF_ESC, FSUI_VSTR("Exit"))
-		});
+			std::make_pair(ICON_PF_ESC, FSUI_VSTR("Exit"))});
 	}
 }
 
@@ -1506,16 +1504,14 @@ void FullscreenUI::DrawExitWindow()
 		SetFullscreenFooterText(std::array{
 			std::make_pair(ICON_PF_DPAD_LEFT_RIGHT, FSUI_VSTR("Navigate")),
 			std::make_pair(circleOK ? ICON_PF_BUTTON_CIRCLE : ICON_PF_BUTTON_CROSS, FSUI_VSTR("Select")),
-			std::make_pair(circleOK ? ICON_PF_BUTTON_CROSS : ICON_PF_BUTTON_CIRCLE, FSUI_VSTR("Back"))}
-		);
+			std::make_pair(circleOK ? ICON_PF_BUTTON_CROSS : ICON_PF_BUTTON_CIRCLE, FSUI_VSTR("Back"))});
 	}
 	else
 	{
 		SetFullscreenFooterText(std::array{
 			std::make_pair(ICON_PF_ARROW_LEFT ICON_PF_ARROW_RIGHT, FSUI_VSTR("Navigate")),
 			std::make_pair(ICON_PF_ENTER, FSUI_VSTR("Select")),
-			std::make_pair(ICON_PF_ESC, FSUI_VSTR("Back"))}
-		);
+			std::make_pair(ICON_PF_ESC, FSUI_VSTR("Back"))});
 	}
 }
 
@@ -4098,8 +4094,7 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 	static constexpr const char* s_gsdump_compression[] = {
 		FSUI_NSTR("Uncompressed"),
 		FSUI_NSTR("LZMA (xz)"),
-		FSUI_NSTR("Zstandard (zst)")
-		};
+		FSUI_NSTR("Zstandard (zst)")};
 
 	if (show_advanced_settings)
 	{
@@ -4889,15 +4884,13 @@ void FullscreenUI::DrawAdvancedSettingsPage()
 		FSUI_NSTR("Uncompressed"),
 		FSUI_NSTR("Deflate64"),
 		FSUI_NSTR("Zstandard"),
-		FSUI_NSTR("LZMA2")
-	};
+		FSUI_NSTR("LZMA2")};
 
 	static constexpr const char* s_savestate_compression_ratio[] = {
 		FSUI_NSTR("Low (Fast)"),
 		FSUI_NSTR("Medium (Recommended)"),
 		FSUI_NSTR("High"),
-		FSUI_NSTR("Very High (Slow, Not Recommended)")
-	};
+		FSUI_NSTR("Very High (Slow, Not Recommended)")};
 
 	if (show_advanced_settings)
 	{

--- a/pcsx2/ImGui/FullscreenUI.h
+++ b/pcsx2/ImGui/FullscreenUI.h
@@ -32,6 +32,7 @@ namespace FullscreenUI
 	void ReturnToPreviousWindow();
 	void ReturnToMainWindow();
 	void SetStandardSelectionFooterText(bool back_instead_of_cancel);
+	void LocaleChanged();
 
 	void Shutdown(bool clear_state);
 	void Render();
@@ -51,4 +52,7 @@ namespace Host
 
 	void OnCoverDownloaderOpenRequested();
 	void OnCreateMemoryCardOpenRequested();
+
+	/// Did Playstation in the currently selected locale use circle as confirm
+	bool LocaleCircleConfirm();
 } // namespace Host

--- a/tests/ctest/core/StubHost.cpp
+++ b/tests/ctest/core/StubHost.cpp
@@ -238,6 +238,11 @@ void Host::OnCreateMemoryCardOpenRequested()
 {
 }
 
+bool Host::LocaleCircleConfirm()
+{
+	return false;
+}
+
 bool Host::ShouldPreferHostFileSelector()
 {
 	return false;


### PR DESCRIPTION
### Description of Changes
Add an auto mode to swapping X and O in BPM
This is based on either the user language, or the selected BIOS region
Also format the FSUI file

### Rationale behind Changes
We can infer the users preference for the confirm button based on these settings
In future we can also set O as confirm when a switch controller is used, this will be after (or part of) the SDL3 pr

### Suggested Testing Steps
Set "Swap OK/Cancel in Big Picture Mode" to Automatic
Change your language to Japanese/Chinese/Korean and check if X and O swap
Change your BIOS between an Asian and non-Asian region one (if you have multiple) and check if X and O swap.