### PR TITLE
GS/Shaders: Try to fix Warning X4000: FxaaPixelShader potentially unitialized variable.

### DIFF
--- a/bin/resources/shaders/common/fxaa.fx
+++ b/bin/resources/shaders/common/fxaa.fx
@@ -160,10 +160,7 @@ float FxaaLuma(float4 rgba)
 
 float4 FxaaPixelShader(float2 pos, FxaaTex tex, float2 fxaaRcpFrame, float fxaaSubpix, float fxaaEdgeThreshold, float fxaaEdgeThresholdMin)
 {
-	float2 posM;
-	posM.x = pos.x;
-	posM.y = pos.y;
-
+	float2 posM = pos;
 	float4 rgbyM = FxaaTexTop(tex, posM);
 	rgbyM.w = RGBLuminance(rgbyM.xyz);
 	#define lumaM rgbyM.w
@@ -186,9 +183,10 @@ float4 FxaaPixelShader(float2 pos, FxaaTex tex, float2 fxaaRcpFrame, float fxaaS
 	float rangeMaxScaled = rangeMax * fxaaEdgeThreshold;
 	float rangeMaxClamped = max(fxaaEdgeThresholdMin, rangeMaxScaled);
 
-	bool earlyExit = range < rangeMaxClamped;
 	#if (FxaaEarlyExit == 1)
-	if(earlyExit) { return rgbyM; }
+	// Potential optimization, early exit.
+	if (range < rangeMaxClamped)
+		return rgbyM;
 	#endif
 
 	float lumaNW = FxaaLuma(FxaaTexOff(tex, posM, int2(-1,-1), fxaaRcpFrame.xy));

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 63;
+static constexpr u32 SHADER_CACHE_VERSION = 64;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/Shaders: Try to fix Warning X4000: FxaaPixelShader potentially unitialized variable.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Clean up shader warnings on DX12.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
I wasn't able to reproduce it after a system restart so I dunno, just in case let's clean it up, remove extra conditions, make sure everything is initialized for returning values.
Test Fxaa on all renderers if it still works, see if any warnings are present on dx12, make sure to clean shader cache.