### PR TITLE
CDVD: Adjust precache osd to display decimal value for required ram, adjust linux get available memory logic.

### DIFF
--- a/common/Darwin/DarwinMisc.cpp
+++ b/common/Darwin/DarwinMisc.cpp
@@ -55,17 +55,22 @@ u64 GetAvailablePhysicalMemory()
 	const mach_port_t host_port = mach_host_self();
 	vm_size_t page_size;
 
+	// Get the system's page size.
 	if (host_page_size(host_port, &page_size) != KERN_SUCCESS)
 		return 0;
 
 	vm_statistics64_data_t vm_stat;
 	mach_msg_type_number_t host_size = sizeof(vm_statistics64_data_t) / sizeof(integer_t);
 
+	// Get system memory statistics.
 	if (host_statistics64(host_port, HOST_VM_INFO, reinterpret_cast<host_info64_t>(&vm_stat), &host_size) != KERN_SUCCESS)
 		return 0;
 
+	// Get the number of free and inactive pages.
 	const u64 free_pages = static_cast<u64>(vm_stat.free_count);
 	const u64 inactive_pages = static_cast<u64>(vm_stat.inactive_count);
+
+	// Calculate available memory.
 	const u64 get_available_mem = (free_pages + inactive_pages) * page_size;
 
 	return get_available_mem;

--- a/pcsx2/CDVD/ThreadedFileReader.cpp
+++ b/pcsx2/CDVD/ThreadedFileReader.cpp
@@ -275,8 +275,8 @@ bool ThreadedFileReader::CheckAvailableMemoryForPrecaching(u64 required_size, Er
 	if (required_size > max_precache_size)
 	{
 		Error::SetStringFmt(error,
-			TRANSLATE_FS("CDVD", "Not enough free memory available for precaching, ({}GB) required."),
-			(required_size + memory_reserve) / _1gb);
+			TRANSLATE_FS("CDVD", "Not enough memory available for precaching ({:.2f} GB required)."),
+			static_cast<double>(required_size + memory_reserve) / static_cast<double>(_1gb));
 		return false;
 	}
 

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -2504,11 +2504,13 @@ void VMManager::LogCPUCapabilities()
 
 	Console.WriteLnFmt(
 		"  Operating System = {}\n"
-		"  Available RAM    = {} MB\n"
-		"  Physical RAM     = {} MB\n",
+		"  Available RAM    = {} MB ({:.2f} GB)\n"
+		"  Physical RAM     = {} MB ({:.2f} GB)\n",
 		GetOSVersionString(),
 		GetAvailablePhysicalMemory() / _1mb,
-		GetPhysicalMemory() / _1mb);
+		static_cast<double>(GetAvailablePhysicalMemory()) / static_cast<double>(_1gb),
+		GetPhysicalMemory() / _1mb,
+		static_cast<double>(GetPhysicalMemory()) / static_cast<double>(_1gb));
 
 	Console.WriteLnFmt("  Processor        = {}", cpuinfo_get_package(0)->name);
 	Console.WriteLnFmt("  Core Count       = {} cores", cpuinfo_get_cores_count());


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
CDVD: Adjust precache osd to display decimal value for required ram.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Qol.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
![image](https://github.com/user-attachments/assets/781f31d6-45a0-40cb-9728-f351265a6aab)
Test precache when there's not enough available ram.