### PR TITLE
DebugTools: Fix uninitialized variable in breakpoint code

### DIFF
--- a/pcsx2/DebugTools/Breakpoints.h
+++ b/pcsx2/DebugTools/Breakpoints.h
@@ -33,7 +33,7 @@ struct BreakPoint
 	bool temporary = false;
 	bool stepping = false;
 
-	bool hasCond;
+	bool hasCond = false;
 	BreakPointCond cond;
 	BreakPointCpu cpu;
 


### PR DESCRIPTION
### Description of Changes
Makes sure the `hasCond` member variable in breakpoints is initialized.

### Rationale behind Changes
I think this is why breakpoints stopped working for the AppImage builds. Looks like it was my fault.

### Suggested Testing Steps
Make sure that breakpoints work with the AppImage.

### Did you use AI to help find, test, or implement this issue or feature?
No.