### PR TITLE
Qt: Allow translating the default adapter text

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -74,7 +74,6 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 	//////////////////////////////////////////////////////////////////////////
 	// Global Settings
 	//////////////////////////////////////////////////////////////////////////
-	SettingWidgetBinder::BindWidgetToStringSetting(sif, m_ui.adapterDropdown, "EmuCore/GS", "Adapter");
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.enableHWFixes, "EmuCore/GS", "UserHacks", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.spinGPUDuringReadbacks, "EmuCore/GS", "HWSpinGPUForReadbacks", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.spinCPUDuringReadbacks, "EmuCore/GS", "HWSpinCPUForReadbacks", false);
@@ -294,6 +293,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 	}
 
 	connect(m_ui.rendererDropdown, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &GraphicsSettingsWidget::onRendererChanged);
+	connect(m_ui.adapterDropdown, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &GraphicsSettingsWidget::onAdapterChanged);
 	connect(m_ui.enableHWFixes, &QCheckBox::checkStateChanged, this, &GraphicsSettingsWidget::updateRendererDependentOptions);
 	connect(m_ui.extendedUpscales, &QCheckBox::checkStateChanged, this, &GraphicsSettingsWidget::updateRendererDependentOptions);
 	connect(m_ui.textureFiltering, &QComboBox::currentIndexChanged, this, &GraphicsSettingsWidget::onTextureFilteringChange);
@@ -1172,13 +1172,17 @@ void GraphicsSettingsWidget::updateRendererDependentOptions()
 		std::string current_adapter = Host::GetBaseStringSettingValue("EmuCore/GS", "Adapter", "");
 		m_ui.adapterDropdown->clear();
 		m_ui.adapterDropdown->setEnabled(!adapters.empty());
-		m_ui.adapterDropdown->addItem(GetDefaultAdapter().c_str());
+		m_ui.adapterDropdown->addItem(tr("(Default)"));
 		m_ui.adapterDropdown->setCurrentIndex(0);
+
+		// Treat default adapter as empty
+		if (current_adapter == GetDefaultAdapter())
+			current_adapter.clear();
 
 		if (m_dialog->isPerGameSettings())
 		{
 			m_ui.adapterDropdown->insertItem(
-				0, tr("Use Global Setting [%1]").arg(current_adapter.empty() ? GetDefaultAdapter().c_str() : QString::fromStdString(current_adapter)));
+				0, tr("Use Global Setting [%1]").arg((current_adapter.empty()) ? tr("(Default)") : QString::fromStdString(current_adapter)));
 			if (!m_dialog->getSettingsInterface()->GetStringValue("EmuCore/GS", "Adapter", &current_adapter))
 			{
 				// clear the adapter so we don't set it to the global value


### PR DESCRIPTION
### Description of Changes
Adjust Qt logic to handle "(Default)" as an empty string
Adjust previously unused logic to save the default adapter as "(Default)" (untranslated) instead of an empty string
Use said previously unused logic to handle saving the adapter setting
Enable translating the default adapter string

### Rationale behind Changes
Strangely, the needed logic was already present (but partly unused), it just needed adjustment to match https://github.com/PCSX2/pcsx2/commit/1b50057764a351e942c8087dc46cc81e73907889

Prior to https://github.com/PCSX2/pcsx2/commit/1b50057764a351e942c8087dc46cc81e73907889, we where accidentality saving "(Default)" in the users language (instead of an empty string as intended).
https://github.com/PCSX2/pcsx2/commit/1b50057764a351e942c8087dc46cc81e73907889 switched to intentionally saving "(Default)" in the config file, but prevented the displayed string from getting translated.

The "(Default)" string as presented to the user should be translatable, even if we are storing a non-translated string into the config file.

### Suggested Testing Steps
Make sure saving and loading the default adapter works for both global and game settings when using a non-English language where "(Default)" is translated
Check the ini file to make sure the untranslated "(Default)" is saved instead of any translated text
