### PR TITLE
Deps: Add an extra include path for KDDockWidgets

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -119,6 +119,12 @@ add_subdirectory(3rdparty/ccc EXCLUDE_FROM_ALL)
 
 # The docking system for the debugger.
 find_package(KDDockWidgets-qt6 REQUIRED)
+# Add an extra include path to work around a broken include directive.
+# TODO: Remove this the next time we update KDDockWidgets.
+get_target_property(KDDOCKWIDGETS_INCLUDE_DIRECTORY KDAB::kddockwidgets INTERFACE_INCLUDE_DIRECTORIES)
+target_include_directories(KDAB::kddockwidgets INTERFACE
+	${KDDOCKWIDGETS_INCLUDE_DIRECTORY}/kddockwidgets
+)
 
 # Architecture-specific.
 if(_M_X86)


### PR DESCRIPTION
### Description of Changes
Add an extra include path to work around [an include bug](https://github.com/KDAB/KDDockWidgets/commit/3d6954f07dbe647295f7d295aa372b9b2daa27b3).

The `INTERFACE_INCLUDE_DIRECTORIES` property I'm using is set in `lib/cmake/KDDockWidgets-qt6/KDDockWidgets-qt6Targets.cmake`:
```
set_target_properties(KDAB::kddockwidgets PROPERTIES
  INTERFACE_COMPILE_DEFINITIONS "KDDW_FRONTEND_QTWIDGETS;KDDW_FRONTEND_QT"
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include/kddockwidgets-qt6"
  INTERFACE_LINK_LIBRARIES "Qt6::Widgets"
)
```

### Rationale behind Changes
Keep Linux package maintainers happy until a new KDDockWidgets release is published.

### Suggested Testing Steps
I've not done much testing on this. I'm sorry about that but I'm a bit busy at the moment.
