### PR TITLE
GS/HW: Fix up some regressions from RT in RT

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2899,17 +2899,24 @@ bool GSState::TrianglesAreQuads(bool shuffle_check)
 		if (idx > 0)
 		{
 			const u16* const prev_tri= m_index.buff + (idx - 3);
-			GIFRegXYZ vert = v[i[0]].XYZ;
-			GIFRegXYZ last_vert = v[i[2]].XYZ;
+			GIFRegXYZ new_verts[3] = {v[i[0]].XYZ, v[i[1]].XYZ, v[i[2]].XYZ};
 
 			if (shuffle_check)
 			{
-				vert.X -= 8 << 4;
-				last_vert.X -= 8 << 4;
+				new_verts[0].X -= 8 << 4;
+				new_verts[1].X -= 8 << 4;
+				new_verts[2].X -= 8 << 4;
 			}
+			u32 match_vert_count = 0;
 
-			if (vert != m_vertex.buff[prev_tri[0]].XYZ && vert != m_vertex.buff[prev_tri[1]].XYZ && vert != m_vertex.buff[prev_tri[2]].XYZ &&
-				last_vert != m_vertex.buff[prev_tri[0]].XYZ && last_vert != m_vertex.buff[prev_tri[1]].XYZ && last_vert != m_vertex.buff[prev_tri[2]].XYZ)
+			if (!(new_verts[0] != m_vertex.buff[prev_tri[0]].XYZ && new_verts[0] != m_vertex.buff[prev_tri[1]].XYZ && new_verts[0] != m_vertex.buff[prev_tri[2]].XYZ))
+				match_vert_count++;
+			if (!(new_verts[1] != m_vertex.buff[prev_tri[0]].XYZ && new_verts[1] != m_vertex.buff[prev_tri[1]].XYZ && new_verts[1] != m_vertex.buff[prev_tri[2]].XYZ))
+				match_vert_count++;
+			if (!(new_verts[2] != m_vertex.buff[prev_tri[0]].XYZ && new_verts[2] != m_vertex.buff[prev_tri[1]].XYZ && new_verts[2] != m_vertex.buff[prev_tri[2]].XYZ))
+				match_vert_count++;
+
+			if (match_vert_count != 2)
 				return false;
 		}
 		// Degenerate triangles should've been culled already, so we can check indices.

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2482,7 +2482,7 @@ void GSRendererHW::Draw()
 	//                                |       0.5,2.25 |        1-1 |    1 |
 	//                                |        0.5,2.5 |        1-2 |    2 |
 	//                                --------------------------------------
-	m_r = GSVector4i(m_vt.m_min.p.upld(m_vt.m_max.p) + GSVector4::cxpr(0.5f));
+	m_r = GSVector4i((m_vt.m_min.p.upld(m_vt.m_max.p) + GSVector4::cxpr(0.4f)).round<Round_NearestInt>());
 	m_r = m_r.blend8(m_r + GSVector4i::cxpr(0, 0, 1, 1), (m_r.xyxy() == m_r.zwzw()));
 	m_r_no_scissor = m_r;
 	m_r = m_r.rintersect(context->scissor.in);
@@ -6492,8 +6492,9 @@ __ri void GSRendererHW::HandleTextureHazards(const GSTextureCache::Target* rt, c
 		// Can't use box filtering on depth (yet), or fractional scales.
 		if (src_target->m_texture->IsDepthStencil() || std::floor(src_target->GetScale()) != src_target->GetScale())
 		{
-			const GSVector4 dst_rect = GSVector4(GSVector4i::loadh(src_unscaled_size));
-			g_gs_device->StretchRect(src_target->m_texture, GSVector4::cxpr(0.0f, 0.0f, 1.0f, 1.0f), src_copy.get(), dst_rect,
+			GSVector4 src_rect = GSVector4(tmm.coverage) / GSVector4(GSVector4i::loadh(src_unscaled_size).zwzw());
+			const GSVector4 dst_rect = GSVector4(tmm.coverage);
+			g_gs_device->StretchRect(src_target->m_texture, src_rect, src_copy.get(), dst_rect,
 				src_target->m_texture->IsDepthStencil() ? ShaderConvert::DEPTH_COPY : ShaderConvert::COPY, false);
 		}
 		else


### PR DESCRIPTION
### Description of Changes
Fixes regressions with the BIOS, BloodRayne (when upscaling), Prince of Persia Warrior Within (was showing when upscaling but was a caused by an error/waste of time even in native) and Rumble Racing.

### Rationale behind Changes
BIOS: When we calculate the draw area, it was one pixel short due to a small fraction, which should draw more, so we were loading garbage from VRAM after my changes in RT in RT, so now it accounts more for any fraction.
Fixes https://github.com/PCSX2/pcsx2/issues/12547

BloodRayne: This was disappearing when HPO was set to anything below Align to Native due to some invalidation code which relied on that, but the problem was really misdetection of Triangles being Quads, the game was drawing a border around the screen and we took that as covering the entire thing, so it was getting nuked.

Prince of Persia: This was getting in to a mess trying to copy out a depth buffer, which wasn't even valid at the time and was completely dirty, so now it skips updating the RGB of a target if the depth it's connected to is dirty.

Rumble Racing: A check when a target is changing dimensions was checking if it had any dirty area, letting the removal of that target trigger, however Rumble Racing was only dirtying a small amount to the bottom of the screen, so now I check that the entire draw area is being covered by the dirty amount before authorizing the clear.

### Suggested Testing Steps
Test the above games and a few others for luck.
