### PR TITLE
Core:macOS: Initialize all address variables passed to vm_map

### DIFF
--- a/common/Darwin/DarwinMisc.cpp
+++ b/common/Darwin/DarwinMisc.cpp
@@ -437,7 +437,7 @@ std::unique_ptr<SharedMemoryMappingArea> SharedMemoryMappingArea::Create(size_t 
 {
 	pxAssertRel(Common::IsAlignedPow2(size, __pagesize), "Size is page aligned");
 
-	mach_vm_address_t alloc;
+	mach_vm_address_t alloc = 0;
 	const kern_return_t res =
 		mach_vm_map(mach_task_self(), &alloc, size, 0, VM_FLAGS_ANYWHERE,
 			MEMORY_OBJECT_NULL, 0, false, VM_PROT_NONE, VM_PROT_NONE, VM_INHERIT_NONE);


### PR DESCRIPTION
### Description of Changes
vm_map reads the address you pass it, so we need to initialize it.
Dolphin had a similar issue that they just fixed: https://github.com/dolphin-emu/dolphin/pull/13521

IDK if this affected anyone in release builds, but it definitely affected my debug builds

### Rationale behind Changes
Less broken

### Suggested Testing Steps
Open PCSX2 and check if it complains about failing to allocate memory
Might help with #11728

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Insert an X in one of the boxes. This is a required field. -->
- [x] No, I did not use AI.

- [ ] Yes (please explain briefly):
