### PR TITLE
GS/HW: Combine target using the drawn area, not valid area

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3264,8 +3264,6 @@ void GSRendererHW::Draw()
 				const GSVector4i new_drect = GSVector4i(0, new_offset * rt->m_scale, new_size.x * rt->m_scale, new_size.y * rt->m_scale);
 				rt->ResizeTexture(new_size.x, new_size.y, true, true, new_drect);
 
-				g_texture_cache->CombineAlignedInsideTargets(rt, src);
-
 				if (src && src->m_from_target && src->m_from_target == rt && src->m_target_direct)
 				{
 					src->m_texture = rt->m_texture;
@@ -3282,6 +3280,8 @@ void GSRendererHW::Draw()
 				rt->m_valid.w += new_offset;
 				rt->m_drawn_since_read.y += new_offset;
 				rt->m_drawn_since_read.w += new_offset;
+
+				g_texture_cache->CombineAlignedInsideTargets(rt, src);
 
 				if (rt->m_dirty.size())
 				{


### PR DESCRIPTION
### Description of Changes
When combining targets used the drawn area not the valid area.

### Rationale behind Changes
Valid area can be garbage if the target is preloaded from GS memory but only draws a tiny bit, then if it's combined in to another target, it could destroy perfectly valid data.

### Suggested Testing Steps
Test Valkyrie Profile 2

Fixes some glitching with Valkyrie Profile 2 (mostly single frames)

Master:
![image](https://github.com/user-attachments/assets/edf8bcf0-ed1f-46cd-89c4-4eb82be71838)
PR:
![image](https://github.com/user-attachments/assets/cb741755-1aee-4832-b481-371d019e026f)

Master:
![image](https://github.com/user-attachments/assets/5df63efc-5642-4450-bdce-7359abbc43e5)
PR:
![image](https://github.com/user-attachments/assets/9474fb64-6b1c-40f6-897a-052223c8e79c)
