### PR TITLE
Common: Allow shared reading of log files

### DIFF
--- a/common/Console.cpp
+++ b/common/Console.cpp
@@ -342,7 +342,7 @@ bool Log::SetFileOutputLevel(LOGLEVEL level, std::string path)
 			if (!s_file_handle || s_file_path != path)
 			{
 				s_file_handle.reset();
-				s_file_handle = FileSystem::OpenManagedCFile(path.c_str(), "wb");
+				s_file_handle = FileSystem::OpenManagedSharedCFile(path.c_str(), "wb", FileSystem::FileShareMode::DenyWrite);
 				if (s_file_handle)
 				{
 					s_file_path = std::move(path);


### PR DESCRIPTION
### Description of Changes
Use the shared file function, allowing shared read

### Rationale behind Changes
Noticed by https://github.com/PCSX2/pcsx2/issues/12503
Not really any reason to prevent the file from being read while the emulator is open, and it seems like a simple enough change

### Suggested Testing Steps
Run the emulator and try to open the log file