### PR TITLE
Qt/Cheats: Add tooltip to cheat descriptions

### DIFF
--- a/pcsx2-qt/Settings/GameCheatSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GameCheatSettingsWidget.cpp
@@ -283,6 +283,7 @@ QList<QStandardItem*> GameCheatSettingsWidget::populateTreeViewRow(const Patch::
 
 	QStandardItem* authorItem = new QStandardItem(QString::fromStdString(pi.author));
 	QStandardItem* descriptionItem = new QStandardItem(QString::fromStdString(pi.description));
+	descriptionItem->setToolTip(QString::fromStdString(pi.description));
 
 	items.push_back(nameItem);
 	items.push_back(authorItem);


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
This PR adds a tooltip to the cheat description. unfortunately adding a word wrap to the description requires a significant rework to the code so this will do for now.

Partially fixes #12492 
![image](https://github.com/user-attachments/assets/c412882f-d5f7-4d0c-9b8f-97ac54507a99)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Better usability and UX.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test if the cheat descriptions tooltip shows up properly