### PR TITLE
GS/HW: Unlink source texture from old target before deletion.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2694,6 +2694,15 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVe
 				// Probably an old target, get rid of it.
 				if (remove_target)
 				{
+					// DT Racer hits this path and causes a crash when RT in RT is disabled,
+					// so let's make sure source and target texture isn't linked/shared before deleting the target.
+					if (src && src->m_target && src->m_from_target == t && src->m_target_direct)
+					{
+						src->m_target_direct = false;
+						src->m_shared_texture = false;
+						t->m_texture = nullptr;
+					}
+
 					InvalidateSourcesFromTarget(t);
 					i = rev_list.erase(i);
 					delete t;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/HW: Unlink source texture from old target before deletion.
DT Racer hits this path and causes a crash when RT in RT is disabled, so let's make sure source and target texture isn't linked/shared before deleting the target.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Fixes DT Racer crashing when RT in RT is disabled (old issue and was present before RT in RT was introduced).

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test DT Racer and variety of games, no difference on dump runner.
Most easy to test the crash is with debug build or when switching between renderers, mostly OpenGL.
