### PR TITLE
DEV9: Various socket fixes

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -309,6 +309,7 @@ set(pcsx2DEV9Sources
 	DEV9/Sessions/TCP_Session/TCP_Session.cpp
 	DEV9/Sessions/TCP_Session/TCP_Session_In.cpp
 	DEV9/Sessions/TCP_Session/TCP_Session_Out.cpp
+	DEV9/Sessions/UDP_Session/UDP_Common.cpp
 	DEV9/Sessions/UDP_Session/UDP_FixedPort.cpp
 	DEV9/Sessions/UDP_Session/UDP_Session.cpp
 	DEV9/smap.cpp
@@ -354,6 +355,7 @@ set(pcsx2DEV9Headers
 	DEV9/Sessions/BaseSession.h
 	DEV9/Sessions/ICMP_Session/ICMP_Session.h
 	DEV9/Sessions/TCP_Session/TCP_Session.h
+	DEV9/Sessions/UDP_Session/UDP_Common.h
 	DEV9/Sessions/UDP_Session/UDP_FixedPort.h
 	DEV9/Sessions/UDP_Session/UDP_BaseSession.h
 	DEV9/Sessions/UDP_Session/UDP_Session.h

--- a/pcsx2/DEV9/Sessions/UDP_Session/UDP_BaseSession.h
+++ b/pcsx2/DEV9/Sessions/UDP_Session/UDP_BaseSession.h
@@ -16,5 +16,6 @@ namespace Sessions
 		}
 
 		virtual bool WillRecive(PacketReader::IP::IP_Address parDestIP) = 0;
+		virtual void ForceClose() { RaiseEventConnectionClosed(); };
 	};
 } // namespace Sessions

--- a/pcsx2/DEV9/Sessions/UDP_Session/UDP_Common.cpp
+++ b/pcsx2/DEV9/Sessions/UDP_Session/UDP_Common.cpp
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#include <bit>
+
+#include "common/Console.h"
+
+#ifdef __POSIX__
+#define SOCKET_ERROR -1
+#define INVALID_SOCKET -1
+#include <errno.h>
+#include <sys/ioctl.h>
+#include <sys/select.h>
+#include <netinet/in.h>
+#endif
+
+#ifdef _WIN32
+#include "common/RedtapeWindows.h"
+#include <winsock2.h>
+#else
+#include <unistd.h>
+#endif
+
+#include "UDP_Common.h"
+#include "DEV9/PacketReader/IP/UDP/UDP_Packet.h"
+
+using namespace PacketReader;
+using namespace PacketReader::IP;
+using namespace PacketReader::IP::UDP;
+
+namespace Sessions::UDP_Common
+{
+#ifdef _WIN32
+	SOCKET CreateSocket(IP_Address adapterIP, std::optional<u16> port)
+	{
+		SOCKET client = INVALID_SOCKET;
+#elif defined(__POSIX__)
+	int CreateSocket(IP_Address adapterIP, std::optional<u16> port)
+	{
+		int client = INVALID_SOCKET;
+#endif
+
+		int ret;
+		client = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+		if (client == INVALID_SOCKET)
+		{
+			Console.Error("DEV9: UDP: Failed to open socket. Error: %d",
+#ifdef _WIN32
+				WSAGetLastError());
+#elif defined(__POSIX__)
+				errno);
+#endif
+			return INVALID_SOCKET;
+		}
+
+		constexpr int reuseAddress = true; // BOOL on Windows
+		ret = setsockopt(client, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char*>(&reuseAddress), sizeof(reuseAddress));
+
+		if (ret == SOCKET_ERROR)
+			Console.Error("DEV9: UDP: Failed to set SO_REUSEADDR. Error: %d",
+#ifdef _WIN32
+				WSAGetLastError());
+#elif defined(__POSIX__)
+				errno);
+#endif
+
+		if (port.has_value() || adapterIP != IP_Address{{{0, 0, 0, 0}}})
+		{
+			sockaddr_in endpoint{};
+			endpoint.sin_family = AF_INET;
+			endpoint.sin_addr = std::bit_cast<in_addr>(adapterIP);
+			if (port.has_value())
+				endpoint.sin_port = htons(port.value());
+
+			ret = bind(client, reinterpret_cast<const sockaddr*>(&endpoint), sizeof(endpoint));
+
+			if (ret == SOCKET_ERROR)
+				Console.Error("DEV9: UDP: Failed to bind socket. Error: %d",
+#ifdef _WIN32
+					WSAGetLastError());
+#elif defined(__POSIX__)
+					errno);
+#endif
+		}
+		return client;
+	}
+
+#ifdef _WIN32
+	std::tuple<std::optional<ReceivedPayload>, bool> RecvFrom(SOCKET client, u16 port)
+#elif defined(__POSIX__)
+	std::tuple<std::optional<ReceivedPayload>, bool> RecvFrom(int client, u16 port)
+#endif
+	{
+		int ret;
+		fd_set sReady;
+		fd_set sExcept;
+
+		// not const Linux
+		timeval nowait{};
+		FD_ZERO(&sReady);
+		FD_ZERO(&sExcept);
+		FD_SET(client, &sReady);
+		FD_SET(client, &sExcept);
+		ret = select(client + 1, &sReady, nullptr, &sExcept, &nowait);
+
+		if (ret == SOCKET_ERROR)
+		{
+			Console.Error("DEV9: UDP: select failed. Error code: %d",
+#ifdef _WIN32
+				WSAGetLastError());
+#elif defined(__POSIX__)
+				errno);
+#endif
+			return {std::nullopt, true};
+		}
+		else if (FD_ISSET(client, &sExcept))
+		{
+#ifdef _WIN32
+			int len = sizeof(ret);
+			if (getsockopt(client, SOL_SOCKET, SO_ERROR, reinterpret_cast<char*>(&ret), &len) < 0)
+			{
+				Console.Error("DEV9: UDP: Unknown UDP connection error (getsockopt error: %d)", WSAGetLastError());
+			}
+#elif defined(__POSIX__)
+			socklen_t len = sizeof(ret);
+			if (getsockopt(client, SOL_SOCKET, SO_ERROR, reinterpret_cast<char*>(&ret), &len) < 0)
+				Console.Error("DEV9: UDP: Unknown UDP connection error (getsockopt error: %d)", errno);
+#endif
+			else
+				Console.Error("DEV9: UDP: Socket error: %d", ret);
+
+			return {std::nullopt, false};
+		}
+		else if (FD_ISSET(client, &sReady))
+		{
+			unsigned long available = 0;
+			PayloadData* recived = nullptr;
+			std::unique_ptr<u8[]> buffer;
+			sockaddr_in endpoint{};
+
+			// FIONREAD returns total size of all available messages
+			// however, we only read one message at a time
+#ifdef _WIN32
+			ret = ioctlsocket(client, FIONREAD, &available);
+#elif defined(__POSIX__)
+			ret = ioctl(client, FIONREAD, &available);
+#endif
+			if (ret != SOCKET_ERROR)
+			{
+				buffer = std::make_unique<u8[]>(available);
+
+#ifdef _WIN32
+				int fromlen = sizeof(endpoint);
+#elif defined(__POSIX__)
+				socklen_t fromlen = sizeof(endpoint);
+#endif
+				ret = recvfrom(client, reinterpret_cast<char*>(buffer.get()), available, 0, reinterpret_cast<sockaddr*>(&endpoint), &fromlen);
+			}
+
+			if (ret == SOCKET_ERROR)
+			{
+				Console.Error("DEV9: UDP: UDP recv error: %d",
+#ifdef _WIN32
+					WSAGetLastError());
+#elif defined(__POSIX__)
+					errno);
+#endif
+				return {std::nullopt, false};
+			}
+
+			recived = new PayloadData(ret);
+			memcpy(recived->data.get(), buffer.get(), ret);
+
+			std::unique_ptr<UDP_Packet> iRet = std::make_unique<UDP_Packet>(recived);
+			iRet->destinationPort = port;
+			iRet->sourcePort = ntohs(endpoint.sin_port);
+
+			return {ReceivedPayload{std::bit_cast<IP_Address>(endpoint.sin_addr), std::move(iRet)}, true};
+		}
+		return {std::nullopt, true};
+	}
+} // namespace Sessions::UDP_Common

--- a/pcsx2/DEV9/Sessions/UDP_Session/UDP_Common.h
+++ b/pcsx2/DEV9/Sessions/UDP_Session/UDP_Common.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#pragma once
+#include <tuple>
+#ifdef _WIN32
+#include <winsock2.h>
+#elif defined(__POSIX__)
+#include <sys/socket.h>
+#endif
+
+#include "common/Pcsx2Defs.h"
+#include "DEV9/Sessions/BaseSession.h"
+
+namespace Sessions::UDP_Common
+{
+	// Binds the socket when provided with an IP
+#ifdef _WIN32
+	SOCKET CreateSocket(PacketReader::IP::IP_Address adapterIP, std::optional<u16> port);
+#elif defined(__POSIX__)
+	int CreateSocket(PacketReader::IP::IP_Address adapterIP, std::optional<u16> port);
+#endif
+
+	// Receives from the client and packages the data into ReceivedPayload
+	// port is the local port to be written to the UDP header in ReceivedPayload
+#ifdef _WIN32
+	std::tuple<std::optional<ReceivedPayload>, bool> RecvFrom(SOCKET client, u16 port);
+#elif defined(__POSIX__)
+	std::tuple<std::optional<ReceivedPayload>, bool> RecvFrom(int client, u16 port);
+#endif
+} // namespace Sessions::UDP_Common

--- a/pcsx2/pcsx2.vcxproj
+++ b/pcsx2/pcsx2.vcxproj
@@ -195,6 +195,7 @@
     <ClCompile Include="DEV9\Sessions\TCP_Session\TCP_Session_Out.cpp" />
     <ClCompile Include="DEV9\Win32\pcap_io_win32.cpp" />
     <ClCompile Include="DEV9\Sessions\BaseSession.cpp" />
+    <ClCompile Include="DEV9\Sessions\UDP_Session\UDP_Common.cpp" />
     <ClCompile Include="DEV9\Sessions\UDP_Session\UDP_FixedPort.cpp" />
     <ClCompile Include="DEV9\Sessions\UDP_Session\UDP_Session.cpp" />
     <ClCompile Include="DEV9\smap.cpp" />
@@ -636,6 +637,7 @@
     <ClInclude Include="DEV9\Sessions\BaseSession.h" />
     <ClInclude Include="DEV9\Sessions\ICMP_Session\ICMP_Session.h" />
     <ClInclude Include="DEV9\Sessions\TCP_Session\TCP_Session.h" />
+    <ClInclude Include="DEV9\Sessions\UDP_Session\UDP_Common.h" />
     <ClInclude Include="DEV9\Sessions\UDP_Session\UDP_FixedPort.h" />
     <ClInclude Include="DEV9\Sessions\UDP_Session\UDP_BaseSession.h" />
     <ClInclude Include="DEV9\Sessions\UDP_Session\UDP_Session.h" />

--- a/pcsx2/pcsx2.vcxproj.filters
+++ b/pcsx2/pcsx2.vcxproj.filters
@@ -944,6 +944,9 @@
     <ClCompile Include="DEV9\Sessions\TCP_Session\TCP_Session_Out.cpp">
       <Filter>System\Ps2\DEV9\Sessions\TCP_Session</Filter>
     </ClCompile>
+    <ClCompile Include="DEV9\Sessions\UDP_Session\UDP_Common.cpp">
+      <Filter>System\Ps2\DEV9\Sessions\UDP_Session</Filter>
+    </ClCompile>
     <ClCompile Include="DEV9\Sessions\UDP_Session\UDP_FixedPort.cpp">
       <Filter>System\Ps2\DEV9\Sessions\UDP_Session</Filter>
     </ClCompile>
@@ -1843,6 +1846,9 @@
     </ClInclude>
     <ClInclude Include="DEV9\Sessions\TCP_Session\TCP_Session.h">
       <Filter>System\Ps2\DEV9\Sessions\TCP_Session</Filter>
+    </ClInclude>
+    <ClInclude Include="DEV9\Sessions\UDP_Session\UDP_Common.h">
+      <Filter>System\Ps2\DEV9\Sessions\UDP_Session</Filter>
     </ClInclude>
     <ClInclude Include="DEV9\Sessions\UDP_Session\UDP_FixedPort.h">
       <Filter>System\Ps2\DEV9\Sessions\UDP_Session</Filter>


### PR DESCRIPTION
### Description of Changes
Deduplicate sockets code regarding UDP sessions
Fix various race conditions
Ignore (but still log) ICMP errors received from UDP sockets when calling `recvfrom()`.

### Rationale behind Changes
Previously, we treated ICMP destination unreachable errors as fatal when gotten from `recvfrom()` from a UDP socket
We already ignore these on send, so match that behaviour, and dedup some code while we are at it.

This also exposed some race conditions in sockets code (causing a lockup), which are also fixed

### Suggested Testing Steps
Test networking using Sockets