### PR TITLE
GS/HW: Adjust AA1 draw behavior.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -6177,6 +6177,7 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 	{
 		m_conf.blend = {}; // No blending please
 		m_conf.ps.no_color1 = true;
+		m_conf.ps.fixed_one_a = IsCoverageAlpha();
 
 		if (can_scale_rt_alpha && !new_scale_rt_alpha && m_conf.colormask.wa)
 		{


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/HW: Adjust AA1 draw behavior.

Make sure we use coverage alpha on aa1 draw when there's no blending.
Make sure we set coverage alpha to 128 in vertex trace alpha min max.
Some const and cast cleanup.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Bugfix, accuracy, fixes https://github.com/PCSX2/pcsx2/issues/12442

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Dump run no changes except the fixed issue.
![image](https://github.com/user-attachments/assets/cd2c4eec-4aa3-42a8-ae82-d8a57e461664)

