### PR TITLE
Qt: Fix pad vibration binding window

### DIFF
--- a/pcsx2-qt/Settings/InputBindingWidget.cpp
+++ b/pcsx2-qt/Settings/InputBindingWidget.cpp
@@ -475,14 +475,14 @@ void InputVibrationBindingWidget::onClicked()
 
 	for (QString motor : input_setting_options)
 	{
-		SmallStringBase motor_ui(motor.toStdString());
+		SmallString motor_ui{std::string_view{motor.toStdString()}};
 		InputManager::PrettifyInputBinding(motor_ui, false);
 		input_ui_options.push_back(QString(motor_ui));
 	}
 
 	if (!current.isEmpty() && input_ui_options.indexOf(current) < 0)
 	{
-		input_setting_options.append(current);
+		input_ui_options.append(current);
 	}
 	else if (input_setting_options.isEmpty())
 	{
@@ -503,8 +503,8 @@ void InputVibrationBindingWidget::onClicked()
 
 	// If a controller is unplugged, we won't have the setting string to save
 	// Skip saving if selected is an existing bind from an unplugged controller
-	const int selected = input_setting_options.indexOf(input_dialog.textValue());
-	if (selected >= 0)
+	const int selected = input_ui_options.indexOf(input_dialog.textValue());
+	if (selected >= 0 && selected < input_setting_options.size())
 	{
 		// Update config
 		const std::string new_setting_value(input_setting_options[selected].toStdString());

--- a/pcsx2/Input/SDLInputSource.cpp
+++ b/pcsx2/Input/SDLInputSource.cpp
@@ -966,9 +966,9 @@ TinyString SDLInputSource::ConvertKeyToString(InputBindingKey key, bool display,
 		else if (key.source_subtype == InputSubclass::ControllerMotor)
 		{
 			if (display)
-				ret.format("SDL-{} {} Motor", static_cast<u32>(key.source_index), key.data ? "Large" : "Small");
+				ret.format("SDL-{} {} Motor", static_cast<u32>(key.source_index), key.data ? "Small" : "Large");
 			else
-				ret.format("SDL-{}/{}Motor", static_cast<u32>(key.source_index), key.data ? "Large" : "Small");
+				ret.format("SDL-{}/{}Motor", static_cast<u32>(key.source_index), key.data ? "Small" : "Large");
 		}
 		else if (key.source_subtype == InputSubclass::ControllerHaptic)
 		{

--- a/pcsx2/Input/XInputSource.cpp
+++ b/pcsx2/Input/XInputSource.cpp
@@ -374,9 +374,9 @@ TinyString XInputSource::ConvertKeyToString(InputBindingKey key, bool display, b
 		else if (key.source_subtype == InputSubclass::ControllerMotor)
 		{
 			if (display)
-				ret.format("XInput-{} {} Motor", static_cast<u32>(key.source_index), key.data ? "Large" : "Small");
+				ret.format("XInput-{} {} Motor", static_cast<u32>(key.source_index), key.data ? "Small" : "Large");
 			else
-				ret.format("XInput-{}/{}Motor", static_cast<u32>(key.source_index), key.data ? "Large" : "Small");
+				ret.format("XInput-{}/{}Motor", static_cast<u32>(key.source_index), key.data ? "Small" : "Large");
 		}
 	}
 


### PR DESCRIPTION
### Description of Changes
Fixes the vibration input binding window

### Rationale behind Changes
I did a poor job of updating this for UI strings during the SDL3 pr

### Suggested Testing Steps
Test manually selecting a vibration motor in the controller settings window