### PR TITLE
Debugger: Use a consistent context string when translating layout names

### DIFF
--- a/pcsx2-qt/Debugger/Docking/DockManager.cpp
+++ b/pcsx2-qt/Debugger/Docking/DockManager.cpp
@@ -298,7 +298,10 @@ void DockManager::resetAllLayouts()
 	m_layouts.clear();
 
 	for (const DockTables::DefaultDockLayout& layout : DockTables::DEFAULT_DOCK_LAYOUTS)
-		createLayout(tr(layout.name.c_str()), layout.cpu, true, layout.name);
+	{
+		QString name = QCoreApplication::translate("DebuggerLayout", layout.name.c_str());
+		createLayout(name, layout.cpu, true, layout.name);
+	}
 
 	switchToLayout(0);
 	updateLayoutSwitcher();
@@ -313,7 +316,10 @@ void DockManager::resetDefaultLayouts()
 	m_layouts = std::vector<DockLayout>();
 
 	for (const DockTables::DefaultDockLayout& layout : DockTables::DEFAULT_DOCK_LAYOUTS)
-		createLayout(tr(layout.name.c_str()), layout.cpu, true, layout.name);
+	{
+		QString name = QCoreApplication::translate("DebuggerLayout", layout.name.c_str());
+		createLayout(name, layout.cpu, true, layout.name);
+	}
 
 	for (DockLayout& layout : old_layouts)
 		if (!layout.isDefault())


### PR DESCRIPTION
### Description of Changes
Use a consistent context string when translating layout names.

### Rationale behind Changes
Previously when the layout names were defined in code the "DebuggerLayout" context string was used, but when the translations were actually applied the tr function was used inside the DockManager object.

### Suggested Testing Steps
N/A