### PR TITLE
GameDB: Switch Rule of Rose to SoftwareFMV

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -2264,9 +2264,9 @@ SCAJ-20167:
     preloadFrameData: 1 # Fixes some missing effects.
 SCAJ-20168:
   name: "Rule of Rose"
-  region: "NTSC-Unk"
-  gsHWFixes:
-    preloadFrameData: 1 # Fixes Black FMV's.
+  region: "NTSC-C"
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes black FMVs in hardware and hash cache disabling itself.
 SCAJ-20169:
   name: "Dirge of Cerberus - Final Fantasy VII"
   region: "NTSC-Unk"
@@ -8896,8 +8896,8 @@ SCPS-15093:
   name-en: "Rule of Rose"
   region: "NTSC-J"
   compat: 5
-  gsHWFixes:
-    preloadFrameData: 1 # Fixes Black FMV's.
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes black FMVs in hardware and hash cache disabling itself.
 SCPS-15094:
   name: "アイトーイ プレイ2 [ソフト単体]"
   name-sort: "あいとーい ぷれい2 [そふとたんたい]"
@@ -24960,8 +24960,8 @@ SLES-54217:
 SLES-54218:
   name: "Rule of Rose"
   region: "PAL-M5"
-  gsHWFixes:
-    preloadFrameData: 1 # Fixes Black FMV's.
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes black FMVs in hardware and hash cache disabling itself.
 SLES-54221:
   name: "LEGO Star Wars II - The Original Trilogy"
   region: "PAL-M6"
@@ -69595,8 +69595,8 @@ SLUS-21448:
   name: "Rule of Rose"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    preloadFrameData: 1 # Fixes Black FMV's.
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes black FMVs in hardware and hash cache disabling itself.
 SLUS-21449:
   name: "The Fast and the Furious"
   name-sort: "Fast and the Furious, The"
@@ -72367,8 +72367,8 @@ SLUS-28062:
 SLUS-28063:
   name: "Rule of Rose [Trade Demo]"
   region: "NTSC-U"
-  gsHWFixes:
-    preloadFrameData: 1 # Fixes Black FMV's.
+  gameFixes:
+    - SoftwareRendererFMVHack # Fixes black FMVs in hardware and hash cache disabling itself.
 SLUS-28064:
   name: "Shin Megami Tensei - Devil Summoner [Trade Demo]"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Changes preload frame data to software FMV to fix both the black FMVs issue and hash cache disabling itself.

### Rationale behind Changes
Hash cache disabling itself is not good very bad.

### Suggested Testing Steps
Make sure CI is happy boi.