### PR TITLE
GS/HW: Use correct vertex colour on target clear

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -8642,7 +8642,8 @@ ClearType GSRendererHW::IsConstantDirectWriteMemClear()
 u32 GSRendererHW::GetConstantDirectWriteMemClearColor() const
 {
 	// Take the vertex colour, but check if the blending would make it black.
-	u32 vert_color = m_vertex.buff[1].RGBAQ.U32[0];
+	const u32 vert_index = (m_vt.m_primclass == GS_TRIANGLE_CLASS) ? 2 : 1;
+	u32 vert_color = m_vertex.buff[m_index.buff[vert_index]].RGBAQ.U32[0];
 	if (PRIM->ABE && m_context->ALPHA.IsBlack())
 		vert_color &= 0xFF000000u;
 


### PR DESCRIPTION
### Description of Changes
Uses the correct vertex colour on target clears. Fixes screen transitions in Sega Ages 2005 Vol 1 Phantasy Star: Generation and Dodgeball.

Before:
![image](https://github.com/user-attachments/assets/a0f63321-dc04-473c-96d6-6e8cdea4d437)
After:
![image](https://github.com/user-attachments/assets/304c63b5-d38f-4861-832f-8b905da7aa35)

### Rationale behind Changes
Transitions should fade to black not a deep purple.

### Suggested Testing Steps
Test aforementioned games and any other random assortment of games.
