### PR TITLE
Revert "Debugger: Set default breakpoint size to 4"

### DIFF
--- a/pcsx2-qt/Debugger/Breakpoints/BreakpointDialog.ui
+++ b/pcsx2-qt/Debugger/Breakpoints/BreakpointDialog.ui
@@ -212,7 +212,7 @@
          </size>
         </property>
         <property name="text">
-         <string>4</string>
+         <string>1</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
This reverts commit 92b9390c51ea4e0caaf9f7d3de5e9d4ed2624073.

### Description of Changes
Reverts changes in https://github.com/PCSX2/pcsx2/pull/12356.

### Rationale behind Changes
A size of 1 captures all read/write operations which affect the byte at the given address, while a size of 4 is too inclusive and will capture additional variables if the variable at the address broken at is shorter than 32-bits.