### PR TITLE
DPM: Add option to replicate SDL2s layout for Nintendo gamepads

### DIFF
--- a/pcsx2/ImGui/ImGuiManager.h
+++ b/pcsx2/ImGui/ImGuiManager.h
@@ -97,6 +97,12 @@ namespace ImGuiManager
 	/// Called on the CPU thread when any input event fires. Allows imgui to take over controller navigation.
 	bool ProcessGenericInputEvent(GenericInputBinding key, InputLayout layout, float value);
 
+	/// Called to swap North/West gamepad buttons within ImGui
+	void SwapGamepadNorthWest(bool value);
+
+	/// Checks if the North/West gamepad buttons are swapped within ImGui
+	bool IsGamepadNorthWestSwapped();
+
 	/// Sets an image and scale for a software cursor. Software cursors can be used for things like crosshairs.
 	void SetSoftwareCursor(u32 index, std::string image_path, float image_scale, u32 multiply_color = 0xFFFFFF);
 	bool HasSoftwareCursor(u32 index);

--- a/pcsx2/Input/SDLInputSource.cpp
+++ b/pcsx2/Input/SDLInputSource.cpp
@@ -6,6 +6,8 @@
 #include "Input/InputManager.h"
 #include "Host.h"
 
+#include "ImGui/FullscreenUI.h"
+
 #include "common/Assertions.h"
 #include "common/Console.h"
 #include "common/Error.h"
@@ -700,6 +702,20 @@ std::optional<InputBindingKey> SDLInputSource::ParseKeyString(const std::string_
 										TRANSLATE("SDLInputSource", "As part of our upgrade to SDL3, we've had to migrate your binds\n"
 																	"Your controller did not match the Xbox layout and may need rebinding\n"
 																	"Please verify your controller settings and amend if required"));
+
+									// Also apply BPM setting for legacy binds
+									// We assume this is a Nintendo controller, BPM will check if it is
+									// Defer this, as we are probably under a setting lock
+									Host::RunOnCPUThread([] {
+										if (!Host::ContainsBaseSettingValue("UI", "SDL2NintendoLayout"))
+										{
+											Host::SetBaseStringSettingValue("UI", "SDL2NintendoLayout", "auto");
+											Host::CommitBaseSettingChanges();
+											// Get FSUI to recheck setting
+											if (FullscreenUI::IsInitialized())
+												FullscreenUI::GamepadLayoutChanged();
+										}
+									});
 								}
 								key.data = pos;
 							}


### PR DESCRIPTION
### Description of Changes
Addresses Tellow's comment https://github.com/PCSX2/pcsx2/pull/12311#issuecomment-2677562911
This is currently off by default, but does get toggled to auto when a legacy bind for a controller not matching the PS/Xbox layout is migrated

### Rationale behind Changes
Uses with Nintendo controllers who used BPM might have muscle memory and could prefer the mapping SDL2 provided

### Suggested Testing Steps
Test the Use Legacy Nintendo Layout option (either Enabled with any controller of auto with a Nintendo controller)
Migrating binds from pre-SDL3 PCSX2 made against a Nintendo controller (it should only set the legacy option only if no pre-existing setting was found)
