### PR TITLE
GS/DX12: Fix command list not flushing when in surfaceless mode.

### DIFF
--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -1087,7 +1087,14 @@ GSDevice::PresentResult GSDevice12::BeginPresent(bool frame_skip)
 		return PresentResult::DeviceLost;
 
 	if (frame_skip || !m_swap_chain)
+	{
+		if (!m_swap_chain)
+		{
+			ExecuteCommandList(WaitType::None);
+			InvalidateCachedState();
+		}
 		return PresentResult::FrameSkipped;
+	}
 
 	// Check if we lost exclusive fullscreen. If so, notify the host, so it can switch to windowed mode.
 	// This might get called repeatedly if it takes a while to switch back, that's the host's problem.


### PR DESCRIPTION
### Description of Changes
Flushes the command list on present when in surfaceless mode (like the GS Dump Runner)

### Rationale behind Changes
This wasn't flushing before, because of the nature of surfaceless, it never processes the frame.  VK already had this fix in place.

### Suggested Testing Steps
Do a dump run, or trust me, your choice lol.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Insert an X in one of the boxes. This is a required field. -->
- [X] No, I did not use AI.

- [ ] Yes (please explain briefly):
