### PR TITLE
Debugger: Fix a typo in the memory search view

### DIFF
--- a/pcsx2-qt/Debugger/Memory/MemorySearchView.ui
+++ b/pcsx2-qt/Debugger/Memory/MemorySearchView.ui
@@ -72,7 +72,7 @@
        </item>
        <item>
         <property name="text">
-         <string>Array of byte</string>
+         <string>Byte Array</string>
         </property>
        </item>
       </widget>


### PR DESCRIPTION
### Description of Changes
- The drop down option "Array of byte" has been changed to "Byte Array".

### Rationale behind Changes
Better grammar.

### Suggested Testing Steps
N/A
