### PR TITLE
GS/HW: Improve tex is ds handle on DX, clean up some stuff.

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -291,7 +291,6 @@ public:
 	std::unique_ptr<GSDownloadTexture> CreateDownloadTexture(u32 width, u32 height, GSTexture::Format format) override;
 
 	void CommitClear(GSTexture* t);
-	void CloneTexture(GSTexture* src, GSTexture** dest, const GSVector4i& rect);
 
 	void CopyRect(GSTexture* sTex, GSTexture* dTex, const GSVector4i& r, u32 destX, u32 destY) override;
 

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -2489,12 +2489,15 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 
 	if (config.require_one_barrier && !m_features.texture_barrier)
 	{
-		// Requires a copy of the RT
+		// Requires a copy of the RT.
 		draw_rt_clone = CreateTexture(rtsize.x, rtsize.y, 1, colclip_rt ? GSTexture::Format::ColorClip : GSTexture::Format::Color, true);
-		GL_PUSH("Copy RT to temp texture for fbmask {%d,%d %dx%d}",
-			config.drawarea.left, config.drawarea.top,
-			config.drawarea.width(), config.drawarea.height());
-		CopyRect(colclip_rt ? colclip_rt : config.rt, draw_rt_clone, config.drawarea, config.drawarea.left, config.drawarea.top);
+		if (draw_rt_clone)
+		{
+			GL_PUSH("GL: Copy RT to temp texture {%d,%d %dx%d}",
+				config.drawarea.left, config.drawarea.top,
+				config.drawarea.width(), config.drawarea.height());
+			CopyRect(colclip_rt ? colclip_rt : config.rt, draw_rt_clone, config.drawarea, config.drawarea.left, config.drawarea.top);
+		}
 	}
 
 	IASetVertexBuffer(config.verts, config.nverts);
@@ -2563,7 +2566,7 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 	if (check_barrier && ((config.tex && (config.tex == config.ds || config.tex == config.rt)) || ((psel.ps.IsFeedbackLoop() || psel.ps.blend_c == 1) && GLState::rt == config.rt)))
 	{
 		// Ensure all depth writes are finished before sampling
-		GL_INS("Texture barrier to flush depth or rt before reading");
+		GL_INS("GL: Texture barrier to flush depth or rt before reading");
 		glTextureBarrier();
 	}
 	// additional non-pipeline config stuff


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/GL: Check for texture creation hazard for fb copy.

GS/DX11: Merge CloneTexture with CopyRect.
Unified between renderers, easier to make shared changes.

GS/DX: DX requires a copy to sample the depth buffer.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Accuracy, bugfixes, robustness.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test time crisis 3, test games that use shuffles, make sure dx11/12, gl didn't break.
Fixes Time Crisis on DX11/12 which costs +79 copies

Master:
![image](https://github.com/user-attachments/assets/d917b0e1-5851-422e-aa4a-2725b2bc10e6)
PR:
![image](https://github.com/user-attachments/assets/d3209491-bb26-4218-9168-7b1eba62d39c)