### PR TITLE
MacOS: Mark our help menu as the macOS help menu

### DIFF
--- a/common/CocoaTools.h
+++ b/common/CocoaTools.h
@@ -19,6 +19,8 @@ namespace CocoaTools
 	void AddThemeChangeHandler(void* ctx, void(handler)(void* ctx));
 	/// Remove a handler previously added using AddThemeChangeHandler with the given context
 	void RemoveThemeChangeHandler(void* ctx);
+	/// Mark an NSMenu as the help menu
+	void MarkHelpMenu(void* menu);
 	/// Returns the bundle path.
 	std::optional<std::string> GetBundlePath();
 	/// Get the bundle path to the actual application without any translocation fun

--- a/common/CocoaTools.mm
+++ b/common/CocoaTools.mm
@@ -143,6 +143,11 @@ void CocoaTools::RemoveThemeChangeHandler(void* ctx)
 	[s_themeChangeHandler removeCallback:ctx];
 }
 
+void CocoaTools::MarkHelpMenu(void* menu)
+{
+	[NSApp setHelpMenu:(__bridge NSMenu*)menu];
+}
+
 // MARK: - Sound playback
 
 bool Common::PlaySoundAsync(const char* path)

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -151,6 +151,10 @@ void MainWindow::initialize()
 			ctx->updateTheme(); // Qt won't notice the style change without us touching the palette in some way
 		});
 	});
+	// The cocoa backing isn't initialized yet, delay this until stuff is set up with a `RunOnUIThread` call
+	QtHost::RunOnUIThread([this]{
+		CocoaTools::MarkHelpMenu(m_ui.menuHelp->toNSMenu());
+	});
 #endif
 	m_ui.setupUi(this);
 	setupAdditionalUi();


### PR DESCRIPTION
### Description of Changes
This gives it a nice search box for searching other menus.

This would happen automatically to menus named help, but only if the name matched the macOS name for the help menu in the system language.  By explicitly telling macOS which menu is the help menu, this will work regardless of what language is set in PCSX2 vs macOS.

### Rationale behind Changes
Searchable menus are nice

### Suggested Testing Steps
Check the help menu and see if it has a search box