### PR TITLE
GS/DX12: Copy/bind rt when tex is fb on slot 0.

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -2631,7 +2631,7 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 	}
 
 	GSTexture* rt_copy = nullptr;
-	if (config.require_one_barrier || (config.tex && config.tex == config.rt)) // Used as "bind rt" flag when texture barrier is unsupported
+	if (config.require_one_barrier || (config.tex && config.tex == config.rt)) // Used as "bind rt" flag when texture barrier is unsupported.
 	{
 		// Bind the RT.This way special effect can use it.
 		// Do not always bind the rt when it's not needed,

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -3900,7 +3900,7 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 		}
 	}
 
-	if (config.require_one_barrier)
+	if (config.require_one_barrier || (config.tex && config.tex == config.rt)) // Used as "bind rt" flag when texture barrier is unsupported.
 	{
 		// requires a copy of the RT
 		draw_rt_clone = static_cast<GSTexture12*>(CreateTexture(rtsize.x, rtsize.y, 1, colclip_rt ? GSTexture::Format::ColorClip : GSTexture::Format::Color, true));
@@ -3913,7 +3913,10 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 
 			draw_rt_clone->SetState(GSTexture::State::Invalidated);
 			CopyRect(draw_rt, draw_rt_clone, config.drawarea, config.drawarea.left, config.drawarea.top);
-			PSSetShaderResource(2, draw_rt_clone, true);
+			if (config.require_one_barrier)
+				PSSetShaderResource(2, draw_rt_clone, true);
+			if (config.tex && config.tex == config.rt)
+				PSSetShaderResource(0, draw_rt_clone, true);
 		}
 	}
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/DX12: Copy/bind rt when tex is fb on slot 0.
Copy the rt when draw is is tex in fb, we already do this for dx11 since it doesn't support texture barriers.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Accuracy, better parity with dx11.
Fixes Death By Degrees top left issue.
Fixes Time Crisis 3 top left issue.
Fixes Thrillville - Off the Rails.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test the mentioned games.
Thrillville - Off the Rails
master dx12:
![image](https://github.com/user-attachments/assets/4917bad0-60dc-4638-afb1-e37b26b00a2f)

pr dx12:
![image](https://github.com/user-attachments/assets/a5d983d2-fa40-4d69-8d3c-59dd1cf13d63)


Note: Death By Degrees and Time Crisis 3 need medium blending.
master dx12:
![Unknown Game_20250418195346](https://github.com/user-attachments/assets/25c95be7-9105-4c27-82d8-030107e0c36e)

pr dx12:
![image](https://github.com/user-attachments/assets/a1a2bdc6-2250-48c8-9f02-ff218a2215b0)
