### PR TITLE
Qt: Fix display of LED colours on Windows native themes

### DIFF
--- a/pcsx2-qt/ColorPickerButton.cpp
+++ b/pcsx2-qt/ColorPickerButton.cpp
@@ -29,7 +29,7 @@ void ColorPickerButton::setColor(u32 rgb)
 
 void ColorPickerButton::updateBackgroundColor()
 {
-	setStyleSheet(QStringLiteral("background-color: #%1;").arg(static_cast<uint>(m_color), 8, 16, QChar('0')));
+	setStyleSheet(QStringLiteral("background-color: #%1;").arg(static_cast<uint>(m_color), 6, 16, QChar('0')));
 }
 
 void ColorPickerButton::onClicked()


### PR DESCRIPTION
### Description of Changes
Fix the display of the LED colours on Windows with the native theme

### Rationale behind Changes
The native themes would treat the colour set in the stylesheet as ARGB as its 8 hexadecimal digits long
As we never set the alpha, the colour would be fully transparent with these themes
Instead, only use 6 hexadecimal digits for an RGB format

### Suggested Testing Steps
In Controller->Global->Light bulb Icon
Check the Windows native themes to see LED colours are visible
Check other themes to make sure nothing broke there
