### PR TITLE
GS/Runner: Set the screenshot compression low to stop slow dump times

### DIFF
--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -113,6 +113,10 @@ bool GSRunner::InitializeConfig()
 	si.SetBoolValue("EmuCore/GS", "FrameLimitEnable", false);
 	si.SetIntValue("EmuCore/GS", "VsyncEnable", false);
 
+	// Force screenshot quality settings to something more performant, overriding any defaults good for users.
+	si.SetIntValue("EmuCore/GS", "ScreenshotFormat", static_cast<int>(GSScreenshotFormat::PNG));
+	si.SetIntValue("EmuCore/GS", "ScreenshotQuality", 10);
+
 	// ensure all input sources are disabled, we're not using them
 	si.SetBoolValue("InputSources", "SDL", false);
 	si.SetBoolValue("InputSources", "XInput", false);


### PR DESCRIPTION
### Description of Changes
Lowers the PNG compression on the dump runner

### Rationale behind Changes
the new default quality/compression of 90% for screenshots was making each frame take 1.56 seconds to dump, which adds up when you're doing thousands of them.  This lowers the compression to 10% which takes 0.0356 seconds to dump, at the cost of being 25% bigger files.

Do note that this is using PNG so the compression is lossless, so the only thing being lost here is a tiny bit of hdd space, and it's not much different from what it was pre the default change.

### Suggested Testing Steps
No need, immediately going to merge.