### PR TITLE
Audio: Fix global settings overriding per-game ones

### DIFF
--- a/pcsx2-qt/Settings/AudioSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.cpp
@@ -310,7 +310,7 @@ void AudioSettingsWidget::onOutputVolumeChanged(int new_value)
 	pxAssert(!m_dialog->isPerGameSettings());
 	Host::SetBaseIntSettingValue("SPU2/Output", "OutputVolume", new_value);
 	Host::CommitBaseSettingChanges();
-	g_emu_thread->setAudioOutputVolume(new_value, m_ui.fastForwardVolume->value());
+	g_emu_thread->applySettings();
 
 	updateVolumeLabel();
 }
@@ -321,7 +321,7 @@ void AudioSettingsWidget::onFastForwardVolumeChanged(int new_value)
 	pxAssert(!m_dialog->isPerGameSettings());
 	Host::SetBaseIntSettingValue("SPU2/Output", "FastForwardVolume", new_value);
 	Host::CommitBaseSettingChanges();
-	g_emu_thread->setAudioOutputVolume(m_ui.volume->value(), new_value);
+	g_emu_thread->applySettings();
 
 	updateVolumeLabel();
 }
@@ -334,7 +334,7 @@ void AudioSettingsWidget::onOutputMutedChanged(int new_state)
 	const bool muted = (new_state != 0);
 	Host::SetBaseBoolSettingValue("SPU2/Output", "OutputMuted", muted);
 	Host::CommitBaseSettingChanges();
-	g_emu_thread->setAudioOutputMuted(muted);
+	g_emu_thread->applySettings();
 }
 
 void AudioSettingsWidget::onExpansionSettingsClicked()


### PR DESCRIPTION
### Description of Changes
Fixes an issue where the global volume, fast-forward volume, and mute settings would override what was in the per-game settings if the global settings were changed while the VM was running. This was because we unconditionally changed what the emu thread was doing with those specific settings if the global ones changed – rather than using `applySettings()` after committing the changes which would give per-game settings precedence over global ones.

### Rationale behind Changes
Fixes #12408 as well as two related bugs.

### Suggested Testing Steps
* Set the volume, fast-forward volume, and mute settings to something in the per-game settings.
* Go into a game.
* Try to mess with these settings globally and see if those global settings interfere with the per-game settings (the per-game settings should take priority).