### PR TITLE
Debugger: Don't jump to PC if the breakpoint code paused the core

### DIFF
--- a/pcsx2-qt/Debugger/DebuggerWindow.cpp
+++ b/pcsx2-qt/Debugger/DebuggerWindow.cpp
@@ -323,6 +323,13 @@ void DebuggerWindow::onVMPaused()
 			CBreakPoints::SetSkipFirst(BREAKPOINT_IOP, r3000Debug.getPC());
 		});
 	}
+
+	// Stops us from telling the disassembly widget to jump somwhere because
+	// breakpoint code paused the core.
+	if (!CBreakPoints::GetCorePaused())
+		emit onVMActuallyPaused();
+	else
+		CBreakPoints::SetCorePaused(false);
 }
 
 void DebuggerWindow::onVMResumed()

--- a/pcsx2-qt/Debugger/DebuggerWindow.h
+++ b/pcsx2-qt/Debugger/DebuggerWindow.h
@@ -51,6 +51,11 @@ public slots:
 	void onStepOver();
 	void onStepOut();
 
+Q_SIGNALS:
+	// Only emitted if the pause wasn't a temporary one triggered by the
+	// breakpoint code.
+	void onVMActuallyPaused();
+
 protected:
 	void closeEvent(QCloseEvent* event);
 

--- a/pcsx2-qt/Debugger/DisassemblyWidget.cpp
+++ b/pcsx2-qt/Debugger/DisassemblyWidget.cpp
@@ -3,8 +3,9 @@
 
 #include "DisassemblyWidget.h"
 
-#include "Debugger/Breakpoints/BreakpointModel.h"
+#include "Debugger/DebuggerWindow.h"
 #include "Debugger/JsonValueWrapper.h"
+#include "Debugger/Breakpoints/BreakpointModel.h"
 
 #include "DebugTools/DebugInterface.h"
 #include "DebugTools/DisassemblyManager.h"
@@ -35,7 +36,8 @@ DisassemblyWidget::DisassemblyWidget(const DebuggerWidgetParameters& parameters)
 	setContextMenuPolicy(Qt::CustomContextMenu);
 	connect(this, &DisassemblyWidget::customContextMenuRequested, this, &DisassemblyWidget::openContextMenu);
 
-	connect(g_emu_thread, &EmuThread::onVMPaused, this, &DisassemblyWidget::gotoProgramCounterOnPause);
+	connect(g_debugger_window, &DebuggerWindow::onVMActuallyPaused,
+		this, &DisassemblyWidget::gotoProgramCounterOnPause);
 
 	receiveEvent<DebuggerEvents::Refresh>([this](const DebuggerEvents::Refresh& event) -> bool {
 		update();


### PR DESCRIPTION
### Description of Changes
Prevent the disassembler from jumping to the program counter if the breakpoint code paused the core.

### Rationale behind Changes
Fix a regression from my docking PR.

### Suggested Testing Steps
Make sure adding a breakpoint when the core is running doesn't make the disassembler jump to the program counter.