### PR TITLE
Debugger: Add dummy actions to the Tools and Windows menus

### DIFF
--- a/pcsx2-qt/Debugger/DebuggerWindow.ui
+++ b/pcsx2-qt/Debugger/DebuggerWindow.ui
@@ -24,7 +24,7 @@
      <x>0</x>
      <y>0</y>
      <width>1000</width>
-     <height>20</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -50,6 +50,7 @@
     <property name="title">
      <string>Windows</string>
     </property>
+    <addaction name="actionWindowsDummy"/>
    </widget>
    <widget class="QMenu" name="menuView">
     <property name="title">
@@ -72,6 +73,7 @@
     <property name="title">
      <string>Tools</string>
     </property>
+    <addaction name="actionToolsDummy"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuView"/>
@@ -316,6 +318,16 @@
    </property>
    <property name="menuRole">
     <enum>QAction::NoRole</enum>
+   </property>
+  </action>
+  <action name="actionToolsDummy">
+   <property name="text">
+    <string/>
+   </property>
+  </action>
+  <action name="actionWindowsDummy">
+   <property name="text">
+    <string/>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
### Description of Changes
Add dummy items to the Tools and Windows menus. These menus are regenerated every time they're opened, so the dummy items should never actually be visible.

### Rationale behind Changes
Fixes #12541 apparently.

### Suggested Testing Steps
Test on macOS.