### PR TITLE
GameDB: Adds Software FMV hack to Soulcalibur 2/3 Games

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1408,6 +1408,8 @@ SCAJ-20023:
   region: "NTSC-Unk"
   clampModes:
     vuClampMode: 2 # Respawn issues, Fixes SPS, avoids teleporting characters.
+  gameFixes:
+    - SoftwareRendererFMVHack # Horizontal bottom line in FMV.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SCAJ-20024:
@@ -2196,10 +2198,11 @@ SCAJ-20158:
 SCAJ-20159:
   name: "SoulCalibur III"
   region: "NTSC-C"
-  gameFixes:
-    - EETimingHack # Fixes bad colours on character select when in Progressive Scan.
   clampModes:
     vuClampMode: 2 # Respawn issues, Fixes SPS, avoids teleporting characters.
+  gameFixes:
+    - EETimingHack # Fixes bad colours on character select when in Progressive Scan.
+    - SoftwareRendererFMVHack # Horizontal bottom line in FMV.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     nativeScaling: 2 # Fixes misaligned bloom.
@@ -4192,10 +4195,11 @@ SCED-53662:
 SCED-53674:
   name: "SoulCalibur III [Demo]"
   region: "PAL-E"
-  gameFixes:
-    - EETimingHack # Fixes bad colours on character select when in Progressive Scan.
   clampModes:
     vuClampMode: 2 # Respawn issues, Fixes SPS, avoids teleporting characters.
+  gameFixes:
+    - EETimingHack # Fixes bad colours on character select when in Progressive Scan.
+    - SoftwareRendererFMVHack # Horizontal bottom line in FMV.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     nativeScaling: 2 # Fixes misaligned bloom.
@@ -5866,10 +5870,11 @@ SCES-53312:
   name: "SoulCalibur III"
   region: "PAL-M5"
   compat: 5
-  gameFixes:
-    - EETimingHack # Fixes bad colours on character select when in Progressive Scan.
   clampModes:
     vuClampMode: 2 # Respawn issues, Fixes SPS, avoids teleporting characters.
+  gameFixes:
+    - EETimingHack # Fixes bad colours on character select when in Progressive Scan.
+    - SoftwareRendererFMVHack # Horizontal bottom line in FMV.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     nativeScaling: 2 # Fixes misaligned bloom.
@@ -6999,6 +7004,8 @@ SCKA-20016:
   compat: 5
   clampModes:
     vuClampMode: 2 # Respawn issues, Fixes SPS, avoids teleporting characters.
+  gameFixes:
+    - SoftwareRendererFMVHack # Horizontal bottom line in FMV.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SCKA-20017:
@@ -7298,10 +7305,11 @@ SCKA-20059:
   name: "SoulCalibur III"
   region: "NTSC-K"
   compat: 5
-  gameFixes:
-    - EETimingHack # Fixes bad colours on character select when in Progressive Scan.
   clampModes:
     vuClampMode: 2 # Respawn issues, Fixes SPS, avoids teleporting characters.
+  gameFixes:
+    - EETimingHack # Fixes bad colours on character select when in Progressive Scan.
+    - SoftwareRendererFMVHack # Horizontal bottom line in FMV.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     nativeScaling: 2 # Fixes misaligned bloom.
@@ -13163,6 +13171,8 @@ SLED-51901:
   region: "PAL-E"
   clampModes:
     vuClampMode: 2 # Respawn issues, Fixes SPS, avoids teleporting characters.
+  gameFixes:
+    - SoftwareRendererFMVHack # Horizontal bottom line in FMV.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLED-51902:
@@ -17928,6 +17938,8 @@ SLES-51799:
   compat: 5
   clampModes:
     vuClampMode: 2 # Respawn issues, Fixes SPS, avoids teleporting characters.
+  gameFixes:
+    - SoftwareRendererFMVHack # Horizontal bottom line in FMV.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLES-51800:
@@ -34945,10 +34957,11 @@ SLPM-61133:
   name-sort: "そうるきゃりばー3 [たいけんばん]"
   name-en: "SoulCalibur III [Trial]"
   region: "NTSC-J"
-  gameFixes:
-    - EETimingHack # Fixes bad colours on character select when in Progressive Scan.
   clampModes:
     vuClampMode: 2 # Respawn issues, Fixes SPS, avoids teleporting characters.
+  gameFixes:
+    - EETimingHack # Fixes bad colours on character select when in Progressive Scan.
+    - SoftwareRendererFMVHack # Horizontal bottom line in FMV.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     nativeScaling: 2 # Fixes misaligned bloom.
@@ -56217,6 +56230,8 @@ SLPS-25230:
   compat: 5
   clampModes:
     vuClampMode: 2 # Respawn issues, Fixes SPS, avoids teleporting characters.
+  gameFixes:
+    - SoftwareRendererFMVHack # Horizontal bottom line in FMV.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLPS-25231:
@@ -58253,10 +58268,11 @@ SLPS-25577:
   name-en: "SoulCalibur III"
   region: "NTSC-J"
   compat: 5
-  gameFixes:
-    - EETimingHack # Fixes bad colours on character select when in Progressive Scan.
   clampModes:
     vuClampMode: 2 # Respawn issues, Fixes SPS, avoids teleporting characters.
+  gameFixes:
+    - EETimingHack # Fixes bad colours on character select when in Progressive Scan.
+    - SoftwareRendererFMVHack # Horizontal bottom line in FMV.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     nativeScaling: 2 # Fixes misaligned bloom.
@@ -64656,6 +64672,8 @@ SLUS-20643:
   compat: 5
   clampModes:
     vuClampMode: 2 # Respawn issues, Fixes SPS, avoids teleporting characters.
+  gameFixes:
+    - SoftwareRendererFMVHack # Horizontal bottom line in FMV.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLUS-20644:
@@ -67954,10 +67972,11 @@ SLUS-21216:
   name: "SoulCalibur III"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - EETimingHack # Fixes bad colours on character select when in Progressive Scan.
   clampModes:
     vuClampMode: 2 # Respawn issues, Fixes SPS, avoids teleporting characters.
+  gameFixes:
+    - EETimingHack # Fixes bad colours on character select when in Progressive Scan.
+    - SoftwareRendererFMVHack # Horizontal bottom line in FMV.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
     nativeScaling: 2 # Fixes misaligned bloom.
@@ -72578,6 +72597,8 @@ SLUS-29058:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 2 # Respawn issues, Fixes SPS, avoids teleporting characters.
+  gameFixes:
+    - SoftwareRendererFMVHack # Horizontal bottom line in FMV.
   gsHWFixes:
     alignSprite: 1 # Fixes vertical lines.
 SLUS-29059:


### PR DESCRIPTION
Fixes https://github.com/PCSX2/pcsx2/issues/2852

An horizontal & a vertical colored line are present when upscaled in the intro FMV of Soulcalibur II/III, this adds the Software FMV hack to solve it.