### PR TITLE
Debugger: Prevent blinking animation when stepping

### DIFF
--- a/pcsx2-qt/Debugger/DebuggerWindow.cpp
+++ b/pcsx2-qt/Debugger/DebuggerWindow.cpp
@@ -306,12 +306,18 @@ void DebuggerWindow::onVMPaused()
 	m_ui.actionStepOver->setEnabled(true);
 	m_ui.actionStepOut->setEnabled(true);
 
-	// Switch to the CPU tab that triggered the breakpoint.
-	// Also blink the tab text to indicate that a breakpoint was triggered.
 	if (CBreakPoints::GetBreakpointTriggered())
 	{
-		const BreakPointCpu triggeredCpu = CBreakPoints::GetBreakpointTriggeredCpu();
-		m_dock_manager->switchToLayoutWithCPU(triggeredCpu, true);
+		// Select a layout tab corresponding to the CPU that triggered the
+		// breakpoint and make it start blinking unless said breakpoint was
+		// generated as a result of stepping.
+		const BreakPointCpu cpu_type = CBreakPoints::GetBreakpointTriggeredCpu();
+		if (cpu_type == BREAKPOINT_EE || cpu_type == BREAKPOINT_IOP)
+		{
+			DebugInterface& cpu = DebugInterface::get(cpu_type);
+			bool blink_tab = !CBreakPoints::IsSteppingBreakPoint(cpu_type, cpu.getPC());
+			m_dock_manager->switchToLayoutWithCPU(cpu_type, blink_tab);
+		}
 
 		Host::RunOnCPUThread([] {
 			CBreakPoints::ClearTemporaryBreakPoints();
@@ -417,7 +423,7 @@ void DebuggerWindow::onStepInto()
 		bpAddr = info.branchTarget; // Syscalls are always taken
 
 	Host::RunOnCPUThread([cpu, bpAddr] {
-		CBreakPoints::AddBreakPoint(cpu->getCpuType(), bpAddr, true);
+		CBreakPoints::AddBreakPoint(cpu->getCpuType(), bpAddr, true, true, true);
 		cpu->resumeCpu();
 	});
 
@@ -467,7 +473,7 @@ void DebuggerWindow::onStepOver()
 	}
 
 	Host::RunOnCPUThread([cpu, bpAddr] {
-		CBreakPoints::AddBreakPoint(cpu->getCpuType(), bpAddr, true);
+		CBreakPoints::AddBreakPoint(cpu->getCpuType(), bpAddr, true, true, true);
 		cpu->resumeCpu();
 	});
 
@@ -508,7 +514,7 @@ void DebuggerWindow::onStepOut()
 	u32 breakpoint_pc = stack_frames.at(1).pc;
 
 	Host::RunOnCPUThread([cpu, breakpoint_pc] {
-		CBreakPoints::AddBreakPoint(cpu->getCpuType(), breakpoint_pc, true);
+		CBreakPoints::AddBreakPoint(cpu->getCpuType(), breakpoint_pc, true, true, true);
 		cpu->resumeCpu();
 	});
 

--- a/pcsx2/DebugTools/Breakpoints.cpp
+++ b/pcsx2/DebugTools/Breakpoints.cpp
@@ -172,7 +172,13 @@ bool CBreakPoints::IsTempBreakPoint(BreakPointCpu cpu, u32 addr)
 	return bp != INVALID_BREAKPOINT;
 }
 
-void CBreakPoints::AddBreakPoint(BreakPointCpu cpu, u32 addr, bool temp, bool enabled)
+bool CBreakPoints::IsSteppingBreakPoint(BreakPointCpu cpu, u32 addr)
+{
+	const size_t bp = FindBreakpoint(cpu, addr, true, true);
+	return bp != INVALID_BREAKPOINT && breakPoints_[bp].stepping;
+}
+
+void CBreakPoints::AddBreakPoint(BreakPointCpu cpu, u32 addr, bool temp, bool enabled, bool stepping)
 {
 	const size_t bp = FindBreakpoint(cpu, addr, true, temp);
 	if (bp == INVALID_BREAKPOINT)
@@ -180,6 +186,7 @@ void CBreakPoints::AddBreakPoint(BreakPointCpu cpu, u32 addr, bool temp, bool en
 		BreakPoint pt;
 		pt.enabled = enabled;
 		pt.temporary = temp;
+		pt.stepping = stepping;
 		pt.addr = addr;
 		pt.cpu = cpu;
 

--- a/pcsx2/DebugTools/Breakpoints.h
+++ b/pcsx2/DebugTools/Breakpoints.h
@@ -12,14 +12,9 @@
 
 struct BreakPointCond
 {
-	DebugInterface* debug;
+	DebugInterface* debug = nullptr;
 	PostfixExpression expression;
 	std::string expressionString;
-
-	BreakPointCond()
-		: debug(NULL)
-	{
-	}
 
 	u32 Evaluate()
 	{
@@ -33,17 +28,10 @@ struct BreakPointCond
 
 struct BreakPoint
 {
-	BreakPoint()
-		: addr(0)
-		, enabled(false)
-		, temporary(false)
-		, hasCond(false)
-	{
-	}
-
-	u32 addr;
-	bool enabled;
-	bool temporary;
+	u32 addr = 0;
+	bool enabled = false;
+	bool temporary = false;
+	bool stepping = false;
 
 	bool hasCond;
 	BreakPointCond cond;
@@ -120,7 +108,8 @@ public:
 	static bool IsAddressBreakPoint(BreakPointCpu cpu, u32 addr);
 	static bool IsAddressBreakPoint(BreakPointCpu cpu, u32 addr, bool* enabled);
 	static bool IsTempBreakPoint(BreakPointCpu cpu, u32 addr);
-	static void AddBreakPoint(BreakPointCpu cpu, u32 addr, bool temp = false, bool enabled = true);
+	static bool IsSteppingBreakPoint(BreakPointCpu cpu, u32 addr);
+	static void AddBreakPoint(BreakPointCpu cpu, u32 addr, bool temp = false, bool enabled = true, bool stepping = false);
 	static void RemoveBreakPoint(BreakPointCpu cpu, u32 addr);
 	static void ChangeBreakPoint(BreakPointCpu cpu, u32 addr, bool enable);
 	static void ClearAllBreakPoints();


### PR DESCRIPTION
### Description of Changes
Keep a track of which breakpoints were created by the stepping code, and prevent the layout tab corresponding to the CPU the stepping breakpoint was triggered for from blinking.

### Rationale behind Changes
Fewer distractions while single stepping. I needed to make it its own flag since otherwise it would disable the animation when clicking "Run To Cursor" too, which I think should still make the tab blink.

### Suggested Testing Steps
Test breakpoints and stepping.
