### PR TITLE
GS/HW: Mask 16bit colours when blending is disabled

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -852,6 +852,8 @@ void ps_color_clamp_wrap(inout float3 C)
 		else if (PS_COLCLIP == 1 || PS_HDR == 1)
 			C = (float3)((int3)C & (int3)0xFF);
 	}
+	else if (PS_DST_FMT == FMT_16 && PS_DITHER != 3 && PS_BLEND_MIX == 0 && PS_BLEND_HW == 0)
+		C = (float3)((int3)C & (int3)0xF8);
 }
 
 void ps_blend(inout float4 Color, inout float4 As_rgba, float2 pos_xy)

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -775,6 +775,8 @@ void ps_color_clamp_wrap(inout vec3 C)
 	C = vec3(ivec3(C) & ivec3(0xFF));
 #endif
 
+#elif PS_DST_FMT == FMT_16 && PS_DITHER != 3 && PS_BLEND_MIX == 0 && PS_BLEND_HW == 0
+	C = vec3(ivec3(C) & ivec3(0xF8));
 #endif
 }
 

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -1045,6 +1045,8 @@ void ps_color_clamp_wrap(inout vec3 C)
 	C = vec3(ivec3(C) & ivec3(0xFF));
 #endif
 
+#elif PS_DST_FMT == FMT_16 && PS_DITHER != 3 && PS_BLEND_MIX == 0 && PS_BLEND_HW == 0
+	C = vec3(ivec3(C) & ivec3(0xF8));
 #endif
 }
 

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 60;
+static constexpr u32 SHADER_CACHE_VERSION = 61;


### PR DESCRIPTION
### Description of Changes
Masks 16 bit colours when blending is disabled. Currently known to fix Need for Speed Carbon car colour compared to software.

Master Hardware:
![Need for Speed - Carbon_SLES-54321_20250411223359](https://github.com/user-attachments/assets/3c086a81-b213-48fa-8725-7d4c37fb17dc)

Master Software:
![Need for Speed - Carbon_SLES-54321_20250411223409](https://github.com/user-attachments/assets/96fbaf0f-b62d-4396-a08c-c62e5d7cb8ae)

PR Hardware:
![Need for Speed - Carbon_SLES-54321_20250411223249](https://github.com/user-attachments/assets/ff481774-0172-4123-8102-48459385ef87)

### Rationale behind Changes
The colours are incorrect and this is bad.

### Suggested Testing Steps
Check any games you have and see if you spot an visual differences and also make sure nothing go boom.
