### PR TITLE
Qt: Add GammaRay build scripts

### DIFF
--- a/.github/workflows/scripts/linux/build-gammaray.sh
+++ b/.github/workflows/scripts/linux/build-gammaray.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ "$#" -ne 2 ]; then
+	echo "Syntax: $0 <deps directory> <output directory>"
+	exit 1
+fi
+
+DEPSDIR=$(realpath "$1")
+INSTALLDIR=$(realpath "$2")
+
+if [ ! -d "$DEPSDIR/include/QtCore" ]; then
+	echo "Error: The build-dependencies-qt.sh script must be run on the deps directory first."
+	exit 1
+fi
+
+GAMMARAY=master
+
+mkdir -p gammaray-build
+cd gammaray-build
+
+echo "Downloading..."
+curl -L -o "GammaRay-$GAMMARAY.tar.gz" https://github.com/KDAB/GammaRay/archive/$GAMMARAY.tar.gz
+
+rm -fr "GammaRay-$GAMMARAY"
+
+echo "Extracting..."
+tar xf "GammaRay-$GAMMARAY.tar.gz"
+
+cd "GammaRay-$GAMMARAY"
+mkdir build
+cd build
+
+echo "Configuring..."
+cmake -DCMAKE_PREFIX_PATH="$DEPSDIR" -G Ninja -DCMAKE_INSTALL_PREFIX="$INSTALLDIR" -DGAMMARAY_BUILD_DOCS=false ..
+
+echo "Building..."
+cmake --build . --parallel
+
+echo "Installing..."
+cmake --build . --target install
+
+cd ../..
+
+echo "Cleaning up..."
+cd ..
+rm -r gammaray-build

--- a/.github/workflows/scripts/windows/build-gammaray.bat
+++ b/.github/workflows/scripts/windows/build-gammaray.bat
@@ -1,0 +1,68 @@
+@echo off
+setlocal enabledelayedexpansion
+
+echo Setting environment...
+if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat" (
+  call "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+) else if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat" (
+  call "%ProgramFiles%\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
+) else (
+  echo Visual Studio 2022 not found.
+  goto error
+)
+
+pushd %~dp0
+
+cd ..\..\..\..
+cd deps || goto error
+set "DEPSDIR=%CD%"
+cd ..
+mkdir gammaray
+cd gammaray || goto error
+set "INSTALLDIR=%CD%"
+cd ..
+mkdir gammaray-build
+cd gammaray-build || goto error
+set "BUILDDIR=%CD%"
+
+echo DEPSDIR=%DEPSDIR%
+echo BUILDDIR=%BUILDDIR%
+echo INSTALLDIR=%INSTALLDIR%
+
+set GAMMARAY="master"
+
+echo Downloading...
+curl -L -o "GammaRay-%GAMMARAY%.tar.gz" "https://github.com/KDAB/GammaRay/archive/%GAMMARAY%.tar.gz" || goto error
+
+rmdir /s /q "GammaRay-%GAMMARAY%"
+
+echo Extracting...
+tar -xf "GammaRay-%GAMMARAY%.tar.gz" || goto error
+
+echo Configuring...
+cmake "GammaRay-%GAMMARAY%" -B build -DCMAKE_PREFIX_PATH="%DEPSDIR%" -G Ninja -DCMAKE_INSTALL_PREFIX="%INSTALLDIR%" -DGAMMARAY_BUILD_DOCS=false || goto error
+
+echo Building...
+cmake --build build --parallel || goto error
+
+echo Installing...
+cmake --build build --target install || goto errorlevel
+
+echo Copying DLLs...
+xcopy /y "%DEPSDIR%\bin\*.dll" "%INSTALLDIR%\bin\"
+xcopy /y /e /s "%DEPSDIR%\plugins" "%INSTALLDIR%\bin\"
+
+echo Cleaning up...
+cd ..
+rd /s /q gammaray-build
+
+echo Exiting with success.
+popd
+pause
+exit 0
+
+:error
+echo Failed with error #%errorlevel%.
+popd
+pause
+exit %errorlevel%

--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,8 @@ oprofile_data/
 /deps-build
 /deps
 /deps-arm64
+/gammaray-build
+/gammaray
 /ipch
 
 !/3rdparty/libjpeg/change.log


### PR DESCRIPTION
### Description of Changes
Adds build scripts for [GammaRay](https://github.com/KDAB/GammaRay), a debugging tool for Qt applications.

Screenshots:

![Screenshot_20250322_005508](https://github.com/user-attachments/assets/76f6fab9-238a-4e03-851a-0373fac59750)

![Screenshot_20250322_005106](https://github.com/user-attachments/assets/e9160c7f-366d-4bd9-8323-a50171c00a89)


### Rationale behind Changes
After my positive experience with KDDockWidgets, I found KDAB also make this. Should make it easier to debug issues with the Qt frontend.

I didn't have much luck with the latest release (3.1.0 at time of writing), so currently it just downloads the version from the master branch.

### Suggested Testing Steps
Try building it and using it to debug PCSX2.

On Linux:
```
.github/workflows/scripts/linux/build-gammaray.sh deps gammaray
./gammaray/bin/gammaray build/bin/pcsx2-qt
```

On Windows (for example):
```
.github\workflows\scripts\windows\build-gammaray.bat
gammaray\bin\gammaray.exe bin\pcsx2-qtx64-avx2.exe
```

Note: You must run the script to build PCSX2's dependencies first (or in the case of Windows, you can download them).