### PR TITLE
GS/HW: Improve rt in rt lenience and dirty/new rt handling

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -222,8 +222,8 @@ public:
 	GSVector4i ComputeBoundingBox(const GSVector2i& rtsize, float rtscale);
 	void MergeSprite(GSTextureCache::Source* tex);
 	float GetTextureScaleFactor() override;
-	GSVector2i GetValidSize(const GSTextureCache::Source* tex = nullptr);
-	GSVector2i GetTargetSize(const GSTextureCache::Source* tex = nullptr, const bool can_expand = true);
+	GSVector2i GetValidSize(const GSTextureCache::Source* tex = nullptr, const bool is_shuffle = false);
+	GSVector2i GetTargetSize(const GSTextureCache::Source* tex = nullptr, const bool can_expand = true, const bool is_shuffle = false);
 
 	void Reset(bool hardware_reset) override;
 	void UpdateSettings(const Pcsx2Config::GSOptions& old_config) override;


### PR DESCRIPTION
### Description of Changes
Deletes fully dirtied targets on source lookup
Allows RT in RT to use targets last used up to 3 draws ago instead of 1
Updates a source is it's pulling from GS memory but should be using the newly created target
Detects shuffles to avoid the target height cache being poisoned with double heights

### Rationale behind Changes
More stuff in Valkyrie Profile 2 not working correctly, then came across the height cache issue with The Getaway whilst attempting to fix this.

### Suggested Testing Steps
Test Valkyrie Profile 2 and some random games with Tex in RT enabled.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No