### PR TITLE
Qt: Add option to disable global menus on Linux/macOS

### DIFF
--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -174,6 +174,7 @@ private Q_SLOTS:
 	void updateLanguage();
 	void onThemeChanged();
 	void onLanguageChanged();
+	void onGlobalMenusChanged();
 	void onScreenshotActionTriggered();
 	void onSaveGSDumpActionTriggered();
 	void onBlockDumpActionToggled(bool checked);

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -108,6 +108,13 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsWindow* dialog, QWidget
 	SettingWidgetBinder::BindWidgetToStringSetting(sif, m_ui.language, "UI", "Language", QtHost::GetDefaultLanguage());
 	connect(m_ui.language, QOverload<int>::of(&QComboBox::currentIndexChanged), [this]() { emit languageChanged(); });
 
+#ifndef _WIN32
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.globalMenus, "UI", "GlobalMenus", true);
+	connect(m_ui.globalMenus, &QCheckBox::checkStateChanged, [this]() { emit globalMenusChanged(); });
+#else
+	m_ui.globalMenus->hide();
+#endif
+
 	// Per-game settings is special, we don't want to bind it if we're editing per-game settings.
 	if (!dialog->isPerGameSettings())
 	{
@@ -181,6 +188,9 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsWindow* dialog, QWidget
 	dialog->registerWidgetHelp(
 		m_ui.disableWindowResizing, tr("Disable Window Resizing"), tr("Unchecked"),
 		tr("Prevents the main window from being resized."));
+	dialog->registerWidgetHelp(
+		m_ui.globalMenus, tr("Enable Global Menus"), tr("Checked"),
+		tr("Display menu bars in a system-wide location if possible rather than at the top of each window."));
 
 	onRenderToSeparateWindowChanged();
 }

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.h
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.h
@@ -20,6 +20,7 @@ public:
 Q_SIGNALS:
 	void themeChanged();
 	void languageChanged();
+	void globalMenusChanged();
 
 private Q_SLOTS:
 	void onRenderToSeparateWindowChanged();

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>698</width>
-    <height>512</height>
+    <height>574</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -138,15 +138,18 @@
       <string>Preferences</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="1">
+       <widget class="QComboBox" name="language"/>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="theme"/>
+      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="languageLabel">
         <property name="text">
          <string>Language:</string>
         </property>
        </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="language"/>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="themeLabel">
@@ -155,8 +158,12 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="theme"/>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="globalMenus">
+        <property name="text">
+         <string>Enable Global Menus</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -215,7 +222,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Orientation::Vertical</enum>
+      <enum>Qt::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>


### PR DESCRIPTION
### Description of Changes
Adds an option to the interface settings screen to disable global menus on Linux/macOS. The option is hidden on Windows to prevent confusion.

![Screenshot_20250330_201023](https://github.com/user-attachments/assets/8801e13e-d599-4bfd-892d-9f44e7516dfa)

### Rationale behind Changes
I received some feedback that the debugger was now harder to use on macOS since the menu bar for the debugger overrides the menu bar for the main window. Eventually I want to add more functionality to the debugger menu bar so that this is less of an issue, but I also think providing this option as an alternative solution is a good idea.

### Suggested Testing Steps
Needs testing on macOS.
