### PR TITLE
Core: Const Reg flushing fix + COP2/Int CLIP fix

### DIFF
--- a/pcsx2/VU0.cpp
+++ b/pcsx2/VU0.cpp
@@ -198,6 +198,8 @@ void CTC2() {
 			vu1Finish(true);
 			vu1ExecMicro(cpuRegs.GPR.r[_Rt_].US[0]);	// Execute VU1 Micro SubRoutine
 			break;
+		case REG_CLIP_FLAG:
+			VU0.clipflag = cpuRegs.GPR.r[_Rt_].UL[0];
 		default:
 			VU0.VI[_Fs_].UL = cpuRegs.GPR.r[_Rt_].UL[0];
 			break;

--- a/pcsx2/x86/iCore.h
+++ b/pcsx2/x86/iCore.h
@@ -109,7 +109,7 @@ void _freeX86reg(int x86reg);
 void _freeX86regWithoutWriteback(int x86reg);
 void _freeX86regs();
 void _flushX86regs();
-void _flushConstRegs();
+void _flushConstRegs(bool delete_const);
 void _flushConstReg(int reg);
 void _validateRegs();
 void _writebackX86Reg(int x86reg);

--- a/pcsx2/x86/ix86-32/iCore.cpp
+++ b/pcsx2/x86/ix86-32/iCore.cpp
@@ -105,7 +105,7 @@ void _flushConstReg(int reg)
 	}
 }
 
-void _flushConstRegs()
+void _flushConstRegs(bool delete_const)
 {
 	int zero_reg_count = 0;
 	int minusone_reg_count = 0;
@@ -134,6 +134,8 @@ void _flushConstRegs()
 			{
 				xMOV(ptr64[&cpuRegs.GPR.r[i].UD[0]], rax);
 				g_cpuFlushedConstReg |= 1u << i;
+				if (delete_const)
+					g_cpuHasConstReg &= ~(1u << i);
 			}
 		}
 		rax_is_zero = true;
@@ -154,6 +156,8 @@ void _flushConstRegs()
 			{
 				xMOV(ptr64[&cpuRegs.GPR.r[i].UD[0]], rax);
 				g_cpuFlushedConstReg |= 1u << i;
+				if (delete_const)
+					g_cpuHasConstReg &= ~(1u << i);
 			}
 		}
 	}
@@ -166,6 +170,8 @@ void _flushConstRegs()
 
 		xWriteImm64ToMem(&cpuRegs.GPR.r[i].UD[0], rax, g_cpuConstRegs[i].UD[0]);
 		g_cpuFlushedConstReg |= 1u << i;
+		if (delete_const)
+			g_cpuHasConstReg &= ~(1u << i);
 	}
 }
 

--- a/pcsx2/x86/ix86-32/iR5900.cpp
+++ b/pcsx2/x86/ix86-32/iR5900.cpp
@@ -227,7 +227,7 @@ void _eeFlushAllDirty()
 	_flushX86regs();
 
 	// flush constants, do them all at once for slightly better codegen
-	_flushConstRegs();
+	_flushConstRegs(false);
 }
 
 void _eeMoveGPRtoR(const xRegister32& to, int fromgpr, bool allow_preload)
@@ -1225,7 +1225,7 @@ void iFlushCall(int flushtype)
 		_flushXMMregs();
 
 	if (flushtype & FLUSH_CONSTANT_REGS)
-		_flushConstRegs();
+		_flushConstRegs(true);
 
 	if ((flushtype & FLUSH_PC) && !g_cpuFlushedPC)
 	{


### PR DESCRIPTION
### Description of Changes
Delete Const registers when flushing them completely for drop to interpreter

Propagate the CLIP_FLAG value if it gets written via CTC2 on the EE interpreters, as if the CLIP instruction is run directly after, it will have the wrong clip value. VU JIT doesn't suffer from this as COP2 is direct for both.

### Rationale behind Changes
With constants, if you dropped to interpreter and the reg that was constant got written it didn't clear the constant status, causing everything to explode. No idea if this affects anything outside of development where we may force dropping to interpreter, I noticed it when forcing FPU RECOMPILE down to interpreter while trying Soft Float on Twin Caliber. I don't expect any real performance impact as we don't drop out of the EE JIT very often at all.

the CLIP_FLAG issue is because the VU Int (used by EE Interpreter for COP2 instructions) only uses its internal VU0.clipflag value, which it then overwrites the real CLIP_FLAG after the CLIP operation has run, however if the CLIP_FLAG was updated via CTC2, it didn't update VU0.clipflag, so the CLIP operation was running on the incorrect value. Noticed with Simple 2000 Series Vol. 109 - The Taxi 2.

### Suggested Testing Steps
Test some random stuff on EE interpreter and JIT, just make sure everything is okay.
