### PR TITLE
Savestate: Add backup slot loading ability

### DIFF
--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -267,13 +267,13 @@ private:
 	QString getDiscDevicePath(const QString& title);
 
 	void startGameListEntry(
-		const GameList::Entry* entry, std::optional<s32> save_slot = std::nullopt, std::optional<bool> fast_boot = std::nullopt);
+		const GameList::Entry* entry, std::optional<s32> save_slot = std::nullopt, std::optional<bool> fast_boot = std::nullopt, bool load_backup = false);
 	void setGameListEntryCoverImage(const GameList::Entry* entry);
 	void clearGameListEntryPlayTime(const GameList::Entry* entry);
 	void goToWikiPage(const GameList::Entry* entry);
 
 	std::optional<bool> promptForResumeState(const QString& save_state_path);
-	void loadSaveStateSlot(s32 slot);
+	void loadSaveStateSlot(s32 slot, bool load_backup = false);
 	void loadSaveStateFile(const QString& filename, const QString& state_filename);
 	void populateLoadStateMenu(QMenu* menu, const QString& filename, const QString& serial, quint32 crc);
 	void populateSaveStateMenu(QMenu* menu, const QString& serial, quint32 crc);

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -320,18 +320,18 @@ void EmuThread::loadState(const QString& filename)
 	VMManager::LoadState(filename.toUtf8().constData());
 }
 
-void EmuThread::loadStateFromSlot(qint32 slot)
+void EmuThread::loadStateFromSlot(qint32 slot, bool load_backup)
 {
 	if (!isOnEmuThread())
 	{
-		QMetaObject::invokeMethod(this, "loadStateFromSlot", Qt::QueuedConnection, Q_ARG(qint32, slot));
+		QMetaObject::invokeMethod(this, "loadStateFromSlot", Qt::QueuedConnection, Q_ARG(qint32, slot), Q_ARG(bool, load_backup));
 		return;
 	}
 
 	if (!VMManager::HasValidVM())
 		return;
 
-	VMManager::LoadStateFromSlot(slot);
+	VMManager::LoadStateFromSlot(slot, load_backup);
 }
 
 void EmuThread::saveState(const QString& filename)

--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -87,7 +87,7 @@ public Q_SLOTS:
 	void setVMPaused(bool paused);
 	void shutdownVM(bool save_state = true);
 	void loadState(const QString& filename);
-	void loadStateFromSlot(qint32 slot);
+	void loadStateFromSlot(qint32 slot, bool load_backup = false);
 	void saveState(const QString& filename);
 	void saveStateToSlot(qint32 slot);
 	void toggleFullscreen();

--- a/pcsx2/Hotkeys.cpp
+++ b/pcsx2/Hotkeys.cpp
@@ -244,6 +244,11 @@ DEFINE_HOTKEY("LoadStateFromSlot", TRANSLATE_NOOP("Hotkeys", "Save States"),
 		if (!pressed && VMManager::HasValidVM())
 			SaveStateSelectorUI::LoadCurrentSlot();
 	})
+	DEFINE_HOTKEY("LoadBackupStateFromSlot", TRANSLATE_NOOP("Hotkeys", "Save States"),
+	TRANSLATE_NOOP("Hotkeys", "Load Backup State From Selected Slot"), [](s32 pressed) {
+		if (!pressed && VMManager::HasValidVM())
+			SaveStateSelectorUI::LoadCurrentBackupSlot();
+	})
 DEFINE_HOTKEY("SaveStateAndSelectNextSlot", TRANSLATE_NOOP("Hotkeys", "Save States"),
 	TRANSLATE_NOOP("Hotkeys", "Save State and Select Next Slot"), [](s32 pressed) {
 		if (!pressed && VMManager::HasValidVM())

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -438,7 +438,7 @@ namespace FullscreenUI
 
 	static void InitializePlaceholderSaveStateListEntry(SaveStateListEntry* li, s32 slot);
 	static bool InitializeSaveStateListEntry(
-		SaveStateListEntry* li, const std::string& title, const std::string& serial, u32 crc, s32 slot);
+		SaveStateListEntry* li, const std::string& title, const std::string& serial, u32 crc, s32 slot, bool backup = false);
 	static void ClearSaveStateEntryList();
 	static u32 PopulateSaveStateListEntries(const std::string& title, const std::string& serial, u32 crc);
 	static bool OpenLoadStateSelectorForGame(const std::string& game_path);
@@ -5625,9 +5625,9 @@ void FullscreenUI::InitializePlaceholderSaveStateListEntry(SaveStateListEntry* l
 }
 
 bool FullscreenUI::InitializeSaveStateListEntry(
-	SaveStateListEntry* li, const std::string& title, const std::string& serial, u32 crc, s32 slot)
+	SaveStateListEntry* li, const std::string& title, const std::string& serial, u32 crc, s32 slot, bool backup)
 {
-	std::string filename(VMManager::GetSaveStateFileName(serial.c_str(), crc, slot));
+	std::string filename(VMManager::GetSaveStateFileName(serial.c_str(), crc, slot, backup));
 	FILESYSTEM_STAT_DATA sd;
 	if (filename.empty() || !FileSystem::StatFile(filename.c_str(), &sd))
 	{
@@ -5635,7 +5635,7 @@ bool FullscreenUI::InitializeSaveStateListEntry(
 		return false;
 	}
 
-	li->title = fmt::format("{}##game_slot_{}", TinyString::from_format(FSUI_FSTR("Save Slot {0}"), slot), slot);
+	li->title = fmt::format("{}##game_slot_{}", TinyString::from_format(FSUI_FSTR("{0} Slot {1}"), backup ? "Backup Save" : "Save", slot), slot);
 	li->summary = fmt::format(FSUI_FSTR("Saved {}"), TimeToPrintableString(sd.ModificationTime));
 	li->slot = slot;
 	li->timestamp = sd.ModificationTime;
@@ -5680,6 +5680,10 @@ u32 FullscreenUI::PopulateSaveStateListEntries(const std::string& title, const s
 		SaveStateListEntry li;
 		if (InitializeSaveStateListEntry(&li, title, serial, crc, i) || !s_save_state_selector_loading)
 			s_save_state_selector_slots.push_back(std::move(li));
+
+		SaveStateListEntry bli;
+		if (InitializeSaveStateListEntry(&bli, title, serial, crc, i, true) || !s_save_state_selector_loading)
+			s_save_state_selector_slots.push_back(std::move(bli));
 	}
 
 	return static_cast<u32>(s_save_state_selector_slots.size());

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -1107,6 +1107,14 @@ void SaveStateSelectorUI::LoadCurrentSlot()
 	Close();
 }
 
+void SaveStateSelectorUI::LoadCurrentBackupSlot()
+{
+	Host::RunOnCPUThread([slot = GetCurrentSlot()]() {
+		VMManager::LoadStateFromSlot(slot, true);
+	});
+	Close();
+}
+
 void SaveStateSelectorUI::SaveCurrentSlot()
 {
 	Host::RunOnCPUThread([slot = GetCurrentSlot()]() {

--- a/pcsx2/ImGui/ImGuiOverlays.h
+++ b/pcsx2/ImGui/ImGuiOverlays.h
@@ -26,6 +26,7 @@ namespace SaveStateSelectorUI
 
 	s32 GetCurrentSlot();
 	void LoadCurrentSlot();
+	void LoadCurrentBackupSlot();
 	void SaveCurrentSlot();
 } // namespace SaveStateSelectorUI
 

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -118,10 +118,10 @@ namespace VMManager
 	void ReloadInputBindings(bool force = false);
 
 	/// Returns the save state filename for the given game serial/crc.
-	std::string GetSaveStateFileName(const char* game_serial, u32 game_crc, s32 slot);
+	std::string GetSaveStateFileName(const char* game_serial, u32 game_crc, s32 slot, bool backup = false);
 
 	/// Returns the path to save state for the specified disc/elf.
-	std::string GetSaveStateFileName(const char* filename, s32 slot);
+	std::string GetSaveStateFileName(const char* filename, s32 slot, bool backup = false);
 
 	/// Returns true if there is a save state in the specified slot.
 	bool HasSaveStateInSlot(const char* game_serial, u32 game_crc, s32 slot);
@@ -130,7 +130,7 @@ namespace VMManager
 	bool LoadState(const char* filename);
 
 	/// Loads state from the specified slot.
-	bool LoadStateFromSlot(s32 slot);
+	bool LoadStateFromSlot(s32 slot, bool backup = false);
 
 	/// Saves state to the specified filename.
 	bool SaveState(const char* filename, bool zip_on_thread = true, bool backup_old_state = false);


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
This PR adds the option for you to load backup savestates using either hotkey or the Load State menu.
![image](https://github.com/user-attachments/assets/e2ea196f-280d-4d9d-8423-1ac71b412d24)

![image](https://github.com/user-attachments/assets/8ca88943-1bb9-452e-b834-3ab6301ecda4)

NOTE: The hotkey are not bound by default and has to be bound manually.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
QoL Improvements.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test loading backup savestates, either do it through the context menu or by using hotkey (you need to bind it first)