### PR TITLE
GS/HW: Fix ResizeTexture not getting the proper new_drect values.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3260,7 +3260,8 @@ void GSRendererHW::Draw()
 
 				new_size.y += new_offset;
 
-				rt->ResizeTexture(new_size.x, new_size.y, true, true, GSVector4i::loadh(new_size * rt->m_scale).loadl(GSVector2i(0, new_offset * rt->m_scale)));
+				const GSVector4i new_drect = GSVector4i(0, new_offset * rt->m_scale, new_size.x * rt->m_scale, new_size.y * rt->m_scale);
+				rt->ResizeTexture(new_size.x, new_size.y, true, true, new_drect);
 
 				if (src && src->m_from_target && src->m_from_target == rt && src->m_target_direct)
 				{

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3266,6 +3266,13 @@ void GSRendererHW::Draw()
 				if (src && src->m_from_target && src->m_from_target == rt && src->m_target_direct)
 				{
 					src->m_texture = rt->m_texture;
+
+					// If we've moved it and the source is expecting to be inside this target, we need to update the region to point to it.
+					u32 max_region_y = src->m_region.GetMaxY() + new_offset;
+					if (max_region_y == new_offset)
+						max_region_y = new_size.y;
+
+					src->m_region.SetY(src->m_region.GetMinY() + new_offset, max_region_y);
 				}
 
 				rt->m_valid.y += new_offset;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/HW: Fix ResizeTexture not getting the proper new_drect values.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Bugfix, accuracy, fixes vkCmdSetScissor validation layer errors.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Improves VP2 a bit.
![image](https://github.com/user-attachments/assets/b960ac62-b83f-4e64-abf0-5c9dfefb7538)
