### PR TITLE
3rdparty: Soundtouch bump to v2.4.0

### DIFF
--- a/3rdparty/soundtouch/README.html
+++ b/3rdparty/soundtouch/README.html
@@ -15,8 +15,8 @@
 
 <body class="normal">
   <hr>
-  <h1>SoundTouch audio processing library v2.3.3</h1>
-  <p class="normal">SoundTouch library Copyright &copy; Olli Parviainen 2001-2024</p>
+  <h1>SoundTouch audio processing library v2.4.0</h1>
+  <p class="normal">SoundTouch library Copyright &copy; Olli Parviainen 2001-2025</p>
   <hr>
   <h2>1. Introduction </h2>
   <p>SoundTouch is an open-source audio processing library that allows
@@ -81,8 +81,8 @@
   <p>The SoundTouch library compiles in practically any platform
     supporting GNU compiler (GCC) tools.
   <h4>2.2.1 Compiling with autotools</h4>
-  <p>To install build prerequisites for 'autotools' tool chain:</p>
-  <pre>    sudo apt-get install automake autoconf libtool build-essential</pre>
+  <p>To install build prerequisites for 'autotools' tool chain (for Ubuntu/Debian. Use dnf/yum/etc in other distros):</p>
+  <pre>    sudo apt install -y automake autoconf libtool build-essential</pre>
   <p>To build and install the binaries, run the following commands in
     /soundtouch directory:</p>
   <table border="0" cellpadding="0" cellspacing="4">
@@ -140,8 +140,8 @@
 
   <h4><b>2.2.2 Compiling with cmake</b></h4>
   <p>'cmake' build scripts are provided as an alternative to the autotools toolchain.</p>
-  <p>To install cmake build prerequisites:</p>
-  <pre>    sudo apt-get install libtool build-essential cmake</pre>
+  <p>To install cmake build prerequisites (for Ubuntu/Debian. Use dnf/yum/etc in other distros):</p>
+  <pre>    sudo apt install -y libtool build-essential cmake</pre>
   <p>To build:</p>
   <pre>
     cmake .
@@ -205,7 +205,7 @@
       separate mono channels, this isn't recommended because processing the
       channels separately would result in losing the phase coherency between
       the channels, which consequently would ruin the stereo effect.</p>
-    <p>Sample rates between 8000-48000H are supported.</p>
+    <p>Sample rates between 8000-48000Hz are supported.</p>
     <h3>3.2. Processing latency</h3>
     <p>The processing and latency constraints of the SoundTouch library are:</p>
     <ul>
@@ -606,10 +606,17 @@
       <pre>soundstretch original.wav output.wav -pitch=-0.318</pre>
     </blockquote>
     <hr>
-    <h2>5. Change History</h2>
+    <a name="changehistory"><h2>5. Change History</h2></a>
     <h3>5.1. SoundTouch library Change History </h3>
-    <p><b>2.3.3:</b></p>
+    <p><b>2.4.0:</b></p>
     <ul class="current">
+        <li>Set CMake minimum version to 3.5 to avoid deprecation warning</li>
+        <li>Increase max nr. of channels from 16 to 32</li>
+        <li>Don't use `pow()` when using integer precision samples</li>
+        <li>Replace `-Ofast` that's being deprecated in some compilers, by `-O3 -ffast-math`</li>
+    </ul>
+    <p><b>2.3.3:</b></p>
+    <ul>
         <li>Fixing compiler warnings, maintenance fixes to make/build files for various systems
         </li>
     </ul>
@@ -881,9 +888,14 @@
     <ul>
       <li> Initial release</li>
     </ul>
+    <br><br>
     <h3>5.2. SoundStretch application Change History </h3>
-    <p><b>2.3.3:</b></p>
+    <p><b>2.4.0:</b></p>
     <ul class="current_soundstretch">
+      <li>parse command-line argument values with double float precision.</li>
+    </ul>
+    <p><b>2.3.3:</b></p>
+    <ul>
       <li>Added support for Asian / non-latin filenames in Windows. Gnu platform has supported them already earlier.</li>
     </ul>
     <p><b>1.9:</b></p>

--- a/3rdparty/soundtouch/soundtouch/STTypes.h
+++ b/3rdparty/soundtouch/soundtouch/STTypes.h
@@ -56,8 +56,9 @@ typedef unsigned long   ulong;
 
 namespace soundtouch
 {
-    /// Max allowed number of channels
-    #define SOUNDTOUCH_MAX_CHANNELS     16
+    /// Max allowed number of channels. This is not a hard limit but to have some
+    /// maximum value for argument sanity checks -- can be increased if necessary
+    #define SOUNDTOUCH_MAX_CHANNELS     32
 
     /// Activate these undef's to overrule the possible sampletype
     /// setting inherited from some other header file:

--- a/3rdparty/soundtouch/soundtouch/SoundTouch.h
+++ b/3rdparty/soundtouch/soundtouch/SoundTouch.h
@@ -72,10 +72,10 @@ namespace soundtouch
 {
 
 /// Soundtouch library version string
-#define SOUNDTOUCH_VERSION          "2.3.3"
+#define SOUNDTOUCH_VERSION          "2.4.0"
 
 /// SoundTouch library version id
-#define SOUNDTOUCH_VERSION_ID       (20303)
+#define SOUNDTOUCH_VERSION_ID       (20400)
 
 //
 // Available setting IDs for the 'setSetting' & 'get_setting' functions:

--- a/3rdparty/soundtouch/source/SoundTouch/BPMDetect.cpp
+++ b/3rdparty/soundtouch/source/SoundTouch/BPMDetect.cpp
@@ -301,7 +301,7 @@ void BPMDetect::updateXCorr(int process_samples)
     pBuffer = buffer->ptrBegin();
 
     // calculate decay factor for xcorr filtering
-    float xcorr_decay = (float)pow(0.5, 1.0 / (XCORR_DECAY_TIME_CONSTANT * TARGET_SRATE / process_samples));
+    float xcorr_decay = (float)pow(0.5, process_samples / (XCORR_DECAY_TIME_CONSTANT * TARGET_SRATE));
 
     // prescale pbuffer
     float tmp[XCORR_UPDATE_SEQUENCE];

--- a/3rdparty/soundtouch/source/SoundTouch/FIRFilter.cpp
+++ b/3rdparty/soundtouch/source/SoundTouch/FIRFilter.cpp
@@ -56,7 +56,6 @@ using namespace soundtouch;
 FIRFilter::FIRFilter()
 {
     resultDivFactor = 0;
-    resultDivider = 0;
     length = 0;
     lengthDiv8 = 0;
     filterCoeffs = nullptr;
@@ -79,7 +78,7 @@ uint FIRFilter::evaluateFilterStereo(SAMPLETYPE *dest, const SAMPLETYPE *src, ui
     uint ilength = length & -8;
 
     assert((length != 0) && (length == ilength) && (src != nullptr) && (dest != nullptr) && (filterCoeffs != nullptr));
-    assert(numSamples > ilength);
+    assert(numSamples >= ilength);
 
     end = 2 * (numSamples - ilength);
 
@@ -155,7 +154,7 @@ uint FIRFilter::evaluateFilterMulti(SAMPLETYPE *dest, const SAMPLETYPE *src, uin
     assert(src != nullptr);
     assert(dest != nullptr);
     assert(filterCoeffs != nullptr);
-    assert(numChannels < 16);
+    assert(numChannels <= SOUNDTOUCH_MAX_CHANNELS);
 
     // hint compiler autovectorization that loop length is divisible by 8
     int ilength = length & -8;
@@ -207,24 +206,24 @@ void FIRFilter::setCoefficients(const SAMPLETYPE *coeffs, uint newLength, uint u
     assert(newLength > 0);
     if (newLength % 8) ST_THROW_RT_ERROR("FIR filter length not divisible by 8");
 
-    #ifdef SOUNDTOUCH_FLOAT_SAMPLES
-        // scale coefficients already here if using floating samples
-        double scale = 1.0 / resultDivider;
-    #else
-        short scale = 1;
-    #endif
-
     lengthDiv8 = newLength / 8;
     length = lengthDiv8 * 8;
     assert(length == newLength);
 
     resultDivFactor = uResultDivFactor;
-    resultDivider = (SAMPLETYPE)::pow(2.0, (int)resultDivFactor);
 
     delete[] filterCoeffs;
     filterCoeffs = new SAMPLETYPE[length];
     delete[] filterCoeffsStereo;
     filterCoeffsStereo = new SAMPLETYPE[length*2];
+
+#ifdef SOUNDTOUCH_FLOAT_SAMPLES
+    // scale coefficients already here if using floating samples
+    const double scale = ::pow(0.5, (int)resultDivFactor);;
+#else
+    const short scale = 1;
+#endif
+
     for (uint i = 0; i < length; i ++)
     {
         filterCoeffs[i] = (SAMPLETYPE)(coeffs[i] * scale);

--- a/3rdparty/soundtouch/source/SoundTouch/FIRFilter.h
+++ b/3rdparty/soundtouch/source/SoundTouch/FIRFilter.h
@@ -52,9 +52,6 @@ protected:
     // Result divider factor in 2^k format
     uint resultDivFactor;
 
-    // Result divider value.
-    SAMPLETYPE resultDivider;
-
     // Memory for filter coefficients
     SAMPLETYPE *filterCoeffs;
     SAMPLETYPE *filterCoeffsStereo;

--- a/3rdparty/soundtouch/source/SoundTouch/sse_optimized.cpp
+++ b/3rdparty/soundtouch/source/SoundTouch/sse_optimized.cpp
@@ -211,9 +211,6 @@ FIRFilterSSE::~FIRFilterSSE()
 // (overloaded) Calculates filter coefficients for SSE routine
 void FIRFilterSSE::setCoefficients(const float *coeffs, uint newLength, uint uResultDivFactor)
 {
-    uint i;
-    float fDivider;
-
     FIRFilter::setCoefficients(coeffs, newLength, uResultDivFactor);
 
     // Scale the filter coefficients so that it won't be necessary to scale the filtering result
@@ -223,13 +220,13 @@ void FIRFilterSSE::setCoefficients(const float *coeffs, uint newLength, uint uRe
     filterCoeffsUnalign = new float[2 * newLength + 4];
     filterCoeffsAlign = (float *)SOUNDTOUCH_ALIGN_POINTER_16(filterCoeffsUnalign);
 
-    fDivider = (float)resultDivider;
+    const float scale = ::pow(0.5, (int)resultDivFactor);
 
-    // rearrange the filter coefficients for mmx routines
-    for (i = 0; i < newLength; i ++)
+    // rearrange the filter coefficients for sse routines
+    for (auto i = 0U; i < newLength; i ++)
     {
         filterCoeffsAlign[2 * i + 0] =
-        filterCoeffsAlign[2 * i + 1] = coeffs[i + 0] / fDivider;
+        filterCoeffsAlign[2 * i + 1] = coeffs[i] * scale;
     }
 }
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Author also moved to https://codeberg.org/soundtouch/soundtouch
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Minor update, also increases audio channels from 16 to 32.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test soundtouch (specifically, SoundTouch is used in the AudioStretch or AudioResampler components, which are responsible for time-stretching audio frames to maintain sync with the emulated CPU and video section or also known as the SPU2).
### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.