### PR TITLE
VMManager: Enable file logging by default

### DIFF
--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -474,7 +474,7 @@ void VMManager::UpdateLoggingSettings(SettingsInterface& si)
 
 	const bool system_console_enabled = !s_log_block_system_console && si.GetBoolValue("Logging", "EnableSystemConsole", false);
 	const bool log_window_enabled = !s_log_block_system_console && si.GetBoolValue("Logging", "EnableLogWindow", false);
-	const bool file_logging_enabled = s_log_force_file_log || si.GetBoolValue("Logging", "EnableFileLogging", false);
+	const bool file_logging_enabled = s_log_force_file_log || si.GetBoolValue("Logging", "EnableFileLogging", true);
 
 	if (system_console_enabled != Log::IsConsoleOutputEnabled())
 		Log::SetConsoleOutputLevel(system_console_enabled ? level : LOGLEVEL_NONE);


### PR DESCRIPTION
### Description of Changes
Enables file logging by default.

### Rationale behind Changes
Make support easier when asking for an emulog.

### Suggested Testing Steps
Make sure on a clean build file logging is enabled.
