### PR TITLE
GS: Allow for widescreen and ultrawide patches to specify their target aspect ratio

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -502,7 +502,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 
 		dialog->registerWidgetHelp(m_ui.aspectRatio, tr("Aspect Ratio"), tr("Auto Standard (4:3/3:2 Progressive)"),
 			tr("Changes the aspect ratio used to display the console's output to the screen. The default is Auto Standard (4:3/3:2 "
-			   "Progressive) which automatically adjusts the aspect ratio to match how a game would be shown on a typical TV of the era."));
+			   "Progressive) which automatically adjusts the aspect ratio to match how a game would be shown on a typical TV of the era, and adapts to widescreen/ultrawide game patches."));
 
 		dialog->registerWidgetHelp(m_ui.interlacing, tr("Deinterlacing"), tr("Automatic (Default)"), tr("Determines the deinterlacing method to be used on the interlaced screen of the emulated console. Automatic should be able to correctly deinterlace most games, but if you see visibly shaky graphics, try one of the available options."));
 

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -106,7 +106,7 @@
          </item>
          <item>
           <property name="text">
-           <string>Native (10:7)</string>
+           <string>Native/Full (10:7)</string>
           </property>
          </item>
         </widget>
@@ -142,7 +142,7 @@
          </item>
          <item>
           <property name="text">
-           <string>Native (10:7)</string>
+           <string>Native/Full (10:7)</string>
           </property>
          </item>
         </widget>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -223,8 +223,8 @@ enum class DebugFunctionScanMode
 
 enum class AspectRatioType : u8
 {
-	Stretch,
-	RAuto4_3_3_2,
+	Stretch, // Stretches to the whole window/display size
+	RAuto4_3_3_2, // Automatically scales to the target aspect ratio if there's a widescreen patch
 	R4_3,
 	R16_9,
 	R10_7,
@@ -233,7 +233,7 @@ enum class AspectRatioType : u8
 
 enum class FMVAspectRatioSwitchType : u8
 {
-	Off,
+	Off, // Falls back on the selected generic aspect ratio type
 	RAuto4_3_3_2,
 	R4_3,
 	R16_9,
@@ -1324,6 +1324,8 @@ struct Pcsx2Config
 	std::string CurrentIRX;
 	std::string CurrentGameArgs;
 	AspectRatioType CurrentAspectRatio = AspectRatioType::RAuto4_3_3_2;
+	// Fall back aspect ratio for games that have patches (when AspectRatioType::RAuto4_3_3_2) is active.
+	float CurrentCustomAspectRatio = 0.f;
 	bool IsPortableMode = false;
 
 	Pcsx2Config();

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -636,7 +636,7 @@ void Pcsx2Config::CpuOptions::LoadSave(SettingsWrapper& wrap)
 	Recompiler.LoadSave(wrap);
 }
 
-const char* Pcsx2Config::GSOptions::AspectRatioNames[] = {
+const char* Pcsx2Config::GSOptions::AspectRatioNames[(size_t)AspectRatioType::MaxCount + 1] = {
 	"Stretch",
 	"Auto 4:3/3:2",
 	"4:3",
@@ -644,7 +644,7 @@ const char* Pcsx2Config::GSOptions::AspectRatioNames[] = {
 	"10:7",
 	nullptr};
 
-const char* Pcsx2Config::GSOptions::FMVAspectRatioSwitchNames[] = {
+const char* Pcsx2Config::GSOptions::FMVAspectRatioSwitchNames[(size_t)FMVAspectRatioSwitchType::MaxCount + 1] = {
 	"Off",
 	"Auto 4:3/3:2",
 	"4:3",
@@ -1983,7 +1983,12 @@ void Pcsx2Config::LoadSaveCore(SettingsWrapper& wrap)
 
 	if (wrap.IsLoading())
 	{
+		// Patches will get re-applied after loading the state so this doesn't matter too much
 		CurrentAspectRatio = GS.AspectRatio;
+		if (CurrentAspectRatio == AspectRatioType::RAuto4_3_3_2)
+		{
+			CurrentCustomAspectRatio = 0.f;
+		}
 	}
 }
 
@@ -2035,6 +2040,7 @@ void Pcsx2Config::CopyRuntimeConfig(Pcsx2Config& cfg)
 	CurrentIRX = std::move(cfg.CurrentIRX);
 	CurrentGameArgs = std::move(cfg.CurrentGameArgs);
 	CurrentAspectRatio = cfg.CurrentAspectRatio;
+	CurrentCustomAspectRatio = cfg.CurrentCustomAspectRatio;
 	IsPortableMode = cfg.IsPortableMode;
 
 	for (u32 i = 0; i < sizeof(Mcd) / sizeof(Mcd[0]); i++)

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -876,7 +876,9 @@ void VMManager::RequestDisplaySize(float scale /*= 0.0f*/)
 	switch (GSConfig.AspectRatio)
 	{
 		case AspectRatioType::RAuto4_3_3_2:
-			if (GSgetDisplayMode() == GSVideoMode::SDTV_480P)
+			if (EmuConfig.CurrentCustomAspectRatio > 0.f)
+				x_scale = EmuConfig.CurrentCustomAspectRatio / (static_cast<float>(iwidth) / static_cast<float>(iheight));
+			else if (GSgetDisplayMode() == GSVideoMode::SDTV_480P)
 				x_scale = (3.0f / 2.0f) / (static_cast<float>(iwidth) / static_cast<float>(iheight));
 			else
 				x_scale = (4.0f / 3.0f) / (static_cast<float>(iwidth) / static_cast<float>(iheight));


### PR DESCRIPTION
This allows users with monitors of any aspect ratios to use patches made for any other aspect ratio. For example, if on 32:9 one uses a 21:9 patch, pcsx2 will automatically size the presentation to 21:9 within 32:9. This also removes some ugly or hardcoded stuff from the code :). It also opens the door to add a "Custom" user aspect ratio, without the patch needing to specify the aspect ratio, so users could stretch the image to any AR they'd like, but for now there's no need to add that.

Automatic 21:9 within 32:9 (stretched because the cheat wasn't for the right version of the game):
![pcsx2-qtx64-dev_JdddD31Fnz](https://github.com/user-attachments/assets/91bb553f-cbbb-430d-9fa3-6b067b00fbc0)

one of the most important things is that 21:9 isn't an actual real aspect ratio, every "21:9" monitor has a slightly different aspect ratio, so patches should specify the exact aspect ratio (3440x1440 being 43:18, instead of 21:9).

Examples:
![pcsx2-qtx64-dev_qfZSxF9oLj](https://github.com/user-attachments/assets/2cc4480c-beb6-4fb2-9ac6-0ceb33d6b139)
![Notepad_WIWVu5txwE](https://github.com/user-attachments/assets/f456f7a1-4ae6-4874-bd54-5dd885eb1f22)
