### PR TITLE
GameDB/Link: Fix validation limit for Half Pixel Offset

### DIFF
--- a/pcsx2/Docs/GameIndex.md
+++ b/pcsx2/Docs/GameIndex.md
@@ -179,7 +179,7 @@ The clamp modes are also numerically based.
 * bilinearUpscale            [`0` or `1` or `2`]                        {Automatic, Force Bilinear, Force Nearest}     Default: Automatic
 * skipDrawStart              [Value between `0` to `10000`]             {0-10000}                          Default: Off (`0`)
 * skipDrawEnd                [Value between `0` to `10000`]             {0-10000}                          Default: Off (`0`)
-* halfPixelOffset            [`0` or `1` or `2` or `3` or `4`] {Off, Normal Vertex, Special (Texture), Special (Texture Aggressive), Align to Native} Default: Off (`0`)
+* halfPixelOffset            [`0` or `1` or `2` or `3` or `4` or `5`] {Off, Normal Vertex, Special (Texture), Special (Texture Aggressive), Align to Native, Align to Native with Texture Offsets} Default: Off (`0`)
 * nativeScaling              [`0` or `1` or `2`]    {Normal, Aggressive or Off}             Default: Normal (`0`)
 * nativePaletteDraw          [`0` or `1`]           {Off, On}                               Default: Off (`0`)
 * roundSprite                [`0` or `1` or `2`]    {Off, Half or Full}                     Default: Off (`0`)

--- a/pcsx2/Docs/gamedb-schema.json
+++ b/pcsx2/Docs/gamedb-schema.json
@@ -237,7 +237,7 @@
             "halfPixelOffset": {
               "type": "integer",
               "minimum": 0,
-              "maximum": 4
+              "maximum": 5
             },
             "nativeScaling": {
               "type": "integer",


### PR DESCRIPTION
### Description of Changes
Forgot to allow limit for Align to Native with Texture Offsets

### Rationale behind Changes
Github getting angry

### Suggested Testing Steps
Make sure it builds
