### PR TITLE
GS/HW: Only reuse dirty targets that were recently accessed

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2223,7 +2223,8 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVe
 						
 						continue;
 					}
-					else if (t->m_dirty.empty() || (t->m_TEX0.TBP0 <= bp && t->m_dirty.GetTotalRect(t->m_TEX0, t->m_unscaled_size).rintersect(GSVector4i(0, 0, 0, 0) .max_i32(TranslateAlignedRectByPage(t, TEX0.TBP0, TEX0.PSM, TEX0.TBW, min_rect))).rempty()))
+					else if (t->m_dirty.empty() || (t->m_TEX0.TBP0 <= bp && t->m_last_draw >= (GSState::s_n - 1) && 
+													t->m_dirty.GetTotalRect(t->m_TEX0, t->m_unscaled_size).rintersect(GSVector4i(0, 0, 0, 0).max_i32(TranslateAlignedRectByPage(t, TEX0.TBP0, TEX0.PSM, TEX0.TBW, min_rect))).rempty()))
 					{
 						if (TEX0.TBW == t->m_TEX0.TBW && !is_shuffle && widthpage_offset == 0 && ((min_rect.w + 63)/ 64) > 1)
 						{


### PR DESCRIPTION
### Description of Changes
Checks that a dirty target has been accessed recently when accessing inside of it. only affects games using Tex in RT/RT in RT

### Rationale behind Changes
This is just a paranoia thing to try and make Valkyrie Profile 2 suck less as it creates lots of targets slightly offset from each other and it gets in a mess. I'm full expecting it to break in a new exciting way. There's no real logic behind this except maybe it could be an old target we don't want to use.

### Suggested Testing Steps
Test Valkyrie Profile 2 and Project Snowblind (if possible, just to confirm it's ok) 

Fixes Valkyrie Profile 2 bug:
Master:
![image](https://github.com/user-attachments/assets/9e8e17d8-53fc-40fc-aafe-83be7c29b883)
PR:
![image](https://github.com/user-attachments/assets/1f39a6c0-62a5-4bb5-990c-c2bad0bc133f)
