### PR TITLE
Misc: Fix warnings relating to SDL3 update

### DIFF
--- a/pcsx2/Input/InputManager.cpp
+++ b/pcsx2/Input/InputManager.cpp
@@ -284,11 +284,13 @@ TinyString InputManager::ConvertKeyboardKeyToString(InputBindingKey key, bool di
 	{
 		const std::optional<std::string> str(ConvertHostKeyboardCodeToString(key.data));
 		if (str.has_value() && !str->empty())
+		{
 			if (display)
 				// Keyboard keys arn't spaced out for display yet
 				ret.format("Keyboard {}", str->c_str());
 			else
 				ret.format("Keyboard/{}", str->c_str());
+		}
 	}
 
 	return ret;
@@ -320,7 +322,7 @@ TinyString InputManager::ConvertPointerKeyToString(InputBindingKey key, bool dis
 		else if (key.source_subtype == InputSubclass::PointerAxis)
 		{
 			if (display)
-				ret.format("Pointer-{} {}{:c}", u32{key.source_index}, s_pointer_axis_setting_names[key.data],
+				ret.format("Pointer-{} {}{:c}", u32{key.source_index}, s_pointer_axis_names[key.data],
 					key.modifier == InputModifier::Negate ? '-' : '+');
 			else
 				ret.format("Pointer-{}/{}{:c}", u32{key.source_index}, s_pointer_axis_setting_names[key.data],
@@ -608,7 +610,7 @@ void InputManager::AddBindings(const std::vector<std::string>& bindings, const I
 		std::vector<std::string> new_bindings;
 		new_bindings.reserve(bindings.size());
 
-		for (int i = 0; i < bindings.size(); i++)
+		for (size_t i = 0; i < bindings.size(); i++)
 		{
 			if (ibindings[i])
 				new_bindings.push_back(ConvertInputBindingKeysToString(binding_type, ibindings[i]->keys, ibindings[i]->num_keys, true));
@@ -627,7 +629,7 @@ void InputManager::AddBindings(const std::vector<std::string>& bindings, const I
 		{
 			// LayeredSettingsInterface, Need to find which layer our binding came from
 			LayeredSettingsInterface& lsi = static_cast<LayeredSettingsInterface&>(si);
-			for (int i = 0; i < LayeredSettingsInterface::NUM_LAYERS; i++)
+			for (u32 i = 0; i < LayeredSettingsInterface::NUM_LAYERS; i++)
 			{
 				SettingsInterface* layer = lsi.GetLayer(static_cast<LayeredSettingsInterface::Layer>(i));
 				if (layer && layer->GetStringList(section, key) == bindings)

--- a/pcsx2/Input/SDLInputSource.cpp
+++ b/pcsx2/Input/SDLInputSource.cpp
@@ -1047,15 +1047,15 @@ bool SDLInputSource::ProcessSDLEvent(const SDL_Event* event)
 	{
 		case SDL_EVENT_GAMEPAD_ADDED:
 		{
-			Console.WriteLn("SDLInputSource: Gamepad %d inserted", event->cdevice.which);
-			OpenDevice(event->cdevice.which, true);
+			Console.WriteLn("SDLInputSource: Gamepad %d inserted", event->gdevice.which);
+			OpenDevice(event->gdevice.which, true);
 			return true;
 		}
 
 		case SDL_EVENT_GAMEPAD_REMOVED:
 		{
-			Console.WriteLn("SDLInputSource: Gamepad %d removed", event->cdevice.which);
-			CloseDevice(event->cdevice.which);
+			Console.WriteLn("SDLInputSource: Gamepad %d removed", event->gdevice.which);
+			CloseDevice(event->gdevice.which);
 			return true;
 		}
 
@@ -1066,18 +1066,18 @@ bool SDLInputSource::ProcessSDLEvent(const SDL_Event* event)
 				return false;
 
 			Console.WriteLn("SDLInputSource: Joystick %d inserted", event->jdevice.which);
-			OpenDevice(event->cdevice.which, false);
+			OpenDevice(event->jdevice.which, false);
 			return true;
 		}
 		break;
 
 		case SDL_EVENT_JOYSTICK_REMOVED:
 		{
-			if (auto it = GetControllerDataForJoystickId(event->cdevice.which); it != m_controllers.end() && it->gamepad)
+			if (auto it = GetControllerDataForJoystickId(event->jdevice.which); it != m_controllers.end() && it->gamepad)
 				return false;
 
 			Console.WriteLn("SDLInputSource: Joystick %d removed", event->jdevice.which);
-			CloseDevice(event->cdevice.which);
+			CloseDevice(event->jdevice.which);
 			return true;
 		}
 
@@ -1119,7 +1119,7 @@ SDL_Joystick* SDLInputSource::GetJoystickForDevice(const std::string_view device
 	return it->joystick;
 }
 
-SDLInputSource::ControllerDataVector::iterator SDLInputSource::GetControllerDataForJoystickId(int id)
+SDLInputSource::ControllerDataVector::iterator SDLInputSource::GetControllerDataForJoystickId(SDL_JoystickID id)
 {
 	return std::find_if(m_controllers.begin(), m_controllers.end(), [id](const ControllerData& cd) { return cd.joystick_id == id; });
 }
@@ -1146,7 +1146,7 @@ int SDLInputSource::GetFreePlayerId() const
 	return 0;
 }
 
-bool SDLInputSource::OpenDevice(int index, bool is_gamepad)
+bool SDLInputSource::OpenDevice(SDL_JoystickID index, bool is_gamepad)
 {
 	SDL_Gamepad* gamepad;
 	SDL_Joystick* joystick;
@@ -1327,7 +1327,7 @@ bool SDLInputSource::OpenDevice(int index, bool is_gamepad)
 	return true;
 }
 
-bool SDLInputSource::CloseDevice(int joystick_index)
+bool SDLInputSource::CloseDevice(SDL_JoystickID joystick_index)
 {
 	auto it = GetControllerDataForJoystickId(joystick_index);
 	if (it == m_controllers.end())

--- a/pcsx2/Input/SDLInputSource.h
+++ b/pcsx2/Input/SDLInputSource.h
@@ -74,12 +74,12 @@ private:
 	void LoadSettings(SettingsInterface& si);
 	void SetHints();
 
-	ControllerDataVector::iterator GetControllerDataForJoystickId(int id);
+	ControllerDataVector::iterator GetControllerDataForJoystickId(SDL_JoystickID id);
 	ControllerDataVector::iterator GetControllerDataForPlayerId(int id);
 	int GetFreePlayerId() const;
 
-	bool OpenDevice(int index, bool is_gamepad);
-	bool CloseDevice(int joystick_index);
+	bool OpenDevice(SDL_JoystickID index, bool is_gamepad);
+	bool CloseDevice(SDL_JoystickID joystick_index);
 	bool HandleGamepadAxisEvent(const SDL_GamepadAxisEvent* ev);
 	bool HandleGamepadButtonEvent(const SDL_GamepadButtonEvent* ev);
 	bool HandleJoystickAxisEvent(const SDL_JoyAxisEvent* ev);


### PR DESCRIPTION
### Description of Changes
Fix warnings emitted at build time
Also correct issues made apparent by said warnings

### Rationale behind Changes
Fixing warnings is good
Wrong array was used for mouse axis UI strings
Correct using the wrong event type for device (dis)connect, That issue had been around in SDL2 as well

### Suggested Testing Steps
Test to make input still works