### PR TITLE
GS/HW: Allow partial depth copy on dx12.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -9097,10 +9097,7 @@ void GSRendererHW::EndHLEHardwareDraw(bool force_copy_on_hazard /* = false */)
 				return;
 			}
 
-			// DX11 can't partial copy depth textures.
-			const GSVector4i copy_rect = (src->IsDepthStencil() && !features.test_and_sample_depth) ?
-											 src->GetRect() :
-											 config.drawarea.rintersect(src->GetRect());
+			const GSVector4i copy_rect =  config.drawarea.rintersect(src->GetRect());
 			g_gs_device->CopyRect(src, copy, copy_rect - copy_rect.xyxy(), copy_rect.x, copy_rect.y);
 			config.tex = copy;
 		}


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/HW: Allow partial depth copy on dx12.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Optimization, unlike dx11 dx12 supports partial depth copy which is faster so we don't need the sample depth check, the check is no longer needed for dx11 as it's already handled in device11.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Didn't find any games that hit this code path, smoke test.