### PR TITLE
Debugger: Add setting to change UI refresh interval

### DIFF
--- a/pcsx2-qt/Debugger/DebuggerWindow.h
+++ b/pcsx2-qt/Debugger/DebuggerWindow.h
@@ -8,6 +8,7 @@
 #include "DebugTools/DebugInterface.h"
 
 #include <kddockwidgets/MainWindow.h>
+#include <QtCore/QTimer>
 
 class DockManager;
 
@@ -36,6 +37,8 @@ public:
 	void saveWindowGeometry();
 	void restoreWindowGeometry();
 	bool shouldSaveWindowGeometry();
+
+	void updateFromSettings();
 
 public slots:
 	void onVMStarting();
@@ -67,6 +70,7 @@ private:
 	DockManager* m_dock_manager;
 
 	QByteArray m_default_toolbar_state;
+	QTimer* m_refresh_timer = nullptr;
 
 	int m_font_size;
 	static const constexpr int DEFAULT_FONT_SIZE = 10;

--- a/pcsx2-qt/Settings/DebugUserInterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DebugUserInterfaceSettingsWidget.cpp
@@ -4,6 +4,7 @@
 #include "DebugUserInterfaceSettingsWidget.h"
 
 #include "SettingWidgetBinder.h"
+#include "Debugger/DebuggerWindow.h"
 
 static const char* s_drop_indicators[] = {
 	QT_TRANSLATE_NOOP("DebugUserInterfaceSettingsWidget", "Classic"),
@@ -19,32 +20,40 @@ DebugUserInterfaceSettingsWidget::DebugUserInterfaceSettingsWidget(SettingsWindo
 
 	m_ui.setupUi(this);
 
-	SettingWidgetBinder::BindWidgetToBoolSetting(
-		sif, m_ui.showOnStartupCheckBox, "Debugger/UserInterface", "ShowOnStartup", false);
-
+	SettingWidgetBinder::BindWidgetToIntSetting(
+		sif, m_ui.refreshInterval, "Debugger/UserInterface", "RefreshInterval", 1000);
+	connect(m_ui.refreshInterval, &QSpinBox::valueChanged, this, []() {
+		if (g_debugger_window)
+			g_debugger_window->updateFromSettings();
+	});
 	dialog->registerWidgetHelp(
-		m_ui.showOnStartupCheckBox, tr("Show On Startup"), tr("Unchecked"),
+		m_ui.refreshInterval, tr("Refresh Interval"), tr("1000ms"),
+		tr("The amount of time to wait between subsequent attempts to update the user interface to reflect the state "
+		   "of the virtual machine."));
+
+	SettingWidgetBinder::BindWidgetToBoolSetting(
+		sif, m_ui.showOnStartup, "Debugger/UserInterface", "ShowOnStartup", false);
+	dialog->registerWidgetHelp(
+		m_ui.showOnStartup, tr("Show On Startup"), tr("Unchecked"),
 		tr("Open the debugger window automatically when PCSX2 starts."));
 
 	SettingWidgetBinder::BindWidgetToBoolSetting(
-		sif, m_ui.saveWindowGeometryCheckBox, "Debugger/UserInterface", "SaveWindowGeometry", true);
-
+		sif, m_ui.saveWindowGeometry, "Debugger/UserInterface", "SaveWindowGeometry", true);
 	dialog->registerWidgetHelp(
-		m_ui.saveWindowGeometryCheckBox, tr("Save Window Geometry"), tr("Checked"),
+		m_ui.saveWindowGeometry, tr("Save Window Geometry"), tr("Checked"),
 		tr("Save the position and size of the debugger window when it is closed so that it can be restored later."));
 
 	SettingWidgetBinder::BindWidgetToEnumSetting(
 		sif,
-		m_ui.dropIndicatorCombo,
+		m_ui.dropIndicator,
 		"Debugger/UserInterface",
 		"DropIndicatorStyle",
 		s_drop_indicators,
 		s_drop_indicators,
 		s_drop_indicators[0],
 		"DebugUserInterfaceSettingsWidget");
-
 	dialog->registerWidgetHelp(
-		m_ui.dropIndicatorCombo, tr("Drop Indicator Style"), tr("Classic"),
+		m_ui.dropIndicator, tr("Drop Indicator Style"), tr("Classic"),
 		tr("Choose how the drop indicators that appear when you drag dock windows in the debugger are styled. "
 		   "You will have to restart the debugger for this option to take effect."));
 }

--- a/pcsx2-qt/Settings/DebugUserInterfaceSettingsWidget.ui
+++ b/pcsx2-qt/Settings/DebugUserInterfaceSettingsWidget.ui
@@ -38,15 +38,8 @@
       <string>Debugger Window</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
-      <item row="0" column="1">
-       <widget class="QCheckBox" name="saveWindowGeometryCheckBox">
-        <property name="text">
-         <string>Save Window Geometry</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="showOnStartupCheckBox">
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="showOnStartup">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
           <horstretch>0</horstretch>
@@ -55,6 +48,36 @@
         </property>
         <property name="text">
          <string>Show On Startup</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QCheckBox" name="saveWindowGeometry">
+        <property name="text">
+         <string>Save Window Geometry</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="refreshIntervalLabel">
+        <property name="text">
+         <string>Refresh Interval:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QSpinBox" name="refreshInterval">
+        <property name="suffix">
+         <string>ms</string>
+        </property>
+        <property name="minimum">
+         <number>10</number>
+        </property>
+        <property name="maximum">
+         <number>100000</number>
+        </property>
+        <property name="value">
+         <number>1000</number>
         </property>
        </widget>
       </item>
@@ -76,12 +99,12 @@
       <item row="0" column="0">
        <widget class="QLabel" name="dropIndicatorLabel">
         <property name="text">
-         <string>Drop Indicator Style</string>
+         <string>Drop Indicator Style:</string>
         </property>
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QComboBox" name="dropIndicatorCombo"/>
+       <widget class="QComboBox" name="dropIndicator"/>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
### Description of Changes
Adds an option to change the UI refresh interval for the debugger. The default refresh interval remains 1000ms.

![Screenshot_20250406_153405](https://github.com/user-attachments/assets/873f6729-6a00-4853-b879-522ec4442146)

### Rationale behind Changes
Fixes #12489. It's a good suggestion.

### Suggested Testing Steps
Change the setting, see the register and memory views update accordingly.
