### PR TITLE
ImGui SVG Fixes

### DIFF
--- a/.github/workflows/scripts/linux/build-dependencies-qt.sh
+++ b/.github/workflows/scripts/linux/build-dependencies-qt.sh
@@ -231,7 +231,7 @@ echo "Building PlutoVG..."
 rm -fr "plutovg-$PLUTOVG"
 tar xf "plutovg-$PLUTOVG.tar.gz"
 cd "plutovg-$PLUTOVG"
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$INSTALLDIR" -DCMAKE_INSTALL_PREFIX="$INSTALLDIR" -DPLUTOVG_BUILD_EXAMPLES=OFF -B build -G Ninja
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$INSTALLDIR" -DCMAKE_INSTALL_PREFIX="$INSTALLDIR" -DBUILD_SHARED_LIBS=ON -DPLUTOVG_BUILD_EXAMPLES=OFF -B build -G Ninja
 cmake --build build --parallel
 ninja -C build install
 cd ..

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -19,7 +19,7 @@ find_package(LZ4 REQUIRED)
 find_package(WebP REQUIRED) # v1.3.2, spews an error on Linux because no pkg-config.
 find_package(SDL3 3.2.6 REQUIRED)
 find_package(Freetype 2.11.1 REQUIRED)
-find_package(plutovg 0.0.13 REQUIRED)
+find_package(plutovg REQUIRED) # v0.0.13 is needed for building plutosvg, but we can support v1.0.0
 find_package(plutosvg 0.0.6 REQUIRED)
 
 if(USE_VULKAN)

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -242,7 +242,6 @@ namespace FullscreenUI
 	static void ApplyLayoutSettings(const SettingsInterface* bsi = nullptr);
 
 	void DrawSvgTexture(GSTexture* padded_texture, ImVec2 unpadded_size);
-	void DrawSvgTexture_UV(GSTexture* padded_texture, ImVec2 unpadded_size, ImVec2 unpadded_uv0, ImVec2 unpadded_uv1);
 	void DrawCachedSvgTexture(const std::string& path, ImVec2 size, SvgScaling mode);
 	void DrawCachedSvgTextureAsync(const std::string& path, ImVec2 size, SvgScaling mode);
 

--- a/pcsx2/ImGui/ImGuiFullscreen.cpp
+++ b/pcsx2/ImGui/ImGuiFullscreen.cpp
@@ -671,7 +671,7 @@ ImRect ImGuiFullscreen::CenterImage(const ImVec2& fit_size, const ImVec2& image_
 
 ImRect ImGuiFullscreen::CenterImage(const ImRect& fit_rect, const ImVec2& image_size, bool fill)
 {
-	ImRect ret(CenterImage(fit_rect.Max - fit_rect.Min, image_size));
+	ImRect ret(CenterImage(fit_rect.Max - fit_rect.Min, image_size, fill));
 	ret.Translate(fit_rect.Min);
 	return ret;
 }


### PR DESCRIPTION
### Description of Changes
Build PlutoVG as a shared lib
Remove the version check for PlutoVG in our CMake file
Fix Fill mode for `CenterImage()` when using an `ImRect` region

### Rationale behind Changes
All other dependencies built with the dependency script are build shared.

The changes between PlutoVG 0.0.13 and 1.0.0 don't impact our code, Arch seems to patch their build of PlutoSVG to accept the newer version of PlutoVG, so we should accept the same version it if building with system packages.

Bug fixes

### Suggested Testing Steps
Make sure CI doesn’t explode
Test AppImage can still render the region and star SVG files
