### PR TITLE
GSDumpRunner: Fix some userhack arguments not working.

### DIFF
--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -671,7 +671,7 @@ bool GSRunner::ParseCommandLineArgs(int argc, char* argv[], VMBootParameters& pa
 				s_settings_interface.SetBoolValue("EmuCore/GS", "UserHacks", true);
 
 				if (str.find("af") != std::string::npos)
-					s_settings_interface.SetBoolValue("EmuCore/GS", "UserHacks_AutoFlush", true);
+					s_settings_interface.SetIntValue("EmuCore/GS", "UserHacks_AutoFlushLevel", 1);
 				if (str.find("cpufb") != std::string::npos)
 					s_settings_interface.SetBoolValue("EmuCore/GS", "UserHacks_CPU_FB_Conversion", true);
 				if (str.find("dds") != std::string::npos)
@@ -679,9 +679,9 @@ bool GSRunner::ParseCommandLineArgs(int argc, char* argv[], VMBootParameters& pa
 				if (str.find("dpi") != std::string::npos)
 					s_settings_interface.SetBoolValue("EmuCore/GS", "UserHacks_DisablePartialInvalidation", true);
 				if (str.find("dsf") != std::string::npos)
-					s_settings_interface.SetBoolValue("EmuCore/GS", "UserHacks_DisableSafeFeatures", true);
+					s_settings_interface.SetBoolValue("EmuCore/GS", "UserHacks_Disable_Safe_Features", true);
 				if (str.find("tinrt") != std::string::npos)
-					s_settings_interface.SetBoolValue("EmuCore/GS", "UserHacks_TextureInsideRt", true);
+					s_settings_interface.SetIntValue("EmuCore/GS", "UserHacks_TextureInsideRt", 1);
 				if (str.find("plf") != std::string::npos)
 					s_settings_interface.SetBoolValue("EmuCore/GS", "preload_frame_with_gs_data", true);
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GSDumpRunner: Fix some userhack arguments not working.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Bugfixes.
Keep in mind  Autoflush and Tex in RT have more than 1 value but maybe not worth expanding so just stick with the first available that we mostly use.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
None.