### PR TITLE
Qt: Fix custom scan range settings and make sure to save symbol sources

### DIFF
--- a/pcsx2-qt/Settings/DebugAnalysisSettingsWidget.h
+++ b/pcsx2-qt/Settings/DebugAnalysisSettingsWidget.h
@@ -38,7 +38,7 @@ protected:
 	void removeSymbolFile();
 	void saveSymbolFiles();
 
-	void functionScanRangeChanged();
+	void saveFunctionScanRange();
 
 	void updateEnabledStates();
 


### PR DESCRIPTION
### Description of Changes
Makes it so the per-game settings dialog no longer forgets previous values for the custom function scan range settings, and removes broken validation checks that should have been removed when the ranges became expressions. Also, make sure symbol sources get saved properly and improve formatting.

### Rationale behind Changes
Fix some bugs.

### Suggested Testing Steps
Make sure that the function scan range settings all work properly.
