### PR TITLE
CDVD: Adjust ram requirements when precaching.

### DIFF
--- a/common/HostSys.h
+++ b/common/HostSys.h
@@ -181,6 +181,10 @@ private:
 extern u64 GetTickFrequency();
 extern u64 GetCPUTicks();
 extern u64 GetPhysicalMemory();
+#ifdef _WIN32
+// TODO: Someone do linux/mac.
+extern u64 GetAvailablePhysicalMemory();
+#endif
 /// Spin for a short period of time (call while spinning waiting for a lock)
 /// Returns the approximate number of ns that passed
 extern u32 ShortSpin();

--- a/common/Windows/WinMisc.cpp
+++ b/common/Windows/WinMisc.cpp
@@ -57,6 +57,14 @@ u64 GetPhysicalMemory()
 	return status.ullTotalPhys;
 }
 
+u64 GetAvailablePhysicalMemory()
+{
+	MEMORYSTATUSEX status;
+	status.dwLength = sizeof(status);
+	GlobalMemoryStatusEx(&status);
+	return status.ullAvailPhys;
+}
+
 // Calculates the Windows OS Version and processor architecture, and returns it as a
 // human-readable string. :)
 std::string GetOSVersionString()


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
CDVD: Adjust ram requirements when precaching.
When precaching check for available ram instead of total physical ram.
Reserve 2GB headroom for the system.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Better precaching, previously we checked total ram in the system which would result in issues/crashes if the ram was already full.
This aims to address that since we are now checking available/not in use ram instead.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Windows only, test precaching with either plenty of available ram or mostly full.
Todo: linux/mac someone else.