### PR TITLE
Core/Qt: Add hotkey support for swapping memory card

### DIFF
--- a/pcsx2/Hotkeys.cpp
+++ b/pcsx2/Hotkeys.cpp
@@ -11,6 +11,7 @@
 #include "Recording/InputRecording.h"
 #include "SPU2/spu2.h"
 #include "VMManager.h"
+#include "SIO/Memcard/MemoryCardFile.h"
 
 #include "common/Assertions.h"
 #include "common/FileSystem.h"
@@ -222,6 +223,11 @@ DEFINE_HOTKEY("InputRecToggleMode", TRANSLATE_NOOP("Hotkeys", "System"),
 	TRANSLATE_NOOP("Hotkeys", "Toggle Input Recording Mode"), [](s32 pressed) {
 		if (!pressed && VMManager::HasValidVM())
 			g_InputRecording.getControls().toggleRecordMode();
+	})
+DEFINE_HOTKEY("SwapMemCards", TRANSLATE_NOOP("Hotkeys", "System"),
+	TRANSLATE_NOOP("Hotkeys", "Swap Memory Cards"), [](s32 pressed) {
+		if (!pressed && VMManager::HasValidVM())
+			FileMcd_Swap();
 	})
 
 DEFINE_HOTKEY("PreviousSaveStateSlot", TRANSLATE_NOOP("Hotkeys", "Save States"),

--- a/pcsx2/SIO/Memcard/MemoryCardFile.h
+++ b/pcsx2/SIO/Memcard/MemoryCardFile.h
@@ -42,6 +42,7 @@ void FileMcd_EmuOpen();
 void FileMcd_EmuClose();
 void FileMcd_CancelEject();
 void FileMcd_Reopen(std::string new_serial);
+void FileMcd_Swap();
 s32 FileMcd_IsPresent(uint port, uint slot);
 void FileMcd_GetSizeInfo(uint port, uint slot, McdSizeInfo* outways);
 bool FileMcd_IsPSX(uint port, uint slot);


### PR DESCRIPTION
### Description of Changes

- Creates a core Swap Memory Card function.
- Add field to set a custom hotkey under Controllers>Hotkeys>to quickly swap memory cards.

### Rationale behind Changes

- Allow users to change memory cards on demand. This is really useful on shared machines, specially with kids around (Forget kids accidentally overwriting your save games with over 100 hours of gameplay!).
- By creating a memory card swap function in the core, we can now use it anywhere

### Suggested Testing Steps

- Make sure to create a backup of your memory card file/folder before testing, although there shouldn't be any issues what so ever.
- Having save files on the memory card will help testing as swaps will be more evident.
- Assign hotkey under Controllers>Hotkeys>Swap Memory Cards and test while on BIOS Browser or in game.
- Try pressing the hotkey while on different stages of active/inactive memory card and compare results. 

Special thanks to @kamfretoz , @RedDevilus , @RedPanda4552 , and @Mrlinkwii for the feedback, suggestions and troubleshooting! Everyone in Discord was really helpful! Thank you!

Edit 1: Added extra steps for testing for extra safety checks.