### PR TITLE
Debugger: Fix crash during breakpoint deletion

### DIFF
--- a/pcsx2-qt/Debugger/Breakpoints/BreakpointModel.cpp
+++ b/pcsx2-qt/Debugger/Breakpoints/BreakpointModel.cpp
@@ -59,7 +59,7 @@ int BreakpointModel::columnCount(const QModelIndex&) const
 
 QVariant BreakpointModel::data(const QModelIndex& index, int role) const
 {
-	size_t row = static_cast<size_t>(index.row());
+	const size_t row = static_cast<size_t>(index.row());
 	if (!index.isValid() || row >= m_breakpoints.size())
 		return QVariant();
 
@@ -298,7 +298,7 @@ Qt::ItemFlags BreakpointModel::flags(const QModelIndex& index) const
 
 bool BreakpointModel::setData(const QModelIndex& index, const QVariant& value, int role)
 {
-	size_t row = static_cast<size_t>(index.row());
+	const size_t row = static_cast<size_t>(index.row());
 	if (!index.isValid() || row >= m_breakpoints.size())
 		return false;
 
@@ -401,9 +401,14 @@ bool BreakpointModel::setData(const QModelIndex& index, const QVariant& value, i
 
 bool BreakpointModel::removeRows(int row, int count, const QModelIndex& index)
 {
+	const size_t begin_index = static_cast<size_t>(row);
+	const size_t end_index = static_cast<size_t>(row + count);
+	if (end_index > m_breakpoints.size())
+		return false;
+
 	beginRemoveRows(index, row, row + count - 1);
 
-	for (int i = row; i < row + count; i++)
+	for (size_t i = begin_index; i < end_index; i++)
 	{
 		auto bp_mc = m_breakpoints.at(i);
 
@@ -420,6 +425,7 @@ bool BreakpointModel::removeRows(int row, int count, const QModelIndex& index)
 			});
 		}
 	}
+
 	const auto begin = m_breakpoints.begin() + row;
 	const auto end = begin + count;
 	m_breakpoints.erase(begin, end);

--- a/pcsx2-qt/Debugger/Breakpoints/BreakpointWidget.cpp
+++ b/pcsx2-qt/Debugger/Breakpoints/BreakpointWidget.cpp
@@ -111,16 +111,14 @@ void BreakpointWidget::contextDelete()
 	if (!selModel->hasSelection())
 		return;
 
-	QModelIndexList rows = selModel->selectedIndexes();
+	QModelIndexList indices = selModel->selectedIndexes();
 
-	std::sort(rows.begin(), rows.end(), [](const QModelIndex& a, const QModelIndex& b) {
-		return a.row() > b.row();
-	});
+	std::set<int> rows;
+	for (QModelIndex index : indices)
+		rows.emplace(index.row());
 
-	for (const QModelIndex& index : rows)
-	{
-		m_model->removeRows(index.row(), 1);
-	}
+	for (auto row = rows.rbegin(); row != rows.rend(); row++)
+		m_model->removeRows(*row, 1);
 }
 
 void BreakpointWidget::contextNew()


### PR DESCRIPTION
### Description of Changes
If you select multiple columns of the same breakpoint, and then try to delete it, PCSX2 will no longer crash. I've also added some error handling logic to BreakpointModel::removeRows while I was at it.

### Rationale behind Changes
Prevent crashes. At first I was worried this was a regression from my docking PR, but it seems like it isn't.

### Suggested Testing Steps
- Make some breakpoints.
- Select multiple columns from the same breakpoint e.g. with Ctrl+A.
- Hopefully no crash.
