### PR TITLE
Windows: Make PCSX2 long path aware

### DIFF
--- a/pcsx2/windows/PCSX2.manifest
+++ b/pcsx2/windows/PCSX2.manifest
@@ -11,4 +11,9 @@
             <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
         </application>
     </compatibility>
+    <application xmlns="urn:schemas-microsoft-com:asm.v3">
+        <windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+            <ws2:longPathAware>true</ws2:longPathAware>
+        </windowsSettings>
+    </application>
 </assembly>


### PR DESCRIPTION
### Description of Changes
Modify our manifest to allow long paths within PCSX2 

### Rationale behind Changes
[According to the docs](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry#application-manifest-updates-to-declare-long-path-capability) a registry key needs to be set, and applications need to add this key to their manifest.

### Suggested Testing Steps
See if long paths are fixed
Hopefully fixes #12368 