### PR TITLE
Debugger: Make some more strings translatable

### DIFF
--- a/pcsx2-qt/Debugger/Docking/DockManager.cpp
+++ b/pcsx2-qt/Debugger/Docking/DockManager.cpp
@@ -209,7 +209,7 @@ void DockManager::loadLayouts()
 					break;
 				}
 
-				new_name = QString("%1 #%2").arg(name).arg(i);
+				new_name = tr("%1 #%2").arg(name).arg(i);
 			}
 		}
 

--- a/pcsx2-qt/Debugger/Docking/DockMenuBar.cpp
+++ b/pcsx2-qt/Debugger/Docking/DockMenuBar.cpp
@@ -87,7 +87,7 @@ void DockMenuBar::updateLayoutSwitcher(DockLayout::Index current_index, const st
 	for (const DockLayout& layout : layouts)
 	{
 		const char* cpu_name = DebugInterface::cpuName(layout.cpu());
-		QString tab_name = QString("%1 (%2)").arg(layout.name()).arg(cpu_name);
+		QString tab_name = tr("%1 (%2)").arg(layout.name()).arg(cpu_name);
 		m_layout_switcher->addTab(tab_name);
 	}
 

--- a/pcsx2-qt/Debugger/Docking/DockViews.cpp
+++ b/pcsx2-qt/Debugger/Docking/DockViews.cpp
@@ -233,7 +233,7 @@ void DockTabBar::openContextMenu(QPoint pos)
 	{
 		const char* long_cpu_name = DebugInterface::longCpuName(cpu);
 		const char* cpu_name = DebugInterface::cpuName(cpu);
-		QString text = QString("%1 (%2)").arg(long_cpu_name).arg(cpu_name);
+		QString text = tr("%1 (%2)").arg(long_cpu_name).arg(cpu_name);
 
 		QAction* cpu_action = set_target_menu->addAction(text);
 		cpu_action->setCheckable(true);

--- a/pcsx2-qt/Debugger/Docking/LayoutEditorDialog.cpp
+++ b/pcsx2-qt/Debugger/Docking/LayoutEditorDialog.cpp
@@ -64,7 +64,7 @@ void LayoutEditorDialog::setupInputWidgets(BreakPointCpu cpu, bool can_clone_cur
 	{
 		const char* long_cpu_name = DebugInterface::longCpuName(cpu);
 		const char* cpu_name = DebugInterface::cpuName(cpu);
-		QString text = QString("%1 (%2)").arg(long_cpu_name).arg(cpu_name);
+		QString text = tr("%1 (%2)").arg(long_cpu_name).arg(cpu_name);
 		m_ui.cpuEditor->addItem(text, cpu);
 	}
 

--- a/pcsx2-qt/Debugger/SymbolTree/NewSymbolDialogs.cpp
+++ b/pcsx2-qt/Debugger/SymbolTree/NewSymbolDialogs.cpp
@@ -242,7 +242,7 @@ u32 NewSymbolDialog::parseAddress(QString& error_message)
 NewFunctionDialog::NewFunctionDialog(DebugInterface& cpu, QWidget* parent)
 	: NewSymbolDialog(GLOBAL_STORAGE | SIZE_FIELD | EXISTING_FUNCTIONS_FIELD, 4, cpu, parent)
 {
-	setWindowTitle("New Function");
+	setWindowTitle(tr("New Function"));
 
 	m_ui.customSizeSpinBox->setValue(8);
 }
@@ -367,7 +367,7 @@ void NewFunctionDialog::createSymbol()
 NewGlobalVariableDialog::NewGlobalVariableDialog(DebugInterface& cpu, QWidget* parent)
 	: NewSymbolDialog(GLOBAL_STORAGE | TYPE_FIELD, 1, cpu, parent)
 {
-	setWindowTitle("New Global Variable");
+	setWindowTitle(tr("New Global Variable"));
 }
 
 bool NewGlobalVariableDialog::parseUserInput()
@@ -424,7 +424,7 @@ void NewGlobalVariableDialog::createSymbol()
 NewLocalVariableDialog::NewLocalVariableDialog(DebugInterface& cpu, QWidget* parent)
 	: NewSymbolDialog(GLOBAL_STORAGE | REGISTER_STORAGE | STACK_STORAGE | TYPE_FIELD | FUNCTION_FIELD, 1, cpu, parent)
 {
-	setWindowTitle("New Local Variable");
+	setWindowTitle(tr("New Local Variable"));
 }
 
 bool NewLocalVariableDialog::parseUserInput()
@@ -542,7 +542,7 @@ void NewLocalVariableDialog::createSymbol()
 NewParameterVariableDialog::NewParameterVariableDialog(DebugInterface& cpu, QWidget* parent)
 	: NewSymbolDialog(REGISTER_STORAGE | STACK_STORAGE | TYPE_FIELD | FUNCTION_FIELD, 1, cpu, parent)
 {
-	setWindowTitle("New Parameter Variable");
+	setWindowTitle(tr("New Parameter Variable"));
 }
 
 bool NewParameterVariableDialog::parseUserInput()

--- a/pcsx2-qt/Debugger/SymbolTree/TypeString.cpp
+++ b/pcsx2-qt/Debugger/SymbolTree/TypeString.cpp
@@ -38,7 +38,7 @@ std::unique_ptr<ccc::ast::Node> stringToType(std::string_view string, const ccc:
 		s32 element_count = atoi(&string[j]);
 		if (element_count < 0 || element_count > 1024 * 1024)
 		{
-			error_out = QCoreApplication::tr("Invalid array subscript.");
+			error_out = QCoreApplication::translate("TypeString", "Invalid array subscript.");
 			return nullptr;
 		}
 
@@ -51,7 +51,7 @@ std::unique_ptr<ccc::ast::Node> stringToType(std::string_view string, const ccc:
 	std::string type_name_string(string.data(), string.data() + i);
 	if (type_name_string.empty())
 	{
-		error_out = QCoreApplication::tr("No type name provided.");
+		error_out = QCoreApplication::translate("TypeString", "No type name provided.");
 		return nullptr;
 	}
 
@@ -59,7 +59,7 @@ std::unique_ptr<ccc::ast::Node> stringToType(std::string_view string, const ccc:
 	const ccc::DataType* data_type = database.data_types.symbol_from_handle(handle);
 	if (!data_type || !data_type->type())
 	{
-		error_out = QCoreApplication::tr("Type '%1' not found.").arg(QString::fromStdString(type_name_string));
+		error_out = QCoreApplication::translate("TypeString", "Type '%1' not found.").arg(QString::fromStdString(type_name_string));
 		return nullptr;
 	}
 


### PR DESCRIPTION
### Description of Changes
Make some more strings translatable, and add a type name to the type string error messages.

### Rationale behind Changes
Some of these cases are obvious, for some of them I thought it wouldn't be required when originally writing the code, but I didn't consider some cases e.g. right to left languages, in which case I think translating these could still be useful.

### Suggested Testing Steps
N/A

### Did you use AI to help find, test, or implement this issue or feature?
No.