### PR TITLE
GS/HW: Merge contained targets when expanding target backward.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3263,6 +3263,8 @@ void GSRendererHW::Draw()
 				const GSVector4i new_drect = GSVector4i(0, new_offset * rt->m_scale, new_size.x * rt->m_scale, new_size.y * rt->m_scale);
 				rt->ResizeTexture(new_size.x, new_size.y, true, true, new_drect);
 
+				g_texture_cache->CombineAlignedInsideTargets(rt, src);
+
 				if (src && src->m_from_target && src->m_from_target == rt && src->m_target_direct)
 				{
 					src->m_texture = rt->m_texture;

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -497,6 +497,7 @@ public:
 	Source* LookupDepthSource(const bool is_depth, const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, const GIFRegCLAMP& CLAMP, const GSVector4i& r, const bool possible_shuffle, const bool linear, const u32 frame_fbp = 0xFFFFFFFF, bool req_color = true, bool req_alpha = true, bool palette = false);
 
 	Target* FindTargetOverlap(Target* target, int type, int psm);
+	void CombineAlignedInsideTargets(Target* target, GSTextureCache::Source* src = nullptr);
 	Target* LookupTarget(GIFRegTEX0 TEX0, const GSVector2i& size, float scale, int type, bool used = true, u32 fbmask = 0,
 						 bool is_frame = false, bool preload = GSConfig.PreloadFrameWithGSData, bool preserve_rgb = true, bool preserve_alpha = true,
 		const GSVector4i draw_rc = GSVector4i::zero(), bool is_shuffle = false, bool possible_clear = false, bool preserve_scale = false, GSTextureCache::Source* src = nullptr, GSTextureCache::Target* ds = nullptr, int offset = -1);


### PR DESCRIPTION
### Description of Changes
Merges any targets which fall within a target after expanding the target backwards.

Also don't invalidate RGB on different target types, this conflicts with Gran Turismo 3's transition effects, possibly due to the CRC hack.

### Rationale behind Changes
Bug was exposed with #12581 where a target ended up inside where another target expanded to, causing source lookups to pick the wrong target, this merges the two together so the right data exists inside the expanded target.

### Suggested Testing Steps
Test Valkyrie Profile 2 and Tomb Raider Legend, not sure it affects much else.
