### PR TITLE
Docs: Update licensing documentation

### DIFF
--- a/bin/docs/GPL.html
+++ b/bin/docs/GPL.html
@@ -1,61 +1,65 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<!-- saved from url=(0051)http://www.gnu.org/licenses/gpl-3.0-standalone.html -->
-<HTML><HEAD><META http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 
- <TITLE>GNU General Public License - GNU Project - Free Software Foundation (FSF)</TITLE>
- <LINK rel="alternate" type="application/rdf+xml" href="http://www.gnu.org/licenses/gpl-3.0.rdf">
-</HEAD><BODY>
-<H3 style="text-align: center;">GNU GENERAL PUBLIC LICENSE</H3>
-<P style="text-align: center;">Version 3, 29 June 2007</P>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+ <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+ <title>GNU General Public License v3.0 - GNU Project - Free Software Foundation (FSF)</title>
+ <link rel="alternate" type="application/rdf+xml"
+       href="http://www.gnu.org/licenses/gpl-3.0.rdf" /> 
+</head>
+<body>
+<h3 style="text-align: center;">GNU GENERAL PUBLIC LICENSE</h3>
+<p style="text-align: center;">Version 3, 29 June 2007</p>
 
-<P>Copyright © 2007 Free Software Foundation, Inc.
- &lt;<A href="http://fsf.org/">http://fsf.org/</A>&gt;</P><P>
+<p>Copyright &copy; 2007 Free Software Foundation, Inc.
+ &lt;<a href="https://fsf.org/">https://fsf.org/</a>&gt;</p><p>
  Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.</P>
+ of this license document, but changing it is not allowed.</p>
 
-<H3><A name="preamble"></A>Preamble</H3>
+<h4 id="preamble">Preamble</h4>
 
-<P>The GNU General Public License is a free, copyleft license for
-software and other kinds of works.</P>
+<p>The GNU General Public License is a free, copyleft license for
+software and other kinds of works.</p>
 
-<P>The licenses for most software and other practical works are designed
+<p>The licenses for most software and other practical works are designed
 to take away your freedom to share and change the works.  By contrast,
 the GNU General Public License is intended to guarantee your freedom to
 share and change all versions of a program--to make sure it remains free
 software for all its users.  We, the Free Software Foundation, use the
 GNU General Public License for most of our software; it applies also to
 any other work released this way by its authors.  You can apply it to
-your programs, too.</P>
+your programs, too.</p>
 
-<P>When we speak of free software, we are referring to freedom, not
+<p>When we speak of free software, we are referring to freedom, not
 price.  Our General Public Licenses are designed to make sure that you
 have the freedom to distribute copies of free software (and charge for
 them if you wish), that you receive source code or can get it if you
 want it, that you can change the software or use pieces of it in new
-free programs, and that you know you can do these things.</P>
+free programs, and that you know you can do these things.</p>
 
-<P>To protect your rights, we need to prevent others from denying you
+<p>To protect your rights, we need to prevent others from denying you
 these rights or asking you to surrender the rights.  Therefore, you have
 certain responsibilities if you distribute copies of the software, or if
-you modify it: responsibilities to respect the freedom of others.</P>
+you modify it: responsibilities to respect the freedom of others.</p>
 
-<P>For example, if you distribute copies of such a program, whether
+<p>For example, if you distribute copies of such a program, whether
 gratis or for a fee, you must pass on to the recipients the same
 freedoms that you received.  You must make sure that they, too, receive
 or can get the source code.  And you must show them these terms so they
-know their rights.</P>
+know their rights.</p>
 
-<P>Developers that use the GNU GPL protect your rights with two steps:
+<p>Developers that use the GNU GPL protect your rights with two steps:
 (1) assert copyright on the software, and (2) offer you this License
-giving you legal permission to copy, distribute and/or modify it.</P>
+giving you legal permission to copy, distribute and/or modify it.</p>
 
-<P>For the developers' and authors' protection, the GPL clearly explains
+<p>For the developers' and authors' protection, the GPL clearly explains
 that there is no warranty for this free software.  For both users' and
 authors' sake, the GPL requires that modified versions be marked as
 changed, so that their problems will not be attributed erroneously to
-authors of previous versions.</P>
+authors of previous versions.</p>
 
-<P>Some devices are designed to deny users access to install or run
+<p>Some devices are designed to deny users access to install or run
 modified versions of the software inside them, although the manufacturer
 can do so.  This is fundamentally incompatible with the aim of
 protecting users' freedom to change the software.  The systematic
@@ -64,82 +68,82 @@ use, which is precisely where it is most unacceptable.  Therefore, we
 have designed this version of the GPL to prohibit the practice for those
 products.  If such problems arise substantially in other domains, we
 stand ready to extend this provision to those domains in future versions
-of the GPL, as needed to protect the freedom of users.</P>
+of the GPL, as needed to protect the freedom of users.</p>
 
-<P>Finally, every program is threatened constantly by software patents.
+<p>Finally, every program is threatened constantly by software patents.
 States should not allow patents to restrict development and use of
 software on general-purpose computers, but in those that do, we wish to
 avoid the special danger that patents applied to a free program could
 make it effectively proprietary.  To prevent this, the GPL assures that
-patents cannot be used to render the program non-free.</P>
+patents cannot be used to render the program non-free.</p>
 
-<P>The precise terms and conditions for copying, distribution and
-modification follow.</P>
+<p>The precise terms and conditions for copying, distribution and
+modification follow.</p>
 
-<H3><A name="terms"></A>TERMS AND CONDITIONS</H3>
+<h4 id="terms">TERMS AND CONDITIONS</h4>
 
-<H4><A name="section0"></A>0. Definitions.</H4>
+<h5 id="section0">0. Definitions.</h5>
 
-<P>“This License” refers to version 3 of the GNU General Public License.</P>
+<p>&ldquo;This License&rdquo; refers to version 3 of the GNU General Public License.</p>
 
-<P>“Copyright” also means copyright-like laws that apply to other kinds of
-works, such as semiconductor masks.</P>
+<p>&ldquo;Copyright&rdquo; also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.</p>
+ 
+<p>&ldquo;The Program&rdquo; refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as &ldquo;you&rdquo;.  &ldquo;Licensees&rdquo; and
+&ldquo;recipients&rdquo; may be individuals or organizations.</p>
 
-<P>“The Program” refers to any copyrightable work licensed under this
-License.  Each licensee is addressed as “you”.  “Licensees” and
-“recipients” may be individuals or organizations.</P>
-
-<P>To “modify” a work means to copy from or adapt all or part of the work
+<p>To &ldquo;modify&rdquo; a work means to copy from or adapt all or part of the work
 in a fashion requiring copyright permission, other than the making of an
-exact copy.  The resulting work is called a “modified version” of the
-earlier work or a work “based on” the earlier work.</P>
+exact copy.  The resulting work is called a &ldquo;modified version&rdquo; of the
+earlier work or a work &ldquo;based on&rdquo; the earlier work.</p>
 
-<P>A “covered work” means either the unmodified Program or a work based
-on the Program.</P>
+<p>A &ldquo;covered work&rdquo; means either the unmodified Program or a work based
+on the Program.</p>
 
-<P>To “propagate” a work means to do anything with it that, without
+<p>To &ldquo;propagate&rdquo; a work means to do anything with it that, without
 permission, would make you directly or secondarily liable for
 infringement under applicable copyright law, except executing it on a
 computer or modifying a private copy.  Propagation includes copying,
 distribution (with or without modification), making available to the
-public, and in some countries other activities as well.</P>
+public, and in some countries other activities as well.</p>
 
-<P>To “convey” a work means any kind of propagation that enables other
+<p>To &ldquo;convey&rdquo; a work means any kind of propagation that enables other
 parties to make or receive copies.  Mere interaction with a user through
-a computer network, with no transfer of a copy, is not conveying.</P>
+a computer network, with no transfer of a copy, is not conveying.</p>
 
-<P>An interactive user interface displays “Appropriate Legal Notices”
+<p>An interactive user interface displays &ldquo;Appropriate Legal Notices&rdquo;
 to the extent that it includes a convenient and prominently visible
 feature that (1) displays an appropriate copyright notice, and (2)
 tells the user that there is no warranty for the work (except to the
 extent that warranties are provided), that licensees may convey the
 work under this License, and how to view a copy of this License.  If
 the interface presents a list of user commands or options, such as a
-menu, a prominent item in the list meets this criterion.</P>
+menu, a prominent item in the list meets this criterion.</p>
 
-<H4><A name="section1"></A>1. Source Code.</H4>
+<h5 id="section1">1. Source Code.</h5>
 
-<P>The “source code” for a work means the preferred form of the work
-for making modifications to it.  “Object code” means any non-source
-form of a work.</P>
+<p>The &ldquo;source code&rdquo; for a work means the preferred form of the work
+for making modifications to it.  &ldquo;Object code&rdquo; means any non-source
+form of a work.</p>
 
-<P>A “Standard Interface” means an interface that either is an official
+<p>A &ldquo;Standard Interface&rdquo; means an interface that either is an official
 standard defined by a recognized standards body, or, in the case of
 interfaces specified for a particular programming language, one that
-is widely used among developers working in that language.</P>
+is widely used among developers working in that language.</p>
 
-<P>The “System Libraries” of an executable work include anything, other
+<p>The &ldquo;System Libraries&rdquo; of an executable work include anything, other
 than the work as a whole, that (a) is included in the normal form of
 packaging a Major Component, but which is not part of that Major
 Component, and (b) serves only to enable use of the work with that
 Major Component, or to implement a Standard Interface for which an
 implementation is available to the public in source code form.  A
-“Major Component”, in this context, means a major essential component
+&ldquo;Major Component&rdquo;, in this context, means a major essential component
 (kernel, window system, and so on) of the specific operating system
 (if any) on which the executable work runs, or a compiler used to
-produce the work, or an object code interpreter used to run it.</P>
+produce the work, or an object code interpreter used to run it.</p>
 
-<P>The “Corresponding Source” for a work in object code form means all
+<p>The &ldquo;Corresponding Source&rdquo; for a work in object code form means all
 the source code needed to generate, install, and (for an executable
 work) run the object code and to modify the work, including scripts to
 control those activities.  However, it does not include the work's
@@ -150,26 +154,26 @@ includes interface definition files associated with source files for
 the work, and the source code for shared libraries and dynamically
 linked subprograms that the work is specifically designed to require,
 such as by intimate data communication or control flow between those
-subprograms and other parts of the work.</P>
+subprograms and other parts of the work.</p>
 
-<P>The Corresponding Source need not include anything that users
+<p>The Corresponding Source need not include anything that users
 can regenerate automatically from other parts of the Corresponding
-Source.</P>
+Source.</p>
 
-<P>The Corresponding Source for a work in source code form is that
-same work.</P>
+<p>The Corresponding Source for a work in source code form is that
+same work.</p>
 
-<H4><A name="section2"></A>2. Basic Permissions.</H4>
+<h5 id="section2">2. Basic Permissions.</h5>
 
-<P>All rights granted under this License are granted for the term of
+<p>All rights granted under this License are granted for the term of
 copyright on the Program, and are irrevocable provided the stated
 conditions are met.  This License explicitly affirms your unlimited
 permission to run the unmodified Program.  The output from running a
 covered work is covered by this License only if the output, given its
 content, constitutes a covered work.  This License acknowledges your
-rights of fair use or other equivalent, as provided by copyright law.</P>
+rights of fair use or other equivalent, as provided by copyright law.</p>
 
-<P>You may make, run and propagate covered works that you do not
+<p>You may make, run and propagate covered works that you do not
 convey, without conditions so long as your license otherwise remains
 in force.  You may convey covered works to others for the sole purpose
 of having them make modifications exclusively for you, or provide you
@@ -178,94 +182,94 @@ the terms of this License in conveying all material for which you do
 not control copyright.  Those thus making or running the covered works
 for you must do so exclusively on your behalf, under your direction
 and control, on terms that prohibit them from making any copies of
-your copyrighted material outside their relationship with you.</P>
+your copyrighted material outside their relationship with you.</p>
 
-<P>Conveying under any other circumstances is permitted solely under
+<p>Conveying under any other circumstances is permitted solely under
 the conditions stated below.  Sublicensing is not allowed; section 10
-makes it unnecessary.</P>
+makes it unnecessary.</p>
 
-<H4><A name="section3"></A>3. Protecting Users' Legal Rights From Anti-Circumvention Law.</H4>
+<h5 id="section3">3. Protecting Users' Legal Rights From Anti-Circumvention Law.</h5>
 
-<P>No covered work shall be deemed part of an effective technological
+<p>No covered work shall be deemed part of an effective technological
 measure under any applicable law fulfilling obligations under article
 11 of the WIPO copyright treaty adopted on 20 December 1996, or
 similar laws prohibiting or restricting circumvention of such
-measures.</P>
+measures.</p>
 
-<P>When you convey a covered work, you waive any legal power to forbid
+<p>When you convey a covered work, you waive any legal power to forbid
 circumvention of technological measures to the extent such circumvention
 is effected by exercising rights under this License with respect to
 the covered work, and you disclaim any intention to limit operation or
 modification of the work as a means of enforcing, against the work's
 users, your or third parties' legal rights to forbid circumvention of
-technological measures.</P>
+technological measures.</p>
 
-<H4><A name="section4"></A>4. Conveying Verbatim Copies.</H4>
+<h5 id="section4">4. Conveying Verbatim Copies.</h5>
 
-<P>You may convey verbatim copies of the Program's source code as you
+<p>You may convey verbatim copies of the Program's source code as you
 receive it, in any medium, provided that you conspicuously and
 appropriately publish on each copy an appropriate copyright notice;
 keep intact all notices stating that this License and any
 non-permissive terms added in accord with section 7 apply to the code;
 keep intact all notices of the absence of any warranty; and give all
-recipients a copy of this License along with the Program.</P>
+recipients a copy of this License along with the Program.</p>
 
-<P>You may charge any price or no price for each copy that you convey,
-and you may offer support or warranty protection for a fee.</P>
+<p>You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.</p>
 
-<H4><A name="section5"></A>5. Conveying Modified Source Versions.</H4>
+<h5 id="section5">5. Conveying Modified Source Versions.</h5>
 
-<P>You may convey a work based on the Program, or the modifications to
+<p>You may convey a work based on the Program, or the modifications to
 produce it from the Program, in the form of source code under the
-terms of section 4, provided that you also meet all of these conditions:</P>
+terms of section 4, provided that you also meet all of these conditions:</p>
 
-<UL>
-<LI>a) The work must carry prominent notices stating that you modified
-    it, and giving a relevant date.</LI>
+<ul>
+<li>a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.</li>
 
-<LI>b) The work must carry prominent notices stating that it is
+<li>b) The work must carry prominent notices stating that it is
     released under this License and any conditions added under section
     7.  This requirement modifies the requirement in section 4 to
-    “keep intact all notices”.</LI>
+    &ldquo;keep intact all notices&rdquo;.</li>
 
-<LI>c) You must license the entire work, as a whole, under this
+<li>c) You must license the entire work, as a whole, under this
     License to anyone who comes into possession of a copy.  This
     License will therefore apply, along with any applicable section 7
     additional terms, to the whole of the work, and all its parts,
     regardless of how they are packaged.  This License gives no
     permission to license the work in any other way, but it does not
-    invalidate such permission if you have separately received it.</LI>
+    invalidate such permission if you have separately received it.</li>
 
-<LI>d) If the work has interactive user interfaces, each must display
+<li>d) If the work has interactive user interfaces, each must display
     Appropriate Legal Notices; however, if the Program has interactive
     interfaces that do not display Appropriate Legal Notices, your
-    work need not make them do so.</LI>
-</UL>
+    work need not make them do so.</li>
+</ul>
 
-<P>A compilation of a covered work with other separate and independent
+<p>A compilation of a covered work with other separate and independent
 works, which are not by their nature extensions of the covered work,
 and which are not combined with it such as to form a larger program,
 in or on a volume of a storage or distribution medium, is called an
-“aggregate” if the compilation and its resulting copyright are not
+&ldquo;aggregate&rdquo; if the compilation and its resulting copyright are not
 used to limit the access or legal rights of the compilation's users
 beyond what the individual works permit.  Inclusion of a covered work
 in an aggregate does not cause this License to apply to the other
-parts of the aggregate.</P>
+parts of the aggregate.</p>
 
-<H4><A name="section6"></A>6. Conveying Non-Source Forms.</H4>
+<h5 id="section6">6. Conveying Non-Source Forms.</h5>
 
-<P>You may convey a covered work in object code form under the terms
+<p>You may convey a covered work in object code form under the terms
 of sections 4 and 5, provided that you also convey the
 machine-readable Corresponding Source under the terms of this License,
-in one of these ways:</P>
+in one of these ways:</p>
 
-<UL>
-<LI>a) Convey the object code in, or embodied in, a physical product
+<ul>
+<li>a) Convey the object code in, or embodied in, a physical product
     (including a physical distribution medium), accompanied by the
     Corresponding Source fixed on a durable physical medium
-    customarily used for software interchange.</LI>
+    customarily used for software interchange.</li>
 
-<LI>b) Convey the object code in, or embodied in, a physical product
+<li>b) Convey the object code in, or embodied in, a physical product
     (including a physical distribution medium), accompanied by a
     written offer, valid for at least three years and valid for as
     long as you offer spare parts or customer support for that product
@@ -275,15 +279,15 @@ in one of these ways:</P>
     medium customarily used for software interchange, for a price no
     more than your reasonable cost of physically performing this
     conveying of source, or (2) access to copy the
-    Corresponding Source from a network server at no charge.</LI>
+    Corresponding Source from a network server at no charge.</li>
 
-<LI>c) Convey individual copies of the object code with a copy of the
+<li>c) Convey individual copies of the object code with a copy of the
     written offer to provide the Corresponding Source.  This
     alternative is allowed only occasionally and noncommercially, and
     only if you received the object code with such an offer, in accord
-    with subsection 6b.</LI>
+    with subsection 6b.</li>
 
-<LI>d) Convey the object code by offering access from a designated
+<li>d) Convey the object code by offering access from a designated
     place (gratis or for a charge), and offer equivalent access to the
     Corresponding Source in the same way through the same place at no
     further charge.  You need not require recipients to copy the
@@ -294,40 +298,40 @@ in one of these ways:</P>
     clear directions next to the object code saying where to find the
     Corresponding Source.  Regardless of what server hosts the
     Corresponding Source, you remain obligated to ensure that it is
-    available for as long as needed to satisfy these requirements.</LI>
+    available for as long as needed to satisfy these requirements.</li>
 
-<LI>e) Convey the object code using peer-to-peer transmission, provided
+<li>e) Convey the object code using peer-to-peer transmission, provided
     you inform other peers where the object code and Corresponding
     Source of the work are being offered to the general public at no
-    charge under subsection 6d.</LI>
-</UL>
+    charge under subsection 6d.</li>
+</ul>
 
-<P>A separable portion of the object code, whose source code is excluded
+<p>A separable portion of the object code, whose source code is excluded
 from the Corresponding Source as a System Library, need not be
-included in conveying the object code work.</P>
+included in conveying the object code work.</p>
 
-<P>A “User Product” is either (1) a “consumer product”, which means any
+<p>A &ldquo;User Product&rdquo; is either (1) a &ldquo;consumer product&rdquo;, which means any
 tangible personal property which is normally used for personal, family,
 or household purposes, or (2) anything designed or sold for incorporation
 into a dwelling.  In determining whether a product is a consumer product,
 doubtful cases shall be resolved in favor of coverage.  For a particular
-product received by a particular user, “normally used” refers to a
+product received by a particular user, &ldquo;normally used&rdquo; refers to a
 typical or common use of that class of product, regardless of the status
 of the particular user or of the way in which the particular user
 actually uses, or expects or is expected to use, the product.  A product
 is a consumer product regardless of whether the product has substantial
 commercial, industrial or non-consumer uses, unless such uses represent
-the only significant mode of use of the product.</P>
+the only significant mode of use of the product.</p>
 
-<P>“Installation Information” for a User Product means any methods,
+<p>&ldquo;Installation Information&rdquo; for a User Product means any methods,
 procedures, authorization keys, or other information required to install
 and execute modified versions of a covered work in that User Product from
 a modified version of its Corresponding Source.  The information must
 suffice to ensure that the continued functioning of the modified object
 code is in no case prevented or interfered with solely because
-modification has been made.</P>
+modification has been made.</p>
 
-<P>If you convey an object code work under this section in, or with, or
+<p>If you convey an object code work under this section in, or with, or
 specifically for use in, a User Product, and the conveying occurs as
 part of a transaction in which the right of possession and use of the
 User Product is transferred to the recipient in perpetuity or for a
@@ -336,135 +340,135 @@ Corresponding Source conveyed under this section must be accompanied
 by the Installation Information.  But this requirement does not apply
 if neither you nor any third party retains the ability to install
 modified object code on the User Product (for example, the work has
-been installed in ROM).</P>
+been installed in ROM).</p>
 
-<P>The requirement to provide Installation Information does not include a
+<p>The requirement to provide Installation Information does not include a
 requirement to continue to provide support service, warranty, or updates
 for a work that has been modified or installed by the recipient, or for
 the User Product in which it has been modified or installed.  Access to a
 network may be denied when the modification itself materially and
 adversely affects the operation of the network or violates the rules and
-protocols for communication across the network.</P>
+protocols for communication across the network.</p>
 
-<P>Corresponding Source conveyed, and Installation Information provided,
+<p>Corresponding Source conveyed, and Installation Information provided,
 in accord with this section must be in a format that is publicly
 documented (and with an implementation available to the public in
 source code form), and must require no special password or key for
-unpacking, reading or copying.</P>
+unpacking, reading or copying.</p>
 
-<H4><A name="section7"></A>7. Additional Terms.</H4>
+<h5 id="section7">7. Additional Terms.</h5>
 
-<P>“Additional permissions” are terms that supplement the terms of this
+<p>&ldquo;Additional permissions&rdquo; are terms that supplement the terms of this
 License by making exceptions from one or more of its conditions.
 Additional permissions that are applicable to the entire Program shall
 be treated as though they were included in this License, to the extent
 that they are valid under applicable law.  If additional permissions
 apply only to part of the Program, that part may be used separately
 under those permissions, but the entire Program remains governed by
-this License without regard to the additional permissions.</P>
+this License without regard to the additional permissions.</p>
 
-<P>When you convey a copy of a covered work, you may at your option
+<p>When you convey a copy of a covered work, you may at your option
 remove any additional permissions from that copy, or from any part of
 it.  (Additional permissions may be written to require their own
 removal in certain cases when you modify the work.)  You may place
 additional permissions on material, added by you to a covered work,
-for which you have or can give appropriate copyright permission.</P>
+for which you have or can give appropriate copyright permission.</p>
 
-<P>Notwithstanding any other provision of this License, for material you
+<p>Notwithstanding any other provision of this License, for material you
 add to a covered work, you may (if authorized by the copyright holders of
-that material) supplement the terms of this License with terms:</P>
+that material) supplement the terms of this License with terms:</p>
 
-<UL>
-<LI>a) Disclaiming warranty or limiting liability differently from the
-    terms of sections 15 and 16 of this License; or</LI>
+<ul>
+<li>a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or</li>
 
-<LI>b) Requiring preservation of specified reasonable legal notices or
+<li>b) Requiring preservation of specified reasonable legal notices or
     author attributions in that material or in the Appropriate Legal
-    Notices displayed by works containing it; or</LI>
+    Notices displayed by works containing it; or</li>
 
-<LI>c) Prohibiting misrepresentation of the origin of that material, or
+<li>c) Prohibiting misrepresentation of the origin of that material, or
     requiring that modified versions of such material be marked in
-    reasonable ways as different from the original version; or</LI>
+    reasonable ways as different from the original version; or</li>
 
-<LI>d) Limiting the use for publicity purposes of names of licensors or
-    authors of the material; or</LI>
+<li>d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or</li>
 
-<LI>e) Declining to grant rights under trademark law for use of some
-    trade names, trademarks, or service marks; or</LI>
+<li>e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or</li>
 
-<LI>f) Requiring indemnification of licensors and authors of that
+<li>f) Requiring indemnification of licensors and authors of that
     material by anyone who conveys the material (or modified versions of
     it) with contractual assumptions of liability to the recipient, for
     any liability that these contractual assumptions directly impose on
-    those licensors and authors.</LI>
-</UL>
+    those licensors and authors.</li>
+</ul>
 
-<P>All other non-permissive additional terms are considered “further
-restrictions” within the meaning of section 10.  If the Program as you
+<p>All other non-permissive additional terms are considered &ldquo;further
+restrictions&rdquo; within the meaning of section 10.  If the Program as you
 received it, or any part of it, contains a notice stating that it is
 governed by this License along with a term that is a further
 restriction, you may remove that term.  If a license document contains
 a further restriction but permits relicensing or conveying under this
 License, you may add to a covered work material governed by the terms
 of that license document, provided that the further restriction does
-not survive such relicensing or conveying.</P>
+not survive such relicensing or conveying.</p>
 
-<P>If you add terms to a covered work in accord with this section, you
+<p>If you add terms to a covered work in accord with this section, you
 must place, in the relevant source files, a statement of the
 additional terms that apply to those files, or a notice indicating
-where to find the applicable terms.</P>
+where to find the applicable terms.</p>
 
-<P>Additional terms, permissive or non-permissive, may be stated in the
+<p>Additional terms, permissive or non-permissive, may be stated in the
 form of a separately written license, or stated as exceptions;
-the above requirements apply either way.</P>
+the above requirements apply either way.</p>
 
-<H4><A name="section8"></A>8. Termination.</H4>
+<h5 id="section8">8. Termination.</h5>
 
-<P>You may not propagate or modify a covered work except as expressly
+<p>You may not propagate or modify a covered work except as expressly
 provided under this License.  Any attempt otherwise to propagate or
 modify it is void, and will automatically terminate your rights under
 this License (including any patent licenses granted under the third
-paragraph of section 11).</P>
+paragraph of section 11).</p>
 
-<P>However, if you cease all violation of this License, then your
+<p>However, if you cease all violation of this License, then your
 license from a particular copyright holder is reinstated (a)
 provisionally, unless and until the copyright holder explicitly and
 finally terminates your license, and (b) permanently, if the copyright
 holder fails to notify you of the violation by some reasonable means
-prior to 60 days after the cessation.</P>
+prior to 60 days after the cessation.</p>
 
-<P>Moreover, your license from a particular copyright holder is
+<p>Moreover, your license from a particular copyright holder is
 reinstated permanently if the copyright holder notifies you of the
 violation by some reasonable means, this is the first time you have
 received notice of violation of this License (for any work) from that
 copyright holder, and you cure the violation prior to 30 days after
-your receipt of the notice.</P>
+your receipt of the notice.</p>
 
-<P>Termination of your rights under this section does not terminate the
+<p>Termination of your rights under this section does not terminate the
 licenses of parties who have received copies or rights from you under
 this License.  If your rights have been terminated and not permanently
 reinstated, you do not qualify to receive new licenses for the same
-material under section 10.</P>
+material under section 10.</p>
 
-<H4><A name="section9"></A>9. Acceptance Not Required for Having Copies.</H4>
+<h5 id="section9">9. Acceptance Not Required for Having Copies.</h5>
 
-<P>You are not required to accept this License in order to receive or
+<p>You are not required to accept this License in order to receive or
 run a copy of the Program.  Ancillary propagation of a covered work
 occurring solely as a consequence of using peer-to-peer transmission
 to receive a copy likewise does not require acceptance.  However,
 nothing other than this License grants you permission to propagate or
 modify any covered work.  These actions infringe copyright if you do
 not accept this License.  Therefore, by modifying or propagating a
-covered work, you indicate your acceptance of this License to do so.</P>
+covered work, you indicate your acceptance of this License to do so.</p>
 
-<H4><A name="section10"></A>10. Automatic Licensing of Downstream Recipients.</H4>
+<h5 id="section10">10. Automatic Licensing of Downstream Recipients.</h5>
 
-<P>Each time you convey a covered work, the recipient automatically
+<p>Each time you convey a covered work, the recipient automatically
 receives a license from the original licensors, to run, modify and
 propagate that work, subject to this License.  You are not responsible
-for enforcing compliance by third parties with this License.</P>
+for enforcing compliance by third parties with this License.</p>
 
-<P>An “entity transaction” is a transaction transferring control of an
+<p>An &ldquo;entity transaction&rdquo; is a transaction transferring control of an
 organization, or substantially all assets of one, or subdividing an
 organization, or merging organizations.  If propagation of a covered
 work results from an entity transaction, each party to that
@@ -472,45 +476,45 @@ transaction who receives a copy of the work also receives whatever
 licenses to the work the party's predecessor in interest had or could
 give under the previous paragraph, plus a right to possession of the
 Corresponding Source of the work from the predecessor in interest, if
-the predecessor has it or can get it with reasonable efforts.</P>
+the predecessor has it or can get it with reasonable efforts.</p>
 
-<P>You may not impose any further restrictions on the exercise of the
+<p>You may not impose any further restrictions on the exercise of the
 rights granted or affirmed under this License.  For example, you may
 not impose a license fee, royalty, or other charge for exercise of
 rights granted under this License, and you may not initiate litigation
 (including a cross-claim or counterclaim in a lawsuit) alleging that
 any patent claim is infringed by making, using, selling, offering for
-sale, or importing the Program or any portion of it.</P>
+sale, or importing the Program or any portion of it.</p>
 
-<H4><A name="section11"></A>11. Patents.</H4>
+<h5 id="section11">11. Patents.</h5>
 
-<P>A “contributor” is a copyright holder who authorizes use under this
+<p>A &ldquo;contributor&rdquo; is a copyright holder who authorizes use under this
 License of the Program or a work on which the Program is based.  The
-work thus licensed is called the contributor's “contributor version”.</P>
+work thus licensed is called the contributor's &ldquo;contributor version&rdquo;.</p>
 
-<P>A contributor's “essential patent claims” are all patent claims
+<p>A contributor's &ldquo;essential patent claims&rdquo; are all patent claims
 owned or controlled by the contributor, whether already acquired or
 hereafter acquired, that would be infringed by some manner, permitted
 by this License, of making, using, or selling its contributor version,
 but do not include claims that would be infringed only as a
 consequence of further modification of the contributor version.  For
-purposes of this definition, “control” includes the right to grant
+purposes of this definition, &ldquo;control&rdquo; includes the right to grant
 patent sublicenses in a manner consistent with the requirements of
-this License.</P>
+this License.</p>
 
-<P>Each contributor grants you a non-exclusive, worldwide, royalty-free
+<p>Each contributor grants you a non-exclusive, worldwide, royalty-free
 patent license under the contributor's essential patent claims, to
 make, use, sell, offer for sale, import and otherwise run, modify and
-propagate the contents of its contributor version.</P>
+propagate the contents of its contributor version.</p>
 
-<P>In the following three paragraphs, a “patent license” is any express
+<p>In the following three paragraphs, a &ldquo;patent license&rdquo; is any express
 agreement or commitment, however denominated, not to enforce a patent
 (such as an express permission to practice a patent or covenant not to
-sue for patent infringement).  To “grant” such a patent license to a
+sue for patent infringement).  To &ldquo;grant&rdquo; such a patent license to a
 party means to make such an agreement or commitment not to enforce a
-patent against the party.</P>
+patent against the party.</p>
 
-<P>If you convey a covered work, knowingly relying on a patent license,
+<p>If you convey a covered work, knowingly relying on a patent license,
 and the Corresponding Source of the work is not available for anyone
 to copy, free of charge and under the terms of this License, through a
 publicly available network server or other readily accessible means,
@@ -518,21 +522,21 @@ then you must either (1) cause the Corresponding Source to be so
 available, or (2) arrange to deprive yourself of the benefit of the
 patent license for this particular work, or (3) arrange, in a manner
 consistent with the requirements of this License, to extend the patent
-license to downstream recipients.  “Knowingly relying” means you have
+license to downstream recipients.  &ldquo;Knowingly relying&rdquo; means you have
 actual knowledge that, but for the patent license, your conveying the
 covered work in a country, or your recipient's use of the covered work
 in a country, would infringe one or more identifiable patents in that
-country that you have reason to believe are valid.</P>
-
-<P>If, pursuant to or in connection with a single transaction or
+country that you have reason to believe are valid.</p>
+  
+<p>If, pursuant to or in connection with a single transaction or
 arrangement, you convey, or propagate by procuring conveyance of, a
 covered work, and grant a patent license to some of the parties
 receiving the covered work authorizing them to use, propagate, modify
 or convey a specific copy of the covered work, then the patent license
 you grant is automatically extended to all recipients of the covered
-work and works based on it.</P>
+work and works based on it.</p>
 
-<P>A patent license is “discriminatory” if it does not include within
+<p>A patent license is &ldquo;discriminatory&rdquo; if it does not include within
 the scope of its coverage, prohibits the exercise of, or is
 conditioned on the non-exercise of one or more of the rights that are
 specifically granted under this License.  You may not convey a covered
@@ -545,15 +549,15 @@ patent license (a) in connection with copies of the covered work
 conveyed by you (or copies made from those copies), or (b) primarily
 for and in connection with specific products or compilations that
 contain the covered work, unless you entered into that arrangement,
-or that patent license was granted, prior to 28 March 2007.</P>
+or that patent license was granted, prior to 28 March 2007.</p>
 
-<P>Nothing in this License shall be construed as excluding or limiting
+<p>Nothing in this License shall be construed as excluding or limiting
 any implied license or other defenses to infringement that may
-otherwise be available to you under applicable patent law.</P>
+otherwise be available to you under applicable patent law.</p>
 
-<H4><A name="section12"></A>12. No Surrender of Others' Freedom.</H4>
+<h5 id="section12">12. No Surrender of Others' Freedom.</h5>
 
-<P>If conditions are imposed on you (whether by court order, agreement or
+<p>If conditions are imposed on you (whether by court order, agreement or
 otherwise) that contradict the conditions of this License, they do not
 excuse you from the conditions of this License.  If you cannot convey a
 covered work so as to satisfy simultaneously your obligations under this
@@ -561,59 +565,59 @@ License and any other pertinent obligations, then as a consequence you may
 not convey it at all.  For example, if you agree to terms that obligate you
 to collect a royalty for further conveying from those to whom you convey
 the Program, the only way you could satisfy both those terms and this
-License would be to refrain entirely from conveying the Program.</P>
+License would be to refrain entirely from conveying the Program.</p>
 
-<H4><A name="section13"></A>13. Use with the GNU Affero General Public License.</H4>
+<h5 id="section13">13. Use with the GNU Affero General Public License.</h5>
 
-<P>Notwithstanding any other provision of this License, you have
+<p>Notwithstanding any other provision of this License, you have
 permission to link or combine any covered work with a work licensed
 under version 3 of the GNU Affero General Public License into a single
 combined work, and to convey the resulting work.  The terms of this
 License will continue to apply to the part which is the covered work,
 but the special requirements of the GNU Affero General Public License,
 section 13, concerning interaction through a network will apply to the
-combination as such.</P>
+combination as such.</p>
 
-<H4><A name="section14"></A>14. Revised Versions of this License.</H4>
+<h5 id="section14">14. Revised Versions of this License.</h5>
 
-<P>The Free Software Foundation may publish revised and/or new versions of
+<p>The Free Software Foundation may publish revised and/or new versions of
 the GNU General Public License from time to time.  Such new versions will
 be similar in spirit to the present version, but may differ in detail to
-address new problems or concerns.</P>
+address new problems or concerns.</p>
 
-<P>Each version is given a distinguishing version number.  If the
+<p>Each version is given a distinguishing version number.  If the
 Program specifies that a certain numbered version of the GNU General
-Public License “or any later version” applies to it, you have the
+Public License &ldquo;or any later version&rdquo; applies to it, you have the
 option of following the terms and conditions either of that numbered
 version or of any later version published by the Free Software
 Foundation.  If the Program does not specify a version number of the
 GNU General Public License, you may choose any version ever published
-by the Free Software Foundation.</P>
+by the Free Software Foundation.</p>
 
-<P>If the Program specifies that a proxy can decide which future
+<p>If the Program specifies that a proxy can decide which future
 versions of the GNU General Public License can be used, that proxy's
 public statement of acceptance of a version permanently authorizes you
-to choose that version for the Program.</P>
+to choose that version for the Program.</p>
 
-<P>Later license versions may give you additional or different
+<p>Later license versions may give you additional or different
 permissions.  However, no additional obligations are imposed on any
 author or copyright holder as a result of your choosing to follow a
-later version.</P>
+later version.</p>
 
-<H4><A name="section15"></A>15. Disclaimer of Warranty.</H4>
+<h5 id="section15">15. Disclaimer of Warranty.</h5>
 
-<P>THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+<p>THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
 APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
-HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM “AS IS” WITHOUT WARRANTY
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM &ldquo;AS IS&rdquo; WITHOUT WARRANTY
 OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
 THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
 PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
 IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
-ALL NECESSARY SERVICING, REPAIR OR CORRECTION.</P>
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.</p>
 
-<H4><A name="section16"></A>16. Limitation of Liability.</H4>
+<h5 id="section16">16. Limitation of Liability.</h5>
 
-<P>IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+<p>IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
 WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
 THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
 GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
@@ -621,31 +625,31 @@ USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
 DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
 PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
 EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGES.</P>
+SUCH DAMAGES.</p>
 
-<H4><A name="section17"></A>17. Interpretation of Sections 15 and 16.</H4>
+<h5 id="section17">17. Interpretation of Sections 15 and 16.</h5>
 
-<P>If the disclaimer of warranty and limitation of liability provided
+<p>If the disclaimer of warranty and limitation of liability provided
 above cannot be given local legal effect according to their terms,
 reviewing courts shall apply local law that most closely approximates
 an absolute waiver of all civil liability in connection with the
 Program, unless a warranty or assumption of liability accompanies a
-copy of the Program in return for a fee.</P>
+copy of the Program in return for a fee.</p>
 
-<P>END OF TERMS AND CONDITIONS</P>
+<p>END OF TERMS AND CONDITIONS</p>
 
-<H3><A name="howto"></A>How to Apply These Terms to Your New Programs</H3>
+<h4 id="howto">How to Apply These Terms to Your New Programs</h4>
 
-<P>If you develop a new program, and you want it to be of the greatest
+<p>If you develop a new program, and you want it to be of the greatest
 possible use to the public, the best way to achieve this is to make it
-free software which everyone can redistribute and change under these terms.</P>
+free software which everyone can redistribute and change under these terms.</p>
 
-<P>To do so, attach the following notices to the program.  It is safest
+<p>To do so, attach the following notices to the program.  It is safest
 to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
-the “copyright” line and a pointer to where the full notice is found.</P>
+the &ldquo;copyright&rdquo; line and a pointer to where the full notice is found.</p>
 
-<PRE>    &lt;one line to give the program's name and a brief idea of what it does.&gt;
+<pre>    &lt;one line to give the program's name and a brief idea of what it does.&gt;
     Copyright (C) &lt;year&gt;  &lt;name of author&gt;
 
     This program is free software: you can redistribute it and/or modify
@@ -659,35 +663,34 @@ the “copyright” line and a pointer to where the full notice is found.</P>
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.
-</PRE>
+    along with this program.  If not, see &lt;https://www.gnu.org/licenses/&gt;.
+</pre>
 
-<P>Also add information on how to contact you by electronic and paper mail.</P>
+<p>Also add information on how to contact you by electronic and paper mail.</p>
 
-<P>If the program does terminal interaction, make it output a short
-notice like this when it starts in an interactive mode:</P>
+<p>If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:</p>
 
-<PRE>    &lt;program&gt;  Copyright (C) &lt;year&gt;  &lt;name of author&gt;
+<pre>    &lt;program&gt;  Copyright (C) &lt;year&gt;  &lt;name of author&gt;
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.
-</PRE>
+</pre>
 
-<P>The hypothetical commands `show w' and `show c' should show the appropriate
+<p>The hypothetical commands `show w' and `show c' should show the appropriate
 parts of the General Public License.  Of course, your program's commands
-might be different; for a GUI interface, you would use an “about box”.</P>
+might be different; for a GUI interface, you would use an &ldquo;about box&rdquo;.</p>
 
-<P>You should also get your employer (if you work as a programmer) or school,
-if any, to sign a “copyright disclaimer” for the program, if necessary.
+<p>You should also get your employer (if you work as a programmer) or school,
+if any, to sign a &ldquo;copyright disclaimer&rdquo; for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-&lt;<A href="http://www.gnu.org/licenses/">http://www.gnu.org/licenses/</A>&gt;.</P>
+&lt;<a href="https://www.gnu.org/licenses/">https://www.gnu.org/licenses/</a>&gt;.</p>
 
-<P>The GNU General Public License does not permit incorporating your program
+<p>The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-&lt;<A href="http://www.gnu.org/philosophy/why-not-lgpl.html">http://www.gnu.org/philosophy/why-not-lgpl.html</A>&gt;.</P>
+&lt;<a href="https://www.gnu.org/licenses/why-not-lgpl.html">https://www.gnu.org/licenses/why-not-lgpl.html</a>&gt;.</p>
 
-
-</BODY><STYLE type="text/css">#AdContainer,#RadAd_Skyscraper,#ad-frame,#bbccom_leaderboard,#bbccom_mpu,#center_banner,#footer_adcode,#hbBHeaderSpon,#header_adcode,#hiddenHeaderSpon,#navbar_adcode,#pagelet_adbox,#rightAds,#rightcolumn_adcode,#top-advertising,#topMPU,#tracker_advertorial,.ad-now,.adbox,.adspot,.dfpad,.prWrap,.sponsored,[id^="adbrite"],[id^="dclkAds"],[id^="konaLayer"],a.kLink span[id^="preLoadWrap"][class="preLoadWrap"],A[href^="http://adserver.adpredictive.com"],A[href^="http://ad.doubleclick.net"],div[class^="dms_ad_IDS"],DIV[id="adxLeaderboard"],DIV[id="rm_container"],div[id^="sponsorads"],div[id^="y5_direct"],DIV[id="FFN_Banner_Holder"],DIV[id="FFN_imBox_Container"],DIV[id="p360-format-box"],div[id="tooltipbox"][class^="itxt"],div[id^="adKontekst_"],div[id^="google_ads_div"],div[id^="kona_"][id$="_wrapper"],div[class="wnDVUtilityBlock"],embed[flashvars*="AdID"],embed[id="Advertisement"][name="Advertisement"],iframe[id^="dapIfM"],iframe[name^="AdBrite"],iframe[src*="clicksor.com"],img[src*="clicksor.com"],IMG[src^="http://adservingdaddy.com"],IMG[src^="http://cdn.adnxs.com"],ispan#ab_pointer,[src*="sixsigmatraffic.com"],div#dir_ads_site,div#tads table[align="center"][width="100%"],div#rhs div#rhs_block table#mbEnd,#A9AdsMiddleBoxTop,#A9AdsOutOfStockWidgetTop,#A9AdsServicesWidgetTop,#ADsmallWrapper,#Ad1,#Ad2,#Ad3Left,#Ad3Right,#AdBar1,#AdContainerTop,#AdHeader,#AdMiddle,#AdRectangle,#AdSenseDiv,#AdShowcase_F1,#AdSky23,#AdSkyscraper,#AdSponsor_SF,#AdTargetControl1_iframe,#AdText,#Ad_Block,#Ad_Center1,#Ad_Top,#Adbanner,#Adrectangle,#AdsContent,#AdsWrap,#AdvertMPU23b,#AdvertiseFrame,#Advertisement,#Advertorial,#BannerAdvert,#BigBoxAd,#CompanyDetailsNarrowGoogleAdsPresentationControl,#CompanyDetailsWideGoogleAdsPresentationControl,#ContentAd,#ContentAd1,#ContentAd2,#ContentAdPlaceHolder1,#ContentAdPlaceHolder2,#FooterAd,#FooterAdContainer,#GoogleAdsense,#HEADERAD,#HOME_TOP_RIGHT_BOXAD,#HeaderAdsBlock,#HeroAd,#HomeAd1,#HouseAd,#Journal_Ad_125,#Journal_Ad_300,#LeftAdF1,#LeftAdF2,#PREFOOTER_LEFT_BOXAD,#PREFOOTER_RIGHT_BOXAD,#PageLeaderAd,#RightSponsoredAd,#SectionAd300-250,#SidebarAdContainer,#SkyAd,#SponsoredAd,#TOP_ADROW,#TopAdPos,#VM-MPU-adspace,#VM-header-adwrap,#XEadLeaderboard,#XEadSkyscraper,#ad-160x600,#ad-250x300,#ad-300,#ad-300x250,#ad-300x250Div,#ad-728,#ad-article,#ad-banner,#ad-bottom,#ad-bottom-wrapper,#ad-colB-1,#ad-column,#ad-container,#ad-footer,#ad-footprint-160x600,#ad-front-footer,#ad-front-sponsoredlinks,#ad-halfpage,#ad-label,#ad-leaderboard,#ad-leaderboard-bottom,#ad-leaderboard-spot,#ad-leaderboard-top,#ad-left,#ad-lrec,#ad-medium-rectangle,#ad-middlethree,#ad-middletwo,#ad-module,#ad-mpu,#ad-mpu1-spot,#ad-mpu2-spot,#ad-placard,#ad-rectangle,#ad-righttop,#ad-side-text,#ad-skyscraper,#ad-slug-wrapper,#ad-space,#ad-splash,#ad-target,#ad-target-Leaderbord,#ad-teaser,#ad-top,#ad-top-text-low,#ad-tower,#ad-trailerboard-spot,#ad-typ1,#ad-wrap,#ad-wrap-right,#ad-wrapper1,#ad-yahoo-simple,#ad1,#ad125BL,#ad125BR,#ad125TL,#ad125TR,#ad125x125,#ad160x600,#ad160x600right,#ad1Sp,#ad2,#ad2Sp,#ad3,#ad300,#ad300-250,#ad300X250,#ad300_x_250,#ad300x150,#ad300x250,#ad300x250Module,#ad300x60,#ad336,#ad336x280,#ad375x85,#ad468,#ad526x250,#ad600,#ad7,#ad728,#ad728Wrapper,#ad728x90,#adB,#adBadges,#adBanner,#adBanner120x600,#adBannerTable,#adBannerTop,#adBar,#adBlock125,#adBlocks,#adBox,#adContainer,#adDiv,#adFps,#adFtofrs,#adGallery,#adGroup1,#adHeader,#adL,#adLB,#adMPU,#adMiddle0Frontpage,#adMiniPremiere,#adPlaceHolderRight,#adRight,#adSenseModule,#adServer_marginal,#adSidebar,#adSidebarSq,#adSky,#adSkyscraper,#adSlider,#adSpace3,#adSpace300_ifrMain,#adSpace4,#adSpace5,#adSpace6,#adSpace7,#adSpace_footer,#adSpace_top,#adSpecial,#adSpot-Leader,#adSpot-banner,#adSpot-mrec1,#adSpot-sponsoredlinks,#adSpot-textbox1,#adSpot-widestrip,#adSpotAdvertorial,#adSpotIsland,#adSpotSponsoredLinks,#adSquare,#adStaticA,#adStrip,#adSuperPremiere,#adTableCell,#adTag1,#adTag2,#adTop,#adTopboxright,#adUnit,#adWrapper,#adZoneTop,#ad_160x160,#ad_160x600,#ad_190x90,#ad_300,#ad_300x250,#ad_468_60,#ad_5,#ad_728_foot,#ad_728x90,#ad_A,#ad_B,#ad_Banner,#ad_C,#ad_C2,#ad_D,#ad_E,#ad_F,#ad_G,#ad_H,#ad_I,#ad_J,#ad_K,#ad_L,#ad_M,#ad_N,#ad_O,#ad_P,#ad_YieldManager-300x250,#ad_anchor,#ad_banner,#ad_banner_top,#ad_bar,#ad_block_1,#ad_block_2,#ad_bottom,#ad_box_colspan,#ad_branding,#ad_bs_area,#ad_center_monster,#ad_container,#ad_content_wrap,#ad_feature,#ad_footer,#ad_haha_1,#ad_haha_4,#ad_halfpage,#ad_head,#ad_header,#ad_horseshoe_left,#ad_horseshoe_right,#ad_horseshoe_spacer,#ad_horseshoe_top,#ad_island,#ad_label,#ad_layer2,#ad_leader,#ad_leaderBoard,#ad_leaderboard,#ad_lwr_square,#ad_medium_rectangle,#ad_medium_rectangular,#ad_middle,#ad_mpu,#ad_play_300,#ad_rect,#ad_rect_body,#ad_rect_bottom,#ad_rectangle,#ad_related_links_div,#ad_related_links_div_program,#ad_report_leaderboard,#ad_report_rectangle,#ad_right,#ad_right_main,#ad_ros_tower,#ad_sidebar1,#ad_sidebar2,#ad_sidebar3,#ad_skyscraper,#ad_slot_livesky,#ad_space,#ad_square,#ad_ss,#ad_top,#ad_top_holder,#ad_tp_banner_1,#ad_tp_banner_2,#ad_vertical,#ad_wrapper,#adbanner,#adbnr,#adbottom,#adbox,#adbox2,#adclear,#adcode1,#adcode2,#adcode3,#adcode4,#adcolumnwrapper,#adcontainer,#adcontainsm,#addiv-bottom,#addiv-top,#adframe:not(frameset),#adhead,#adhead_g,#adheader,#adiframe1_iframe,#adiframe2_iframe,#adiframe3_iframe,#adimg,#adlabel,#adlabelFooter,#adleaderboard,#adlinks,#adlinkws,#admid,#admiddle3center,#admiddle3left,#adposition,#adposition-C,#adposition2,#adposition3,#adposition4,#adrectanglea,#adrectangleb,#adright,#adright2,#ads,#ads-468,#ads-area,#ads-block,#ads-bot,#ads-bottom,#ads-dell,#ads-horizontal,#ads-indextext,#ads-leaderboard1,#ads-lrec,#ads-prices,#ads-rhs,#ads-top,#ads2,#ads300,#ads336x280,#ads7,#ads790,#adsDisplay,#adsID,#ads_160,#ads_300,#ads_728,#ads_belowforumlist,#ads_belownav,#ads_bottom_outer,#ads_catDiv,#ads_right,#ads_sidebar_roadblock,#ads_top,#adsbottom,#adsense,#adsense-text,#adsenseWrap,#adsense_placeholder_2,#adsensetopplay,#adskyscraper,#adslot,#adsonar,#adspace,#adspace-300x250,#adspace300x250,#adspaceBox,#adspaceBox300,#adspace_header,#adsright,#adstop,#adtech_takeover,#adtop,#adv-masthead,#adv_google_300,#adv_google_728,#adv_top_banner_wrapper,#adv_wide_banner,#advert,#advert-1,#advert-boomer,#advert-display,#advert-header,#advert-leaderboard,#advert-top,#advertBanner,#advert_250x250,#advert_box,#advert_leaderboard,#advert_lrec_format,#advert_mpu,#advertbox,#advertbox2,#advertbox3,#advertbox4,#adverthome,#advertise,#advertise-now,#advertisement,#advertisement160x600,#advertisement728x90,#advertisementLigatus,#advertisementPrio2,#advertiserLinks,#advertising,#advertising-skyscraper,#adwhitepaperwidget,#adwin_rec,#adwith,#adwords-4-container,#adwrapper,#adxtop,#adzoneBANNER,#agi-ad300x250,#agi-ad300x250overlay,#agi-sponsored,#annoying_ad,#ap_adframe,#araHealthSponsorAd,#article-ad-container,#article-box-ad,#articleAdReplacement,#articleSideAd,#article_ad,#article_box_ad,#atlasAdDivGame,#banner-ad,#banner-ads,#banner468x60,#banner728x90,#bannerAd,#bannerAdTop,#bannerAd_ctr,#banner_ad,#banner_topad,#bannerad,#bannerad2,#bbccom_mpu,#bbo_ad1,#bg_YieldManager-300x250,#bigAd,#bigBoxAd,#bigadbox,#bigadspot,#billboard_ad,#block-ad_cube-1,#block_advert,#blox-big-ad,#blox-halfpage-ad,#blox-tile-ad,#botad,#bottom-ad-container,#bottom-ads,#bottomAd,#bottomAdSenseDiv,#bottomAds,#bottomRightAdSpace,#bottom_ad,#bottom_ad_area,#bottom_ads,#bottom_banner_ad,#bottom_overture,#bottom_sponsor_ads,#bottom_sponsored_links,#bottom_text_ad,#bottomad,#bottomadsense,#box-googleadsense-1,#box-googleadsense-r,#box1ad,#boxAd300,#boxAdContainer,#box_mod_googleadsense,#boxad1,#boxad2,#boxad3,#boxad4,#boxad5,#bps-header-ad-container,#btr_horiz_ad,#burn_header_ad,#button-ads-horizontal,#button-ads-vertical,#button_ad_container,#button_ad_wrap,#cellAd,#channel_ad,#channel_ads,#ciHomeRHSAdslot,#circ_ad,#cnnRR336ad,#cnnTopAd,#colRightAd,#column4-google-ads,#commercial_ads,#common_right_lower_player_adspace,#common_right_player_adspace,#common_top_adspace,#containerLocalAds,#containerMrecAd,#content-ad-header,#contentAd,#content_ad_square,#content_ad_top,#content_ads_content,#content_box_300body_sponsoredoffers,#content_box_adright300_google,#contentad,#contentad_imtext,#contentad_right,#contentads,#contentinlineAd,#contextual-ads-block,#contextualad,#coverads,#ctl00_MasterHolder_IBanner_adHolder,#ctl00_VBanner_adHolder,#ctl00_adFooter,#ctl00_cphMain_hlAd1,#ctl00_cphMain_hlAd2,#ctl00_cphMain_hlAd3,#ctl00_ctl00_MainPlaceHolder_itvAdSkyscraper,#ctl00_ctl00_ctl00_tableAdsTop,#ctrlsponsored,#cubeAd,#cube_ads,#cube_ads_inner,#cubead,#cubead-2,#defer-adright,#detail_page_vid_topads,#divAd,#divAdBox,#divWrapper_Ad,#div_video_ads,#dlads,#dni-header-ad,#download_ads,#ds-mpu,#editorsmpu,#evotopTen_advert,#exads,#featuread,#featuredAdContainer2,#featuredAds,#feed_links_ad_container,#first_ad_unit,#fl_hdrAd,#footer-ad,#footer-sponsored,#footerAd,#footerAdDiv,#footerAds,#footerAdverts,#footer_ad,#footer_ad_block,#footer_ads,#footer_adspace,#footer_text_ad,#footerad,#fr_ad_center,#frnContentAd,#from_our_sponsors,#front_advert,#front_mpu,#ft-ad,#ft-ad-1,#ft-ad-container,#fusionad,#fw-advertisement,#g_ad,#g_adsense,#ga_300x250,#gad,#gallery-ad-m0,#gallery_ads,#game-info-ad,#global_header_ad_area,#gmi-ResourcePageAd,#gmi-ResourcePageLowerAd,#google-ad,#google-ad-art,#google-ad-tower,#google-ads,#google-ads-bottom,#google-ads-left-side,#google-adsense-mpusize,#googleAd,#googleAds,#googleAdsense,#googleAdsenseBanner,#googleAdsenseBannerBlog,#googleAdwordsModule,#googleAfcContainer,#google_ad,#google_ad_test,#google_ads,#google_ads_frame1,#google_ads_test,#googlead,#googleads,#googlesponsor,#grid_ad,#gsyadrectangleload,#gsyadrightload,#gsyadtop,#gsyadtopload,#gtopadvts,#halfPageAd,#halfe-page-ad-box,#hdtv_ad_ss,#head-ad,#head_advert,#header-ad,#header-ads,#header-advert,#headerAd,#headerAdBackground,#headerAdContainer,#headerAdsWrapper,#headerTopAd,#header_ad,#header_advertisement_top,#header_leaderboard_ad_container,#headerad,#headeradbox,#headline_ad,#hiddenadAC,#homeTopRightAd,#home_ad,#home_contentad,#home_spensoredlinks,#homepage-ad,#homepage_right_ad,#homepage_right_ad_container,#hometop_234x60ad,#horizontal-banner-ad,#horizontal_ad,#houseAd,#hp-store-ad,#hpV2_300x250Ad,#hpV2_googAds,#icePage_SearchLinks_AdRightDiv,#icePage_SearchLinks_DownloadToolbarAdRightDiv,#inlinead,#inlinegoogleads,#inner-advert-row,#insider_ad_wrapper,#instoryad,#int-ad,#interstitial_ad_wrapper,#islandAd,#j_ad,#jmp-ad-buttons,#joead,#joead2,#ka_adRightSkyscraperWide,#landing-adserver,#lateAd,#lb-sponsor-left,#lb-sponsor-right,#leader-board-ad,#leader-sponsor,#leaderAdContainer,#leaderad,#leaderad_section,#leaderboard-ad,#leaderboard-bottom-ad,#leaderboard_ad,#leftAdContainer,#leftAd_rdr,#leftAdvert,#leftSectionAd300-100,#left_ad,#left_adspace,#leftad,#leftads,#lg-banner-ad,#linkAds,#live-ad,#longAdSpace,#mBannerAd,#main-ad,#main-ad160x600,#main-ad160x600-img,#main-ad728x90,#mainAdUnit,#mainAdvert,#main_ad,#main_rec_ad,#mastAdvert,#mastad,#masthead_ad,#masthead_topad,#medRecAd,#media_ad,#menuAds,#mi_story_assets_ad,#mid-ad300x250,#mid-table-ad,#mid_ad_title,#mid_mpu,#middlead,#middleads,#midrect_ad,#midstrip_ad,#mini-ad,#module-google_ads,#module_ad,#module_box_ad,#most_popular_ad,#mpu,#mpu-advert,#mpuAd,#mpuDiv,#mpuWrapper,#mpuWrapperAd,#mpu_banner,#mpu_holder,#mpuad,#mrecAdContainer,#ms_ad,#multiLinkAdContainer,#n_sponsor_ads,#natadad300x250,#navi_banner_ad_780,#nba300Ad,#new_topad,#ng_rtcol_ad,#noresultsads,#northad,#oanda_ads,#onespot-ads,#p-googleadsense,#page-header-ad,#page_content_top_ad,#pcworldAdBottom,#pcworldAdTop,#pinball_ad,#player_ad,#portlet-advertisement-left,#portlet-advertisement-right,#post5_adbox,#priceGrabberAd,#print_ads,#printads,#product-adsense,#promo-ad,#promoAds,#ps-vertical-ads,#pub468x60,#publicidad,#r1SoftAd,#rail_ad1,#rail_ad2,#realEstateAds,#rect_ad,#rectangle-ad,#rectangle_ad,#refine-300-ad,#region-top-ad,#rh-ad-container,#rh_tower_ad,#rhsadvert,#right-ad,#rightAd,#rightAd300x250,#rightAdColumn,#rightAd_rdr,#rightColAd,#rightColumnMpuAd,#rightColumnSkyAd,#right_ad_wrapper,#right_ads,#right_advertisement,#right_advertising,#rightad,#rightadvertbar-doubleclickads,#rightbar-ad,#rightside_ad,#rotatingads,#rtMod_ad,#sAdsBox,#sb-ad-sq,#search-google-ads,#search_ads,#secondBoxAdContainer,#section-container-ddc_ads,#servfail-ads,#sew-ad1,#shoppingads,#show-ad,#side-ad,#side-ad-container,#sideAd,#sideBarAd,#side_ad_wrapper,#side_ads_by_google,#sidead,#sidebar-125x125-ads,#sidebar-125x125-ads-below-index,#sidebar-ad-boxes,#sidebar-ad-space,#sidebar-ad-wrap,#sidebar-ads,#sidebar_ad_widget,#sidebar_ads,#sidebar_sponsoredresult_body,#sidebarad,#sideline-ad,#single-mpu,#site-leaderboard-ads,#site_top_ad,#sky-ad,#skyAd,#skyScrapperAd,#sky_ad,#skyscraper-ad,#skyscraperAd,#skyscraper_advert,#sliderAdHolder,#slideshow_ad_300x250,#sm-banner-ad,#small_ad,#smallerAd,#speeds_ads,#speeds_ads_fstitem,#sphereAd,#splinks,#sponLinkDiv_1,#sponlink,#spons_left,#sponseredlinks,#sponsorAd1,#sponsorAd2,#sponsorLinks,#sponsor_banderole,#sponsor_box,#sponsor_deals,#sponsor_panSponsor,#sponsored,#sponsored-ads,#sponsored-features,#sponsored-links,#sponsored-resources,#sponsored1,#sponsoredBox1,#sponsoredBox2,#sponsoredLinks,#sponsoredList,#sponsoredResults,#sponsoredSiteMainline,#sponsoredSiteSidebar,#sponsored_content,#sponsored_game_row_listing,#sponsored_links,#sponsoredlinks,#sponsoredlinks_cntr,#sponsoredresults_top,#sponsorlink,#spotlightAds,#spotlightad,#squareAd,#squareAdSpace,#square_ad,#sticky-ad,#stickyBottomAd,#story-ad-a,#story-ad-b,#story-sponsoredlinks,#storyAd,#storyAdWrap,#subpage-ad-right,#subpage-ad-top,#swads,#synch-ad,#tabAdvertising,#tblAd,#tbl_googlead,#template_ad_leaderboard,#tertiary_advertising,#text-ad,#textAd,#textAds,#text_ad,#text_advert,#the-last-ad-standing,#thefooterad,#themis-ads,#tile-ad,#tmglBannerAd,#top-ad,#top-ad-menu,#top-ads,#top-ads-tabs,#top-advertisement,#top-banner-ad,#top-search-ad-wrapper,#topAd,#topAd728x90,#topAdBanner,#topAdContainer,#topAdSenseDiv,#topAds,#topAdvert,#topBannerAd,#topNavLeaderboardAdHolder,#top_ad,#top_ad_area,#top_ad_game,#top_ad_wrapper,#top_ads,#top_advertise,#top_advertising,#topad,#topad_left,#topad_right,#topadblock,#topads,#topcustomad,#toprightAdvert,#towerad,#twogamesAd,#txt_link_ads,#undergameAd,#upperMpu,#upperad,#urban_contentad_article,#v_ad,#vert_ad,#vertical_ad,#vertical_ads,#video_cnv_ad,#video_overlay_ad,#walltopad,#welcomeAdsContainer,#welcome_ad_mrec,#welcome_advertisement,#wgtAd,#whatsnews_top_ad,#whitepaper-ad,#widget_advertisement,#wrapAdRight,#wrapAdTop,#yahoo-ads,#yahoo-sponsors,#yahoo_ads,#yahoo_ads_2010,#yahooad-tbl,#yan-sponsored,#ybf-ads,#yfi_fp_ad_mort,#yfi_fp_ad_nns,#yfi_pf_ad_mort,#ygrp-sponsored-links,#ymap_adbanner,#yn-gmy-ad-lrec,#yreSponsoredLinks,#ysm_ad_iframe,#zoneAdserverMrec,#zoneAdserverSuper,.ADBAR,.Ad120x600,.Ad160x600,.Ad247x90,.Ad300x250,.Ad300x250L,.Ad728x90,.AdBox,.AdBox7,.AdContainerBox308,.AdHere,.AdInfo,.AdPlaceHolder,.AdRingtone,.AdSense,.AdSpace,.AdTitle,.AdUnit,.AdUnit300,.Ad_C,.Ad_D_Wrapper,.Ad_E_Wrapper,.Ad_Right,.Ads,.AdsBoxSection,.AdsLinks1,.AdsLinks2,.AdvertMidPage,.AdvertiseWithUs,.AdvertisementTextTag,.ArticleInlineAd,.BannerAd,.BlockAd,.BottomAffiliate,.CG_adkit_leaderboard,.CommentAd,.DeptAd,.FT_Ad,.FlatAds,.HPNewAdsBannerDiv,.HomeContentAd,.LeftTowerAd,.M2Advertisement,.MD_adZone,.MPU,.MPUHolder,.MiddleAdContainer,.PU_DoubleClickAdsContent,.Post5ad,.RBboxAd,.RelatedAds,.RightRailTop300x250Ad,.RightSponsoredAdTitle,.RightTowerAd,.SidebarAd,.SponsoredAdTitle,.SponsoredLinksGrayBox,.StandardAdLeft,.StandardAdRight,.TextAd,.TheEagleGoogleAdSense300x250,.TopAd,.TopAdL,.TopAdR,.UIStandardFrame_SidebarAds,.UIWashFrame_SidebarAds,.UnderAd,.VerticalAd,.WidgetAdvertiser,.ad-160x600,.ad-300,.ad-300-block,.ad-300-blog,.ad-300x100,.ad-300x250,.ad-600,.ad-728,.ad-background,.ad-banner,.ad-bigsize,.ad-block,.ad-blog2biz,.ad-bottom,.ad-box,.ad-button,.ad-cell,.ad-container,.ad-div,.ad-filler,.ad-footer,.ad-footer-leaderboard,.ad-google,.ad-gray,.ad-hdr,.ad-head,.ad-holder,.ad-homeleaderboard,.ad-img,.ad-island,.ad-leaderboard,.ad-links,.ad-medium,.ad-medium-two,.ad-mpu,.ad-other,.ad-placeholder,.ad-postText,.ad-poster,.ad-rect,.ad-rectangle,.ad-rectangle-text,.ad-related,.ad-rh,.ad-ri,.ad-right,.ad-right-txt,.ad-section,.ad-sidebar300,.ad-slot,.ad-space,.ad-space-mpu-box,.ad-spot,.ad-statement,.ad-text,.ad-tile,.ad-top,.ad-top-left,.ad-unit,.ad-vtu,.ad-wrap,.ad-wrapper,.ad0,.ad1,.ad10,.ad120,.ad160,.ad18,.ad19,.ad2,.ad21,.ad250c,.ad3,.ad300,.ad300_250,.ad300x250,.ad300x250Top,.ad300x250box,.ad300x600,.ad310,.ad336x280,.ad343x290,.ad450,.ad468,.ad468_60,.ad6,.ad620x70,.ad626X35,.ad7,.ad728,.ad728_90,.ad728x90,.ad8,.adAgate,.adBanner,.adBannerTyp1,.adBannerTypSortableList,.adBannerTypW300,.adBgBottom,.adBgMId,.adBgTop,.adBox,.adBoxContent,.adBoxSidebar,.adBoxSingle,.adCMRight,.adColumn,.adContainer,.adCreative,.adDiv,.adElement,.adFrame,.adFtr,.adFullWidthMiddle,.adGoogle,.adHeader,.adHeadline,.adHolder,.adHome300x250,.adInNews,.adLabel,.adLeader,.adLeaderForum,.adLeaderboard,.adLeft,.adMastheadLeft,.adMastheadRight,.adMkt2Colw,.adModule,.adNewsChannel,.adNoOutline,.adNoticeOut,.adObj,.adPageBorderL,.adPageBorderR,.adPanel,.adRect,.adRight,.adSelfServiceAdvertiseLink,.adServer,.adSlot,.adSpBelow,.adSpace,.adSpacer,.adSpot,.adSpot-searchAd,.adSpot-textBox,.adSpotIsland,.adSquare,.adSummary,.adSuperboard,.adTag,.adText,.adTileWrap,.adTiler,.adTitle,.adTout,.adTxt,.adWithTab,.adWrap,.adWrapper,.ad_1,.ad_125,.ad_130x90,.ad_160,.ad_160x600,.ad_2,.ad_3,.ad_300,.ad_300_250,.ad_300x250,.ad_336,.ad_336x280,.ad_350x250,.ad_468,.ad_600,.ad_728,.ad_728x90,.ad_amazon,.ad_biz,.ad_block_338,.ad_bottom_leaderboard,.ad_box,.ad_box2,.ad_caption,.ad_contain,.ad_container,.ad_content,.ad_content_wide,.ad_contents,.ad_descriptor,.ad_footer,.ad_framed,.ad_front_promo,.ad_header,.ad_hpm,.ad_info_block,.ad_launchpad,.ad_leader,.ad_leaderboard,.ad_left,.ad_linkunit,.ad_loc,.ad_lrec,.ad_medrect,.ad_mpu,.ad_mr,.ad_mrec,.ad_mrec_title_article,.ad_notice,.ad_p360,.ad_partner,.ad_partners,.ad_plus,.ad_post,.ad_power,.ad_rectangle,.ad_right,.ad_sidebar,.ad_skyscraper,.ad_slug_table,.ad_space,.ad_sponsor,.ad_sponsoredsection,.ad_spot_b,.ad_spot_c,.ad_square_r,.ad_square_top,.ad_text,.ad_title,.ad_top,.ad_top_leaderboard,.ad_tower,.ad_unit,.ad_unit_rail,.ad_wide,.ad_wrap,.ad_wrapper,.ad_wrapper_fixed,.ad_zone,.adarea,.adbanner,.adbannerright,.adbar,.adborder,.adbot,.adbottom,.adbox,.adbox-outer,.adbox_366x280,.adbox_468X60,.adbox_bottom,.adboxclass,.adcode,.adcolumn_wrapper,.adcontainer,.adcopy,.addiv,.adfoot,.adfootbox,.adframe,.adhead,.adheader,.adheader100,.adhere,.adi,.adinfo,.adinside,.adjlink,.adkit-advert,.adkit-lb-footer,.adlabel-horz,.adlabel-vert,.adline,.adlink,.adlist,.adlnklst,.admarker,.admedrec,.admodule,.admpu,.adnotice,.adops,.adpadding,.adpic,.adright,.adrow,.adrow-post,.adrule,.ads-banner,.ads-categories-bsa,.ads-links-general,.ads-mpu,.ads-profile,.ads-right,.ads-sidebar,.ads-sky,.ads-text,.ads2,.ads3,.ads:not(body),.adsArea,.adsBelowHeadingNormal,.adsBox,.adsImages,.adsTextHouse,.adsWithUs,.ads_300,.ads_728x90,.ads_big,.ads_big-half,.ads_catDiv,.ads_container,.ads_disc_anchor,.ads_disc_leader,.ads_disc_lwr_square,.ads_disc_skyscraper,.ads_disc_square,.ads_div,.ads_header,.ads_mpu,.ads_right,.ads_sc_tl_i,.ads_side,.ads_takeover,.ads_tr,.adsborder,.adsbyyahoo,.adscreen,.adsection_a2,.adsection_c2,.adsense,.adsense-heading,.adsense-right,.adsense-title,.adsenseBlock,.adsenseContainer,.adsenselr,.adsensesq,.adsidebox,.adsingle,.adslogan,.adspace,.adspace-MR,.adspacer,.adstrip,.adtag,.adtext,.adtop,.adtravel,.adv-mpu,.adverTag,.adver_cont_below,.advert,.advert-box,.advert-head,.advert-horizontal,.advert-mpu,.advert-skyscraper,.advert-text,.advertCont,.advertContainer,.advertHeadline,.advertRight,.advertText,.advert_468x60,.advert_box,.advert_cont,.advert_leaderboard,.advert_note,.advertise,.advertise-homestrip,.advertise-horz,.advertise-leaderboard,.advertise-vert,.advertiseContainer,.advertisement,.advertisement-728x90,.advertisement-block,.advertisement-top,.advertisement468,.advertisementColumnGroup,.advertisementContainer,.advertisementLabel,.advertisementPanel,.advertisement_caption,.advertisement_g,.advertisement_header,.advertisement_horizontal,.advertiser,.advertising,.advertising-header,.advertising2,.advertisingTable,.advertising_block,.advertisment,.advertisment_two,.advertize,.advertorial,.adverts,.advt,.advt-banner-3,.advt300,.advt720,.adwrapper,.adwrapper-lrec,.adwrapper948,.affiliate,.affiliate-link,.affiliate-sidebar,.affiliateAdvertText,.agi-adsaleslinks,.alt_ad,.anchorAd,.aolSponsoredLinks,.aopsadvert,.article-ads,.articleAd,.articleAds,.articleAdsL,.articleEmbeddedAdBox,.article_ad,.article_adbox,.article_mpu_box,.aseadn,.aux-ad-widget-2,.b-astro-sponsored-links_horizontal,.b-astro-sponsored-links_vertical,.banner-ad,.banner-ads,.banner-adverts,.banner300x100,.banner300x250,.banner468,.bannerAd,.bannerAdWrapper300x250,.bannerAdWrapper730x86,.banner_300x250,.banner_728x90,.banner_ad,.banner_ad_footer,.banner_ad_leaderboard,.bannerad,.barkerAd,.base-ad-mpu,.bgnavad,.bigAd,.big_ads,.bigad,.billboard_ad,.block-ad,.block-adsense,.block_ad,.blocked-ads,.blog-ads-container,.blogAdvertisement,.blogBigAd,.blog_ad,.body_ad,.body_sponsoredresults_bottom,.body_sponsoredresults_middle,.body_sponsoredresults_top,.bookseller-header-advt,.bottomAd,.bottomAds,.bottom_ad_block,.bottom_sponsor,.bottomad,.bottomrightrailAd,.box-ads,.boxAd,.box_ad,.box_advertisment_62_border,.box_content_ad,.box_content_ads,.boxad,.bps-ad-wrapper,.bps-advertisement,.bps-advertisement-inline-ads,.bullet-sponsored-links,.bullet-sponsored-links-gray,.burstContentAdIndex,.buttonAd,.buttonadbox,.bx_ad,.bx_ad_right,.cA-adStrap,.cColumn-TextAdsBox,.care2_adspace,.cb_footer_sponsor,.cb_navigation_ad,.cbstv_ad_label,.cbzadvert,.cdAdTitle,.cdmainlineSearchAdParent,.cdsidebarSearchAdParent,.centerAd,.center_ad,.centerad,.clearerad,.cm_ads,.cms-Advert,.cnn160AdFooter,.cnnAd,.cnnMosaic160Container,.cnnStoreAd,.cnnStoryElementBoxAd,.cnnWCAdBox,.cnnWireAdLtgBox,.cnn_728adbin,.cnn_adcntr300x100,.cnn_adspc336cntr,.cnn_adtitle,.column2-ad,.conductor_ad,.confirm_ad_left,.confirm_ad_right,.confirm_leader_ad,.consoleAd,.container_serendipity_plugin_google_adsense,.contentAd,.content_ad,.content_adsq,.contentad,.contenttextad,.cp_ad,.cpmstarHeadline,.cpmstarText,.cs-mpu,.cspAd,.ct_ad,.cubeAd,.cube_ads,.darla_ad,.dartAdImage,.dart_ad,.dart_tag,.dartadvert,.dartiframe,.dc-ad,.dcAdvertHeader,.deckAd,.deckads,.detail-ads,.detailMpu,.divads,.dmco_advert_iabrighttitle,.download_ad,.downloadad,.dynamic_ad,.ec-ads,.entryad,.ez-clientAd,.f_Ads,.featuredAds,.featuredadvertising,.flagads,.flash_advert,.flashad,.flexiad,.flipbook_v2_sponsor_ad,.footerAd,.footerAdModule,.footerTextAd,.footer_ad,.footer_ads,.footer_block_ad,.footer_line_ad,.footerad,.ft-ad,.ftdContentAd,.full_ad_box,.g3rtn-ad-site,.g_ggl_ad,.ga-textads-bottom,.ga-textads-top,.gads_cb,.gglAds,.googads,.google-ad-container,.google-ads,.google-ads-boxout,.google-right-ad,.google-sponsored-ads,.google468_60,.googleAd,.googleAd-content,.googleAd-list,.googleAdBox,.googleAdSense,.googleAd_body,.googleAds,.googleAds_article_page_above_comments,.googleAdsense,.googleProfileAd,.google_ads_bom_title,.googlead,.googleads,.googleads_300x250,.googleads_title,.gpAds,.gradientAd,.gsfAd,.gt_ad_300x250,.gt_ad_728x90,.gutter-ad-left,.gutter-ad-right,.h_Ads,.h_ad,.hd_advert,.header-ad,.header-advert,.headerAd,.headerAds,.headerAdvert,.header_ad,.header_ad_center,.header_advertisment,.hi5-ad,.highlightsAd,.hm_advertisment,.home-ad-links,.homeAd,.homeMediumAdGroup,.homepage-ad,.homepageFlexAdOuter,.homepageMPU,.hor_ad,.horizontalAd,.horizontal_ad,.hortad,.houseAdsStyle,.hp2-adtag,.hp_ad_cont,.hp_ad_text,.hp_t_ad,.hp_w_ad,.ic-ads,.ico-adv,.idMultiAd,.image-advertisement,.imageads,.in-page-ad,.in-story-text-ad,.indy_googleads,.inline-mpu-left,.inlineSideAd,.inline_ad_title,.inlinead,.inlist-ad,.inner-advt-banner-3,.innerAds,.innerad,.inpostad,.islandAd,.islandAdvert,.islandad,.jp-advertisment-promotional,.js-advert,.kw_advert,.kw_advert_pair,.l_ad_sub,.l_banner.ads_show_if,.largeRectangleAd,.leader_ad,.leaderboardAd,.left-ad,.leftAd,.leftad,.leftnavad,.lgRecAd,.linead,.link_advertise,.live-search-list-ad-container,.log_ads,.lowerAds,.m_banner_ads,.macAd,.macad,.main-tabs-ad-block,.main_ad,.main_adbox,.map_media_banner_ad,.marginadsthin,.marketing-ad,.mdl-ad,.media-advert,.medium-rectangle-ad,.messageBoardAd,.micro_ad,.mid_ad,.midad,.min_navi_ad,.miniad,.mod-ad-lrec,.mod-ad-n,.mod-adopenx,.mod_admodule,.module-ad-small,.module-ads,.moduleAdvertContent,.modulegad,.moduletable-advert,.moduletablesquaread,.mpu,.mpu-ad,.mpu-footer,.mpu-fp,.mpu-title,.mpu-top-left,.mpu-top-right,.mpuAd,.mpuBox,.mpuContainer,.mpuTextAd,.mpu_ad,.mpu_gold,.mpu_platinum,.mpuholderportalpage,.mrec_advert,.ms-ads-link,.msfg-shopping-mpu,.mwaads,.nSponsoredLcContent,.nSponsoredLcTopic,.nadvt300,.narrow_ads,.naviad,.nba300Ad,.nbaT3Ad160,.nbaTVPodAd,.nbaTwo130Ads,.nbc_ad_carousel_wrp,.newTopAdContainer,.newad,.nf-adbox,.nn-mpu,.noAdForLead,.normalAds,.nrAds,.oas-bottom-ads,.oio-banner-zone,.oio-link-sidebar,.oio-zone-position,.onethirdadholder,.openx,.openx-ad,.ov_spns,.pageLeaderAd,.pagead,.partnersTextLinks,.pencil_ad,.player_ad_box,.player_page_ad_box,.pnp_ad,.podSponsoredLink,.post-ad,.post_ad,.post_sponsor_unit,.postbit_adbit_register,.postbit_adcode,.prebodyads,.premium_ad_container,.promo-text,.promoAd,.promoAds,.promo_ad,.publication-ad,.publicidad,.puff-advertorials,.qa_ad_left,.quigo-ad,.qzvAdDiv,.r_ad_box,.rad_container,.rectad,.rectangleAd,.rectanglead,.redads_cont,.regularad,.relatedAds,.remads,.result_ad,.results_sponsor,.results_sponsor_right,.rght300x250,.rhads,.rhs-ad,.rhs-ads-panel,.right-ad,.right-ad-holder,.right-ad2,.right-ads2,.rightAd,.right_ad,.right_ad_text,.right_hand_advert_column,.rightad,.rightad_1,.rightad_2,.rightads,.rightadunit,.rightcol_boxad,.rightcoladvert,.rt_ad1_300x90,.rt_ad_300x250,.rt_ad_call,.savvyad_unit,.sb-ad-sq-bg,.sbAdUnitContainer,.sb_adsN,.sb_adsNv2,.sb_adsW,.sb_adsWv2,.scanAd,.sci-ad-main,.sci-ad-sub,.search-results-ad,.search-sponsor,.search-sponsored,.searchAd,.searchSponsoredResultsBox,.search_column_results_sponsored,.search_results_sponsored_top,.section-sponsor,.section_mpu_wrapper,.selfServeAds,.sidbaread,.side-ad,.side-ads,.side_ad,.sidead,.sideadsbox,.sideadvert,.sidebar-ad,.sidebar-text-ad,.sidebarAd,.sidebarAdUnit,.sidebarAdvert,.sidebar_ad,.sidebar_box_ad,.sidebarad,.sidebarad_bottom,.sideheadnarrowad,.sideheadsponsorsad,.singleAd,.singleAdsContainer,.singlead,.sitesponsor,.skinAd,.skin_ad_638,.sky-ad,.skyAd,.skyAdd,.sky_ad,.skyscraper-ad,.smallSkyAd1,.smallSkyAd2,.small_ad,.small_ads,.smallad-left,.smallsponsorad,.specialAd175x90,.spl_ad,.spl_ad2,.spl_ad_plus,.splitAd,.spons-link,.sponslink,.sponsor-ad,.sponsor-links,.sponsorArea,.sponsorPost,.sponsorPostWrap,.sponsor_line,.sponsoradtitle,.sponsorbox,.sponsored,.sponsored-chunk,.sponsored-links,.sponsored-post,.sponsored-text,.sponsoredLinks,.sponsoredLinksHeader,.sponsored_ads,.sponsored_box,.sponsored_box_search,.sponsored_by,.sponsored_links,.sponsored_links_title_container,.sponsored_links_title_container_top,.sponsored_links_top,.sponsoredibbox,.sponsoredlinks,.sponsorlink,.squareAd,.square_ad,.squared_ad,.ss-ad-mpu,.staticAd,.store-ads,.story_AD,.subad,.subcontent-ad,.supercommentad_left,.supercommentad_right,.supportAdItem,.surveyad,.t10ad,.tab_ad,.tab_ad_area,.tablebordersponsor,.tadsanzeige,.tadsbanner,.tadselement,.tblTopAds,.tbl_ad,.teaserAdContainer,.teaser_adtiles,.text-ad-links,.text-g-advertisement,.text-g-group-short-rec-ad,.text-g-net-grp-google-ads-article-page,.textAd,.textAds,.text_ad,.text_ads,.textad,.textad_headline,.textadbox,.textads,.textlink-ads,.thisIsAd,.thisIsAnAd,.ticket-ad,.tileAds,.title-ad,.title_adbig,.tncms-region-ads,.toolad,.toolbar-ad,.top-ad,.top-ad-space,.top-ads,.top-menu-ads,.topAdWrap,.topAds,.topAdvertisement,.topBannerAd,.top_ad,.top_ad_disclaimer,.top_ad_wrapper,.top_ads,.top_advert,.top_container_ad,.top_sponsor,.topad,.topadbox,.topadspot,.topcontentadvertisement,.topic_inad,.topstoriesad,.towerAd,.towerAds,.tower_ad_disclaimer,.ts-ad_unit_bigbox,.ts-banner_ad,.ttlAdsensel,.twoColumnAd,.twoadcoll,.twoadcolr,.tx_smartadserver_pi1,.txt-ads,.txtadvertise,.type_miniad,.type_promoads,.usenext,.vertad,.videoAd,.videoBoxAd,.view-promo-mpu-right,.wide-ad,.wide-skyscraper-ad,.wideAdTable,.wide_ads,.widget-entry-ads-160,.wikia_ad_placeholder,.withAds,.wnMultiAd,.wpn_ad_content,.x03-adunit,.x04-adunit,.y-ads,.y7-advertisement,.yahoo-sponsored,.yahoo_ads,.yan-sponsored,.ygrp-ad,.yrail_ad_wrap,.yrail_ads,.ysmsponsor,.ysponsor,a[href^="http://adserving.liveuniversenetwork.com/"],a[href^="http://latestdownloads.net/download.php?"],a[href^="http://www.FriendlyDuck.com/AF_"],a[href^="http://www.adbrite.com/mb/commerce/purchase_form.php?"],a[href^="http://www.liutilities.com/aff"],a[href^="http://www.my-dirty-hobby.com/?sub="],a[href^="http://www.ringtonematcher.com/"],#adt[align="right"][style="border-left: 1px solid rgb(201, 215, 241);"],#mbEnd[cellspacing="0"][style="padding: 0pt; white-space: nowrap;"],#mbEnd[width="30%"][style],#mboxEnd[width="30%"][style],div#mclip_container:first-child:last-child,div#tads.c,div.ch[id^="tba"][style],div.ch[id^="tpa"][style],div[style="font-size: small; background-color: rgb(255, 249, 221);"],div[style^="background: rgb(255, 248, 221) none repeat scroll 0% 0%; margin-top: 10px;"],table.ra[align="left"][width="30%"],table.ra[align="right"][width="30%"],table[align="center"][cellpadding="0"][style*="padding: 8px;"][style*="rgb(255, 248, 221);"][width="100%"],table[style="background: none repeat scroll 0% 0% rgb(255, 248, 231); padding: 8px; margin-top: 0px;"],table[style^="padding: 8px; background: rgb(255, 248, 221) none repeat scroll 0% 0%; -moz-background-clip:"] { visibility:hidden !important;    display:none !important; }</STYLE></HTML>
+</body></html>

--- a/bin/docs/ThirdPartyLicenses.html
+++ b/bin/docs/ThirdPartyLicenses.html
@@ -14,7 +14,8 @@
 <p>PCSX2 contains code written by, and copyrighted by third parties. The copyright statements and licenses for the included third-party code is included below.</p>
 
 <h3>cpuinfo - <a href="https://github.com/pytorch/cpuinfo">https://github.com/pytorch/cpuinfo</a></h3>
-<pre>Copyright (c) 2019 Google LLC
+<pre>
+Copyright (c) 2019 Google LLC
 Copyright (c) 2017-2018 Facebook Inc.
 Copyright (C) 2012-2017 Georgia Institute of Technology
 Copyright (C) 2010-2012 Marat Dukhan
@@ -43,7 +44,8 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</pre>
 
 <h3>cubeb - <a href="https://github.com/mozilla/cubeb">https://github.com/mozilla/cubeb</a></h3>
-<pre>Copyright   2011 Mozilla Foundation
+<pre>
+Copyright   2011 Mozilla Foundation
 
 Permission to use, copy, modify, and distribute this software for any
 purpose with or without fee is hereby granted, provided that the above
@@ -58,7 +60,8 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</pre>
 
 <h3>D3D12 Memory Allocator - <a href="https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator">https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator</a></h3>
-<pre>Copyright (c) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+<pre>
+Copyright (c) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -79,7 +82,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.</pre>
 
 <h3>Discord-RPC - <a href="https://github.com/discord/discord-rpc">https://github.com/discord/discord-rpc</a></h3>
-<pre>Copyright 2017 Discord, Inc.
+<pre>
+Copyright 2017 Discord, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -129,7 +133,8 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.</pre>
 
 <h3>fmt - <a href="https://github.com/fmtlib/fmt">https://github.com/fmtlib/fmt</a></h3>
-<pre>Copyright (c) 2012 - present, Victor Zverovich
+<pre>
+Copyright (c) 2012 - present, Victor Zverovich
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -158,7 +163,8 @@ source code, you may redistribute such embedded portions in such object form
 without including the above copyright and permission notices.</pre>
 
 <h3>glslang - <a href="https://github.com/KhronosGroup/glslang">https://github.com/KhronosGroup/glslang</a></h3>
-<pre>Here, glslang proper means core GLSL parsing, HLSL parsing, and SPIR-V code
+<pre>
+Here, glslang proper means core GLSL parsing, HLSL parsing, and SPIR-V code
 generation. Glslang proper requires use of two licenses, one that covers
 non-preprocessing and an additional one that covers preprocessing.
 
@@ -581,7 +587,8 @@ SOFTWARE.
 </pre>
 
 <h3>Dear ImGui - <a href="https://github.com/ocornut/imgui">https://github.com/ocornut/imgui</a></h3>
-<pre>The MIT License (MIT)
+<pre>
+The MIT License (MIT)
 
 Copyright (c) 2014-2019 Omar Cornut
 
@@ -1470,7 +1477,8 @@ Software.
 </pre>
 
 <h3>LZMA SDK - <a href="https://7-zip.org/sdk.html">https://7-zip.org/sdk.html</a></h3>
-<pre>LZMA SDK is placed in the public domain.
+<pre>
+LZMA SDK is placed in the public domain.
 
 Anyone is free to copy, modify, publish, use, compile, sell, or distribute the
 original LZMA SDK code, either in source code form or as a compiled binary,
@@ -1478,7 +1486,8 @@ for any purpose, commercial or non-commercial, and by any means.
 </pre>
 
 <h3>LZ4 - <a href="https://github.com/lz4/lz4">https://github.com/lz4/lz4</a></h3>
-<pre>   LZ4 - Fast LZ compression algorithm
+<pre>
+   LZ4 - Fast LZ compression algorithm
    Copyright (C) 2011-2020, Yann Collet.
 
    BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
@@ -1508,11 +1517,12 @@ for any purpose, commercial or non-commercial, and by any means.
 
    You can contact the author at :
     - LZ4 homepage : http://www.lz4.org
-    - LZ4 source repository : https://github.com/lz4/lz4</pre>
+    - LZ4 source repository : https://github.com/lz4/lz4
+</pre>
 
-
-<h3>PromptFont - </h3><a href="https://shinmera.github.io/promptfont/">https://shinmera.github.io/promptfont/</a></h3>
-<pre>This Font Software is licensed under the SIL Open Font License,
+<h3>PromptFont - <a href="https://shinmera.github.io/promptfont/">https://shinmera.github.io/promptfont/</a></h3>
+<pre>
+This Font Software is licensed under the SIL Open Font License,
 Version 1.1. This license is copied below, and is also available
 with a FAQ at http://scripts.sil.org/OFL
 
@@ -1606,7 +1616,8 @@ OTHER DEALINGS IN THE FONT SOFTWARE.
 </pre>
 
 <h3>rcheevos - <a href="https://github.com/RetroAchievements/rcheevos/">https://github.com/RetroAchievements/rcheevos/</a></h3>
-<pre>MIT License
+<pre>
+MIT License
 
 Copyright (c) 2019 RetroAchievements.org
 
@@ -1630,7 +1641,8 @@ SOFTWARE.
 </pre>
 
 <h3>libpng - <a href="https://github.com/glennrp/libpng">https://github.com/glennrp/libpng</a></h3>
-<pre>Copyright (c) 2018-2023 Cosmin Truta
+<pre>
+ Copyright (c) 2018-2023 Cosmin Truta
  Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
  Copyright (c) 1996-1997 Andreas Dilger
  Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -1671,7 +1683,8 @@ SOFTWARE.
 </pre>
 
 <h3>libwebp - <a href="https://github.com/webmproject/libwebp">https://github.com/webmproject/libwebp</a></h3>
-<pre>Copyright (c) 2010, Google Inc. All rights reserved.
+<pre>
+Copyright (c) 2010, Google Inc. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -1699,10 +1712,12 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
 DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</pre>
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</pre>
 
 <h3>libzip - <a href="https://libzip.org/">https://libzip.org/</a></h3>
-<pre>Copyright (C) 1999-2020 Dieter Baron and Thomas Klausner
+<pre>
+Copyright (C) 1999-2020 Dieter Baron and Thomas Klausner
 
 The authors can be contacted at <info@libzip.org>
 
@@ -1732,8 +1747,8 @@ GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
 IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
 OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
-IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</pre>
-
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</pre>
 
 <h3>simpleini - <a href="https://github.com/brofield/simpleini">https://github.com/brofield/simpleini</a></h3>
 <pre>
@@ -1760,7 +1775,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 </pre>
 
 <h3>RapidJSON - <a href="https://rapidjson.org/">https://rapidjson.org/</a></h3>
-<pre>Tencent is pleased to support the open source community by making
+<pre>
+Tencent is pleased to support the open source community by making
 RapidJSON available. 
  
 Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip.
@@ -1829,10 +1845,12 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.</pre>
+SOFTWARE.
+</pre>
 
 <h3>Rapid YAML - <a href="https://github.com/biojppm/rapidyaml">https://github.com/biojppm/rapidyaml</a></h3>
-<pre>Copyright (c) 2018, Joao Paulo Magalhaes <dev@jpmag.me>
+<pre>
+Copyright (c) 2018, Joao Paulo Magalhaes <dev@jpmag.me>
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the "Software"),
@@ -1850,10 +1868,10 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.</pre>
+DEALINGS IN THE SOFTWARE.
+</pre>
 
-
-<h3>SoundTouch audio processing library - https://github.com/rspeyer/soundtouch</h3>
+<h3>SoundTouch audio processing library - <a href="https://github.com/rspeyer/soundtouch">https://github.com/rspeyer/soundtouch</a></h3>
 <pre>
 		  GNU LESSER GENERAL PUBLIC LICENSE
 		       Version 2.1, February 1999
@@ -2550,11 +2568,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 </pre>
 
 <h3>stb libraries - <a href="https://github.com/nothings/stb">https://github.com/nothings/stb</a></h3>
+<pre>
 These libraries are in the public domain. You can do anything you want with them.
 You have no legal obligation to do anything else, although I appreciate attribution.
 
 They are also licensed under the MIT open source license, if you have lawyers who are unhappy with public domain.
 Every source file includes an explicit dual-license for you to choose from.
+</pre>
 
 <h3>vixl - <a href="https://git.linaro.org/arm/vixl.git">https://git.linaro.org/arm/vixl.git</a></h3>
 <pre>
@@ -2591,7 +2611,7 @@ The software in this repository is covered by the following licence.
 </pre>
 
 <h3>xbyak - <a href="https://github.com/herumi/xbyak">https://github.com/herumi/xbyak</a></h3>
-    
+<pre>
 Copyright (c) 2007 MITSUNARI Shigeo
 All rights reserved.
 
@@ -2618,6 +2638,7 @@ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 THE POSSIBILITY OF SUCH DAMAGE.
+</pre>
 
 <h3>xxhash - <a href="https://github.com/Cyan4973/xxHash">https://github.com/Cyan4973/xxHash</a></h3>
 <pre>
@@ -3410,631 +3431,680 @@ https://www.gnu.org/licenses/why-not-lgpl.html.
 
 <h3>KDDockWidgets - <a href="https://github.com/KDAB/KDDockWidgets">https://github.com/KDAB/KDDockWidgets</a></h3>
 <pre>
-  GNU GENERAL PUBLIC LICENSE
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
-  Version 3, 29 June 2007
-  
-  Copyright © 2007 Free Software Foundation, Inc. <https://fsf.org/>
-  
-  Everyone is permitted to copy and distribute verbatim copies of this license
-  document, but changing it is not allowed.
-  
-  Preamble
-  
-  The GNU General Public License is a free, copyleft license for software and
-  other kinds of works.
-  
-  The licenses for most software and other practical works are designed to take
-  away your freedom to share and change the works. By contrast, the GNU General
-  Public License is intended to guarantee your freedom to share and change all
-  versions of a program--to make sure it remains free software for all its users.
-  We, the Free Software Foundation, use the GNU General Public License for most
-  of our software; it applies also to any other work released this way by its
-  authors. You can apply it to your programs, too.
-  
-  When we speak of free software, we are referring to freedom, not price. Our
-  General Public Licenses are designed to make sure that you have the freedom
-  to distribute copies of free software (and charge for them if you wish), that
-  you receive source code or can get it if you want it, that you can change
-  the software or use pieces of it in new free programs, and that you know you
-  can do these things.
-  
-  To protect your rights, we need to prevent others from denying you these rights
-  or asking you to surrender the rights. Therefore, you have certain responsibilities
-  if you distribute copies of the software, or if you modify it: responsibilities
-  to respect the freedom of others.
-  
-  For example, if you distribute copies of such a program, whether gratis or
-  for a fee, you must pass on to the recipients the same freedoms that you received.
-  You must make sure that they, too, receive or can get the source code. And
-  you must show them these terms so they know their rights.
-  
-  Developers that use the GNU GPL protect your rights with two steps: (1) assert
-  copyright on the software, and (2) offer you this License giving you legal
-  permission to copy, distribute and/or modify it.
-  
-  For the developers' and authors' protection, the GPL clearly explains that
-  there is no warranty for this free software. For both users' and authors'
-  sake, the GPL requires that modified versions be marked as changed, so that
-  their problems will not be attributed erroneously to authors of previous versions.
-  
-  Some devices are designed to deny users access to install or run modified
-  versions of the software inside them, although the manufacturer can do so.
-  This is fundamentally incompatible with the aim of protecting users' freedom
-  to change the software. The systematic pattern of such abuse occurs in the
-  area of products for individuals to use, which is precisely where it is most
-  unacceptable. Therefore, we have designed this version of the GPL to prohibit
-  the practice for those products. If such problems arise substantially in other
-  domains, we stand ready to extend this provision to those domains in future
-  versions of the GPL, as needed to protect the freedom of users.
-  
-  Finally, every program is threatened constantly by software patents. States
-  should not allow patents to restrict development and use of software on general-purpose
-  computers, but in those that do, we wish to avoid the special danger that
-  patents applied to a free program could make it effectively proprietary. To
-  prevent this, the GPL assures that patents cannot be used to render the program
-  non-free.
-  
-  The precise terms and conditions for copying, distribution and modification
-  follow.
-  
-  TERMS AND CONDITIONS
-  
-     0. Definitions.
-  
-     "This License" refers to version 3 of the GNU General Public License.
-  
-  "Copyright" also means copyright-like laws that apply to other kinds of works,
-  such as semiconductor masks.
-  
-  "The Program" refers to any copyrightable work licensed under this License.
-  Each licensee is addressed as "you". "Licensees" and "recipients" may be individuals
-  or organizations.
-  
-  To "modify" a work means to copy from or adapt all or part of the work in
-  a fashion requiring copyright permission, other than the making of an exact
-  copy. The resulting work is called a "modified version" of the earlier work
-  or a work "based on" the earlier work.
-  
-  A "covered work" means either the unmodified Program or a work based on the
-  Program.
-  
-  To "propagate" a work means to do anything with it that, without permission,
-  would make you directly or secondarily liable for infringement under applicable
-  copyright law, except executing it on a computer or modifying a private copy.
-  Propagation includes copying, distribution (with or without modification),
-  making available to the public, and in some countries other activities as
-  well.
-  
-  To "convey" a work means any kind of propagation that enables other parties
-  to make or receive copies. Mere interaction with a user through a computer
-  network, with no transfer of a copy, is not conveying.
-  
-  An interactive user interface displays "Appropriate Legal Notices" to the
-  extent that it includes a convenient and prominently visible feature that
-  (1) displays an appropriate copyright notice, and (2) tells the user that
-  there is no warranty for the work (except to the extent that warranties are
-  provided), that licensees may convey the work under this License, and how
-  to view a copy of this License. If the interface presents a list of user commands
-  or options, such as a menu, a prominent item in the list meets this criterion.
-  
-     1. Source Code.
-  
-  The "source code" for a work means the preferred form of the work for making
-  modifications to it. "Object code" means any non-source form of a work.
-  
-  A "Standard Interface" means an interface that either is an official standard
-  defined by a recognized standards body, or, in the case of interfaces specified
-  for a particular programming language, one that is widely used among developers
-  working in that language.
-  
-  The "System Libraries" of an executable work include anything, other than
-  the work as a whole, that (a) is included in the normal form of packaging
-  a Major Component, but which is not part of that Major Component, and (b)
-  serves only to enable use of the work with that Major Component, or to implement
-  a Standard Interface for which an implementation is available to the public
-  in source code form. A "Major Component", in this context, means a major essential
-  component (kernel, window system, and so on) of the specific operating system
-  (if any) on which the executable work runs, or a compiler used to produce
-  the work, or an object code interpreter used to run it.
-  
-  The "Corresponding Source" for a work in object code form means all the source
-  code needed to generate, install, and (for an executable work) run the object
-  code and to modify the work, including scripts to control those activities.
-  However, it does not include the work's System Libraries, or general-purpose
-  tools or generally available free programs which are used unmodified in performing
-  those activities but which are not part of the work. For example, Corresponding
-  Source includes interface definition files associated with source files for
-  the work, and the source code for shared libraries and dynamically linked
-  subprograms that the work is specifically designed to require, such as by
-  intimate data communication or control flow between those subprograms and
-  other parts of the work.
-  
-  The Corresponding Source need not include anything that users can regenerate
-  automatically from other parts of the Corresponding Source.
-  
-     The Corresponding Source for a work in source code form is that same work.
-  
-     2. Basic Permissions.
-  
-  All rights granted under this License are granted for the term of copyright
-  on the Program, and are irrevocable provided the stated conditions are met.
-  This License explicitly affirms your unlimited permission to run the unmodified
-  Program. The output from running a covered work is covered by this License
-  only if the output, given its content, constitutes a covered work. This License
-  acknowledges your rights of fair use or other equivalent, as provided by copyright
-  law.
-  
-  You may make, run and propagate covered works that you do not convey, without
-  conditions so long as your license otherwise remains in force. You may convey
-  covered works to others for the sole purpose of having them make modifications
-  exclusively for you, or provide you with facilities for running those works,
-  provided that you comply with the terms of this License in conveying all material
-  for which you do not control copyright. Those thus making or running the covered
-  works for you must do so exclusively on your behalf, under your direction
-  and control, on terms that prohibit them from making any copies of your copyrighted
-  material outside their relationship with you.
-  
-  Conveying under any other circumstances is permitted solely under the conditions
-  stated below. Sublicensing is not allowed; section 10 makes it unnecessary.
-  
-     3. Protecting Users' Legal Rights From Anti-Circumvention Law.
-  
-  No covered work shall be deemed part of an effective technological measure
-  under any applicable law fulfilling obligations under article 11 of the WIPO
-  copyright treaty adopted on 20 December 1996, or similar laws prohibiting
-  or restricting circumvention of such measures.
-  
-  When you convey a covered work, you waive any legal power to forbid circumvention
-  of technological measures to the extent such circumvention is effected by
-  exercising rights under this License with respect to the covered work, and
-  you disclaim any intention to limit operation or modification of the work
-  as a means of enforcing, against the work's users, your or third parties'
-  legal rights to forbid circumvention of technological measures.
-  
-     4. Conveying Verbatim Copies.
-  
-  You may convey verbatim copies of the Program's source code as you receive
-  it, in any medium, provided that you conspicuously and appropriately publish
-  on each copy an appropriate copyright notice; keep intact all notices stating
-  that this License and any non-permissive terms added in accord with section
-  7 apply to the code; keep intact all notices of the absence of any warranty;
-  and give all recipients a copy of this License along with the Program.
-  
-  You may charge any price or no price for each copy that you convey, and you
-  may offer support or warranty protection for a fee.
-  
-     5. Conveying Modified Source Versions.
-  
-  You may convey a work based on the Program, or the modifications to produce
-  it from the Program, in the form of source code under the terms of section
-  4, provided that you also meet all of these conditions:
-  
-  a) The work must carry prominent notices stating that you modified it, and
-  giving a relevant date.
-  
-  b) The work must carry prominent notices stating that it is released under
-  this License and any conditions added under section 7. This requirement modifies
-  the requirement in section 4 to "keep intact all notices".
-  
-  c) You must license the entire work, as a whole, under this License to anyone
-  who comes into possession of a copy. This License will therefore apply, along
-  with any applicable section 7 additional terms, to the whole of the work,
-  and all its parts, regardless of how they are packaged. This License gives
-  no permission to license the work in any other way, but it does not invalidate
-  such permission if you have separately received it.
-  
-  d) If the work has interactive user interfaces, each must display Appropriate
-  Legal Notices; however, if the Program has interactive interfaces that do
-  not display Appropriate Legal Notices, your work need not make them do so.
-  
-  A compilation of a covered work with other separate and independent works,
-  which are not by their nature extensions of the covered work, and which are
-  not combined with it such as to form a larger program, in or on a volume of
-  a storage or distribution medium, is called an "aggregate" if the compilation
-  and its resulting copyright are not used to limit the access or legal rights
-  of the compilation's users beyond what the individual works permit. Inclusion
-  of a covered work in an aggregate does not cause this License to apply to
-  the other parts of the aggregate.
-  
-     6. Conveying Non-Source Forms.
-  
-  You may convey a covered work in object code form under the terms of sections
-  4 and 5, provided that you also convey the machine-readable Corresponding
-  Source under the terms of this License, in one of these ways:
-  
-  a) Convey the object code in, or embodied in, a physical product (including
-  a physical distribution medium), accompanied by the Corresponding Source fixed
-  on a durable physical medium customarily used for software interchange.
-  
-  b) Convey the object code in, or embodied in, a physical product (including
-  a physical distribution medium), accompanied by a written offer, valid for
-  at least three years and valid for as long as you offer spare parts or customer
-  support for that product model, to give anyone who possesses the object code
-  either (1) a copy of the Corresponding Source for all the software in the
-  product that is covered by this License, on a durable physical medium customarily
-  used for software interchange, for a price no more than your reasonable cost
-  of physically performing this conveying of source, or (2) access to copy the
-  Corresponding Source from a network server at no charge.
-  
-  c) Convey individual copies of the object code with a copy of the written
-  offer to provide the Corresponding Source. This alternative is allowed only
-  occasionally and noncommercially, and only if you received the object code
-  with such an offer, in accord with subsection 6b.
-  
-  d) Convey the object code by offering access from a designated place (gratis
-  or for a charge), and offer equivalent access to the Corresponding Source
-  in the same way through the same place at no further charge. You need not
-  require recipients to copy the Corresponding Source along with the object
-  code. If the place to copy the object code is a network server, the Corresponding
-  Source may be on a different server (operated by you or a third party) that
-  supports equivalent copying facilities, provided you maintain clear directions
-  next to the object code saying where to find the Corresponding Source. Regardless
-  of what server hosts the Corresponding Source, you remain obligated to ensure
-  that it is available for as long as needed to satisfy these requirements.
-  
-  e) Convey the object code using peer-to-peer transmission, provided you inform
-  other peers where the object code and Corresponding Source of the work are
-  being offered to the general public at no charge under subsection 6d.
-  
-  A separable portion of the object code, whose source code is excluded from
-  the Corresponding Source as a System Library, need not be included in conveying
-  the object code work.
-  
-  A "User Product" is either (1) a "consumer product", which means any tangible
-  personal property which is normally used for personal, family, or household
-  purposes, or (2) anything designed or sold for incorporation into a dwelling.
-  In determining whether a product is a consumer product, doubtful cases shall
-  be resolved in favor of coverage. For a particular product received by a particular
-  user, "normally used" refers to a typical or common use of that class of product,
-  regardless of the status of the particular user or of the way in which the
-  particular user actually uses, or expects or is expected to use, the product.
-  A product is a consumer product regardless of whether the product has substantial
-  commercial, industrial or non-consumer uses, unless such uses represent the
-  only significant mode of use of the product.
-  
-  "Installation Information" for a User Product means any methods, procedures,
-  authorization keys, or other information required to install and execute modified
-  versions of a covered work in that User Product from a modified version of
-  its Corresponding Source. The information must suffice to ensure that the
-  continued functioning of the modified object code is in no case prevented
-  or interfered with solely because modification has been made.
-  
-  If you convey an object code work under this section in, or with, or specifically
-  for use in, a User Product, and the conveying occurs as part of a transaction
-  in which the right of possession and use of the User Product is transferred
-  to the recipient in perpetuity or for a fixed term (regardless of how the
-  transaction is characterized), the Corresponding Source conveyed under this
-  section must be accompanied by the Installation Information. But this requirement
-  does not apply if neither you nor any third party retains the ability to install
-  modified object code on the User Product (for example, the work has been installed
-  in ROM).
-  
-  The requirement to provide Installation Information does not include a requirement
-  to continue to provide support service, warranty, or updates for a work that
-  has been modified or installed by the recipient, or for the User Product in
-  which it has been modified or installed. Access to a network may be denied
-  when the modification itself materially and adversely affects the operation
-  of the network or violates the rules and protocols for communication across
-  the network.
-  
-  Corresponding Source conveyed, and Installation Information provided, in accord
-  with this section must be in a format that is publicly documented (and with
-  an implementation available to the public in source code form), and must require
-  no special password or key for unpacking, reading or copying.
-  
-     7. Additional Terms.
-  
-  "Additional permissions" are terms that supplement the terms of this License
-  by making exceptions from one or more of its conditions. Additional permissions
-  that are applicable to the entire Program shall be treated as though they
-  were included in this License, to the extent that they are valid under applicable
-  law. If additional permissions apply only to part of the Program, that part
-  may be used separately under those permissions, but the entire Program remains
-  governed by this License without regard to the additional permissions.
-  
-  When you convey a copy of a covered work, you may at your option remove any
-  additional permissions from that copy, or from any part of it. (Additional
-  permissions may be written to require their own removal in certain cases when
-  you modify the work.) You may place additional permissions on material, added
-  by you to a covered work, for which you have or can give appropriate copyright
-  permission.
-  
-  Notwithstanding any other provision of this License, for material you add
-  to a covered work, you may (if authorized by the copyright holders of that
-  material) supplement the terms of this License with terms:
-  
-  a) Disclaiming warranty or limiting liability differently from the terms of
-  sections 15 and 16 of this License; or
-  
-  b) Requiring preservation of specified reasonable legal notices or author
-  attributions in that material or in the Appropriate Legal Notices displayed
-  by works containing it; or
-  
-  c) Prohibiting misrepresentation of the origin of that material, or requiring
-  that modified versions of such material be marked in reasonable ways as different
-  from the original version; or
-  
-  d) Limiting the use for publicity purposes of names of licensors or authors
-  of the material; or
-  
-  e) Declining to grant rights under trademark law for use of some trade names,
-  trademarks, or service marks; or
-  
-  f) Requiring indemnification of licensors and authors of that material by
-  anyone who conveys the material (or modified versions of it) with contractual
-  assumptions of liability to the recipient, for any liability that these contractual
-  assumptions directly impose on those licensors and authors.
-  
-  All other non-permissive additional terms are considered "further restrictions"
-  within the meaning of section 10. If the Program as you received it, or any
-  part of it, contains a notice stating that it is governed by this License
-  along with a term that is a further restriction, you may remove that term.
-  If a license document contains a further restriction but permits relicensing
-  or conveying under this License, you may add to a covered work material governed
-  by the terms of that license document, provided that the further restriction
-  does not survive such relicensing or conveying.
-  
-  If you add terms to a covered work in accord with this section, you must place,
-  in the relevant source files, a statement of the additional terms that apply
-  to those files, or a notice indicating where to find the applicable terms.
-  
-  Additional terms, permissive or non-permissive, may be stated in the form
-  of a separately written license, or stated as exceptions; the above requirements
-  apply either way.
-  
-     8. Termination.
-  
-  You may not propagate or modify a covered work except as expressly provided
-  under this License. Any attempt otherwise to propagate or modify it is void,
-  and will automatically terminate your rights under this License (including
-  any patent licenses granted under the third paragraph of section 11).
-  
-  However, if you cease all violation of this License, then your license from
-  a particular copyright holder is reinstated (a) provisionally, unless and
-  until the copyright holder explicitly and finally terminates your license,
-  and (b) permanently, if the copyright holder fails to notify you of the violation
-  by some reasonable means prior to 60 days after the cessation.
-  
-  Moreover, your license from a particular copyright holder is reinstated permanently
-  if the copyright holder notifies you of the violation by some reasonable means,
-  this is the first time you have received notice of violation of this License
-  (for any work) from that copyright holder, and you cure the violation prior
-  to 30 days after your receipt of the notice.
-  
-  Termination of your rights under this section does not terminate the licenses
-  of parties who have received copies or rights from you under this License.
-  If your rights have been terminated and not permanently reinstated, you do
-  not qualify to receive new licenses for the same material under section 10.
-  
-     9. Acceptance Not Required for Having Copies.
-  
-  You are not required to accept this License in order to receive or run a copy
-  of the Program. Ancillary propagation of a covered work occurring solely as
-  a consequence of using peer-to-peer transmission to receive a copy likewise
-  does not require acceptance. However, nothing other than this License grants
-  you permission to propagate or modify any covered work. These actions infringe
-  copyright if you do not accept this License. Therefore, by modifying or propagating
-  a covered work, you indicate your acceptance of this License to do so.
-  
-     10. Automatic Licensing of Downstream Recipients.
-  
-  Each time you convey a covered work, the recipient automatically receives
-  a license from the original licensors, to run, modify and propagate that work,
-  subject to this License. You are not responsible for enforcing compliance
-  by third parties with this License.
-  
-  An "entity transaction" is a transaction transferring control of an organization,
-  or substantially all assets of one, or subdividing an organization, or merging
-  organizations. If propagation of a covered work results from an entity transaction,
-  each party to that transaction who receives a copy of the work also receives
-  whatever licenses to the work the party's predecessor in interest had or could
-  give under the previous paragraph, plus a right to possession of the Corresponding
-  Source of the work from the predecessor in interest, if the predecessor has
-  it or can get it with reasonable efforts.
-  
-  You may not impose any further restrictions on the exercise of the rights
-  granted or affirmed under this License. For example, you may not impose a
-  license fee, royalty, or other charge for exercise of rights granted under
-  this License, and you may not initiate litigation (including a cross-claim
-  or counterclaim in a lawsuit) alleging that any patent claim is infringed
-  by making, using, selling, offering for sale, or importing the Program or
-  any portion of it.
-  
-     11. Patents.
-  
-  A "contributor" is a copyright holder who authorizes use under this License
-  of the Program or a work on which the Program is based. The work thus licensed
-  is called the contributor's "contributor version".
-  
-  A contributor's "essential patent claims" are all patent claims owned or controlled
-  by the contributor, whether already acquired or hereafter acquired, that would
-  be infringed by some manner, permitted by this License, of making, using,
-  or selling its contributor version, but do not include claims that would be
-  infringed only as a consequence of further modification of the contributor
-  version. For purposes of this definition, "control" includes the right to
-  grant patent sublicenses in a manner consistent with the requirements of this
-  License.
-  
-  Each contributor grants you a non-exclusive, worldwide, royalty-free patent
-  license under the contributor's essential patent claims, to make, use, sell,
-  offer for sale, import and otherwise run, modify and propagate the contents
-  of its contributor version.
-  
-  In the following three paragraphs, a "patent license" is any express agreement
-  or commitment, however denominated, not to enforce a patent (such as an express
-  permission to practice a patent or covenant not to sue for patent infringement).
-  To "grant" such a patent license to a party means to make such an agreement
-  or commitment not to enforce a patent against the party.
-  
-  If you convey a covered work, knowingly relying on a patent license, and the
-  Corresponding Source of the work is not available for anyone to copy, free
-  of charge and under the terms of this License, through a publicly available
-  network server or other readily accessible means, then you must either (1)
-  cause the Corresponding Source to be so available, or (2) arrange to deprive
-  yourself of the benefit of the patent license for this particular work, or
-  (3) arrange, in a manner consistent with the requirements of this License,
-  to extend the patent license to downstream recipients. "Knowingly relying"
-  means you have actual knowledge that, but for the patent license, your conveying
-  the covered work in a country, or your recipient's use of the covered work
-  in a country, would infringe one or more identifiable patents in that country
-  that you have reason to believe are valid.
-  
-  If, pursuant to or in connection with a single transaction or arrangement,
-  you convey, or propagate by procuring conveyance of, a covered work, and grant
-  a patent license to some of the parties receiving the covered work authorizing
-  them to use, propagate, modify or convey a specific copy of the covered work,
-  then the patent license you grant is automatically extended to all recipients
-  of the covered work and works based on it.
-  
-  A patent license is "discriminatory" if it does not include within the scope
-  of its coverage, prohibits the exercise of, or is conditioned on the non-exercise
-  of one or more of the rights that are specifically granted under this License.
-  You may not convey a covered work if you are a party to an arrangement with
-  a third party that is in the business of distributing software, under which
-  you make payment to the third party based on the extent of your activity of
-  conveying the work, and under which the third party grants, to any of the
-  parties who would receive the covered work from you, a discriminatory patent
-  license (a) in connection with copies of the covered work conveyed by you
-  (or copies made from those copies), or (b) primarily for and in connection
-  with specific products or compilations that contain the covered work, unless
-  you entered into that arrangement, or that patent license was granted, prior
-  to 28 March 2007.
-  
-  Nothing in this License shall be construed as excluding or limiting any implied
-  license or other defenses to infringement that may otherwise be available
-  to you under applicable patent law.
-  
-     12. No Surrender of Others' Freedom.
-  
-  If conditions are imposed on you (whether by court order, agreement or otherwise)
-  that contradict the conditions of this License, they do not excuse you from
-  the conditions of this License. If you cannot convey a covered work so as
-  to satisfy simultaneously your obligations under this License and any other
-  pertinent obligations, then as a consequence you may not convey it at all.
-  For example, if you agree to terms that obligate you to collect a royalty
-  for further conveying from those to whom you convey the Program, the only
-  way you could satisfy both those terms and this License would be to refrain
-  entirely from conveying the Program.
-  
-     13. Use with the GNU Affero General Public License.
-  
-  Notwithstanding any other provision of this License, you have permission to
-  link or combine any covered work with a work licensed under version 3 of the
-  GNU Affero General Public License into a single combined work, and to convey
-  the resulting work. The terms of this License will continue to apply to the
-  part which is the covered work, but the special requirements of the GNU Affero
-  General Public License, section 13, concerning interaction through a network
-  will apply to the combination as such.
-  
-     14. Revised Versions of this License.
-  
-  The Free Software Foundation may publish revised and/or new versions of the
-  GNU General Public License from time to time. Such new versions will be similar
-  in spirit to the present version, but may differ in detail to address new
-  problems or concerns.
-  
-  Each version is given a distinguishing version number. If the Program specifies
-  that a certain numbered version of the GNU General Public License "or any
-  later version" applies to it, you have the option of following the terms and
-  conditions either of that numbered version or of any later version published
-  by the Free Software Foundation. If the Program does not specify a version
-  number of the GNU General Public License, you may choose any version ever
-  published by the Free Software Foundation.
-  
-  If the Program specifies that a proxy can decide which future versions of
-  the GNU General Public License can be used, that proxy's public statement
-  of acceptance of a version permanently authorizes you to choose that version
-  for the Program.
-  
-  Later license versions may give you additional or different permissions. However,
-  no additional obligations are imposed on any author or copyright holder as
-  a result of your choosing to follow a later version.
-  
-     15. Disclaimer of Warranty.
-  
-  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE
-  LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
-  OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER
-  EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS
-  TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM
-  PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR
-  CORRECTION.
-  
-     16. Limitation of Liability.
-  
-  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL
-  ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS THE PROGRAM
-  AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL,
-  INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO
-  USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED
-  INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE
-  PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER
-  PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
-  
-     17. Interpretation of Sections 15 and 16.
-  
-  If the disclaimer of warranty and limitation of liability provided above cannot
-  be given local legal effect according to their terms, reviewing courts shall
-  apply local law that most closely approximates an absolute waiver of all civil
-  liability in connection with the Program, unless a warranty or assumption
-  of liability accompanies a copy of the Program in return for a fee. END OF
-  TERMS AND CONDITIONS
-  
-  How to Apply These Terms to Your New Programs
-  
-  If you develop a new program, and you want it to be of the greatest possible
-  use to the public, the best way to achieve this is to make it free software
-  which everyone can redistribute and change under these terms.
-  
-  To do so, attach the following notices to the program. It is safest to attach
-  them to the start of each source file to most effectively state the exclusion
-  of warranty; and each file should have at least the "copyright" line and a
-  pointer to where the full notice is found.
-  
-  <one line to give the program's name and a brief idea of what it does.>
-  
-  Copyright (C) <year> <name of author>
-  
-  This program is free software: you can redistribute it and/or modify it under
-  the terms of the GNU General Public License as published by the Free Software
-  Foundation, either version 3 of the License, or (at your option) any later
-  version.
-  
-  This program is distributed in the hope that it will be useful, but WITHOUT
-  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-  FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-  
-  You should have received a copy of the GNU General Public License along with
-  this program. If not, see <https://www.gnu.org/licenses/>.
-  
-  Also add information on how to contact you by electronic and paper mail.
-  
-  If the program does terminal interaction, make it output a short notice like
-  this when it starts in an interactive mode:
-  
-  <program> Copyright (C) <year> <name of author>
-  
-  This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
-  
-  This is free software, and you are welcome to redistribute it under certain
-  conditions; type `show c' for details.
-  
-  The hypothetical commands `show w' and `show c' should show the appropriate
-  parts of the General Public License. Of course, your program's commands might
-  be different; for a GUI interface, you would use an "about box".
-  
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
   You should also get your employer (if you work as a programmer) or school,
-  if any, to sign a "copyright disclaimer" for the program, if necessary. For
-  more information on this, and how to apply and follow the GNU GPL, see <https://www.gnu.org/licenses/>.
-  
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
   The GNU General Public License does not permit incorporating your program
-  into proprietary programs. If your program is a subroutine library, you may
-  consider it more useful to permit linking proprietary applications with the
-  library. If this is what you want to do, use the GNU Lesser General Public
-  License instead of this License. But first, please read <https://www.gnu.org/
-  licenses /why-not-lgpl.html>.
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/philosophy/why-not-lgpl.html>.
 </pre>
 
 <h3>JSON for Modern C++ - <a href="https://json.nlohmann.me">https://json.nlohmann.me</a></h3>

--- a/bin/docs/ThirdPartyLicenses.html
+++ b/bin/docs/ThirdPartyLicenses.html
@@ -4035,7 +4035,568 @@ https://www.gnu.org/licenses/why-not-lgpl.html.
   library. If this is what you want to do, use the GNU Lesser General Public
   License instead of this License. But first, please read <https://www.gnu.org/
   licenses /why-not-lgpl.html>.
+</pre>
 
+<h3>JSON for Modern C++ - <a href="https://json.nlohmann.me">https://json.nlohmann.me</a></h3>
+<pre>
+MIT License 
+
+Copyright (c) 2013-2022 Niels Lohmann
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+
+<h3>libiberty - <a href="https://gcc.gnu.org/git">https://gcc.gnu.org/git</a></h3>
+<pre>
+		  GNU LIBRARY GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
+
+ Copyright (C) 1991 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the library GPL.  It is
+ numbered 2 because it goes with version 2 of the ordinary GPL.]
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Library General Public License, applies to some
+specially designated Free Software Foundation software, and to any
+other libraries whose authors decide to use it.  You can use it for
+your libraries, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if
+you distribute copies of the library, or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link a program with the library, you must provide
+complete object files to the recipients so that they can relink them
+with the library, after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  Our method of protecting your rights has two steps: (1) copyright
+the library, and (2) offer you this license which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  Also, for each distributor's protection, we want to make certain
+that everyone understands that there is no warranty for this free
+library.  If the library is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original
+version, so that any problems introduced by others will not reflect on
+the original authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that companies distributing free
+software will individually obtain patent licenses, thus in effect
+transforming the program into proprietary software.  To prevent this,
+we have made it clear that any patent must be licensed for everyone's
+free use or not licensed at all.
+
+  Most GNU software, including some libraries, is covered by the ordinary
+GNU General Public License, which was designed for utility programs.  This
+license, the GNU Library General Public License, applies to certain
+designated libraries.  This license is quite different from the ordinary
+one; be sure to read it in full, and don't assume that anything in it is
+the same as in the ordinary license.
+
+  The reason we have a separate public license for some libraries is that
+they blur the distinction we usually make between modifying or adding to a
+program and simply using it.  Linking a program with a library, without
+changing the library, is in some sense simply using the library, and is
+analogous to running a utility program or application program.  However, in
+a textual and legal sense, the linked executable is a combined work, a
+derivative of the original library, and the ordinary General Public License
+treats it as such.
+
+  Because of this blurred distinction, using the ordinary General
+Public License for libraries did not effectively promote software
+sharing, because most developers did not use the libraries.  We
+concluded that weaker conditions might promote sharing better.
+
+  However, unrestricted linking of non-free programs would deprive the
+users of those programs of all benefit from the free status of the
+libraries themselves.  This Library General Public License is intended to
+permit developers of non-free programs to use free libraries, while
+preserving your freedom as a user of such programs to change the free
+libraries that are incorporated in them.  (We have not seen how to achieve
+this as regards changes in header files, but we have achieved it as regards
+changes in the actual functions of the Library.)  The hope is that this
+will lead to faster development of free libraries.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, while the latter only
+works together with the library.
+
+  Note that it is possible for a library to be covered by the ordinary
+General Public License rather than by this special one.
+
+		  GNU LIBRARY GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library which
+contains a notice placed by the copyright holder or other authorized
+party saying it may be distributed under the terms of this Library
+General Public License (also called "this License").  Each licensee is
+addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+  
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also compile or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    c) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    d) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the source code distributed need not include anything that is normally
+distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Library General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+			    NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+     Appendix: How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Library General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Library General Public License for more details.
+
+    You should have received a copy of the GNU Library General Public
+    License along with this library; if not, write to the Free
+    Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+    MA 02110-1301, USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!
+</pre>
+
+<h3>PlutoVG - <a href="https://github.com/sammycage/plutovg">https://github.com/sammycage/plutovg</a></h3>
+<h3>PlutoSVG - <a href="https://github.com/sammycage/plutosvg">https://github.com/sammycage/plutosvg</a></h3>
+<pre>
+MIT License
+
+Copyright (c) 2020-2025 Samuel Ugochukwu <sammycageagle@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+
+<h3>Twitter Emoji (Twemoji) - <a href="https://github.com/twitter/twemoji">https://github.com/twitter/twemoji</a></h3>
+<pre>
+MIT License
+
+Copyright (c) 2021 Twitter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 </pre>
 
 </body>

--- a/pcsx2/Docs/License.txt
+++ b/pcsx2/Docs/License.txt
@@ -1,19 +1,12 @@
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-[This file contains the template for the PCSX2 code rights license.  For the full
- rant-like preamble of the GPL, see GPL.txt]
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
-
-/*  PCSX2 - PS2 Emulator for PCs
- *  Copyright (C) 2002-2019  PCSX2 Dev Team
- *
- *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
- *  of the GNU Lesser General Public License as published by the Free Software Found-
- *  ation, either version 3 of the License, or (at your option) any later version.
- *
- *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
- *  PURPOSE.  See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with PCSX2.
- *  If not, see <http://www.gnu.org/licenses/>.
- */
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.


### PR DESCRIPTION
### Description of Changes
- Updates an old file that was falsely implying PCSX2 was still licensed under the LGPL.
- Adds missing third party licenses for the nlohmann JSON library (used by KDDockWidgets), libiberty (the symbol demangler), and Pluto(S)VG.
- The formatting of the third party licenses file has been improved.
- The GPL license file has been replaced with a fresh copy, removing some bizarre advertising/tracking gunk that was previously present (GovanifY figured out it was probably injected by an ad blocker).

### Rationale behind Changes
- Comply with the licenses of our dependencies.
- Fix some issues with the existing license documents.

### Suggested Testing Steps
Open the about dialog, make sure Qt is rendering the license and third party licenses documents correctly.
