### PR TITLE
GitHub: Require PR authors to disclose AI usage

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,3 +6,9 @@
 
 ### Suggested Testing Steps
 <!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
+
+### Did you use AI to help find, test, or implement this issue or feature?
+<!-- Insert an X in one of the boxes. This is a required field. -->
+- [ ] No, I did not use AI.
+
+- [ ] Yes (please explain briefly):


### PR DESCRIPTION
### Description of Changes
Add a "Did you use AI blah blah blah" disclosure question for PR authors to answer.

I want this to be a little bit of an RFC. Does anyone else agree / disagree?

### Rationale behind Changes
Unfortunately open source seems to be experiencing a increasingly common pattern of AI slop in many forms. Such as [bogus CVE reports](https://daniel.haxx.se/blog/2023/09/05/bogus-cve-follow-ups/) and [pull requests](https://github.com/PCSX2/pcsx2/pull/11825#issuecomment-2366845879). Avoiding the politics involved with its usage, it's just incredibly time consuming for us when it's used improperly. It would be nice to know when to put on my BS glasses.