### PR TITLE
debugger: fix thread view row lookup

### DIFF
--- a/pcsx2-qt/Debugger/ThreadView.cpp
+++ b/pcsx2-qt/Debugger/ThreadView.cpp
@@ -65,16 +65,17 @@ void ThreadView::openContextMenu(QPoint pos)
 
 void ThreadView::onDoubleClick(const QModelIndex& index)
 {
+	auto real_index = m_proxy_model->mapToSource(index);
 	switch (index.column())
 	{
 		case ThreadModel::ThreadColumns::ENTRY:
 		{
-			goToInMemoryView(m_model->data(index, Qt::UserRole).toUInt(), true);
+			goToInDisassembler(m_model->data(real_index, Qt::UserRole).toUInt(), true);
 			break;
 		}
 		default: // Default to PC
 		{
-			QModelIndex pc_index = m_model->index(index.row(), ThreadModel::ThreadColumns::PC);
+			QModelIndex pc_index = m_model->index(real_index.row(), ThreadModel::ThreadColumns::PC);
 			goToInDisassembler(m_model->data(pc_index, Qt::UserRole).toUInt(), true);
 			break;
 		}


### PR DESCRIPTION
### Description of Changes
Fixes indexing issues with the thread list when sorted in an order that doesn't match the underlying thread array.

Also makes clicking the entry point move the disassembler instead of the memory view.

### Rationale behind Changes
Since the list is sortable we need to look up the real source index through the proxy model to get a correct index.

### Suggested Testing Steps
Make sure the thread list behaves correctly.

### Did you use AI to help find, test, or implement this issue or feature?
No
