### PR TITLE
CI: Generate Breakpad symbols for Linux / OSX Windows debugging ease

### DIFF
--- a/.github/workflows/windows_build_qt.yml
+++ b/.github/workflows/windows_build_qt.yml
@@ -167,8 +167,24 @@ jobs:
             !./bin/**/*.pdb
             !./bin/**/*.lib
 
+      - name: Install the Breakpad Symbol Generator
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: dump_syms
+
+      - name: Generate Breakpad Symbols
+        shell: pwsh
+        run: |
+          Get-ChildItem -Path ./bin -Recurse -File | Where-Object { 
+            ($_.Extension -eq ".exe" -or $_.Extension -eq ".pdb") -and ($_.Name -notmatch "updater") 
+          } | ForEach-Object { 
+            & dump_syms $_.FullName >> pcsx2-qt.bpsym 
+          }
+
       - name: Upload artifact - with symbols
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.artifact-metadata.outputs.artifact-name }}-symbols
-          path: ./bin/**/*.pdb
+          path: |
+            ./bin/**/*.pdb
+            pcsx2-qt.bpsym


### PR DESCRIPTION
### Description of Changes
I wrote up a method for minidump viewing on Linux and OSX.
https://github.com/PCSX2/pcsx2/wiki/17-Viewing-Windows-Minidumps-on-Other-Platforms

We can skip a step by converting the symbols into the format minidump-stackwalk expects and shipping that with our symbol package.

### Rationale behind Changes
We don't have as many active Windows testers as we've once had, and spinning up a VM just to view a users minidump is ridiculous. This PR streamlines one of the steps required to view the minidumps on Linux / OSX.

### Suggested Testing Steps
See if the CI fails (it probably will), and see if the generated symbol file is valid.
