### PR TITLE
GS: Add gamma control to ShadeBoost

### DIFF
--- a/bin/resources/shaders/dx11/shadeboost.fx
+++ b/bin/resources/shaders/dx11/shadeboost.fx
@@ -21,6 +21,7 @@ float4 ContrastSaturationBrightness(float4 color) // Ported to HLSL
 	float brt = params.x;
 	float con = params.y;
 	float sat = params.z;
+	float gam = params.w;
 	
 	// Increase or decrease these values to adjust r, g and b color channels separately
 	const float AvgLumR = 0.5;
@@ -34,8 +35,10 @@ float4 ContrastSaturationBrightness(float4 color) // Ported to HLSL
 	float3 intensity = dot(brtColor, LumCoeff);
 	float3 satColor = lerp(intensity, brtColor, sat);
 	float3 conColor = lerp(AvgLumin, satColor, con);
-
-	color.rgb = conColor;	
+	
+	float3 csb = conColor;
+	csb = pow(csb, 1.0 / gam);
+	color.rgb = csb;
 	return color;
 }
 

--- a/bin/resources/shaders/opengl/shadeboost.glsl
+++ b/bin/resources/shaders/opengl/shadeboost.glsl
@@ -30,6 +30,7 @@ vec4 ContrastSaturationBrightness(vec4 color)
 	float brt = params.x;
 	float con = params.y;
 	float sat = params.z;
+	float gam = params.w;
 
 	// Increase or decrease these values to adjust r, g and b color channels separately
 	const float AvgLumR = 0.5;
@@ -45,7 +46,10 @@ vec4 ContrastSaturationBrightness(vec4 color)
 	vec3 satColor = mix(intensity, brtColor, sat);
 	vec3 conColor = mix(AvgLumin, satColor, con);
 
-	color.rgb = conColor;
+	vec3 csb = conColor;
+	csb = pow(csb, vec3(1.0 / gam));
+	color.rgb = csb;
+
 	return color;
 }
 

--- a/bin/resources/shaders/vulkan/shadeboost.glsl
+++ b/bin/resources/shaders/vulkan/shadeboost.glsl
@@ -44,6 +44,7 @@ vec4 ContrastSaturationBrightness(vec4 color)
     float brt = params.x;
     float con = params.y;
     float sat = params.z;
+    float gam = params.w;
 
     // Increase or decrease these values to adjust r, g and b color channels separately
     const float AvgLumR = 0.5;
@@ -59,7 +60,9 @@ vec4 ContrastSaturationBrightness(vec4 color)
     vec3 satColor = mix(intensity, brtColor, sat);
     vec3 conColor = mix(AvgLumin, satColor, con);
 
-    color.rgb = conColor;
+    vec3 csb = conColor;
+    csb = pow(csb, vec3(1.0 / gam));
+    color.rgb = csb;
     return color;
 }
 

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -135,6 +135,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.shadeBoost, "EmuCore/GS", "ShadeBoost", false);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.shadeBoostBrightness, "EmuCore/GS", "ShadeBoost_Brightness", false);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.shadeBoostContrast, "EmuCore/GS", "ShadeBoost_Contrast", false);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.shadeBoostGamma, "EmuCore/GS", "ShadeBoost_Gamma", false);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.shadeBoostSaturation, "EmuCore/GS", "ShadeBoost_Saturation", false);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.tvShader, "EmuCore/GS", "TVShader", DEFAULT_TV_SHADER_MODE);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.casMode, "EmuCore/GS", "CASMode", static_cast<int>(GSCASMode::Disabled));
@@ -723,6 +724,8 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 
 		dialog->registerWidgetHelp(m_ui.shadeBoostContrast, tr("Contrast"), tr("50"), tr("Adjusts contrast. 50 is normal."));
 
+		dialog->registerWidgetHelp(m_ui.shadeBoostGamma, tr("Gamma"), tr("50"), tr("Adjusts gamma. 50 is normal."));
+
 		dialog->registerWidgetHelp(m_ui.shadeBoostSaturation, tr("Saturation"), tr("50"), tr("Adjusts saturation. 50 is normal."));
 
 		dialog->registerWidgetHelp(m_ui.tvShader, tr("TV Shader"), tr("None (Default)"),
@@ -934,6 +937,7 @@ void GraphicsSettingsWidget::onShadeBoostChanged()
 	const bool enabled = m_dialog->getEffectiveBoolValue("EmuCore/GS", "ShadeBoost", false);
 	m_ui.shadeBoostBrightness->setEnabled(enabled);
 	m_ui.shadeBoostContrast->setEnabled(enabled);
+	m_ui.shadeBoostGamma->setEnabled(enabled);
 	m_ui.shadeBoostSaturation->setEnabled(enabled);
 }
 

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -1434,6 +1434,23 @@
              </widget>
             </item>
             <item>
+             <widget class="QLabel" name="gammaLabel">
+              <property name="text">
+               <string>Gamma:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="shadeBoostGamma">
+              <property name="minimum">
+               <number>1</number>
+              </property>
+              <property name="maximum">
+               <number>100</number>
+              </property>
+             </widget>
+            </item>
+            <item>
              <widget class="QLabel" name="saturationLabel">
               <property name="text">
                <string>Saturation:</string>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -839,6 +839,7 @@ struct Pcsx2Config
 		u8 ShadeBoost_Brightness = 50;
 		u8 ShadeBoost_Contrast = 50;
 		u8 ShadeBoost_Saturation = 50;
+		u8 ShadeBoost_Gamma = 50;
 		u8 PNGCompressionLevel = 1;
 
 		u16 SWExtraThreads = 2;

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -835,6 +835,7 @@ void GSDevice::ShadeBoost()
 			static_cast<float>(GSConfig.ShadeBoost_Brightness) * (1.0f / 50.0f),
 			static_cast<float>(GSConfig.ShadeBoost_Contrast) * (1.0f / 50.0f),
 			static_cast<float>(GSConfig.ShadeBoost_Saturation) * (1.0f / 50.0f),
+			static_cast<float>(GSConfig.ShadeBoost_Gamma) * (1.0f / 50.0f),
 		};
 
 		DoShadeBoost(m_current, m_target_tmp, params);

--- a/pcsx2/GS/Renderers/Metal/convert.metal
+++ b/pcsx2/GS/Renderers/Metal/convert.metal
@@ -527,11 +527,12 @@ fragment half4 ps_imgui(ImGuiShaderData data [[stage_in]], texture2d<half> textu
 	return data.c * texture.sample(s, data.t);
 }
 
-fragment float4 ps_shadeboost(float4 p [[position]], DirectReadTextureIn<float> tex, constant float3& cb [[buffer(GSMTLBufferIndexUniforms)]])
+fragment float4 ps_shadeboost(float4 p [[position]], DirectReadTextureIn<float> tex, constant float4& cb [[buffer(GSMTLBufferIndexUniforms)]])
 {
 	const float brt = cb.x;
 	const float con = cb.y;
 	const float sat = cb.z;
+	const float gam = cb.w;
 	// Increase or decrease these values to adjust r, g and b color channels separately
 	const float AvgLumR = 0.5;
 	const float AvgLumG = 0.5;
@@ -546,5 +547,7 @@ fragment float4 ps_shadeboost(float4 p [[position]], DirectReadTextureIn<float> 
 	float3 satColor = mix(intensity, brtColor, sat);
 	float3 conColor = mix(AvgLumin, satColor, con);
 
-	return float4(conColor, 1);
+	float3 csb = pow(conColor, float3(1.0 / gam));
+
+	return float4(csb, 1);
 }

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -4409,12 +4409,14 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 	{
 		const bool shadeboost_active = GetEffectiveBoolSetting(bsi, "EmuCore/GS", "ShadeBoost", false);
 
-		DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_GEM, "Shade Boost"), FSUI_CSTR("Enables brightness/contrast/saturation adjustment."), "EmuCore/GS",
+		DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_GEM, "Shade Boost"), FSUI_CSTR("Enables brightness/contrast/gamma/saturation adjustment."), "EmuCore/GS",
 			"ShadeBoost", false);
 		DrawIntRangeSetting(bsi, FSUI_ICONSTR(ICON_FA_SUN, "Shade Boost Brightness"), FSUI_CSTR("Adjusts brightness. 50 is normal."), "EmuCore/GS",
 			"ShadeBoost_Brightness", 50, 1, 100, "%d", shadeboost_active);
 		DrawIntRangeSetting(bsi, FSUI_ICONSTR(ICON_FA_LIGHTBULB, "Shade Boost Contrast"), FSUI_CSTR("Adjusts contrast. 50 is normal."), "EmuCore/GS",
 			"ShadeBoost_Contrast", 50, 1, 100, "%d", shadeboost_active);
+		DrawIntRangeSetting(bsi, FSUI_CSTR("Shade Boost Gamma"), FSUI_CSTR("Adjusts gamma. 50 is normal."), "EmuCore/GS",
+			"ShadeBoost_Gamma", 50, 1, 100, "%d", shadeboost_active);
 		DrawIntRangeSetting(bsi, FSUI_ICONSTR(ICON_FA_DROPLET, "Shade Boost Saturation"), FSUI_CSTR("Adjusts saturation. 50 is normal."), "EmuCore/GS",
 			"ShadeBoost_Saturation", 50, 1, 100, "%d", shadeboost_active);
 

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -850,6 +850,7 @@ bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 		OpEqu(ShadeBoost_Brightness) &&
 		OpEqu(ShadeBoost_Contrast) &&
 		OpEqu(ShadeBoost_Saturation) &&
+		OpEqu(ShadeBoost_Gamma) &&
 		OpEqu(PNGCompressionLevel) &&
 		OpEqu(SaveDrawStart) &&
 		OpEqu(SaveDrawCount) &&
@@ -1041,6 +1042,7 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitfield(ShadeBoost_Brightness);
 	SettingsWrapBitfield(ShadeBoost_Contrast);
 	SettingsWrapBitfield(ShadeBoost_Saturation);
+	SettingsWrapBitfield(ShadeBoost_Gamma);
 	SettingsWrapBitfield(ExclusiveFullscreenControl);
 	SettingsWrapBitfieldEx(PNGCompressionLevel, "png_compression_level");
 	SettingsWrapBitfieldEx(SaveDrawStart, "SaveDrawStart");

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 69;
+static constexpr u32 SHADER_CACHE_VERSION = 70;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
- Add a Gamma parameter to ShadeBoost shaders (OpenGL & Vulkan).
- Expose a Gamma slider in the Qt Graphics Settings and the fullscreen in-game menu.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Gamma control lets users adjust mid-tones independently of brightness/contrast/saturation. Fulfills feature request #12515.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
- Open PCSX2.
- Emulate a game.
- Open graphics settings.
- Go to Postprocessing.
- Adjust Gamma as you see fit.