### PR TITLE
GS/Metal: Struct member 'GSMTLMainPSUniform::alpha_fix' is never used

### DIFF
--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -2064,7 +2064,6 @@ static_assert(offsetof(GSHWDrawConfig::PSConstantBuffer, FogColor_AREF.a)  == of
 static_assert(offsetof(GSHWDrawConfig::PSConstantBuffer, WH)               == offsetof(GSMTLMainPSUniform, wh));
 static_assert(offsetof(GSHWDrawConfig::PSConstantBuffer, TA_MaxDepth_Af.x) == offsetof(GSMTLMainPSUniform, ta));
 static_assert(offsetof(GSHWDrawConfig::PSConstantBuffer, TA_MaxDepth_Af.z) == offsetof(GSMTLMainPSUniform, max_depth));
-static_assert(offsetof(GSHWDrawConfig::PSConstantBuffer, TA_MaxDepth_Af.w) == offsetof(GSMTLMainPSUniform, alpha_fix));
 static_assert(offsetof(GSHWDrawConfig::PSConstantBuffer, FbMask)           == offsetof(GSMTLMainPSUniform, fbmask));
 static_assert(offsetof(GSHWDrawConfig::PSConstantBuffer, HalfTexel)        == offsetof(GSMTLMainPSUniform, half_texel));
 static_assert(offsetof(GSHWDrawConfig::PSConstantBuffer, MinMax)           == offsetof(GSMTLMainPSUniform, uv_min_max));

--- a/pcsx2/GS/Renderers/Metal/GSMTLSharedHeader.h
+++ b/pcsx2/GS/Renderers/Metal/GSMTLSharedHeader.h
@@ -109,7 +109,6 @@ struct GSMTLMainPSUniform
 	vector_float4 wh; ///< xy => PS2, zw => actual (upscaled)
 	vector_float2 ta;
 	float max_depth;
-	float alpha_fix;
 	vector_uint4 fbmask;
 
 	vector_float4 half_texel;


### PR DESCRIPTION
### Description of Changes
Line removed in file `pcsx2/GS/Renderers/Metal/GSMTLSharedHeader.h`.

### Rationale behind Changes
Listed as a minor issue on Codacy; minorly reduces project size.

### Suggested Testing Steps
Test a few randomly selected games with the **Metal** renderer.