### PR TITLE
GameDB: Add memcard filters for Mortal Kombat Armageddon Premium

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -69521,6 +69521,9 @@ SLUS-21410:
   name: "Mortal Kombat - Armageddon"
   region: "NTSC-U"
   compat: 5
+  memcardFilters: # Saves from the non-Premium can be imported
+    - "SLUS-21410"
+    - "SLUS-21543"
 SLUS-21411:
   name: "M2 Rock"
   region: "NTSC-U"
@@ -70163,6 +70166,9 @@ SLUS-21543:
   name: "Mortal Kombat - Armageddon [Premium Edition]"
   region: "NTSC-U"
   compat: 5
+  memcardFilters: # Saves from the non-Premium can be imported
+    - "SLUS-21543"
+    - "SLUS-21410"
 SLUS-21544:
   name: "Fantastic 4 - Rise of Silver Surfer"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Adds both normal US version of MKA and MKA Premium edition to the memcard filters, as MKA Premium edition saves and loads its saves as if it was the normal MKA version

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Mortal Kombat has 2 editions, the normal one, and the premium one, the premium edition saves and loads its game data as if it was the normal edition (SLUS-21410 and NOT SLUS-21543).

Without these filters, the premium edition is unable to properly save and load its data

Also, without these changes, assuming you have data in the normal edition and use a folder type memory card with managed saves, when opening the premium edition it will say the memcard has no MK data and when pressing square to format it, it would wipe all your MK game data (RIP my MKA save)

NOTE: I didnt do the same for the PAL-M5 (SLES-54156) version of the game as i dont know if the saves are the same between regions

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
* Use a memcard with type folder and manage saves based on running game checked
* Have some data in MKA Normal edition (SLUS-21410)
* Open MKA Premium edition (SLUS-21543)
* Try to load the saved data from MKA normal edition
* Everything should work fine, loading and saving in premium edition should also affect the save in MKA normal edition