### PR TITLE
IOP Debug: allow reading ROM

### DIFF
--- a/pcsx2/DebugTools/DebugInterface.cpp
+++ b/pcsx2/DebugTools/DebugInterface.cpp
@@ -1029,6 +1029,11 @@ bool R3000DebugInterface::isValidAddress(u32 addr)
 		return true;
 	}
 
+	if (addr >= 0x1FC00000 && addr < 0x20000000)
+	{
+		return true;
+	}
+
 	if (addr < 0x200000)
 	{
 		return true;


### PR DESCRIPTION
### Description of Changes
BIOS ROM is now valid for reading in the IOP debugger.

### Rationale behind Changes
Users might want to inspect it.

### Suggested Testing Steps
0xBFC00000 onwards should now be readable in the debugger.

There appear to be strange issues with breakpoints on/around the initial IOP reset vector, I didn't really investigate though.
