### PR TITLE
GS/TC: Don't allow Tex in RT 32bit target use as 16bit if not a shuffle

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1696,22 +1696,27 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const bool is_color, const 
 					u32 src_psm = psm;
 
 					// If the input is C16 and it's actually a shuffle of 32bits we need to correct the size.
-					if ((tex_color_psm & 0xF) <= PSMCT24 && (psm & 0x7) == PSMCT16 && possible_shuffle)
+					if ((tex_color_psm & 0xF) <= PSMCT24 && (psm & 0x7) == PSMCT16)
 					{
-						src_psm = t->m_TEX0.PSM;
-						// If it's taking double width for the shuffle, half that.
-						if (src_bw == (rt_tbw * 2))
+						if (possible_shuffle)
 						{
-							src_bw = rt_tbw;
+							src_psm = t->m_TEX0.PSM;
+							// If it's taking double width for the shuffle, half that.
+							if (src_bw == (rt_tbw * 2))
+							{
+								src_bw = rt_tbw;
 
-							rect.x /= 2;
-							rect.z /= 2;
+								rect.x /= 2;
+								rect.z /= 2;
+							}
+							else
+							{
+								rect.y /= 2;
+								rect.w /= 2;
+							}
 						}
-						else
-						{
-							rect.y /= 2;
-							rect.w /= 2;
-						}
+						else // Formats are not compatible for normal draws, only shuffles.
+							continue;
 					}
 					if (bp > t->m_TEX0.TBP0)
 					{

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -3290,23 +3290,19 @@ bool GSTextureCache::PreloadTarget(GIFRegTEX0 TEX0, const GSVector2i& size, cons
 
 					if (buffer_width != std::max(1U, t->m_TEX0.TBW))
 					{
+						i++;
 						// Check if this got messed with at some point, if it did just nuke it.
-						if (t->m_valid.width() == dst->m_valid.width())
+						if (!preserve_target && t->m_age > 0)
 						{
-							// Not correct, but it's better than a null reference.
+							// Probably best we don't poke the beast if it's being used as the current source.
 							if (src && src->m_target_direct && src->m_from_target == t)
-							{
-								DevCon.Warning("Replacing source target, texture may be invalid");
-								src->m_texture = dst->m_texture;
-								src->m_from_target = dst;
-							}
+								continue;
 							
 							InvalidateSourcesFromTarget(t);
 							i = list.erase(j);
 							delete t;
 						}
-						else
-							i++;
+
 						continue;
 					}
 					// If the two targets are misaligned, it's likely a relocation, so we can just kill the old target.


### PR DESCRIPTION
### Description of Changes
Improves target selection and shuffle detection

as a bonus it gets rid of a couple of copies here and there, but nothing major.

### Rationale behind Changes
It was possible for a texture inside RT picking a 32bit target for a 16bit draw which as been overwritten and no longer 32bit, and is not a shuffle.  This improves the shuffle detection for some edge cases and disallows reading 32bit as 16bit unless it's a shuffle.

### Suggested Testing Steps
Test random games with Tex in RT/RT in RT, but mainly Star Ocean 3

### Did you use AI to help find, test, or implement this issue or feature?
no


Master:
![image](https://github.com/user-attachments/assets/db371a17-cae4-433d-ac59-8f8c3d450b2f)
![image](https://github.com/user-attachments/assets/cbd35fab-d332-4fa2-a2dd-f8578d320681)

PR:
![image](https://github.com/user-attachments/assets/43286bce-ded3-4a6f-992d-1b22d8a4b9bd)
![image](https://github.com/user-attachments/assets/9a232cdd-3a92-48e2-8c57-2e7c6b06e166)

