### PR TITLE
VMManager: initialize PINE with config-provided slot

### DIFF
--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -3610,7 +3610,7 @@ void VMManager::ReloadPINE()
 	PINEServer::Deinitialize();
 
 	if (EmuConfig.EnablePINE)
-		PINEServer::Initialize();
+		PINEServer::Initialize(EmuConfig.PINESlot);
 }
 
 void VMManager::InitializeDiscordPresence()


### PR DESCRIPTION
Sten broke it during the port to Qt...

This fixes #12375 .

Tested locally, seems to work