### PR TITLE
GameDB: Add ATN to Fatal Frame III

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -2081,7 +2081,7 @@ SCAJ-20139:
   name: "Zero - Shisei no Koe" # Fatal Frame - Rei - Irezumi no Sei
   region: "NTSC-Unk"
   gsHWFixes:
-    halfPixelOffset: 5 # Reduces blurriness.
+    halfPixelOffset: 4 # Reduces blurriness.
 SCAJ-20140:
   name: "Bleach - Erabareshi Tamashi"
   region: "NTSC-Unk"
@@ -23948,7 +23948,7 @@ SLES-53825:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 5 # Reduces blurriness.
+    halfPixelOffset: 4 # Reduces blurriness.
 SLES-53826:
   name: "Tom Clancy's Splinter Cell - Double Agent"
   region: "PAL-M5"
@@ -58220,7 +58220,7 @@ SLPS-25544:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 5 # Reduces blurriness.
+    halfPixelOffset: 4 # Reduces blurriness.
 SLPS-25545:
   name: "ファイティング フォー ワンピース"
   name-sort: "ふぁいてぃんぐ ふぉー わんぴーす"
@@ -61446,7 +61446,7 @@ SLPS-73245:
   name-en: "Fatal Frame III - The Tormented [PlayStation2 the Best]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 5 # Reduces blurriness.
+    halfPixelOffset: 4 # Reduces blurriness.
 SLPS-73246:
   name: "ガンダム トゥルーオデッセイ ～失われしGの伝説～ [PlayStation2 the Best]"
   name-sort: "がんだむ とぅるーおでっせい うしなわれしGのでんせつ [PlayStation2 the Best]"
@@ -61558,7 +61558,7 @@ SLPS-73257:
   name-en: "Fatal Frame III - The Tormented [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 5 # Reduces blurriness.
+    halfPixelOffset: 4 # Reduces blurriness.
 SLPS-73258:
   name: "喧嘩番長2 ～フルスロットル～ [PlayStation2 the Best]"
   name-sort: "けんかばんちょう2 ふるすろっとる [PlayStation2 the Best]"
@@ -68364,7 +68364,7 @@ SLUS-21244:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 5 # Reduces blurriness.
+    halfPixelOffset: 4 # Reduces blurriness.
 SLUS-21245:
   name: "Suikoden Tactics"
   region: "NTSC-U"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -2081,7 +2081,7 @@ SCAJ-20139:
   name: "Zero - Shisei no Koe" # Fatal Frame - Rei - Irezumi no Sei
   region: "NTSC-Unk"
   gsHWFixes:
-    halfPixelOffset: 1 # Reduces blurriness.
+    halfPixelOffset: 5 # Reduces blurriness.
 SCAJ-20140:
   name: "Bleach - Erabareshi Tamashi"
   region: "NTSC-Unk"
@@ -23948,7 +23948,7 @@ SLES-53825:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Reduces blurriness.
+    halfPixelOffset: 5 # Reduces blurriness.
 SLES-53826:
   name: "Tom Clancy's Splinter Cell - Double Agent"
   region: "PAL-M5"
@@ -58219,6 +58219,8 @@ SLPS-25544:
   name-en: "Fatal Frame III - The Tormented"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 5 # Reduces blurriness.
 SLPS-25545:
   name: "ファイティング フォー ワンピース"
   name-sort: "ふぁいてぃんぐ ふぉー わんぴーす"
@@ -61443,6 +61445,8 @@ SLPS-73245:
   name-sort: "ぜろ しせいのこえ [PlayStation2 the Best]"
   name-en: "Fatal Frame III - The Tormented [PlayStation2 the Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    halfPixelOffset: 5 # Reduces blurriness.
 SLPS-73246:
   name: "ガンダム トゥルーオデッセイ ～失われしGの伝説～ [PlayStation2 the Best]"
   name-sort: "がんだむ とぅるーおでっせい うしなわれしGのでんせつ [PlayStation2 the Best]"
@@ -61554,7 +61558,7 @@ SLPS-73257:
   name-en: "Fatal Frame III - The Tormented [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 1 # Reduces blurriness.
+    halfPixelOffset: 5 # Reduces blurriness.
 SLPS-73258:
   name: "喧嘩番長2 ～フルスロットル～ [PlayStation2 the Best]"
   name-sort: "けんかばんちょう2 ふるすろっとる [PlayStation2 the Best]"
@@ -68360,7 +68364,7 @@ SLUS-21244:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Reduces blurriness.
+    halfPixelOffset: 5 # Reduces blurriness.
 SLUS-21245:
   name: "Suikoden Tactics"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Changes Half Pixel Offset from Normal (Vertex) to Align to Native
### Rationale behind Changes
The game looks better and sharper upscaled.
### Suggested Testing Steps
Already tested.

Software
![Software](https://github.com/user-attachments/assets/8c7067b4-edd5-4744-896c-ffdfbfc612b8)

Normal (Vertex)
![Normal (Vertex)](https://github.com/user-attachments/assets/a04bec32-fad5-4e13-ab62-6190717e19d4)

Align to Native
![Align to Native](https://github.com/user-attachments/assets/bc9f8a4e-52d6-4a30-b1e3-1d1facbcf86d)