### PR TITLE
GS/HW: Enable feedback loop if channel shuffle enabled barriers.

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -372,6 +372,7 @@ struct alignas(16) GSHWDrawConfig
 
 				// Others ways to fetch the texture
 				u32 channel : 3;
+				u32 channel_fb : 1;
 
 				// Dithering
 				u32 dither : 2;
@@ -410,7 +411,7 @@ struct alignas(16) GSHWDrawConfig
 		{
 			const u32 sw_blend_bits = blend_a | blend_b | blend_d;
 			const bool sw_blend_needs_rt = (sw_blend_bits != 0 && ((sw_blend_bits | blend_c) & 1u)) || ((a_masked & blend_c) != 0);
-			return tex_is_fb || fbmask || (date > 0 && date != 3) || sw_blend_needs_rt;
+			return channel_fb || tex_is_fb || fbmask || (date > 0 && date != 3) || sw_blend_needs_rt;
 		}
 
 		/// Disables color output from the pixel shader, this is done when all channels are masked.

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5030,6 +5030,8 @@ __ri bool GSRendererHW::EmulateChannelShuffle(GSTextureCache::Target* src, bool 
 		// Hitman suffers from this, not sure on the exact scenario at the moment, but we need the barrier.
 		if (PRIM->ABE && m_context->ALPHA.IsCdInBlend())
 		{
+			// Needed to enable IsFeedbackLoop.
+			m_conf.ps.channel_fb = 1;
 			// Assume no overlap when it's a channel shuffle, no need for full barriers.
 			m_conf.require_one_barrier = true;
 		}


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/HW: Enable feedback loop if channel shuffle enabled barriers.
Need to make sure to enable feedback loop if barriers got enabled on a channel shuffle draw, was mostly an issue on minimum blending on Hitman Blood Money.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Bugfix, yes another Hitman fix.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test Hitman Blood Money on Minimum blend, smoke test some other games maybe?
