### PR TITLE
GameDB: HPO Native w/TO for Resident Evil Dead Aim

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -118,7 +118,7 @@ CPCS-01005:
   name-en: "Gun Survivor 4 - BioHazard - Heroes Never Die [with GunCon2]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 4 # Fixes character offset with flashlight and blurriness.
+    halfPixelOffset: 5 # Fixes character offset with flashlight and blurriness. Fixes water lines.
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes light bloom intensity.
     nativeScaling: 2 # Fixes post processing.
@@ -17320,7 +17320,7 @@ SLES-51448:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 4 # Fixes character offset with flashlight and blurriness.
+    halfPixelOffset: 5 # Fixes character offset with flashlight and blurriness. Fixes water lines.
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes light bloom intensity.
     nativeScaling: 2 # Fixes post processing.
@@ -30092,7 +30092,7 @@ SLKA-25038:
   name: "Gun Survivor 4 - BioHazard - Heroes Never Die"
   region: "NTSC-K"
   gsHWFixes:
-    halfPixelOffset: 4 # Fixes character offset with flashlight and blurriness.
+    halfPixelOffset: 5 # Fixes character offset with flashlight and blurriness. Fixes water lines.
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes light bloom intensity.
     nativeScaling: 2 # Fixes post processing.
@@ -34587,7 +34587,7 @@ SLPM-61039:
   name-en: "BioHazard Gun Survivor 4 - Heroes Never Die [Store Demo]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 4 # Fixes character offset with flashlight and blurriness.
+    halfPixelOffset: 5 # Fixes character offset with flashlight and blurriness. Fixes water lines.
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes light bloom intensity.
     nativeScaling: 2 # Fixes post processing.
@@ -40729,7 +40729,7 @@ SLPM-65245:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 4 # Fixes character offset with flashlight and blurriness.
+    halfPixelOffset: 5 # Fixes character offset with flashlight and blurriness. Fixes water lines.
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes light bloom intensity.
     nativeScaling: 2 # Fixes post processing.
@@ -64957,7 +64957,7 @@ SLUS-20669:
   gsHWFixes:
     PCRTCOverscan: 1 # Shows full image frame.
     PCRTCOffsets: 1 # Shows full image frame.
-    halfPixelOffset: 4 # Fixes character offset with flashlight and blurriness.
+    halfPixelOffset: 5 # Fixes character offset with flashlight and blurriness. Fixes water lines.
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes light bloom intensity.
     nativeScaling: 2 # Fixes post processing.


### PR DESCRIPTION
### Description of Changes
Fixes water lines on sewer levels by preferring HPO Native with Texture Offset.

**Master:**
![Resident Evil - Dead Aim_SLES-51448_20250501190826](https://github.com/user-attachments/assets/e5252921-b042-42c7-8204-ac22a37bc8e1)

**PR:**
![Resident Evil - Dead Aim_SLES-51448_20250501190849](https://github.com/user-attachments/assets/f7871e5f-d2b3-4ae3-aa78-924e3dc4535b)

[GS Dump](https://drive.google.com/file/d/1XhrOsTXsLcRtWfXusWIeNnkVCeH5avbz/view?usp=sharing)

### Rationale behind Changes
Upscaling issues bad.

### Suggested Testing Steps
Check if I didn't screw up anything else.
