### PR TITLE
GS:MTL: Avoid write combined memory on Ryzen

### DIFF
--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
@@ -219,6 +219,7 @@ public:
 	MRCOwned<id<MTLFence>> m_draw_sync_fence;
 	MRCOwned<MTLFunctionConstantValues*> m_fn_constants;
 	MRCOwned<MTLVertexDescriptor*> m_hw_vertex;
+	MTLResourceOptions m_resource_options_shared_wc;
 
 	// Previously in MetalHostDisplay.
 	MRCOwned<NSView*> m_view;


### PR DESCRIPTION
### Description of Changes
Write combined memory appears to be broken on Ryzen, making the Metal renderer horribly slow

### Rationale behind Changes
Less slow

### Suggested Testing Steps
Test Metal on your Ryzen hackintosh