### PR TITLE
GS/HW: Detect double buffers when Z not offset during RT in RT

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -210,6 +210,7 @@ public:
 	{
 		u32 ZBP;
 		u32 offset;
+		GSVector4i rect_since;
 	};
 
 	class Target : public Surface
@@ -564,6 +565,7 @@ public:
 	GSTexture* GetTemporaryZ();
 	TempZAddress GetTemporaryZInfo();
 	void SetTemporaryZInfo(u32 address, u32 offset);
+	void SetTemporaryZInfo(TempZAddress address_info);
 	/// Invalidates a temporary Z, a partial copy only created from the current DS for the current draw when Z is not offset but RT is.
 	void InvalidateTemporaryZ();
 


### PR DESCRIPTION
### Description of Changes
Detect if RT in RT is finding a double buffer when Z isn't offset and split them.

### Rationale behind Changes
It is impossible for us to write to the Z buffer in a different location to the colour pixels, which caused a copy to happen every draw this happened, which in some situations, like Stolen, caused 1200+ copies per frame, and as you can imagine, this was very slow.

### Suggested Testing Steps
Test Stolen, maybe a smattering of other games fixed by RT in RT #11461

Stat changes for Stolen:
Draw Calls: -837 [3488=>2651]
Render Passes: -772 [3227=>2455]
Copies: -964 [1242=>278]
Uploads: -4 [54=>50]

Framerate roughly doubles and a bit.
