### PR TITLE
Swap Memory Cards Hotkey

### DIFF
--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
@@ -283,6 +283,12 @@ void MemoryCardSettingsWidget::convertCard()
 		refresh();
 }
 
+void MemoryCardSettingsWidget::MemoryCardSettingsWidget(QWidget* parent)
+	: QWidget(parent)
+{
+	connect(this, &MemoryCardSettingsWidget::requestSwapCards, this, &MemoryCardSettingsWidget::swapCards);
+}
+
 void MemoryCardSettingsWidget::listContextMenuRequested(const QPoint& pos)
 {
 	QMenu menu(this);

--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.h
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.h
@@ -73,6 +73,9 @@ protected:
 	void resizeEvent(QResizeEvent* event);
 	bool eventFilter(QObject* watched, QEvent* event);
 
+Q_SIGNALS:
+	void requestSwapCards();
+
 private Q_SLOTS:
 	void listContextMenuRequested(const QPoint& pos);
 	void refresh();

--- a/pcsx2/Hotkeys.cpp
+++ b/pcsx2/Hotkeys.cpp
@@ -222,6 +222,11 @@ DEFINE_HOTKEY("InputRecToggleMode", TRANSLATE_NOOP("Hotkeys", "System"),
 	TRANSLATE_NOOP("Hotkeys", "Toggle Input Recording Mode"), [](s32 pressed) {
 		if (!pressed && VMManager::HasValidVM())
 			g_InputRecording.getControls().toggleRecordMode();
+	}
+DEFINE_HOTKEY("SwapMemCard", TRANSLATE_NOOP("Hotkeys", "System"),
+	TRANSLATE_NOOP("Hotkeys", "Swap Memory Card"), [](s32 pressed) {
+	if (!pressed && VMManager::HasValidVM())
+		g_InputRecording.getControls().requestSwapCards();
 	})
 
 DEFINE_HOTKEY("PreviousSaveStateSlot", TRANSLATE_NOOP("Hotkeys", "Save States"),

--- a/pcsx2/Hotkeys.cpp
+++ b/pcsx2/Hotkeys.cpp
@@ -11,6 +11,7 @@
 #include "Recording/InputRecording.h"
 #include "SPU2/spu2.h"
 #include "VMManager.h"
+#include "pcsx2-qt/Settings/MemoryCardSettingsWidget.h"
 
 #include "common/Assertions.h"
 #include "common/FileSystem.h"

--- a/pcsx2/Hotkeys.cpp
+++ b/pcsx2/Hotkeys.cpp
@@ -226,7 +226,7 @@ DEFINE_HOTKEY("InputRecToggleMode", TRANSLATE_NOOP("Hotkeys", "System"),
 DEFINE_HOTKEY("SwapMemCard", TRANSLATE_NOOP("Hotkeys", "System"),
 	TRANSLATE_NOOP("Hotkeys", "Swap Memory Card"), [](s32 pressed) {
 		if (!pressed && VMManager::HasValidVM())
-			g_InputRecording.getControls().requestSwapCards();
+			MemoryCardSettingsWidget.getControls().requestSwapCards();
 	})
 
 DEFINE_HOTKEY("PreviousSaveStateSlot", TRANSLATE_NOOP("Hotkeys", "Save States"),

--- a/pcsx2/Hotkeys.cpp
+++ b/pcsx2/Hotkeys.cpp
@@ -222,11 +222,11 @@ DEFINE_HOTKEY("InputRecToggleMode", TRANSLATE_NOOP("Hotkeys", "System"),
 	TRANSLATE_NOOP("Hotkeys", "Toggle Input Recording Mode"), [](s32 pressed) {
 		if (!pressed && VMManager::HasValidVM())
 			g_InputRecording.getControls().toggleRecordMode();
-	}
+	})
 DEFINE_HOTKEY("SwapMemCard", TRANSLATE_NOOP("Hotkeys", "System"),
 	TRANSLATE_NOOP("Hotkeys", "Swap Memory Card"), [](s32 pressed) {
-	if (!pressed && VMManager::HasValidVM())
-		g_InputRecording.getControls().requestSwapCards();
+		if (!pressed && VMManager::HasValidVM())
+			g_InputRecording.getControls().requestSwapCards();
 	})
 
 DEFINE_HOTKEY("PreviousSaveStateSlot", TRANSLATE_NOOP("Hotkeys", "Save States"),

--- a/pcsx2/Hotkeys.cpp
+++ b/pcsx2/Hotkeys.cpp
@@ -223,8 +223,8 @@ DEFINE_HOTKEY("InputRecToggleMode", TRANSLATE_NOOP("Hotkeys", "System"),
 		if (!pressed && VMManager::HasValidVM())
 			g_InputRecording.getControls().toggleRecordMode();
 	})
-DEFINE_HOTKEY("SwapMemCard", TRANSLATE_NOOP("Hotkeys", "System"),
-	TRANSLATE_NOOP("Hotkeys", "Swap Memory Card"), [](s32 pressed) {
+DEFINE_HOTKEY("SwapMemCards", TRANSLATE_NOOP("Hotkeys", "System"),
+	TRANSLATE_NOOP("Hotkeys", "Swap Memory Cards"), [](s32 pressed) {
 		if (!pressed && VMManager::HasValidVM())
 			MemoryCardSettingsWidget.getControls().requestSwapCards();
 	})


### PR DESCRIPTION
"Useful for users who share the same PC with another user and don't wanna risk losing any of your savefiles or getting them corrupted for whatever the reason (Kids lol).

This will help you assign a hotkey for Swapping Memory Cards on the fly!

I'm new to coding! Please leave your feedback! I didn't manage to run the local debug though, not sure why."

### Description of Changes

- Created field to assign a hotkey to swap memory cards

### Rationale behind Changes
- Allow users to change memory cards on the fly, which is really useful on shared machines where other users also plays on PCSX2.

### Suggested Testing Steps
- Nothing much to add besides trying to assign the hotkey for yourself and testing it on PS2 Bios Browser to check if they are being properly swapped.
