### PR TITLE
GS/HW: Also unlink source texture from target before deletion on z draws.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2666,6 +2666,13 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVe
 			if (!is_shuffle && (!ds || (ds != t)) && 
 				t->m_TEX0.TBW != TEX0.TBW && TEX0.TBW != 1 && !preserve_rgb && min_rect.w > GSLocalMemory::m_psm[t->m_TEX0.PSM].pgs.y)
 			{
+				if (src && src->m_target && src->m_from_target == t && src->m_target_direct)
+				{
+					src->m_target_direct = false;
+					src->m_shared_texture = false;
+					t->m_texture = nullptr;
+				}
+
 				DevCon.Warning("Deleting Z draw %d", GSState::s_n);
 				InvalidateSourcesFromTarget(t);
 				i = rev_list.erase(i);


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/HW: Also unlink source texture from target before deletion on z draws.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Futureproof bugfix.
There's got to be that one game that does this, so far we don't have any hits but better play it safe than sorry.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Hard to test, the only way to get it to crash is random or debug build consistently.
