### PR TITLE
GS/HW: Fix typo on Tekken 5 CRC

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -212,7 +212,7 @@ bool GSHwHack::GSC_Tekken5(GSRendererHW& r, int& skip)
 {
 	if (skip == 0)
 	{
-		if (r.IsPossibleChannelShuffle() && (RTBP0 & 31))
+		if (r.IsPossibleChannelShuffle() && !(RTBP0 & 31))
 		{
 			GSVertex* v = &r.m_vertex.buff[0];
 


### PR DESCRIPTION
### Description of Changes
Fix typo on Tekken 5 CRC

### Rationale behind Changes
Condition was backward

### Suggested Testing Steps
Don't :)
