### PR TITLE
Qt: Enable mouse tracking on Windows 11 native theme

### DIFF
--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -181,6 +181,7 @@ void GameListWidget::initialize()
 	m_table_view->setSelectionBehavior(QAbstractItemView::SelectRows);
 	m_table_view->setContextMenuPolicy(Qt::CustomContextMenu);
 	m_table_view->setAlternatingRowColors(true);
+	m_table_view->setMouseTracking(true);
 	m_table_view->setShowGrid(false);
 	m_table_view->setCurrentIndex({});
 	m_table_view->horizontalHeader()->setHighlightSections(false);


### PR DESCRIPTION
### Description of Changes
Enables mouse tracking on the Windows 11 native theme.

### Rationale behind Changes
Fixes the highlight selection getting stuck after our update to Qt 6.9.0.

### Suggested Testing Steps
Make sure the highlight box does not get stuck when using the Windows 11 native theme.
