### PR TITLE
GS/HW: Remove Haunting Ground CRC

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -20903,11 +20903,10 @@ SLES-52877:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces blurriness. Normal Vertex works better, but causes some lights to disappear.
-    roundSprite: 1 # Further reduces blurriness.
+    halfPixelOffset: 5 # Reduces blurriness.
     bilinearUpscale: 1 # Smooths out fire textures.
     nativeScaling: 2 # Fixes post processing.
-    beforeDraw: "OI_HauntingGround" # Fix bloom.
+    textureInsideRT: 1 # Fixes post effects.
 SLES-52882:
   name: "Stolen"
   region: "PAL-M5"
@@ -44525,11 +44524,10 @@ SLPM-65913:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces blurriness. Normal Vertex works better, but causes some lights to disappear.
-    roundSprite: 1 # Further reduces blurriness.
+    halfPixelOffset: 5 # Reduces blurriness.
     bilinearUpscale: 1 # Smooths out fire textures.
     nativeScaling: 2 # Fixes post processing.
-    beforeDraw: "OI_HauntingGround" # Fix bloom.
+    textureInsideRT: 1 # Fixes post effects.
 SLPM-65914:
   name: "NANA"
   name-sort: "ナナ"
@@ -49059,11 +49057,10 @@ SLPM-66638:
   name-en: "Demento [CapColle]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces blurriness. Normal Vertex works better, but causes some lights to disappear.
-    roundSprite: 1 # Further reduces blurriness.
+    halfPixelOffset: 5 # Reduces blurriness.
     bilinearUpscale: 1 # Smooths out fire textures.
     nativeScaling: 2 # Fixes post processing.
-    beforeDraw: "OI_HauntingGround" # Fix bloom.
+    textureInsideRT: 1 # Fixes post effects.
 SLPM-66639:
   name: "ストリートファイターⅢ 3rd STRIKE Fight for the future [カプコレ]"
   name-sort: "すとりーとふぁいたー3 3rd STRIKE Fight for the future [かぷこれ]"
@@ -67323,11 +67320,10 @@ SLUS-21075:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Reduces blurriness. Normal Vertex works better, but causes some lights to disappear.
-    roundSprite: 1 # Further reduces blurriness.
+    halfPixelOffset: 5 # Reduces blurriness.
     bilinearUpscale: 1 # Smooths out fire textures.
     nativeScaling: 2 # Fixes post processing.
-    beforeDraw: "OI_HauntingGround" # Fix bloom.
+    textureInsideRT: 1 # Fixes post effects.
 SLUS-21076:
   name: "Atari Anthology"
   region: "NTSC-U"

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -1200,75 +1200,6 @@ bool GSHwHack::OI_BurnoutGames(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GS
 	return false;
 }
 
-bool GSHwHack::OI_HauntingGround(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t)
-{
-	// Haunting Ground clears two targets by doing a direct colour write at 0x3000, covering a target at 0x3380.
-	// To make matters worse, it's masked. This currently isn't handled in our HLE clears, so we need to manually
-	// remove the other target.
-	if (rt && !ds && !t && r.IsConstantDirectWriteMemClear())
-	{
-		GL_CACHE("GSHwHack::OI_HauntingGround()");
-
-		const u32 bp = RFBP;
-		const u32 bw = RFBW;
-		const u32 psm = RFPSM;
-		const u32 fbmsk = RFBMSK;
-		const GSVector4i rc = r.m_r;
-
-		for (int type = 0; type < 2; type++)
-		{
-			auto& list = g_texture_cache->m_dst[type];
-
-			for (auto i = list.begin(); i != list.end();)
-			{
-				GSTextureCache::Target* t = *i;
-				auto ei = i++;
-
-				// There's two cases we hit here - when we clear 3380 via 3000, and when we overlap 3000 by writing to 3380.
-				// The latter is actually only 256x224, which ends at 337F, but because the game's a pain in the ass, it
-				// shuffles 512x512, causing the target to expand. It'd actually be shuffling junk and wasting draw cycles,
-				// but when did that stop anyone? So, we can get away with just saying "if it's before, ignore".
-				if (t->m_TEX0.TBP0 <= bp)
-				{
-					// don't remove ourself..
-					continue;
-				}
-
-				// Has to intersect.
-				if (!t->Overlaps(bp, bw, psm, rc))
-					continue;
-
-				// Another annoying case. Sometimes it clears with RGB masked, only writing to A. We don't want to kill the
-				// target in this case, so we'll dirty A instead.
-				if (fbmsk != 0)
-				{
-					GL_CACHE("OI_HauntingGround(%x, %u, %s, %d,%d => %d,%d): Dirty target at %x %u %s %08X", bp, bw,
-						psm_str(psm), rc.x, rc.y, rc.z, rc.w, t->m_TEX0.TBP0, t->m_TEX0.TBW, psm_str(t->m_TEX0.PSM),
-						fbmsk);
-
-					g_texture_cache->AddDirtyRectTarget(t, rc, psm, bw, RGBAMask{GSUtil::GetChannelMask(psm, fbmsk)});
-				}
-				else
-				{
-					GL_CACHE("OI_HauntingGround(%x, %u, %s, %d,%d => %d,%d): Removing target at %x %u %s", bp, bw,
-						psm_str(psm), rc.x, rc.y, rc.z, rc.w, t->m_TEX0.TBP0, t->m_TEX0.TBW, psm_str(t->m_TEX0.PSM));
-
-					// Need to also remove any sources which reference this target.
-					g_texture_cache->InvalidateSourcesFromTarget(t);
-
-					list.erase(ei);
-					delete t;
-				}
-			}
-		}
-
-		g_texture_cache->InvalidateVideoMemType(GSTextureCache::DepthStencil, bp);
-	}
-
-	// Not skipping anything. This is just an invalidation hack.
-	return true;
-}
-
 #undef RPRIM
 #undef RCONTEXT
 
@@ -1519,7 +1450,6 @@ const GSHwHack::Entry<GSRendererHW::OI_Ptr> GSHwHack::s_before_draw_functions[] 
 	CRC_F(OI_SonicUnleashed),
 	CRC_F(OI_ArTonelico2),
 	CRC_F(OI_BurnoutGames),
-	CRC_F(OI_HauntingGround),
 };
 
 const GSHwHack::Entry<GSRendererHW::MV_Ptr> GSHwHack::s_move_handler_functions[] = {

--- a/pcsx2/GS/Renderers/HW/GSHwHack.h
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.h
@@ -37,7 +37,6 @@ public:
 	static bool OI_SonicUnleashed(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	static bool OI_ArTonelico2(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 	static bool OI_BurnoutGames(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
-	static bool OI_HauntingGround(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GSTextureCache::Source* t);
 
 	static bool MV_Growlanser(GSRendererHW& r);
 	static bool MV_Ico(GSRendererHW& r);


### PR DESCRIPTION
### Description of Changes
Removes the Haunting Ground CRC and round sprite half replacing it with Tex in RT and ATNWTO.

Fixes #12594 

### Rationale behind Changes
The CRC breaks the game now and Tex in RT can fix the issue without it.

### Suggested Testing Steps
Make sure the game is not broken in any new fun ways.
