### PR TITLE
GS/HW: Fix some regressions relating to overlapping targets

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -13656,6 +13656,7 @@ SLED-53440:
   name: "Area 51"
   region: "PAL-Unk"
   gsHWFixes:
+    textureInsideRT: 1 # Fixes shadows in some scenarios.
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects, needs Special otherwise lights flicker.
     nativeScaling: 2 # Fixes lights.
 SLED-53442:
@@ -20228,6 +20229,7 @@ SLES-52570:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
+    textureInsideRT: 1 # Fixes shadows in some scenarios.
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects, needs Special otherwise lights flicker.
     nativeScaling: 2 # Fixes lights.
 SLES-52571:
@@ -21857,6 +21859,7 @@ SLES-53075:
   name: "Area 51"
   region: "PAL-M5"
   gsHWFixes:
+    textureInsideRT: 1 # Fixes shadows in some scenarios.
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects, needs Special otherwise lights flicker.
     nativeScaling: 2 # Fixes lights.
 SLES-53076:
@@ -48415,6 +48418,7 @@ SLPM-66468:
   name-en: "Area 51"
   region: "NTSC-J"
   gsHWFixes:
+    textureInsideRT: 1 # Fixes shadows in some scenarios.
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects, needs Special otherwise lights flicker.
     nativeScaling: 2 # Fixes lights.
 SLPM-66469:
@@ -65100,6 +65104,7 @@ SLUS-20595:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
+    textureInsideRT: 1 # Fixes shadows in some scenarios.
     halfPixelOffset: 2 # Fixes misaligned lighting and other effects, needs Special otherwise lights flicker.
     nativeScaling: 2 # Fixes lights.
 SLUS-20596:

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -28947,6 +28947,7 @@ SLES-55349:
   region: "PAL-E"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
+    textureInsideRT: 1 # Fixes sun glare.
     halfPixelOffset: 2 # Fixes blurriness.
     bilinearUpscale: 2 # Fixes sun glare textures.
     gpuTargetCLUT: 1 # Fixes sun penetration.
@@ -28969,6 +28970,7 @@ SLES-55350:
   region: "PAL-F-G"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
+    textureInsideRT: 1 # Fixes sun glare.
     halfPixelOffset: 2 # Fixes blurriness.
     bilinearUpscale: 2 # Fixes sun glare textures.
     gpuTargetCLUT: 1 # Fixes sun penetration.
@@ -28991,6 +28993,7 @@ SLES-55351:
   region: "PAL-I-S"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
+    textureInsideRT: 1 # Fixes sun glare.
     halfPixelOffset: 2 # Fixes blurriness.
     bilinearUpscale: 2 # Fixes sun glare textures.
     gpuTargetCLUT: 1 # Fixes sun penetration.
@@ -29014,6 +29017,7 @@ SLES-55352:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
+    textureInsideRT: 1 # Fixes sun glare.
     halfPixelOffset: 2 # Fixes blurriness.
     bilinearUpscale: 2 # Fixes sun glare textures.
     gpuTargetCLUT: 1 # Fixes sun penetration.
@@ -29036,6 +29040,7 @@ SLES-55353:
   region: "PAL-M6"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
+    textureInsideRT: 1 # Fixes sun glare.
     halfPixelOffset: 2 # Fixes blurriness.
     bilinearUpscale: 2 # Fixes sun glare textures.
     gpuTargetCLUT: 1 # Fixes sun penetration.
@@ -32193,6 +32198,7 @@ SLKA-25446:
   region: "NTSC-K"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
+    textureInsideRT: 1 # Fixes sun glare.
     halfPixelOffset: 2 # Fixes blurriness.
     getSkipCount: "GSC_NFSUndercover"
   memcardFilters:
@@ -33058,6 +33064,7 @@ SLPM-55127:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
+    textureInsideRT: 1 # Fixes sun glare.
     halfPixelOffset: 2 # Fixes blurriness.
     bilinearUpscale: 2 # Fixes sun glare textures.
     gpuTargetCLUT: 1 # Fixes sun penetration.
@@ -33656,6 +33663,7 @@ SLPM-55244:
   region: "NTSC-J"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
+    textureInsideRT: 1 # Fixes sun glare.
     halfPixelOffset: 2 # Fixes blurriness.
     bilinearUpscale: 2 # Fixes sun glare textures.
     gpuTargetCLUT: 1 # Fixes sun penetration.
@@ -72223,6 +72231,7 @@ SLUS-21801:
   compat: 5
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves car reflections.
+    textureInsideRT: 1 # Fixes sun glare.
     halfPixelOffset: 2 # Fixes blurriness.
     bilinearUpscale: 2 # Fixes sun glare textures.
     gpuTargetCLUT: 1 # Fixes sun penetration.

--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -1455,7 +1455,7 @@ static uint cdvdStartSeek(uint newsector, CDVD_MODE_TYPE mode, bool transition_t
 		}
 		isSeeking = true;
 	}
-	else if(!drive_speed_change_cycles)
+	else if (!drive_speed_change_cycles)
 	{
 		CDVD_LOG("CdSeek Begin > Contiguous block without seek - delta=%d sectors", delta);
 

--- a/pcsx2/CDVD/Windows/IOCtlSrc.cpp
+++ b/pcsx2/CDVD/Windows/IOCtlSrc.cpp
@@ -222,7 +222,7 @@ bool IOCtlSrc::ReadDVDInfo()
 		{
 			Console.Warning("IOCTL_DVD_READ_STRUCTURE not supported");
 		}
-		else if(GetLastError() != ERROR_UNRECOGNIZED_MEDIA) // ERROR_UNRECOGNIZED_MEDIA means probably a CD or no disc
+		else if (GetLastError() != ERROR_UNRECOGNIZED_MEDIA) // ERROR_UNRECOGNIZED_MEDIA means probably a CD or no disc
 		{
 			Console.Warning("IOCTL Unknown Error %d", GetLastError());
 		}

--- a/pcsx2/Dmac.cpp
+++ b/pcsx2/Dmac.cpp
@@ -236,7 +236,7 @@ static __ri void DmaExec( void (*func)(), u32 mem, u32 value )
 				cpuClearInt( 10 );
 				QueuedDMA._u16 &= ~(1 << 10); //Clear any queued DMA requests for this channel
 			}
-			else if(channel == 2)
+			else if (channel == 2)
 			{
 				cpuClearInt( 11 );
 				QueuedDMA._u16 &= ~(1 << 11); //Clear any queued DMA requests for this channel
@@ -274,7 +274,7 @@ static __ri void DmaExec( void (*func)(), u32 mem, u32 value )
 	{
 		func();
 	}
-	else if(reg.chcr.STR)
+	else if (reg.chcr.STR)
 	{
 		//DevCon.Warning(L"32bit %s DMA Start while DMAC Disabled\n", ChcrName(mem));
 		QueuedDMA._u16 |= (1 << ChannelNumber(mem)); //Queue the DMA up to be started then the DMA's are Enabled and or the Suspend is lifted

--- a/pcsx2/GS/GSClut.cpp
+++ b/pcsx2/GS/GSClut.cpp
@@ -339,7 +339,7 @@ void GSClut::Read(const GIFRegTEX0& TEX0)
 				break;
 			}
 		}
-		else if(TEX0.CPSM == PSMCT16 || TEX0.CPSM == PSMCT16S)
+		else if (TEX0.CPSM == PSMCT16 || TEX0.CPSM == PSMCT16S)
 		{
 			switch(TEX0.PSM)
 			{

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2260,7 +2260,7 @@ void GSState::Move()
 				vm[doff] = (vm[doff] & 0xff000000) | (vm[soff] & 0x00ffffff);
 			});
 		}
-		else // if(spsm.trbpp == 16)
+		else // if (spsm.trbpp == 16)
 		{
 			u16* vm = m_mem.vm16();
 			copy(dpo.assertSizesMatch(GSLocalMemory::swizzle16), spo.assertSizesMatch(GSLocalMemory::swizzle16), [vm](u32 doff, u32 soff)

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4366,7 +4366,7 @@ void GSRendererHW::Draw()
 					g_gs_device->StretchRect(g_texture_cache->GetTemporaryZ(), sRect, ds->m_texture, GSVector4(dRect), ShaderConvert::DEPTH_COPY, false);
 					g_perfmon.Put(GSPerfMon::TextureCopies, 1);
 				}
-				else if(m_temp_z_full_copy)
+				else if (m_temp_z_full_copy)
 				{
 					GSVector4i dRect = GSVector4i((ds->m_valid.x + z_horizontal_offset) * ds->m_scale, (ds->m_valid.y + z_vertical_offset) * ds->m_scale, (ds->m_valid.z + z_horizontal_offset + (1.0f / ds->m_scale)) * ds->m_scale, (ds->m_valid.w + z_vertical_offset + (1.0f / ds->m_scale)) * ds->m_scale);
 					GSVector4 sRect = GSVector4(((ds->m_valid.x + horizontal_offset) * ds->m_scale) / static_cast<float>(g_texture_cache->GetTemporaryZ()->GetWidth()), static_cast<float>((ds->m_valid.y + vertical_offset) * ds->m_scale) / static_cast<float>(g_texture_cache->GetTemporaryZ()->GetHeight()), (((ds->m_valid.z + horizontal_offset) + (1.0f / ds->m_scale)) * ds->m_scale) / static_cast<float>(g_texture_cache->GetTemporaryZ()->GetWidth()),

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1107,17 +1107,15 @@ GSTextureCache::Source* GSTextureCache::LookupDepthSource(const bool is_depth, c
 					if (dst->m_unscaled_size != t->m_unscaled_size)
 					{
 						t->ResizeTexture(t->m_unscaled_size.x, t->m_unscaled_size.y);
-						t->m_valid = dst->m_valid;
 					}
 
 					CopyRGBFromDepthToColor(t, dst);
 				}
 
+				t->m_valid = t->m_valid.runion(dst->m_valid);
 				dst = t;
 
-				if (GSUtil::GetChannelMask(TEX0.PSM) & 0x8)
-					t->UnscaleRTAlpha();
-
+				// Don't need to de-RTA here as we were actually copying the RGB over, preserving the existing alpha.
 				inside_target = false;
 				break;
 			}

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2277,7 +2277,7 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVe
 					dst->m_32_bits_fmt |= (psm_s.bpp != 16);
 					break;
 				}
-				else if(!(src && src->m_from_target == t))
+				else if (!(src && src->m_from_target == t))
 				{
 					GL_INS("TC: Deleting RT BP 0x%x BW %d PSM %s due to change in target", t->m_TEX0.TBP0, t->m_TEX0.TBW, psm_str(t->m_TEX0.PSM));
 					InvalidateSourcesFromTarget(t);
@@ -2600,7 +2600,7 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVe
 					src->m_target_direct = false;
 					src->m_shared_texture = false;
 
-					if(!req_copy)
+					if (!req_copy)
 						dst->ResizeTexture(new_size.x, new_size.y, true, true, GSVector4i(dRect), true);
 					else
 					{
@@ -2650,7 +2650,7 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVe
 			if ((!is_shuffle && (GSLocalMemory::m_psm[dst->m_TEX0.PSM].bpp != GSLocalMemory::m_psm[TEX0.PSM].bpp || GSLocalMemory::m_psm[dst->m_TEX0.PSM].depth != GSLocalMemory::m_psm[TEX0.PSM].depth)) || 
 				(is_shuffle && GSLocalMemory::m_psm[dst->m_TEX0.PSM].bpp == 16))
 			{
-				if(GSLocalMemory::m_psm[dst->m_TEX0.PSM].depth != GSLocalMemory::m_psm[TEX0.PSM].depth || dst->m_TEX0.TBW != TEX0.TBW)
+				if (GSLocalMemory::m_psm[dst->m_TEX0.PSM].depth != GSLocalMemory::m_psm[TEX0.PSM].depth || dst->m_TEX0.TBW != TEX0.TBW)
 					dst->m_32_bits_fmt = GSLocalMemory::m_psm[TEX0.PSM].bpp != 16;
 
 				if (!is_shuffle || (is_shuffle && GSLocalMemory::m_psm[dst->m_TEX0.PSM].bpp == 16))
@@ -5441,7 +5441,7 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 			src->m_unscaled_size = dst->m_unscaled_size;
 			src->m_shared_texture = true;
 
-			if(channel_shuffle)
+			if (channel_shuffle)
 				m_temporary_source = src;
 		}
 
@@ -5791,7 +5791,7 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 					src->m_region.SetX(x_offset, x_offset + tw);
 					src->m_region.SetY(y_offset, y_offset + th);
 
-					if(!GSConfig.UserHacks_NativePaletteDraw)
+					if (!GSConfig.UserHacks_NativePaletteDraw)
 						m_temporary_source = src;
 				}
 				else
@@ -6781,7 +6781,7 @@ GSTextureCache::Source::~Source()
 	// to recycle.
 	if (!m_shared_texture && !m_from_hash_cache && m_texture)
 	{
-		if(m_from_target)
+		if (m_from_target)
 			g_texture_cache->m_target_memory_usage -= m_texture->GetMemUsage();
 		else
 			g_texture_cache->m_source_memory_usage -= m_texture->GetMemUsage();

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -209,7 +209,7 @@ public:
 	struct TempZAddress
 	{
 		u32 ZBP;
-		u32 offset;
+		int offset;
 		GSVector4i rect_since;
 	};
 

--- a/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
@@ -1491,7 +1491,7 @@ __ri void GSDrawScanline::CDrawScanline(int pixels, int left, int top, const GSV
 						case 2: break;
 					}
 
-					if(!(sel.fpsm == 1 && sel.abc == 1))
+					if (!(sel.fpsm == 1 && sel.abc == 1))
 					{
 						switch(sel.abc)
 						{

--- a/pcsx2/GS/Renderers/SW/GSDrawScanlineCodeGenerator.all.cpp
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanlineCodeGenerator.all.cpp
@@ -562,7 +562,7 @@ L("loop");
 
 L("step");
 
-	// if(steps <= 0) break;
+	// if (steps <= 0) break;
 
 	if (!m_sel.edge)
 	{
@@ -768,7 +768,7 @@ void GSDrawScanlineCodeGenerator::Init()
 				cvttps2dq(xym6, vt);
 
 				// s = vti.xxxx() + m_local.d[skip].s;
-				// t = vti.yyyy(); if(!sprite) t += m_local.d[skip].t;
+				// t = vti.yyyy(); if (!sprite) t += m_local.d[skip].t;
 
 				pshufd(s, xym6, _MM_SHUFFLE(0, 0, 0, 0));
 				pshufd(t, xym6, _MM_SHUFFLE(1, 1, 1, 1));
@@ -925,7 +925,7 @@ void GSDrawScanlineCodeGenerator::Step()
 				// GSVector4i stq = m_local.d4.stq;
 
 				// s += stq.xxxx();
-				// if(!sprite) t += st.yyyy();
+				// if (!sprite) t += st.yyyy();
 
 				broadcasti128(stq, _rip_local_d(stq));
 
@@ -2096,7 +2096,7 @@ void GSDrawScanlineCodeGenerator::AlphaTFX()
 
 			clamp16(_ga, tmp);
 
-			// if(!tcc) gat = gat.mix16(ga.srl16(7));
+			// if (!tcc) gat = gat.mix16(ga.srl16(7));
 
 			if (!m_sel.tcc)
 			{
@@ -2109,7 +2109,7 @@ void GSDrawScanlineCodeGenerator::AlphaTFX()
 
 		case TFX_DECAL:
 
-			// if(!tcc) gat = gat.mix16(ga.srl16(7));
+			// if (!tcc) gat = gat.mix16(ga.srl16(7));
 			if (!m_sel.tcc)
 			{
 				// GSVector4i ga = iip ? gaf : m_local.c.ga;
@@ -2139,7 +2139,7 @@ void GSDrawScanlineCodeGenerator::AlphaTFX()
 
 		case TFX_HIGHLIGHT2:
 
-			// if(!tcc) gat = gat.mix16(ga.srl16(7));
+			// if (!tcc) gat = gat.mix16(ga.srl16(7));
 
 			if (!m_sel.tcc)
 			{
@@ -2990,8 +2990,8 @@ void GSDrawScanlineCodeGenerator::WritePixel(const XYm& src_, const AddressReg& 
 	{
 		if (fast)
 		{
-			// if(fzm & 0x0f) GSVector4i::storel(&vm16[addr + 0], fs);
-			// if(fzm & 0xf0) GSVector4i::storeh(&vm16[addr + 8], fs);
+			// if (fzm & 0x0f) GSVector4i::storel(&vm16[addr + 0], fs);
+			// if (fzm & 0xf0) GSVector4i::storeh(&vm16[addr + 8], fs);
 
 			test(mask, 0x0000000f << shift);
 			je("@f");
@@ -3020,10 +3020,10 @@ void GSDrawScanlineCodeGenerator::WritePixel(const XYm& src_, const AddressReg& 
 		}
 		else
 		{
-			// if(fzm & 0x03) WritePixel(fpsm, &vm16[addr + 0], fs.extract32<0>());
-			// if(fzm & 0x0c) WritePixel(fpsm, &vm16[addr + 2], fs.extract32<1>());
-			// if(fzm & 0x30) WritePixel(fpsm, &vm16[addr + 8], fs.extract32<2>());
-			// if(fzm & 0xc0) WritePixel(fpsm, &vm16[addr + 10], fs.extract32<3>());
+			// if (fzm & 0x03) WritePixel(fpsm, &vm16[addr + 0], fs.extract32<0>());
+			// if (fzm & 0x0c) WritePixel(fpsm, &vm16[addr + 2], fs.extract32<1>());
+			// if (fzm & 0x30) WritePixel(fpsm, &vm16[addr + 8], fs.extract32<2>());
+			// if (fzm & 0xc0) WritePixel(fpsm, &vm16[addr + 10], fs.extract32<3>());
 
 			test(mask, 0x00000003 << shift);
 			je("@f");

--- a/pcsx2/GS/Renderers/SW/GSDrawScanlineCodeGenerator.arm64.cpp
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanlineCodeGenerator.arm64.cpp
@@ -158,7 +158,7 @@ void GSDrawScanlineCodeGenerator::Generate()
 	Label exit;
 	armAsm->Bind(&m_step_label);
 
-	// if(steps <= 0) break;
+	// if (steps <= 0) break;
 
 	if (!m_sel.edge)
 	{
@@ -332,7 +332,7 @@ void GSDrawScanlineCodeGenerator::Init()
 				armAsm->Fcvtzs(v6.V4S(), v4.V4S());
 
 				// s = vti.xxxx() + m_local.d[skip].s;
-				// t = vti.yyyy(); if(!sprite) t += m_local.d[skip].t;
+				// t = vti.yyyy(); if (!sprite) t += m_local.d[skip].t;
 
 				armAsm->Dup(_temp_s.V4S(), v6.V4S(), 0);
 				armAsm->Dup(_temp_t.V4S(), v6.V4S(), 1);
@@ -485,7 +485,7 @@ void GSDrawScanlineCodeGenerator::Step()
 				// GSVector4i stq = m_local.d4.stq;
 
 				// s += stq.xxxx();
-				// if(!sprite) t += stq.yyyy();
+				// if (!sprite) t += stq.yyyy();
 
 				armAsm->Dup(_vscratch.V4S(), _d4_stq.V4S(), 0);
 				if (m_sel.prim != GS_SPRITE_CLASS || m_sel.mmin)
@@ -1394,7 +1394,7 @@ void GSDrawScanlineCodeGenerator::AlphaTFX()
 			modulate16(v6, _temp_ga, 1);
 			clamp16(v6, v3);
 
-			// if(!tcc) gat = gat.mix16(ga.srl16(7));
+			// if (!tcc) gat = gat.mix16(ga.srl16(7));
 
 			if (!m_sel.tcc)
 			{
@@ -1407,7 +1407,7 @@ void GSDrawScanlineCodeGenerator::AlphaTFX()
 
 		case TFX_DECAL:
 
-			// if(!tcc) gat = gat.mix16(ga.srl16(7));
+			// if (!tcc) gat = gat.mix16(ga.srl16(7));
 
 			if (!m_sel.tcc)
 			{
@@ -1435,7 +1435,7 @@ void GSDrawScanlineCodeGenerator::AlphaTFX()
 
 		case TFX_HIGHLIGHT2:
 
-			// if(!tcc) gat = gat.mix16(ga.srl16(7));
+			// if (!tcc) gat = gat.mix16(ga.srl16(7));
 
 			if (!m_sel.tcc)
 			{
@@ -2158,8 +2158,8 @@ void GSDrawScanlineCodeGenerator::WritePixel(const VRegister& src, const Registe
 	{
 		if (fast)
 		{
-			// if(fzm & 0x0f) GSVector4i::storel(&vm16[addr + 0], fs);
-			// if(fzm & 0xf0) GSVector4i::storeh(&vm16[addr + 8], fs);
+			// if (fzm & 0x0f) GSVector4i::storel(&vm16[addr + 0], fs);
+			// if (fzm & 0xf0) GSVector4i::storeh(&vm16[addr + 8], fs);
 
 			Label skip_low, skip_high;
 			armAsm->Lsl(_wscratch, addr, 1); // *2
@@ -2177,10 +2177,10 @@ void GSDrawScanlineCodeGenerator::WritePixel(const VRegister& src, const Registe
 		}
 		else
 		{
-			// if(fzm & 0x03) WritePixel(fpsm, &vm16[addr + 0], fs.extract32<0>());
-			// if(fzm & 0x0c) WritePixel(fpsm, &vm16[addr + 2], fs.extract32<1>());
-			// if(fzm & 0x30) WritePixel(fpsm, &vm16[addr + 8], fs.extract32<2>());
-			// if(fzm & 0xc0) WritePixel(fpsm, &vm16[addr + 10], fs.extract32<3>());
+			// if (fzm & 0x03) WritePixel(fpsm, &vm16[addr + 0], fs.extract32<0>());
+			// if (fzm & 0x0c) WritePixel(fpsm, &vm16[addr + 2], fs.extract32<1>());
+			// if (fzm & 0x30) WritePixel(fpsm, &vm16[addr + 8], fs.extract32<2>());
+			// if (fzm & 0xc0) WritePixel(fpsm, &vm16[addr + 10], fs.extract32<3>());
 
 			Label skip_0, skip_1, skip_2, skip_3;
 

--- a/pcsx2/GS/Renderers/SW/GSRasterizer.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRasterizer.cpp
@@ -444,9 +444,9 @@ void GSRasterizer::DrawTriangle(const GSVertexSW* vertex, const u16* index)
 
 	m1 = (y0011 == y1221).mask() & 7;
 
-	// if(i == 0) => y0 < y1 < y2
-	// if(i == 1) => y0 == y1 < y2
-	// if(i == 4) => y0 < y1 == y2
+	// if (i == 0) => y0 < y1 < y2
+	// if (i == 1) => y0 == y1 < y2
+	// if (i == 4) => y0 < y1 == y2
 
 	if (m1 == 7) // y0 == y1 == y2
 		return;
@@ -623,9 +623,9 @@ void GSRasterizer::DrawTriangle(const GSVertexSW* vertex, const u16* index)
 
 	m1 = (y0011 == y1221).mask() & 7;
 
-	// if(i == 0) => y0 < y1 < y2
-	// if(i == 1) => y0 == y1 < y2
-	// if(i == 4) => y0 < y1 == y2
+	// if (i == 0) => y0 < y1 < y2
+	// if (i == 1) => y0 == y1 < y2
+	// if (i == 4) => y0 < y1 == y2
 
 	if (m1 == 7)
 		return; // y0 == y1 == y2

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -94,7 +94,7 @@ void GSRendererSW::VSync(u32 field, bool registers_written, bool idle_frame)
 	m_tc->IncAge();
 
 	m_draw_transfers.clear();
-	// if((m_perfmon.GetFrame() & 255) == 0) m_rl->PrintStats();
+	// if ((m_perfmon.GetFrame() & 255) == 0) m_rl->PrintStats();
 }
 
 GSTexture* GSRendererSW::GetOutput(int i, float& scale, int& y_offset)

--- a/pcsx2/GS/Renderers/SW/GSSetupPrimCodeGenerator.all.cpp
+++ b/pcsx2/GS/Renderers/SW/GSSetupPrimCodeGenerator.all.cpp
@@ -515,7 +515,7 @@ void GSSetupPrimCodeGenerator::Color()
 		pshufd(xym1, xym0, _MM_SHUFFLE(1, 0, 3, 2));
 		punpcklwd(xym0, xym1);
 
-		// if(!tme) c = c.srl16(7);
+		// if (!tme) c = c.srl16(7);
 
 		if (m_sel.tfx == TFX_NONE)
 		{

--- a/pcsx2/GS/Renderers/SW/GSSetupPrimCodeGenerator.arm64.cpp
+++ b/pcsx2/GS/Renderers/SW/GSSetupPrimCodeGenerator.arm64.cpp
@@ -322,7 +322,7 @@ void GSSetupPrimCodeGenerator::Color()
 		armAsm->Ext(v1.V16B(), v0.V16B(), v0.V16B(), 8);
 		armAsm->Zip1(v0.V8H(), v0.V8H(), v1.V8H());
 
-		// if(!tme) c = c.srl16(7);
+		// if (!tme) c = c.srl16(7);
 
 		if (m_sel.tfx == TFX_NONE)
 			armAsm->Ushr(v0.V8H(), v0.V8H(), 7);

--- a/pcsx2/IPU/IPU.h
+++ b/pcsx2/IPU/IPU.h
@@ -10,9 +10,9 @@
 #define ipumsk( src ) ( (src) & 0xff )
 #define ipucase( src ) case ipumsk(src)
 
-#define IPU_INT_TO( cycles )  if(!(cpuRegs.interrupt & (1<<4))) CPU_INT( DMAC_TO_IPU, cycles )
+#define IPU_INT_TO( cycles )  if (!(cpuRegs.interrupt & (1<<4))) CPU_INT( DMAC_TO_IPU, cycles )
 #define IPU_INT_FROM( cycles )  CPU_INT( DMAC_FROM_IPU, cycles )
-#define IPU_INT_PROCESS( cycles ) if(!(cpuRegs.interrupt & (1 << IPU_PROCESS))) CPU_INT( IPU_PROCESS, cycles )
+#define IPU_INT_PROCESS( cycles ) if (!(cpuRegs.interrupt & (1 << IPU_PROCESS))) CPU_INT( IPU_PROCESS, cycles )
 //
 // Bitfield Structures
 //

--- a/pcsx2/Interpreter.cpp
+++ b/pcsx2/Interpreter.cpp
@@ -190,7 +190,7 @@ static void execI()
 #if 0
 	static long int print_me = 0;
 	// Based on cycle
-	// if( cpuRegs.cycle > 0x4f24d714 )
+	// if ( cpuRegs.cycle > 0x4f24d714 )
 	// Or dump from a particular PC (useful to debug handler/syscall)
 	if (pc == 0x80000000)
 	{

--- a/pcsx2/IopGte.cpp
+++ b/pcsx2/IopGte.cpp
@@ -20,7 +20,7 @@
 #define G_GC(reg)
 #endif
 
-#define SUM_FLAG if(gteFLAG & 0x7F87E000) gteFLAG |= 0x80000000;
+#define SUM_FLAG if (gteFLAG & 0x7F87E000) gteFLAG |= 0x80000000;
 
 #ifdef _MSC_VER_
 #pragma warning(disable:4244)

--- a/pcsx2/Memory.cpp
+++ b/pcsx2/Memory.cpp
@@ -356,7 +356,7 @@ void ba0W16(u32 mem, u16 value)
 				s_ba_command_executing = true;
 				s_ba_error_detected = false;
 			}
-			else if(s_ba[0x2] == 0x42) // Read Mode
+			else if (s_ba[0x2] == 0x42) // Read Mode
 			{
 				int size = (s_ba[masked_mem] & 0xF);
 
@@ -406,7 +406,7 @@ u16 ba0R16(u32 mem)
 
 void MyMemCheck(u32 mem)
 {
-    if( mem == 0x1c02f2a0 )
+    if ( mem == 0x1c02f2a0 )
         Console.WriteLn("yo; (mem == 0x1c02f2a0) in MyMemCheck...");
 }
 

--- a/pcsx2/R3000A.cpp
+++ b/pcsx2/R3000A.cpp
@@ -256,7 +256,7 @@ void iopTestIntc()
 		// Note: No need to set the iop's branch delta here, since the EE
 		// will run an IOP branch test regardless.
 	}
-	else if( !iopEventTestIsActive )
+	else if ( !iopEventTestIsActive )
 		psxSetNextBranchDelta( 2 );
 }
 

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -127,9 +127,9 @@ __ri void cpuException(u32 code, u32 bd)
 			cpuUpdateOperationMode();
 			return;
 		}
-		else if((code & 0x38000) == 0x10000)
+		else if ((code & 0x38000) == 0x10000)
 			offset = 0x80; //Performance Counter
-		else if((code & 0x38000) == 0x18000)
+		else if ((code & 0x38000) == 0x18000)
 			offset = 0x100; //Debug
 		else
 			Console.Error("Unknown Level 2 Exception!! Cause %x", code);

--- a/pcsx2/SPU2/spu2sys.cpp
+++ b/pcsx2/SPU2/spu2sys.cpp
@@ -1117,7 +1117,7 @@ static void RegWrite_Core(u16 value)
 
 			if (!thiscore.DmaMode && !(thiscore.Regs.STATX & 0x400))
 				thiscore.Regs.STATX &= ~0x80;
-			else if(!oldDmaMode && thiscore.DmaMode)
+			else if (!oldDmaMode && thiscore.DmaMode)
 				thiscore.Regs.STATX |= 0x80;
 
 			thiscore.ActiveTSA = thiscore.TSA;

--- a/pcsx2/USB/usb-eyetoy/jo_mpeg.cpp
+++ b/pcsx2/USB/usb-eyetoy/jo_mpeg.cpp
@@ -164,7 +164,7 @@ static int jo_processDU(jo_bits_t *bits, float A[64], const unsigned char htdc[9
 			jo_writeBits(bits, run, 6);
 			if (AC < -127) {
 				jo_writeBits(bits, 128, 12);
-			} else if(AC > 127) {
+			} else if (AC > 127) {
 				jo_writeBits(bits, 0, 12);
 			}
 			code = AC & 0xFFF;

--- a/pcsx2/Vif_Transfer.cpp
+++ b/pcsx2/Vif_Transfer.cpp
@@ -93,7 +93,7 @@ _vifT static __fi bool vifTransfer(u32 *data, int size, bool TTE) {
 
 		if(!vifXch.qwc)
 			vifX.inprogress &= ~0x1;
-		else if(vifX.irqoffset.value != 0)
+		else if (vifX.irqoffset.value != 0)
 			vifX.irqoffset.enabled = true;
 	}
 	else

--- a/pcsx2/ps2/Iop/IopHwRead.cpp
+++ b/pcsx2/ps2/Iop/IopHwRead.cpp
@@ -70,12 +70,12 @@ mem8_t iopHwRead8_Page1( u32 addr )
 				DevCon.Warning( "HwRead8 from Counter16 [ignored] @ 0x%08x = 0x%02x", addr, psxHu8(addr) );
 				ret = psxHu8( addr );
 			}
-			else if( masked_addr >= 0x480 && masked_addr < 0x4a0 )
+			else if ( masked_addr >= 0x480 && masked_addr < 0x4a0 )
 			{
 				DevCon.Warning( "HwRead8 from Counter32 [ignored] @ 0x%08x = 0x%02x", addr, psxHu8(addr) );
 				ret = psxHu8( addr );
 			}
-			else if( (masked_addr >= pgmsk(HW_USB_START)) && (masked_addr < pgmsk(HW_USB_END)) )
+			else if ( (masked_addr >= pgmsk(HW_USB_START)) && (masked_addr < pgmsk(HW_USB_END)) )
 			{
 				ret = USBread8( addr );
 				PSXHW_LOG( "HwRead8 from USB @ 0x%08x = 0x%02x", addr, ret );
@@ -179,7 +179,7 @@ static __fi T _HwRead_16or32_Page1( u32 addr )
 	// ------------------------------------------------------------------------
 	// Counters, 32-bit varieties!
 	//
-	else if( masked_addr >= 0x480 && masked_addr < 0x4b0 )
+	else if ( masked_addr >= 0x480 && masked_addr < 0x4b0 )
 	{
 		int cntidx = (( masked_addr >> 4 ) & 0xf) - 5;
 		switch( masked_addr & 0xf )
@@ -218,14 +218,14 @@ static __fi T _HwRead_16or32_Page1( u32 addr )
 	// ------------------------------------------------------------------------
 	// USB, with both 16 and 32 bit interfaces
 	//
-	else if( (masked_addr >= pgmsk(HW_USB_START)) && (masked_addr < pgmsk(HW_USB_END)) )
+	else if ( (masked_addr >= pgmsk(HW_USB_START)) && (masked_addr < pgmsk(HW_USB_END)) )
 	{
 		ret = (sizeof(T) == 2) ? USBread16( addr ) : USBread32( addr );
 	}
 	// ------------------------------------------------------------------------
 	// SPU2, accessible in 16 bit mode only!
 	//
-	else if( masked_addr >= pgmsk(HW_SPU2_START) && masked_addr < pgmsk(HW_SPU2_END) )
+	else if ( masked_addr >= pgmsk(HW_SPU2_START) && masked_addr < pgmsk(HW_SPU2_END) )
 	{
 		if( sizeof(T) == 2 )
 			ret = SPU2read( addr );
@@ -238,7 +238,7 @@ static __fi T _HwRead_16or32_Page1( u32 addr )
 	// ------------------------------------------------------------------------
 	// PS1 GPU access
 	//
-	else if( (masked_addr >= pgmsk(HW_PS1_GPU_START)) && (masked_addr < pgmsk(HW_PS1_GPU_END)) )
+	else if ( (masked_addr >= pgmsk(HW_PS1_GPU_START)) && (masked_addr < pgmsk(HW_PS1_GPU_END)) )
 	{
 		// todo: psx mode: this is new
 		if( sizeof(T) == 2 )
@@ -418,7 +418,7 @@ mem32_t iopHwRead32_Page8( u32 addr )
 			ret = g_Sio2.send3[parm];
 			Sio2Log.WriteLn("%s(%08X) SIO2 SEND3 Read (%08X)", __FUNCTION__, addr, ret);
 		}
-		else if( masked_addr < 0x260 )
+		else if ( masked_addr < 0x260 )
 		{
 			// SIO2 Send commands alternate registers.  First reg maps to Send1, second
 			// to Send2, third to Send1, etc.  And the following clever code does this:
@@ -426,7 +426,7 @@ mem32_t iopHwRead32_Page8( u32 addr )
 			ret = (masked_addr & 4) ? g_Sio2.send2[parm] : g_Sio2.send1[parm];
 			Sio2Log.WriteLn("%s(%08X) SIO2 SEND1/2 Read (%08X)", __FUNCTION__, addr, ret);
 		}
-		else if( masked_addr <= 0x280 )
+		else if ( masked_addr <= 0x280 )
 		{
 			switch( masked_addr )
 			{
@@ -471,7 +471,7 @@ mem32_t iopHwRead32_Page8( u32 addr )
 					break;
 			}
 		}
-		else if( masked_addr >= pgmsk(HW_FW_START) && masked_addr <= pgmsk(HW_FW_END) )
+		else if ( masked_addr >= pgmsk(HW_FW_START) && masked_addr <= pgmsk(HW_FW_END) )
 		{
 			ret = FWread32( addr );
 		} else {

--- a/pcsx2/ps2/Iop/IopHwWrite.cpp
+++ b/pcsx2/ps2/Iop/IopHwWrite.cpp
@@ -104,12 +104,12 @@ void iopHwWrite8_Page1( u32 addr, mem8_t val )
 				DbgCon.Warning( "HwWrite8 to Counter16 [ignored] @ addr 0x%08x = 0x%02x", addr, psxHu8(addr) );
 				psxHu8( addr ) = val;
 			}
-			else if( masked_addr >= 0x480 && masked_addr < 0x4a0 )
+			else if ( masked_addr >= 0x480 && masked_addr < 0x4a0 )
 			{
 				DbgCon.Warning( "HwWrite8 to Counter32 [ignored] @ addr 0x%08x = 0x%02x", addr, psxHu8(addr) );
 				psxHu8( addr ) = val;
 			}
-			else if( (masked_addr >= pgmsk(HW_USB_START)) && (masked_addr < pgmsk(HW_USB_END)) )
+			else if ( (masked_addr >= pgmsk(HW_USB_START)) && (masked_addr < pgmsk(HW_USB_END)) )
 			{
 				USBwrite8( addr, val );
 			}
@@ -219,7 +219,7 @@ static __fi void _HwWrite_16or32_Page1( u32 addr, T val )
 	// ------------------------------------------------------------------------
 	// Counters, 32-bit varieties!
 	//
-	else if( masked_addr >= 0x480 && masked_addr < 0x4b0 )
+	else if ( masked_addr >= 0x480 && masked_addr < 0x4b0 )
 	{
 		int cntidx = (( masked_addr >> 4 ) & 0xf) - 5;
 		switch( masked_addr & 0xf )
@@ -252,14 +252,14 @@ static __fi void _HwWrite_16or32_Page1( u32 addr, T val )
 	// ------------------------------------------------------------------------
 	// USB, with both 16 and 32 bit interfaces
 	//
-	else if( (masked_addr >= pgmsk(HW_USB_START)) && (masked_addr < pgmsk(HW_USB_END)) )
+	else if ( (masked_addr >= pgmsk(HW_USB_START)) && (masked_addr < pgmsk(HW_USB_END)) )
 	{
 		if( sizeof(T) == 2 ) USBwrite16( addr, val ); else USBwrite32( addr, val );
 	}
 	// ------------------------------------------------------------------------
 	// SPU2, accessible in 16 bit mode only!
 	//
-	else if( (masked_addr >= pgmsk(HW_SPU2_START)) && (masked_addr < pgmsk(HW_SPU2_END)) )
+	else if ( (masked_addr >= pgmsk(HW_SPU2_START)) && (masked_addr < pgmsk(HW_SPU2_END)) )
 	{
 		if( sizeof(T) == 2 )
 			SPU2write( addr, val );
@@ -272,7 +272,7 @@ static __fi void _HwWrite_16or32_Page1( u32 addr, T val )
 	// ------------------------------------------------------------------------
 	// PS1 GPU access
 	//
-	else if( (masked_addr >= pgmsk(HW_PS1_GPU_START)) && (masked_addr < pgmsk(HW_PS1_GPU_END)) )
+	else if ( (masked_addr >= pgmsk(HW_PS1_GPU_START)) && (masked_addr < pgmsk(HW_PS1_GPU_END)) )
 	{
 		// todo: psx mode: this is new
 		if( sizeof(T) == 2 )
@@ -599,7 +599,7 @@ void iopHwWrite32_Page8( u32 addr, mem32_t val )
 			const int parm = (masked_addr - 0x200) / 4;
 			g_Sio2.SetSend3(parm, val);
 		}
-		else if( masked_addr < 0x260 )
+		else if ( masked_addr < 0x260 )
 		{
 			// SIO2 Send commands alternate registers.  First reg maps to Send1, second
 			// to Send2, third to Send1, etc.  And the following clever code does this:
@@ -617,7 +617,7 @@ void iopHwWrite32_Page8( u32 addr, mem32_t val )
 				g_Sio2.send1[parm] = val;
 			}
 		}
-		else if( masked_addr <= 0x280 )
+		else if ( masked_addr <= 0x280 )
 		{
 			switch( masked_addr )
 			{
@@ -661,7 +661,7 @@ void iopHwWrite32_Page8( u32 addr, mem32_t val )
 				break;
 			}
 		}
-		else if( masked_addr >= pgmsk(HW_FW_START) && masked_addr <= pgmsk(HW_FW_END) )
+		else if ( masked_addr >= pgmsk(HW_FW_START) && masked_addr <= pgmsk(HW_FW_END) )
 		{
 			FWwrite32( addr, val );
 		}

--- a/pcsx2/ps2/Iop/IopHw_Internal.h
+++ b/pcsx2/ps2/Iop/IopHw_Internal.h
@@ -161,7 +161,7 @@ static __ri const char* _ioplog_GetHwName( u32 addr, T val )
 					default: return "Invalid Counter";
 				}
 			}
-			else if( addr >= 0x1f801480 && addr < 0x1f8014b0 )
+			else if ( addr >= 0x1f801480 && addr < 0x1f8014b0 )
 			{
 				switch( addr & 0xf )
 				{
@@ -174,20 +174,20 @@ static __ri const char* _ioplog_GetHwName( u32 addr, T val )
 					default: return "Invalid Counter";
 				}
 			}
-			else if( (addr >= HW_USB_START) && (addr < HW_USB_END) )
+			else if ( (addr >= HW_USB_START) && (addr < HW_USB_END) )
 			{
 				return "USB";
 			}
-			else if( (addr >= HW_SPU2_START) && (addr < HW_SPU2_END) )
+			else if ( (addr >= HW_SPU2_START) && (addr < HW_SPU2_END) )
 			{
 				return "SPU2";
 			}
-			else if( addr >= pgmsk(HW_FW_START) && addr <= pgmsk(HW_FW_END) )
+			else if ( addr >= pgmsk(HW_FW_START) && addr <= pgmsk(HW_FW_END) )
 			{
 				return "FW";
 			}
-			else if( addr >= 0x1f808200 && addr < 0x1f808240 ) { return "SIO2 param"; }
-			else if( addr >= 0x1f808240 && addr < 0x1f808260 ) { return "SIO2 send"; }
+			else if ( addr >= 0x1f808200 && addr < 0x1f808240 ) { return "SIO2 param"; }
+			else if ( addr >= 0x1f808240 && addr < 0x1f808260 ) { return "SIO2 send"; }
 
 		return NULL; //"Unknown";
 	}

--- a/pcsx2/vtlb.cpp
+++ b/pcsx2/vtlb.cpp
@@ -648,7 +648,7 @@ static OperandType vtlbUnmappedPReadSm(u32 addr) {
 	}
 	return 0;
 }
-static RETURNS_R128 vtlbUnmappedPReadLg(u32 addr) { vtlb_BusError(addr, 0); if(!CHECK_EEREC && CHECK_CACHE && CheckCache(addr)){ return readCache128(addr, false); } return r128_zero(); }
+static RETURNS_R128 vtlbUnmappedPReadLg(u32 addr) { vtlb_BusError(addr, 0); if (!CHECK_EEREC && CHECK_CACHE && CheckCache(addr)){ return readCache128(addr, false); } return r128_zero(); }
 
 template <typename OperandType>
 static void vtlbUnmappedPWriteSm(u32 addr, OperandType data) {
@@ -663,7 +663,7 @@ static void vtlbUnmappedPWriteSm(u32 addr, OperandType data) {
 		}
 	}
 }
-static void TAKES_R128 vtlbUnmappedPWriteLg(u32 addr, r128 data) { vtlb_BusError(addr, 1); if(!CHECK_EEREC && CHECK_CACHE && CheckCache(addr)) { writeCache128(addr, reinterpret_cast<mem128_t*>(&data) /*Safe??*/, false); }}
+static void TAKES_R128 vtlbUnmappedPWriteLg(u32 addr, r128 data) { vtlb_BusError(addr, 1); if (!CHECK_EEREC && CHECK_CACHE && CheckCache(addr)) { writeCache128(addr, reinterpret_cast<mem128_t*>(&data) /*Safe??*/, false); }}
 // clang-format on
 
 // --------------------------------------------------------------------------------------

--- a/pcsx2/x86/ix86-32/iR5900.cpp
+++ b/pcsx2/x86/ix86-32/iR5900.cpp
@@ -1356,7 +1356,7 @@ static void iBranchTest(u32 newpc)
 	// Check the Event scheduler if our "cycle target" has been reached.
 	// Equiv code to:
 	//    cpuRegs.cycle += blockcycles;
-	//    if( cpuRegs.cycle > g_nextEventCycle ) { DoEvents(); }
+	//    if ( cpuRegs.cycle > g_nextEventCycle ) { DoEvents(); }
 
 	if (EmuConfig.Speedhacks.WaitLoop && s_nBlockFF && newpc == s_branchTo)
 	{

--- a/pcsx2/x86/microVU_Branch.inl
+++ b/pcsx2/x86/microVU_Branch.inl
@@ -247,7 +247,7 @@ void mVUendProgram(mV, microFlagCycles* mFC, int isEbit)
 			xAND(ptr32[&VU0.VI[REG_VPU_STAT].UL], (isVU1 ? ~0x100 : ~0x001)); // VBS0/VBS1 flag
 		}
 	}
-	else if(isEbit)
+	else if (isEbit)
 	{
 		if (EmuConfig.Gamefixes.VUSyncHack || EmuConfig.Gamefixes.FullVU0SyncHack)
 			xMOV(ptr32[&mVU.regs().nextBlockCycles], 0);

--- a/pcsx2/x86/microVU_Lower.inl
+++ b/pcsx2/x86/microVU_Lower.inl
@@ -1949,7 +1949,7 @@ mVUop(mVU_B)
 	pass2
 	{
 		if (mVUlow.badBranch)  { xMOV(ptr32[&mVU.badBranch],  branchAddr(mVU)); }
-		if (mVUlow.evilBranch) { if(isEvilBlock) xMOV(ptr32[&mVU.evilevilBranch], branchAddr(mVU)); else xMOV(ptr32[&mVU.evilBranch], branchAddr(mVU)); }
+		if (mVUlow.evilBranch) { if (isEvilBlock) xMOV(ptr32[&mVU.evilevilBranch], branchAddr(mVU)); else xMOV(ptr32[&mVU.evilBranch], branchAddr(mVU)); }
 		mVU.profiler.EmitOp(opB);
 	}
 	pass3 { mVUlog("B [<a href=\"#addr%04x\">%04x</a>]", branchAddr(mVU), branchAddr(mVU)); }


### PR DESCRIPTION
### Description of Changes
Fixes some regressions from RT in RT and attempts to improve valid areas.

### Rationale behind Changes
Regressions needed fixing which caused massive/incorrect valid areas and massive targets, but it always irked me how RGB was always valid even when it wasn't and this was causing some issues.

### Suggested Testing Steps
Try a bunch of games, namely Area 51, Valkyrie Profile 2, Sniper Elite, Rogue Galaxy, the Hitman Games, Stolen, Barnyard and Jurassic Park

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Insert an X in one of the boxes. This is a required field. -->
- [X] No, I did not use AI.

- [ ] Yes (please explain briefly):

Fixes https://github.com/PCSX2/pcsx2/issues/11430 shadow in Area 51
Fixes some darkened light issue in 007 Russia With Love
Fixes some inconsistencies between HW and SW
Fixes bad sun glare texture in Need for Speed Undercover

Sniper Elite and Armored Core 2 no longer require the SW FMV fix, however I've not removed them in this PR

007 Russia With Love:
Master:
![image](https://github.com/user-attachments/assets/e68a3af1-a0fd-408c-a2d0-335ddd09134e)
PR:
![image](https://github.com/user-attachments/assets/0fc79389-f5cf-4766-b003-807d8df105de)

Area 51:
Master:
![image](https://github.com/user-attachments/assets/d3cdd9a3-0319-4cd6-bf02-1c62a0d56131)
PR:
![image](https://github.com/user-attachments/assets/64aff6a6-5913-4025-adc0-53e17db9f0fd)

Valkyrie Profile 2 (This was some individual frames which should have had a slight blur but didn't)
Master:
![image](https://github.com/user-attachments/assets/fea17fc4-9ea9-4b96-9828-8ebd05747f1e)
PR:
![image](https://github.com/user-attachments/assets/73fd0c2d-825c-4ea2-8c88-eb84b5d90acf)

Need for Speed Undercover:
Master:
![Need for Speed - Undercover_SLUS-21801_20250517024441](https://github.com/user-attachments/assets/b51b1386-6db6-419d-9f24-9ead43dbf41d)
PR:
![Need for Speed - Undercover_SLUS-21801_20250517024516](https://github.com/user-attachments/assets/07159f5e-ddff-48d1-8b95-61fe4dc6e622)
