### PR TITLE
CI: Harden security by pinning third-party actions to a SHA

### DIFF
--- a/.github/workflows/cron_update_base_translation.yml
+++ b/.github/workflows/cron_update_base_translation.yml
@@ -17,7 +17,7 @@ jobs:
         run: ./.github/workflows/scripts/common/update_base_translation.sh
       
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@4320041ed380b20e97d388d56a7fb4f9b8c20e79
         with:
           title: "Qt: Update Base Translation"
           commit-message: "[ci skip] Qt: Update Base Translation."

--- a/.github/workflows/cron_update_controller_db.yml
+++ b/.github/workflows/cron_update_controller_db.yml
@@ -19,7 +19,7 @@ jobs:
           mv ./game_controller_db.txt ${{github.workspace}}/bin/resources/game_controller_db.txt
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@4320041ed380b20e97d388d56a7fb4f9b8c20e79
         with:
           title: "PAD: Update to latest controller database"
           commit-message: "[ci skip] PAD: Update to latest controller database."

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -160,7 +160,7 @@ jobs:
 
       - name: Sign the Application
         if: ${{ inputs.sign_and_notarize == true && env.SIGN_KEY }}
-        uses: indygreg/apple-code-sign-action@v1.1
+        uses: indygreg/apple-code-sign-action@44d0985b7f4363198e80b6fea63ac3e9dd3e9957
         with:
           input_path: 'PCSX2.app'
           p12_file: cert.p12

--- a/.github/workflows/release_cut_new.yml
+++ b/.github/workflows/release_cut_new.yml
@@ -40,7 +40,7 @@ jobs:
       # Docs - https://github.com/mathieudutour/github-tag-action
       - name: Bump Version and Push Tag
         id: tag_version
-        uses: mathieudutour/github-tag-action@v6.2
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b
         with:
           github_token: ${{ github.token }}
           tag_prefix: v
@@ -68,7 +68,7 @@ jobs:
           mv ./release-notes.md ${GITHUB_WORKSPACE}/release-notes.md
 
       - name: Create a GitHub Release (Manual)
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda
         if: steps.tag_version.outputs.new_tag && github.event_name == 'workflow_dispatch'
         with:
           body_path: ./release-notes.md
@@ -77,7 +77,7 @@ jobs:
           tag_name: ${{ steps.tag_version.outputs.new_tag }}
 
       - name: Create a GitHub Release (Push)
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda
         if: steps.tag_version.outputs.new_tag && github.event_name != 'workflow_dispatch'
         with:
           body_path: ./release-notes.md

--- a/.github/workflows/triage_pr.yml
+++ b/.github/workflows/triage_pr.yml
@@ -12,7 +12,7 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: xTVaser/first-interaction@v1.2.4
+    - uses: xTVaser/first-interaction@d62d6eb3c1215eae9f9d6dbfabf12d6725834cb3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         debug-mode: false

--- a/.github/workflows/windows_build_qt.yml
+++ b/.github/workflows/windows_build_qt.yml
@@ -168,7 +168,7 @@ jobs:
             !./bin/**/*.lib
 
       - name: Install the Breakpad Symbol Generator
-        uses: baptiste0928/cargo-install@v3
+        uses: baptiste0928/cargo-install@91c5da15570085bcde6f4d7aed98cb82d6769fd3
         with:
           crate: dump_syms
 


### PR DESCRIPTION
### Description of Changes
In wake of a massive supply chain attack in a thirdparty action with [over 23000 repositories having their secrets leaked](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised). I think it's in our best interest to pin actions to the full length commit sha. This is recommended by GitHub on their [Security Hardening Documentation](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

I've left out actions coming from trusted sources such as GitHub or Microsoft.

### Rationale behind Changes
Using tags is convenient, but a bad actor is able to change what commit a tag points to. In the case of the above incident, all of the tags were silently changed and pointed to the malicious commit. If we pin our actions to commit SHAs, there is no way for an outside attacker to change what commit our actions scripts use.

### Suggested Testing Steps
See if our CI scripts work.
