### PR TITLE
GS/HW: Fix copy range for shuffles.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -6411,8 +6411,8 @@ __ri void GSRendererHW::HandleTextureHazards(const GSTextureCache::Target* rt, c
 				}
 			}
 
-			copy_range.z = std::min(copy_range.z, copy_size.x);
-			copy_range.w = std::min(copy_range.w, copy_size.y);
+			copy_range.z = std::min(copy_range.z, src_target->m_unscaled_size.x);
+			copy_range.w = std::min(copy_range.w, src_target->m_unscaled_size.y);
 		}
 	}
 	else


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/HW: Fix copy range for shuffles.
We should be using the sizes based on source instead of target when clamping depth range.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Fixes Hitman Blood Money validation errors/crashes/broken graphics varying on renderer.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Dump run all good, test Hitman Blood Money on different renderers.