### PR TITLE
GameDB: R&C Size Matters HPO Native with Texture Offset

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -7651,6 +7651,7 @@ SCKA-20120:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes vendor and other bloom.
     autoFlush: 2 # Fixes missing bloom and shadow definition.
+    halfPixelOffset: 5 # Fixes misaligned bloom. 
 SCKA-20124:
   name: "Piposarugetchu 3" # Ape Escape 3
   region: "NTSC-K"
@@ -12434,6 +12435,7 @@ SCUS-97615:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes vendor and other bloom.
     autoFlush: 2 # Fixes missing bloom and shadow definition.
+    halfPixelOffset: 5 # Fixes misaligned bloom. 
 SCUS-97616:
   name: "SingStar '80s"
   region: "NTSC-U"
@@ -27628,6 +27630,7 @@ SLES-55019:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes vendor and other bloom.
     autoFlush: 2 # Fixes missing bloom and shadow definition.
+    halfPixelOffset: 5 # Fixes misaligned bloom. 
 SLES-55020:
   name: "Die Simpsons - Das Spiel"
   region: "PAL-G"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -6512,7 +6512,12 @@ SCES-54941:
   region: "PAL-E"
 SCES-55019:
   name: "Ratchet & Clank - Size Matters"
-  region: "PAL-M5"
+  region: "PAL-M13"
+  gsHWFixes:
+    recommendedBlendingLevel: 4 # Fixes vendor and other bloom.
+    autoFlush: 2 # Fixes missing bloom and shadow definition.
+    halfPixelOffset: 5 # Fixes misaligned bloom.
+    nativeScaling: 2 # Fixes pixelated bloom.
 SCES-55038:
   name: "EyeToy Play - Hero"
   region: "PAL-M15"
@@ -7651,7 +7656,8 @@ SCKA-20120:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes vendor and other bloom.
     autoFlush: 2 # Fixes missing bloom and shadow definition.
-    halfPixelOffset: 5 # Fixes misaligned bloom. 
+    halfPixelOffset: 5 # Fixes misaligned bloom.
+    nativeScaling: 2 # Fixes pixelated bloom.
 SCKA-20124:
   name: "Piposarugetchu 3" # Ape Escape 3
   region: "NTSC-K"
@@ -12435,7 +12441,8 @@ SCUS-97615:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes vendor and other bloom.
     autoFlush: 2 # Fixes missing bloom and shadow definition.
-    halfPixelOffset: 5 # Fixes misaligned bloom. 
+    halfPixelOffset: 5 # Fixes misaligned bloom.
+    nativeScaling: 2 # Fixes pixelated bloom.
 SCUS-97616:
   name: "SingStar '80s"
   region: "NTSC-U"
@@ -27630,7 +27637,8 @@ SLES-55019:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes vendor and other bloom.
     autoFlush: 2 # Fixes missing bloom and shadow definition.
-    halfPixelOffset: 5 # Fixes misaligned bloom. 
+    halfPixelOffset: 5 # Fixes misaligned bloom.
+    nativeScaling: 2 # Fixes pixelated bloom.
 SLES-55020:
   name: "Die Simpsons - Das Spiel"
   region: "PAL-G"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->Adds "Native with Texture Offset" Half Pixel Offset to Ratchet & Clank: Size Matters to fix misaligned bloom.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Game without Half Pixel Offset:
![Ratchet   Clank - Size Matters_SCUS-97615_20250404063136](https://github.com/user-attachments/assets/352cd91a-7c3b-4d08-a32c-b82d050d6779)

Game with Native with Texture Offset:
![Ratchet   Clank - Size Matters_SCUS-97615_20250404063153](https://github.com/user-attachments/assets/82ba45f0-5c85-4564-b7a0-711cd91bec57)



### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->Test with other regions besides NTSC.
