### PR TITLE
MSBuild: Improve handling of Qt files

### DIFF
--- a/common/vsprops/QtCompile.props
+++ b/common/vsprops/QtCompile.props
@@ -59,23 +59,37 @@
     <Delete Files="@(ResFiles->'$(QtToolOutDir)qrc_%(Filename).cpp')" />
   </Target>
 
-  <!--Passes all .ui files to uic and puts output in the build directory-->
-  <ItemGroup>
-    <UiFiles Include="$(MSBuildProjectDirectory)\**\*.ui" />
-  </ItemGroup>
+  <!--Passes .ui files to uic and puts output in the build directory-->
+  <!--We need to create tlogs so that VS knows the ui files are used-->
+  <!--See https://learn.microsoft.com/en-us/visualstudio/extensibility/visual-cpp-project-extensibility?view=vs-2022#tlog-files-->
   <Target Name="QtUi"
     BeforeTargets="ClCompile"
-    Inputs="@(UiFiles)"
-    Condition="'@(QtUi)'!=''"
-    Outputs="@(UiFiles->'$(QtToolOutDir)ui_%(Filename).h')">
-    <Message Text="uic %(UiFiles.Filename)" Importance="High" />
+    Condition="'@(QtUi)'!=''">
     <Error Condition="!$(QtDirValid)" Text="Qt directory non-existent (download/extract the zip)" />
     <MakeDir Directories="$(QtToolOutDir)" />
-    <Exec Command="&quot;$(QtHostBinDir)uic.exe&quot; &quot;%(UiFiles.FullPath)&quot; -o &quot;$(QtToolOutDir)ui_%(UiFiles.Filename).h&quot;" />
-  </Target>
+    <!--Setup metadata for following tasks-->
+    <ItemGroup>
+      <QtUi>
+        <Message>uic %(Filename)</Message>
+        <Command>
+            "$(QtHostBinDir)uic.exe" "%(FullPath)" -o "$(QtToolOutDir)ui_%(Filename).h"
+        </Command>
+        <Outputs>$(QtToolOutDir)ui_%(Filename).h</Outputs>
+      </QtUi>
+    </ItemGroup>
 
-  <Target Name="QtUiClean">
-    <Delete Files="@(UiFiles->'$(QtToolOutDir)ui_%(Filename).h')" />
+    <!--Helper for dealing with tlogs-->
+    <!--https://learn.microsoft.com/en-us/visualstudio/msbuild/getoutofdateitems-task?view=vs-2022-->
+    <GetOutOfDateItems Sources="@(QtUi)"
+      OutputsMetadataName="Outputs"
+      CommandMetadataName="Command"
+      TLogDirectory="$(TLogLocation)"
+      TLogNamePrefix="QtUi">
+      <Output TaskParameter="OutOfDateSources" ItemName="OutOfDateQtUi"/>
+    </GetOutOfDateItems>
+
+    <CustomBuild Condition="'@(OutOfDateQtUi)'!=''"
+      Sources="@(OutOfDateQtUi)" />
   </Target>
 
   <!--Compile files needed to MOC and output in the build directory-->

--- a/common/vsprops/QtCompile.props
+++ b/common/vsprops/QtCompile.props
@@ -102,7 +102,7 @@
   <Target Name="QtMoc"
     BeforeTargets="ClCompile"
     Condition="'@(QtMoc)'!=''"
-    Inputs="%(QtMoc.Identity);%(QtMoc.AdditionalDependencies);$(MSBuildProjectFile)"
+    Inputs="%(QtMoc.Identity);$(QtHostBinDir)moc.exe"
     Outputs="$(QtToolOutDir)%(QtMoc.RelativeDir)moc_%(QtMoc.Filename).cpp">
     <Message Text="moc %(QtMoc.Filename) $(QtToolOutDir)%(QtMoc.RelativeDir)moc_%(QtMoc.Filename).cpp" Importance="High" />
     <Error Condition="!$(QtDirValid)" Text="Qt directory non-existent (download/extract the zip)" />
@@ -111,7 +111,7 @@
   </Target>
 
   <ItemGroup>
-    <MocOutputs Include="$(QtToolOutDir)moc_*.cpp" />
+    <MocOutputs Include="$(QtToolOutDir)**/moc_*.cpp" />
   </ItemGroup>
   <Target Name="QtMocClean">
     <Delete Files="@(MocOutputs)" />

--- a/common/vsprops/QtCompile.targets
+++ b/common/vsprops/QtCompile.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CleanDependsOn>QtResourceClean;QtUiClean;QtMocClean;QtTsClean;$(CleanDependsOn)</CleanDependsOn>
+    <CleanDependsOn>QtResourceClean;QtMocClean;QtTsClean;$(CleanDependsOn)</CleanDependsOn>
     <!--
     <ComputeLinkInputsTargets>$(ComputeLinkInputsTargets);QtComputeMocOutput;</ComputeLinkInputsTargets>
     <ComputeLibInputsTargets>$(ComputeLibInputsTargets);QtComputeMocOutput;</ComputeLibInputsTargets>

--- a/common/vsprops/QtCompile.xml
+++ b/common/vsprops/QtCompile.xml
@@ -4,10 +4,10 @@
   <ItemType Name="QtUi" DisplayName="Qt User Interface File" />
   <ItemType Name="QtMoc" DisplayName="Qt Meta Object File" />
   <ItemType Name="QtTs" DisplayName="Qt Translation File" />
-  <ContentType Name="QtUi" DisplayName="Qt User Interface Compiler" />
-  <ContentType Name="QtResource" DisplayName="Qt Resource Compiler" />
-  <ContentType Name="QtMoc" DisplayName="Qt Meta Object Compiler" />
-  <ContentType Name="QtTs" DisplayName="Qt Translation Compiler" />
+  <ContentType Name="QtResource" DisplayName="Qt Resource Compiler" ItemType="QtResource" />
+  <ContentType Name="QtUi" DisplayName="Qt User Interface Compiler" ItemType = "QtUi"/>
+  <ContentType Name="QtMoc" DisplayName="Qt Meta Object Compiler" ItemType="QtMoc" />
+  <ContentType Name="QtTs" DisplayName="Qt Translation Compiler" ItemType="QtTs" />
   <FileExtension Name="*.qrc" ContentType="QtResource" />
   <FileExtension Name="*.ui" ContentType="QtUi" />
   <FileExtension Name="*.ts" ContentType="QtTs" />

--- a/pcsx2-qt/pcsx2-qt.vcxproj
+++ b/pcsx2-qt/pcsx2-qt.vcxproj
@@ -351,208 +351,85 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <QtUi Include="MainWindow.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="GameList\EmptyGameListWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="GameList\GameListWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\SettingsWindow.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\GameListSettingsWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\BIOSSettingsWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\EmulationSettingsWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\GraphicsSettingsWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\InterfaceSettingsWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\AdvancedSettingsWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\GameFixSettingsWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\InputBindingDialog.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\ControllerSettingsWindow.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\ControllerBindingWidget_DualShock2.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\ControllerBindingWidget_Guitar.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\ControllerBindingWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\ControllerGlobalSettingsWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\MemoryCardCreateDialog.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\AudioSettingsWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\MemoryCardConvertDialog.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\MemoryCardSettingsWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\DEV9DnsHostDialog.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\DEV9SettingsWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\GameSummaryWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="AutoUpdaterDialog.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="CoverDownloadDialog.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Tools\InputRecording\NewInputRecordingDlg.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\AchievementLoginDialog.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\AchievementSettingsWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Tools\InputRecording\InputRecordingViewer.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Debugger\AnalysisOptionsDialog.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Debugger\DebuggerWindow.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Debugger\DisassemblyWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Debugger\RegisterWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Debugger\Breakpoints\BreakpointDialog.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Debugger\Breakpoints\BreakpointWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Debugger\Docking\LayoutEditorDialog.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Debugger\Docking\NoLayoutsWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Debugger\Memory\MemorySearchWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Debugger\Memory\MemoryViewWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Debugger\Memory\SavedAddressesWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-  </ItemGroup>
-  <ItemGroup>
-    <QtUi Include="SetupWizardDialog.ui">
-      <FileType>Document</FileType>
-    </QtUi>
+    <QtUi Include="AboutDialog.ui" />
+    <QtUi Include="AutoUpdaterDialog.ui" />
+    <QtUi Include="CoverDownloadDialog.ui" />
+    <QtUi Include="Debugger\AnalysisOptionsDialog.ui" />
+    <QtUi Include="Debugger\Breakpoints\BreakpointDialog.ui" />
+    <QtUi Include="Debugger\Breakpoints\BreakpointWidget.ui" />
+    <QtUi Include="Debugger\DebuggerWindow.ui" />
+    <QtUi Include="Debugger\DisassemblyWidget.ui" />
+    <QtUi Include="Debugger\Docking\LayoutEditorDialog.ui" />
+    <QtUi Include="Debugger\Docking\NoLayoutsWidget.ui" />
+    <QtUi Include="Debugger\Memory\MemorySearchWidget.ui" />
+    <QtUi Include="Debugger\Memory\MemoryViewWidget.ui" />
+    <QtUi Include="Debugger\Memory\SavedAddressesWidget.ui" />
+    <QtUi Include="Debugger\RegisterWidget.ui" />
+    <QtUi Include="Debugger\StackWidget.ui" />
+    <QtUi Include="Debugger\SymbolTree\NewSymbolDialog.ui" />
+    <QtUi Include="Debugger\SymbolTree\SymbolTreeWidget.ui" />
+    <QtUi Include="Debugger\ThreadWidget.ui" />
+    <QtUi Include="GameList\EmptyGameListWidget.ui" />
+    <QtUi Include="GameList\GameListWidget.ui" />
+    <QtUi Include="MainWindow.ui" />
+    <QtUi Include="Settings\AchievementLoginDialog.ui" />
+    <QtUi Include="Settings\AchievementSettingsWidget.ui" />
+    <QtUi Include="Settings\AdvancedSettingsWidget.ui" />
+    <QtUi Include="Settings\AudioExpansionSettingsDialog.ui" />
+    <QtUi Include="Settings\AudioSettingsWidget.ui" />
+    <QtUi Include="Settings\AudioStretchSettingsDialog.ui" />
+    <QtUi Include="Settings\BIOSSettingsWidget.ui" />
+    <QtUi Include="Settings\ControllerBindingWidget.ui" />
+    <QtUi Include="Settings\ControllerBindingWidget_DualShock2.ui" />
+    <QtUi Include="Settings\ControllerBindingWidget_Guitar.ui" />
+    <QtUi Include="Settings\ControllerBindingWidget_Jogcon.ui" />
+    <QtUi Include="Settings\ControllerBindingWidget_Negcon.ui" />
+    <QtUi Include="Settings\ControllerBindingWidget_Popn.ui" />
+    <QtUi Include="Settings\ControllerGlobalSettingsWidget.ui" />
+    <QtUi Include="Settings\ControllerLEDSettingsDialog.ui" />
+    <QtUi Include="Settings\ControllerMacroEditWidget.ui" />
+    <QtUi Include="Settings\ControllerMacroWidget.ui" />
+    <QtUi Include="Settings\ControllerMappingSettingsDialog.ui" />
+    <QtUi Include="Settings\ControllerMouseSettingsDialog.ui" />
+    <QtUi Include="Settings\ControllerSettingsWindow.ui" />
+    <QtUi Include="Settings\DebugAnalysisSettingsWidget.ui" />
+    <QtUi Include="Settings\DebugSettingsWidget.ui" />
+    <QtUi Include="Settings\DebugUserInterfaceSettingsWidget.ui" />
+    <QtUi Include="Settings\DEV9DnsHostDialog.ui" />
+    <QtUi Include="Settings\DEV9SettingsWidget.ui" />
+    <QtUi Include="Settings\EmulationSettingsWidget.ui" />
+    <QtUi Include="Settings\FolderSettingsWidget.ui" />
+    <QtUi Include="Settings\GameCheatSettingsWidget.ui" />
+    <QtUi Include="Settings\GameFixSettingsWidget.ui" />
+    <QtUi Include="Settings\GameListSettingsWidget.ui" />
+    <QtUi Include="Settings\GamePatchDetailsWidget.ui" />
+    <QtUi Include="Settings\GamePatchSettingsWidget.ui" />
+    <QtUi Include="Settings\GameSummaryWidget.ui" />
+    <QtUi Include="Settings\GraphicsSettingsWidget.ui" />
+    <QtUi Include="Settings\InputBindingDialog.ui" />
+    <QtUi Include="Settings\InterfaceSettingsWidget.ui" />
+    <QtUi Include="Settings\MemoryCardConvertDialog.ui" />
+    <QtUi Include="Settings\MemoryCardCreateDialog.ui" />
+    <QtUi Include="Settings\MemoryCardSettingsWidget.ui" />
+    <QtUi Include="Settings\PatchDetailsWidget.ui" />
+    <QtUi Include="Settings\SettingsWindow.ui" />
+    <QtUi Include="Settings\USBBindingWidget_Buzz.ui" />
+    <QtUi Include="Settings\USBBindingWidget_DenshaCon.ui" />
+    <QtUi Include="Settings\USBBindingWidget_DrivingForce.ui" />
+    <QtUi Include="Settings\USBBindingWidget_Gametrak.ui" />
+    <QtUi Include="Settings\USBBindingWidget_GTForce.ui" />
+    <QtUi Include="Settings\USBBindingWidget_GunCon2.ui" />
+    <QtUi Include="Settings\USBBindingWidget_RealPlay.ui" />
+    <QtUi Include="Settings\USBBindingWidget_RyojouhenCon.ui" />
+    <QtUi Include="Settings\USBBindingWidget_ShinkansenCon.ui" />
+    <QtUi Include="Settings\USBBindingWidget_TranceVibrator.ui" />
+    <QtUi Include="Settings\USBDeviceWidget.ui" />
     <QtTs Include="Translations\pcsx2-qt_en.ts">
       <FileType>Document</FileType>
     </QtTs>
-    <QtUi Include="Settings\DebugAnalysisSettingsWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\DebugUserInterfaceSettingsWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\DebugSettingsWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\ControllerLEDSettingsDialog.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\ControllerMouseSettingsDialog.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\GameCheatSettingsWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\GamePatchSettingsWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\USBBindingWidget_Buzz.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\USBBindingWidget_DenshaCon.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\USBBindingWidget_DrivingForce.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\USBBindingWidget_Gametrak.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\USBBindingWidget_GTForce.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\USBBindingWidget_GunCon2.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\USBBindingWidget_RealPlay.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\USBBindingWidget_RyojouhenCon.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\USBBindingWidget_ShinkansenCon.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\USBBindingWidget_TranceVibrator.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\USBDeviceWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\ControllerMacroEditWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\ControllerMacroWidget.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <None Include="Debugger\SymbolTree\NewSymbolDialog.ui" />
-    <None Include="Debugger\SymbolTree\SymbolTreeWidget.ui" />
-    <QtUi Include="Settings\AudioExpansionSettingsDialog.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <QtUi Include="Settings\AudioStretchSettingsDialog.ui">
-      <FileType>Document</FileType>
-    </QtUi>
-    <None Include="Settings\ControllerBindingWidget_Popn.ui" />
-    <None Include="Settings\ControllerMappingSettingsDialog.ui" />
-    <None Include="Settings\FolderSettingsWidget.ui" />
+    <QtUi Include="SetupWizardDialog.ui" />
+    <QtUi Include="Tools\InputRecording\InputRecordingViewer.ui" />
+    <QtUi Include="Tools\InputRecording\NewInputRecordingDlg.ui" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Import Project="$(SolutionDir)common\vsprops\QtCompile.targets" />

--- a/pcsx2-qt/pcsx2-qt.vcxproj.filters
+++ b/pcsx2-qt/pcsx2-qt.vcxproj.filters
@@ -735,107 +735,32 @@
     </QtResource>
   </ItemGroup>
   <ItemGroup>
-    <QtUi Include="mainwindow.ui" />
-    <QtUi Include="Settings\BIOSSettingsWidget.ui">
-      <Filter>Settings</Filter>
+    <QtUi Include="Debugger\Breakpoints\BreakpointDialog.ui">
+      <Filter>Debugger\Breakpoints</Filter>
     </QtUi>
-    <QtUi Include="Settings\EmulationSettingsWidget.ui">
-      <Filter>Settings</Filter>
+    <QtUi Include="Debugger\Breakpoints\BreakpointWidget.ui">
+      <Filter>Debugger\Breakpoints</Filter>
     </QtUi>
-    <QtUi Include="Settings\GameListSettingsWidget.ui">
-      <Filter>Settings</Filter>
+    <QtUi Include="Debugger\Docking\LayoutEditorDialog.ui">
+      <Filter>Debugger\Docking</Filter>
     </QtUi>
-    <QtUi Include="Settings\GraphicsSettingsWidget.ui">
-      <Filter>Settings</Filter>
+    <QtUi Include="Debugger\Docking\NoLayoutsWidget.ui">
+      <Filter>Debugger\Docking</Filter>
     </QtUi>
-    <QtUi Include="Settings\InterfaceSettingsWidget.ui">
-      <Filter>Settings</Filter>
+    <QtUi Include="Debugger\Memory\MemorySearchWidget.ui">
+      <Filter>Debugger\Memory</Filter>
     </QtUi>
-    <QtUi Include="Settings\SettingsWindow.ui">
-      <Filter>Settings</Filter>
+    <QtUi Include="Debugger\Memory\MemoryViewWidget.ui">
+      <Filter>Debugger\Memory</Filter>
     </QtUi>
-    <QtUi Include="Settings\AdvancedSettingsWidget.ui">
-      <Filter>Settings</Filter>
+    <QtUi Include="Debugger\Memory\SavedAddressesWidget.ui">
+      <Filter>Debugger\Memory</Filter>
     </QtUi>
-    <QtUi Include="Settings\GameFixSettingsWidget.ui">
-      <Filter>Settings</Filter>
+    <QtUi Include="Debugger\SymbolTree\NewSymbolDialog.ui">
+      <Filter>Debugger\SymbolTree</Filter>
     </QtUi>
-    <QtUi Include="Settings\InputBindingDialog.ui">
-      <Filter>Settings</Filter>
-    </QtUi>
-    <QtUi Include="Settings\ControllerSettingsWindow.ui">
-      <Filter>Settings</Filter>
-    </QtUi>
-    <QtUi Include="Settings\ControllerBindingWidget_DualShock2.ui">
-      <Filter>Settings</Filter>
-    </QtUi>
-    <QtUi Include="Settings\ControllerBindingWidget_Guitar.ui">
-      <Filter>Settings</Filter>
-    </QtUi>
-    <QtUi Include="Settings\ControllerBindingWidget.ui">
-      <Filter>Settings</Filter>
-    </QtUi>
-    <QtUi Include="Settings\ControllerGlobalSettingsWidget.ui">
-      <Filter>Settings</Filter>
-    </QtUi>
-    <QtUi Include="Settings\GameSummaryWidget.ui">
-      <Filter>Settings</Filter>
-    </QtUi>
-    <QtUi Include="Settings\MemoryCardConvertDialog.ui">
-      <Filter>Settings</Filter>
-    </QtUi>
-    <QtUi Include="Settings\MemoryCardSettingsWidget.ui">
-      <Filter>Settings</Filter>
-    </QtUi>
-    <QtUi Include="Settings\AudioSettingsWidget.ui">
-      <Filter>Settings</Filter>
-    </QtUi>
-    <QtUi Include="Settings\MemoryCardCreateDialog.ui">
-      <Filter>Settings</Filter>
-    </QtUi>
-    <QtUi Include="Settings\DEV9DnsHostDialog.ui">
-      <Filter>Settings</Filter>
-    </QtUi>
-    <QtUi Include="Settings\DEV9SettingsWidget.ui">
-      <Filter>Settings</Filter>
-    </QtUi>
-    <QtUi Include="GameList\EmptyGameListWidget.ui">
-      <Filter>GameList</Filter>
-    </QtUi>
-    <QtUi Include="GameList\GameListWidget.ui">
-      <Filter>GameList</Filter>
-    </QtUi>
-    <QtUi Include="AutoUpdaterDialog.ui" />
-    <QtUi Include="Tools\InputRecording\NewInputRecordingDlg.ui">
-      <Filter>Tools\Input Recording</Filter>
-    </QtUi>
-    <QtUi Include="Settings\ControllerMacroWidget.ui">
-      <Filter>Settings</Filter>
-    </QtUi>
-    <QtUi Include="Settings\ControllerMacroEditWidget.ui">
-      <Filter>Settings</Filter>
-    </QtUi>
-    <QtUi Include="Settings\AchievementSettingsWidget.ui">
-      <Filter>Settings</Filter>
-    </QtUi>
-    <QtUi Include="Settings\AchievementLoginDialog.ui">
-      <Filter>Settings</Filter>
-    </QtUi>
-    <QtUi Include="CoverDownloadDialog.ui" />
-    <QtUi Include="Tools\InputRecording\InputRecordingViewer.ui">
-      <Filter>Tools\Input Recording</Filter>
-    </QtUi>
-    <QtUi Include="Settings\USBDeviceWidget.ui">
-      <Filter>Settings</Filter>
-    </QtUi>
-    <QtUi Include="Settings\DebugAnalysisSettingsWidget.ui">
-      <Filter>Settings</Filter>
-    </QtUi>
-    <QtUi Include="Settings\DebugUserInterfaceSettingsWidget.ui">
-      <Filter>Settings</Filter>
-    </QtUi>
-    <QtUi Include="Settings\DebugSettingsWidget.ui">
-      <Filter>Settings</Filter>
+    <QtUi Include="Debugger\SymbolTree\SymbolTreeWidget.ui">
+      <Filter>Debugger\SymbolTree</Filter>
     </QtUi>
     <QtUi Include="Debugger\AnalysisOptionsDialog.ui">
       <Filter>Debugger</Filter>
@@ -849,19 +774,141 @@
     <QtUi Include="Debugger\RegisterWidget.ui">
       <Filter>Debugger</Filter>
     </QtUi>
+    <QtUi Include="Debugger\StackWidget.ui">
+      <Filter>Debugger</Filter>
+    </QtUi>
+    <QtUi Include="Debugger\ThreadWidget.ui">
+      <Filter>Debugger</Filter>
+    </QtUi>
+    <QtUi Include="GameList\EmptyGameListWidget.ui">
+      <Filter>GameList</Filter>
+    </QtUi>
+    <QtUi Include="GameList\GameListWidget.ui">
+      <Filter>GameList</Filter>
+    </QtUi>
+    <QtUi Include="Settings\AchievementLoginDialog.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\AchievementSettingsWidget.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\AdvancedSettingsWidget.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\AudioExpansionSettingsDialog.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\AudioSettingsWidget.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\AudioStretchSettingsDialog.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\BIOSSettingsWidget.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\ControllerBindingWidget.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\ControllerBindingWidget_DualShock2.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\ControllerBindingWidget_Guitar.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\ControllerBindingWidget_Jogcon.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\ControllerBindingWidget_Negcon.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\ControllerBindingWidget_Popn.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\ControllerGlobalSettingsWidget.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
     <QtUi Include="Settings\ControllerLEDSettingsDialog.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\ControllerMacroEditWidget.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\ControllerMacroWidget.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\ControllerMappingSettingsDialog.ui">
       <Filter>Settings</Filter>
     </QtUi>
     <QtUi Include="Settings\ControllerMouseSettingsDialog.ui">
       <Filter>Settings</Filter>
     </QtUi>
+    <QtUi Include="Settings\ControllerSettingsWindow.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\DebugAnalysisSettingsWidget.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\DebugSettingsWidget.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\DebugUserInterfaceSettingsWidget.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\DEV9DnsHostDialog.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\DEV9SettingsWidget.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\EmulationSettingsWidget.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\FolderSettingsWidget.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
     <QtUi Include="Settings\GameCheatSettingsWidget.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\GameFixSettingsWidget.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\GameListSettingsWidget.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\GamePatchDetailsWidget.ui">
       <Filter>Settings</Filter>
     </QtUi>
     <QtUi Include="Settings\GamePatchSettingsWidget.ui">
       <Filter>Settings</Filter>
     </QtUi>
-    <QtUi Include="SetupWizardDialog.ui" />
+    <QtUi Include="Settings\GameSummaryWidget.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\GraphicsSettingsWidget.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\InputBindingDialog.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\InterfaceSettingsWidget.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\MemoryCardConvertDialog.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\MemoryCardCreateDialog.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\MemoryCardSettingsWidget.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\PatchDetailsWidget.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\SettingsWindow.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
     <QtUi Include="Settings\USBBindingWidget_Buzz.ui">
       <Filter>Settings</Filter>
     </QtUi>
@@ -892,50 +939,20 @@
     <QtUi Include="Settings\USBBindingWidget_TranceVibrator.ui">
       <Filter>Settings</Filter>
     </QtUi>
-    <QtUi Include="Settings\AudioExpansionSettingsDialog.ui">
+    <QtUi Include="Settings\USBDeviceWidget.ui">
       <Filter>Settings</Filter>
     </QtUi>
-    <QtUi Include="Settings\AudioStretchSettingsDialog.ui">
-      <Filter>Settings</Filter>
+    <QtUi Include="Tools\InputRecording\InputRecordingViewer.ui">
+      <Filter>Tools\Input Recording</Filter>
     </QtUi>
-    <QtUi Include="Debugger\Breakpoints\BreakpointDialog.ui">
-      <Filter>Debugger\Breakpoints</Filter>
+    <QtUi Include="Tools\InputRecording\NewInputRecordingDlg.ui">
+      <Filter>Tools\Input Recording</Filter>
     </QtUi>
-    <QtUi Include="Debugger\Breakpoints\BreakpointWidget.ui">
-      <Filter>Debugger\Breakpoints</Filter>
-    </QtUi>
-    <QtUi Include="Debugger\Memory\SavedAddressesWidget.ui">
-      <Filter>Debugger\Memory</Filter>
-    </QtUi>
-    <QtUi Include="Debugger\Memory\MemoryViewWidget.ui">
-      <Filter>Debugger\Memory</Filter>
-    </QtUi>
-    <QtUi Include="Debugger\Memory\MemorySearchWidget.ui">
-      <Filter>Debugger\Memory</Filter>
-    </QtUi>
-    <QtUi Include="Debugger\Docking\LayoutEditorDialog.ui">
-      <Filter>Debugger\Docking</Filter>
-    </QtUi>
-    <QtUi Include="Debugger\Docking\NoLayoutsWidget.ui">
-      <Filter>Debugger\Docking</Filter>
-    </QtUi>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Settings\FolderSettingsWidget.ui">
-      <Filter>Settings</Filter>
-    </None>
-    <None Include="Settings\ControllerBindingWidget_Popn.ui">
-      <Filter>Settings</Filter>
-    </None>
-    <None Include="Settings\ControllerMappingSettingsDialog.ui">
-      <Filter>Settings</Filter>
-    </None>
-    <None Include="Debugger\SymbolTree\NewSymbolDialog.ui">
-      <Filter>Debugger\SymbolTree</Filter>
-    </None>
-    <None Include="Debugger\SymbolTree\SymbolTreeWidget.ui">
-      <Filter>Debugger\SymbolTree</Filter>
-    </None>
+    <QtUi Include="AboutDialog.ui" />
+    <QtUi Include="AutoUpdaterDialog.ui" />
+    <QtUi Include="CoverDownloadDialog.ui" />
+    <QtUi Include="MainWindow.ui" />
+    <QtUi Include="SetupWizardDialog.ui" />
   </ItemGroup>
   <ItemGroup>
     <QtTs Include="Translations\pcsx2-qt_en.ts">


### PR DESCRIPTION
### Description of Changes
Switches the `QtUi` task to use [tlog files](https://learn.microsoft.com/en-us/visualstudio/extensibility/visual-cpp-project-extensibility?view=vs-2022#tlog-files)
Link the Qt ItemTypes to the relevant ContentTypes

Set the `moc` tool as an input for the QtMoc task
Fix the QtMocClean task

### Rationale behind Changes
`tlog` files list what files are used or created during the build process.
Visual Studio uses these logs to figure out what files need to be checked for up-to-date checks.
Creating these files will allow Visual Studio to know that a build is needed when the `.ui` files have been edited.
They also get used during clean, making the QtUiClean redundant.
Documentation was pretty thin, only really figured it out thanks to a [blog post](https://www.reedbeta.com/blog/custom-toolchain-with-msbuild/#adding-a-custom-target) and a MS employee [telling someone to refer to VS's built in tasks for reference](https://developercommunity.visualstudio.com/t/custom-build-task-runs-on-every-build-due-to-missi/903334#T-N974983).

Adding ItemType to the relevant ContentTypes will allow VS add the item as the relevant `QtResource/QtUi/QtTs` item type, instead of `None`.
The `ui` files have been readded to the project files, to be consistent with any newly added ui files. 

`QtMoc` continues to use the [output interface](https://learn.microsoft.com/en-us/visualstudio/msbuild/incremental-builds?view=vs-2022#output-inference).
The `moc` tool is added as an input to trigger rebuilding moc files on Qt updates.
This might not be 100% correct but, without creating a [custom task dll](https://learn.microsoft.com/en-us/visualstudio/msbuild/trackedvctooltask-base-class?view=vs-2022), it's good enough for us.

`QtMocClean` task wasn't cleaning files in subdirectories before, requiring them to be manually deleted. 
Add more wildcards to correctly clean these files

### Suggested Testing Steps
Change the ui files and then build, check if the changes are reflected in the just built binary
Check that cleaning the project still works
Make sure the project still builds correctly
