### PR TITLE
GS/HW: Fix texture copies when tex is fb draw, backport missing tex is fb shaders to gl/dx.

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -397,7 +397,11 @@ float4 fetch_raw_color(int2 xy)
 
 float4 fetch_c(int2 uv)
 {
+#if PS_TEX_IS_FB == 1
+	return RtTexture.Load(int3(uv, 0));
+#else
 	return Texture.Load(int3(uv, 0));
+#endif
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -330,7 +330,11 @@ vec4 fetch_raw_color()
 
 vec4 fetch_c(ivec2 uv)
 {
+#if PS_TEX_IS_FB == 1
+	return sample_from_rt();
+#else
 	return texelFetch(TextureSampler, ivec2(uv), 0);
+#endif
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -6507,8 +6507,7 @@ __ri void GSRendererHW::HandleTextureHazards(const GSTextureCache::Target* rt, c
 
 	src_copy.reset(src_target->m_texture->IsDepthStencil() ?
 				   g_gs_device->CreateDepthStencil(scaled_copy_size.x, scaled_copy_size.y, src_target->m_texture->GetFormat(), false) :
-					   (m_downscale_source || copied_rt) ? g_gs_device->CreateRenderTarget(scaled_copy_size.x, scaled_copy_size.y, src_target->m_texture->GetFormat(), true, true) : 
-															g_gs_device->CreateTexture(scaled_copy_size.x, scaled_copy_size.y, 1, src_target->m_texture->GetFormat(), true));
+					   g_gs_device->CreateRenderTarget(scaled_copy_size.x, scaled_copy_size.y, src_target->m_texture->GetFormat(), true, true));
 	if (!src_copy) [[unlikely]]
 	{
 		Console.Error("HW: Failed to allocate %dx%d texture for hazard copy", scaled_copy_size.x, scaled_copy_size.y);
@@ -6548,8 +6547,20 @@ __ri void GSRendererHW::HandleTextureHazards(const GSTextureCache::Target* rt, c
 	}
 	else
 	{
-		g_gs_device->CopyRect(
-			src_target->m_texture, src_copy.get(), scaled_copy_range, scaled_copy_dst_offset.x, scaled_copy_dst_offset.y);
+		g_perfmon.Put(GSPerfMon::TextureCopies, 1);
+		const GSVector4i offset = copy_range - GSVector4i(copy_dst_offset).xyxy();
+
+		// Adjust for bilinear, must be done after calculating offset.
+		copy_range.x -= 1;
+		copy_range.y -= 1;
+		copy_range.z += 1;
+		copy_range.w += 1;
+		copy_range = copy_range.rintersect(src_bounds);
+
+		const GSVector4 src_rect = GSVector4(copy_range) / GSVector4(src_unscaled_size).xyxy();
+		const GSVector4 dst_rect = (GSVector4(copy_range) - GSVector4(offset).xyxy()) * scale;
+		g_gs_device->StretchRect(src_target->m_texture, src_rect, src_copy.get(), dst_rect,
+			src_target->m_texture->IsDepthStencil() ? ShaderConvert::DEPTH_COPY : ShaderConvert::COPY, false);
 	}
 	m_conf.tex = src_copy.get();
 }

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -613,7 +613,7 @@ void FullscreenUI::ApplyLayoutSettings(const SettingsInterface* bsi)
 
 	const InputLayout layout = ImGuiFullscreen::GetGamepadLayout();
 
-	if (sdl2_nintendo_mode == "true" || (sdl2_nintendo_mode == "auto") && layout == InputLayout::Nintendo)
+	if ((sdl2_nintendo_mode == "true" || sdl2_nintendo_mode == "auto") && layout == InputLayout::Nintendo)
 	{
 		// Apply
 		ImGuiManager::SwapGamepadNorthWest(true);

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 64;
+static constexpr u32 SHADER_CACHE_VERSION = 65;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/HW: Fix texture copies when tex is fb draw. 
Fixes an issue with texture copies didn't work properly on tex is fb draw: Fixes Hitman Blood Money on minimum blend. DX can't do partial depth copy so do a shader based copy which works.
Fixes a bunch of games that couldn't do partial depth copy on dx.

GS/HW: Backport some tex is fb shaders to dx and opengl.

Bonus unrelated: FullscreenUI: Fix -Wlogical-op-parentheses warning. 
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Accuracy, bugfixes.
Fixes https://github.com/PCSX2/pcsx2/issues/12309
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Dump run is ok for both dx11, vk and gl.
Test mentioned games on mentioned renderers, test other stuff on all hw renderers too.
Test Hitman on minimum and basic blend, test the other games on basic blend or whatever they use, make sure nothing broke on all hw renderers.
VK fixes:
Hitman Blood Money with minimum blend:
Master:
![image](https://github.com/user-attachments/assets/f0a84332-5d4e-4ef4-95ee-9f03b3a67010)
PR:
![image](https://github.com/user-attachments/assets/e4f53a03-dc89-4b30-92df-e277be4309e4)

DX Fixes:
![image](https://github.com/user-attachments/assets/260b7e1f-98e6-4cd2-8ab0-f1c931cedfaa)
![image](https://github.com/user-attachments/assets/2ec92ea3-1b3d-45c0-8a72-fbb308fd9bd5)
![image](https://github.com/user-attachments/assets/04660496-3c0a-4de5-8f05-4ab12b9a7fbc)
![image](https://github.com/user-attachments/assets/87836e77-560b-4e6a-ab09-53cb15301050)

Death by Degrees master, needs medium blend:
![image](https://github.com/user-attachments/assets/18925a31-529c-488f-826d-c6a5246095ab)
PR:
![image](https://github.com/user-attachments/assets/67c5b0b1-6f58-4cc9-b58a-4c7bcec6d349)
