### PR TITLE
CI: Disable PCH for Linux AppImage builds

### DIFF
--- a/.github/workflows/linux_build_qt.yml
+++ b/.github/workflows/linux_build_qt.yml
@@ -140,9 +140,11 @@ jobs:
             -DCMAKE_CXX_COMPILER=clang++-17 \
             -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
             -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DENABLE_SETCAP=OFF \
             -DDISABLE_ADVANCE_SIMD=TRUE \
+            -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON \
             $ADDITIONAL_CMAKE_ARGS
 
       - name: Build PCSX2

--- a/pcsx2/CDVD/CDVDcommon.h
+++ b/pcsx2/CDVD/CDVDcommon.h
@@ -5,6 +5,7 @@
 
 #include "common/Pcsx2Defs.h"
 
+#include <array>
 #include <string>
 
 class Error;


### PR DESCRIPTION
### Description of Changes
Disable PCH on Linux AppImage builds.

### Rationale behind Changes
This allows us to better utilize ccache. The appimage builds are roughly 5 minutes faster (~7.30 to ~2.30 minutes)

Unfortunately I question if ccache is actually working properly with flatpak-builder. Disabling the PCH there did not exhibit any build time increase, so flatpak builds are going to be left as-is.