### PR TITLE
CMake: Widen the range of configurations that can be imported with a Devel build

### DIFF
--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -64,7 +64,8 @@ set(CMAKE_SHARED_LINKER_FLAGS_DEVEL "${CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO}
 	CACHE STRING "Flags used for linking shared libraries during development builds" FORCE)
 set(CMAKE_EXE_LINKER_FLAGS_DEVEL "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO}"
 	CACHE STRING "Flags used for linking executables during development builds" FORCE)
-set(CMAKE_MAP_IMPORTED_CONFIG_DEVEL "RelWithDebInfo" "Release" ""
+# Exclude Debug from the configurations we can import from
+set(CMAKE_MAP_IMPORTED_CONFIG_DEVEL "RelWithDebInfo" "Release" "MinSizeRel" "None" "NoConfig" ""
 	CACHE STRING "Configurations used when importing packages for development builds" FORCE)
 if(CMAKE_CONFIGURATION_TYPES)
 	list(INSERT CMAKE_CONFIGURATION_TYPES 0 Devel)


### PR DESCRIPTION
### Description of Changes
Widen the range of configurations that can be imported with a Devel build

### Rationale behind Changes
Arch likes to build packages with `CMAKE_BUILD_TYPE=None` because they don't want to build with `-O3` (which apparently is the default for CMake release builds).

The `CMAKE_MAP_IMPORTED_CONFIG_DEVEL` I added to avoid linking to debug libraries didn't factor this in.

While I'm at it, also add in `MinSizeRel` (which I missed) and `NoConfig` (`CMAKE_BUILD_TYPE=""`), since they link against the release runtime.

### Suggested Testing Steps
Build a dependency using a `CMAKE_BUILD_TYPE` such as `RelWithDebInfo/Release/None/""`
See if the project configures

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Insert an X in one of the boxes. This is a required field. -->
- [X] No, I did not use AI.

- [ ] Yes (please explain briefly):
