### PR TITLE
UI: Move Skip Presenting Duplicate Frames

### DIFF
--- a/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
@@ -34,6 +34,7 @@ EmulationSettingsWidget::EmulationSettingsWidget(SettingsWindow* dialog, QWidget
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.vsync, "EmuCore/GS", "VsyncEnable", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.syncToHostRefreshRate, "EmuCore/GS", "SyncToHostRefreshRate", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.useVSyncForTiming, "EmuCore/GS", "UseVSyncForTiming", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.skipPresentingDuplicateFrames, "EmuCore/GS", "SkipDuplicateFrames", false);
 	connect(m_ui.optimalFramePacing, &QCheckBox::checkStateChanged, this, &EmulationSettingsWidget::onOptimalFramePacingChanged);
 	connect(m_ui.vsync, &QCheckBox::checkStateChanged, this, &EmulationSettingsWidget::updateUseVSyncForTimingEnabled);
 	connect(m_ui.syncToHostRefreshRate, &QCheckBox::checkStateChanged, this, &EmulationSettingsWidget::updateUseVSyncForTimingEnabled);
@@ -154,6 +155,11 @@ EmulationSettingsWidget::EmulationSettingsWidget(SettingsWindow* dialog, QWidget
 	dialog->registerWidgetHelp(m_ui.useVSyncForTiming, tr("Use Host VSync Timing"), tr("Unchecked"),
 		tr("When synchronizing with the host refresh rate, this option disable's PCSX2's internal frame timing, and uses the host instead. "
 		   "Can result in smoother frame pacing, <strong>but at the cost of increased input latency</strong>."));
+	dialog->registerWidgetHelp(m_ui.skipPresentingDuplicateFrames, tr("Skip Presenting Duplicate Frames"), tr("Checked"),
+		tr("Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still "
+		   "rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time "
+		   "fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase "
+		   "input lag. Helps when using frame generation on 25/30fps games."));
 	dialog->registerWidgetHelp(m_ui.manuallySetRealTimeClock, tr("Manually Set Real-Time Clock"), tr("Unchecked"),
 		tr("Manually set a real-time clock to use for the virtual PlayStation 2 instead of using your OS' system clock."));
 	dialog->registerWidgetHelp(m_ui.rtcDateTime, tr("Real-Time Clock"), tr("Current date and time"),

--- a/pcsx2-qt/Settings/EmulationSettingsWidget.ui
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>672</width>
-    <height>438</height>
+    <height>500</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -222,17 +222,17 @@
       </item>
       <item row="3" column="0" colspan="2">
        <layout class="QGridLayout" name="basicCheckboxGridLayout">
-        <item row="1" column="1">
-         <widget class="QCheckBox" name="useVSyncForTiming">
-          <property name="text">
-           <string>Use Host VSync Timing</string>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="1">
          <widget class="QCheckBox" name="syncToHostRefreshRate">
           <property name="text">
            <string>Sync to Host Refresh Rate</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QCheckBox" name="vsync">
+          <property name="text">
+           <string>Vertical Sync (VSync)</string>
           </property>
          </widget>
         </item>
@@ -243,10 +243,17 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QCheckBox" name="vsync">
+        <item row="1" column="1">
+         <widget class="QCheckBox" name="useVSyncForTiming">
           <property name="text">
-           <string>Vertical Sync (VSync)</string>
+           <string>Use Host VSync Timing</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QCheckBox" name="skipPresentingDuplicateFrames">
+          <property name="text">
+           <string>Skip Presenting Duplicate Frames</string>
           </property>
          </widget>
         </item>
@@ -282,8 +289,7 @@
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QDateTimeEdit" name="rtcDateTime">
-       </widget>
+       <widget class="QDateTimeEdit" name="rtcDateTime"/>
       </item>
      </layout>
     </widget>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -244,7 +244,6 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 	//////////////////////////////////////////////////////////////////////////
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.useBlitSwapChain, "EmuCore/GS", "UseBlitSwapChain", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.useDebugDevice, "EmuCore/GS", "UseDebugDevice", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.skipPresentingDuplicateFrames, "EmuCore/GS", "SkipDuplicateFrames", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.disableMailboxPresentation, "EmuCore/GS", "DisableMailboxPresentation", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.extendedUpscales, "EmuCore/GS", "ExtendedUpscalingMultipliers", false);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.exclusiveFullscreenControl, "EmuCore/GS", "ExclusiveFullscreenControl", -1, -1);
@@ -395,7 +394,6 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 		m_ui.extendedUpscales = nullptr;
 		m_ui.spinCPUDuringReadbacks = nullptr;
 		m_ui.spinGPUDuringReadbacks = nullptr;
-		m_ui.skipPresentingDuplicateFrames = nullptr;
 		m_ui.overrideTextureBarriers = nullptr;
 		m_ui.disableFramebufferFetch = nullptr;
 		m_ui.disableShaderCache = nullptr;
@@ -860,12 +858,6 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 		dialog->registerWidgetHelp(m_ui.exclusiveFullscreenControl, tr("Allow Exclusive Fullscreen"), tr("Automatic (Default)"),
 			tr("Overrides the driver's heuristics for enabling exclusive fullscreen, or direct flip/scanout.<br>"
 			   "Disallowing exclusive fullscreen may enable smoother task switching and overlays, but increase input latency."));
-
-		dialog->registerWidgetHelp(m_ui.skipPresentingDuplicateFrames, tr("Skip Presenting Duplicate Frames"), tr("Unchecked"),
-			tr("Detects when idle frames are being presented in 25/30fps games, and skips presenting those frames. The frame is still "
-			   "rendered, it just means the GPU has more time to complete it (this is NOT frame skipping). Can smooth out frame time "
-			   "fluctuations when the CPU/GPU are near maximum utilization, but makes frame pacing more inconsistent and can increase "
-			   "input lag."));
 
 		dialog->registerWidgetHelp(m_ui.disableMailboxPresentation, tr("Disable Mailbox Presentation"), tr("Unchecked"),
 			tr("Forces the use of FIFO over Mailbox presentation, i.e. double buffering instead of triple buffering. "

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -2131,6 +2131,13 @@
           </item>
           <item row="10" column="0" colspan="2">
            <layout class="QGridLayout" name="gridLayout_9">
+            <item row="1" column="1">
+             <widget class="QCheckBox" name="extendedUpscales">
+              <property name="text">
+               <string>Extended Upscaling Multipliers</string>
+              </property>
+             </widget>
+            </item>
             <item row="2" column="0">
              <widget class="QCheckBox" name="disableMailboxPresentation">
               <property name="text">
@@ -2145,31 +2152,17 @@
               </property>
              </widget>
             </item>
-            <item row="1" column="1">
-             <widget class="QCheckBox" name="skipPresentingDuplicateFrames">
-              <property name="text">
-               <string>Skip Presenting Duplicate Frames</string>
-              </property>
-             </widget>
-            </item>
             <item row="2" column="1">
-             <widget class="QCheckBox" name="extendedUpscales">
+             <widget class="QCheckBox" name="spinCPUDuringReadbacks">
               <property name="text">
-               <string>Extended Upscaling Multipliers</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="1">
-             <widget class="QCheckBox" name="spinGPUDuringReadbacks">
-              <property name="text">
-               <string>Spin GPU During Readbacks</string>
+               <string>Spin CPU During Readbacks</string>
               </property>
              </widget>
             </item>
             <item row="3" column="0">
-             <widget class="QCheckBox" name="spinCPUDuringReadbacks">
+             <widget class="QCheckBox" name="spinGPUDuringReadbacks">
               <property name="text">
-               <string>Spin CPU During Readbacks</string>
+               <string>Spin GPU During Readbacks</string>
               </property>
              </widget>
             </item>

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -230,7 +230,7 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 
 			// GPU
 			text.clear();
-			text.append_format("GPU: {}", g_gs_device->GetName());
+			text.append_format("GPU: {}{}", g_gs_device->GetName(), GSConfig.UseDebugDevice ? " (Debug)" : "");
 			DRAW_LINE(fixed_font, text.c_str(), IM_COL32(255, 255, 255, 255));
 		}
 

--- a/pcsx2/PerformanceMetrics.cpp
+++ b/pcsx2/PerformanceMetrics.cpp
@@ -15,7 +15,7 @@
 #include "MTVU.h"
 #include "VMManager.h"
 
-static const float UPDATE_INTERVAL = 0.25f;
+static const float UPDATE_INTERVAL = 0.5f;
 
 static float s_fps = 0.0f;
 static float s_internal_fps = 0.0f;

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -3173,6 +3173,11 @@ void VMManager::WarnAboutUnsafeSettings()
 			append(ICON_FA_IMAGES,
 				TRANSLATE_SV("VMManager", "Mipmapping is disabled. This may break rendering in some games."));
 		}
+		if (EmuConfig.GS.UseDebugDevice)
+		{
+			append(ICON_FA_BUG,
+				TRANSLATE_SV("VMManager", "Debug device is enabled. This will massively reduce performance."));
+		}
 		static bool render_change_warn = false;
 		if (EmuConfig.GS.Renderer != GSRendererType::Auto && EmuConfig.GS.Renderer != GSRendererType::SW && !render_change_warn)
 		{


### PR DESCRIPTION
### Description of Changes
Moves Skip Presenting Duplicate Frames from Graphics Settings Advanced to Emulation Settings Frame Pacing/Latency Control,

### Rationale behind Changes
Move skip dupe frames.

### Suggested Testing Steps
Make sure skip duplicate frames still functions.
