### PR TITLE
Debugger: List loaded IOP modules.

### DIFF
--- a/pcsx2-qt/CMakeLists.txt
+++ b/pcsx2-qt/CMakeLists.txt
@@ -173,6 +173,10 @@ target_sources(pcsx2-qt PRIVATE
 	Debugger/DisassemblyView.h
 	Debugger/DisassemblyView.ui
 	Debugger/JsonValueWrapper.h
+	Debugger/ModuleModel.cpp
+	Debugger/ModuleModel.h
+	Debugger/ModuleView.cpp
+	Debugger/ModuleView.h
 	Debugger/RegisterView.cpp
 	Debugger/RegisterView.h
 	Debugger/RegisterView.ui

--- a/pcsx2-qt/Debugger/Docking/DockTables.cpp
+++ b/pcsx2-qt/Debugger/Docking/DockTables.cpp
@@ -5,6 +5,7 @@
 
 #include "Debugger/DebuggerEvents.h"
 #include "Debugger/DisassemblyView.h"
+#include "Debugger/ModuleView.h"
 #include "Debugger/RegisterView.h"
 #include "Debugger/StackView.h"
 #include "Debugger/ThreadView.h"
@@ -49,6 +50,7 @@ const std::map<std::string, DockTables::DebuggerViewDescription> DockTables::DEB
 	DEBUGGER_VIEW(SavedAddressesView, QT_TRANSLATE_NOOP("DebuggerView", "Saved Addresses"), BOTTOM_MIDDLE),
 	DEBUGGER_VIEW(StackView, QT_TRANSLATE_NOOP("DebuggerView", "Stack"), BOTTOM_MIDDLE),
 	DEBUGGER_VIEW(ThreadView, QT_TRANSLATE_NOOP("DebuggerView", "Threads"), BOTTOM_MIDDLE),
+	DEBUGGER_VIEW(ModuleView, QT_TRANSLATE_NOOP("DebuggerView", "Modules"), BOTTOM_MIDDLE),
 };
 
 #undef DEBUGGER_VIEW
@@ -99,6 +101,7 @@ const std::vector<DockTables::DefaultDockLayout> DockTables::DEFAULT_DOCK_LAYOUT
 			{"MemoryView", DefaultDockGroup::BOTTOM},
 			{"BreakpointView", DefaultDockGroup::BOTTOM},
 			{"ThreadView", DefaultDockGroup::BOTTOM},
+			{"ModuleView", DefaultDockGroup::BOTTOM},
 			{"StackView", DefaultDockGroup::BOTTOM},
 			{"SavedAddressesView", DefaultDockGroup::BOTTOM},
 			{"GlobalVariableTreeView", DefaultDockGroup::BOTTOM},

--- a/pcsx2-qt/Debugger/ModuleModel.cpp
+++ b/pcsx2-qt/Debugger/ModuleModel.cpp
@@ -24,13 +24,11 @@ int ModuleModel::columnCount(const QModelIndex&) const
 
 QVariant ModuleModel::data(const QModelIndex& index, int role) const
 {
-	const std::vector<IopMod> Modules = m_cpu.GetModuleList();
-
 	size_t row = static_cast<size_t>(index.row());
-	if (row >= Modules.size())
+	if (row >= m_modules.size())
 		return QVariant();
 
-	const IopMod* mod = &Modules[row];
+	const IopMod* mod = &m_modules[row];
 
 	if (role == Qt::DisplayRole)
 	{
@@ -130,5 +128,6 @@ QVariant ModuleModel::headerData(int section, Qt::Orientation orientation, int r
 void ModuleModel::refreshData()
 {
 	beginResetModel();
+	m_modules = m_cpu.GetModuleList();
 	endResetModel();
 }

--- a/pcsx2-qt/Debugger/ModuleModel.cpp
+++ b/pcsx2-qt/Debugger/ModuleModel.cpp
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "ModuleModel.h"
+
+#include "QtUtils.h"
+#include "fmt/format.h"
+
+ModuleModel::ModuleModel(DebugInterface& cpu, QObject* parent)
+	: QAbstractTableModel(parent)
+	, m_cpu(cpu)
+{
+}
+
+int ModuleModel::rowCount(const QModelIndex&) const
+{
+	return m_cpu.GetModuleList().size();
+}
+
+int ModuleModel::columnCount(const QModelIndex&) const
+{
+	return ModuleModel::COLUMN_COUNT;
+}
+
+QVariant ModuleModel::data(const QModelIndex& index, int role) const
+{
+	const std::vector<IopMod> Modules = m_cpu.GetModuleList();
+
+	size_t row = static_cast<size_t>(index.row());
+	if (row >= Modules.size())
+		return QVariant();
+
+	const IopMod* mod = &Modules[row];
+
+	if (role == Qt::DisplayRole)
+	{
+		switch (index.column())
+		{
+			case ModuleModel::ModuleColumns::NAME:
+				return mod->name.c_str();
+			case ModuleModel::ModuleColumns::VERSION:
+				return fmt::format("{}.{}", mod->version >> 8, mod->version & 0xff).c_str();
+			case ModuleModel::ModuleColumns::ENTRY:
+				return QtUtils::FilledQStringFromValue(mod->entry, 16);
+			case ModuleModel::ModuleColumns::GP:
+				return QtUtils::FilledQStringFromValue(mod->gp, 16);
+			case ModuleModel::ModuleColumns::TEXT_SECTION:
+			{
+				return QString("[%1 - %2]").arg(QtUtils::FilledQStringFromValue(mod->text_addr, 16), QtUtils::FilledQStringFromValue(mod->text_addr + mod->text_size - 1, 16));
+			}
+			case ModuleModel::ModuleColumns::DATA_SECTION:
+			{
+				u32 addr = mod->text_addr + mod->text_size;
+				return QString("[%1 - %2]").arg(QtUtils::FilledQStringFromValue(addr, 16), QtUtils::FilledQStringFromValue(addr + mod->data_size - 1, 16));
+			}
+			case ModuleModel::ModuleColumns::BSS_SECTION:
+			{
+				if (mod->bss_size == 0)
+				{
+					return "";
+				}
+				u32 addr = mod->text_addr + mod->text_size + mod->data_size;
+				return QString("[%1 - %2]").arg(QtUtils::FilledQStringFromValue(addr, 16), QtUtils::FilledQStringFromValue(addr + mod->bss_size - 1, 16));
+			}
+		}
+	}
+	else if (role == Qt::UserRole)
+	{
+		switch (index.column())
+		{
+			case ModuleModel::ModuleColumns::NAME:
+				return mod->name.c_str();
+			case ModuleModel::ModuleColumns::VERSION:
+				return mod->version;
+			case ModuleModel::ModuleColumns::ENTRY:
+				return mod->entry;
+			case ModuleModel::ModuleColumns::GP:
+				return mod->gp;
+			case ModuleModel::ModuleColumns::TEXT_SECTION:
+				return mod->text_addr;
+			case ModuleModel::ModuleColumns::DATA_SECTION:
+				return mod->text_addr + mod->text_size;
+			case ModuleModel::ModuleColumns::BSS_SECTION:
+			{
+				if (mod->bss_size == 0)
+				{
+					return 0;
+				}
+				return mod->text_addr + mod->text_size + mod->data_size;
+			}
+		}
+	}
+	return QVariant();
+}
+
+QVariant ModuleModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+	if (role == Qt::DisplayRole && orientation == Qt::Horizontal)
+	{
+		switch (section)
+		{
+			case ModuleColumns::NAME:
+				//: Warning: short space limit. Abbreviate if needed.
+				return tr("NAME");
+			case ModuleColumns::VERSION:
+				//: Warning: short space limit. Abbreviate if needed. 
+				return tr("VERSION");
+			case ModuleColumns::ENTRY:
+				//: Warning: short space limit. Abbreviate if needed. // Entrypoint of the executable
+				return tr("ENTRY");
+			case ModuleColumns::GP:
+				//: Warning: short space limit. Abbreviate if needed.
+				return tr("GP");
+			case ModuleColumns::TEXT_SECTION:
+				//: Warning: short space limit. Abbreviate if needed. // Text section of the executable
+				return tr("TEXT");
+			case ModuleColumns::DATA_SECTION:
+				//: Warning: short space limit. Abbreviate if needed. // Data section of the executable
+				return tr("DATA");
+			case ModuleColumns::BSS_SECTION:
+				//: Warning: short space limit. Abbreviate if needed. // BSS section of the executable
+				return tr("BSS");
+			default:
+				return QVariant();
+		}
+	}
+	return QVariant();
+}
+
+void ModuleModel::refreshData()
+{
+	beginResetModel();
+	endResetModel();
+}

--- a/pcsx2-qt/Debugger/ModuleModel.h
+++ b/pcsx2-qt/Debugger/ModuleModel.h
@@ -48,4 +48,5 @@ public:
 
 private:
 	DebugInterface& m_cpu;
+	std::vector<IopMod> m_modules;
 };

--- a/pcsx2-qt/Debugger/ModuleModel.h
+++ b/pcsx2-qt/Debugger/ModuleModel.h
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#pragma once
+
+#include <QtCore/QAbstractTableModel>
+#include <QtWidgets/QHeaderView>
+
+#include "DebugTools/DebugInterface.h"
+#include "DebugTools/BiosDebugData.h"
+
+class ModuleModel : public QAbstractTableModel
+{
+	Q_OBJECT
+
+public:
+	enum ModuleColumns : int
+	{
+		NAME = 0,
+		VERSION,
+		ENTRY,
+		GP,
+		TEXT_SECTION,
+		DATA_SECTION,
+		BSS_SECTION,
+		COLUMN_COUNT
+	};
+
+	static constexpr QHeaderView::ResizeMode HeaderResizeModes[ModuleColumns::COLUMN_COUNT] =
+		{
+			QHeaderView::ResizeMode::ResizeToContents,
+			QHeaderView::ResizeMode::Stretch,
+			QHeaderView::ResizeMode::Stretch,
+			QHeaderView::ResizeMode::Stretch,
+			QHeaderView::ResizeMode::ResizeToContents,
+			QHeaderView::ResizeMode::ResizeToContents,
+			QHeaderView::ResizeMode::ResizeToContents,
+		};
+
+	explicit ModuleModel(DebugInterface& cpu, QObject* parent = nullptr);
+
+	int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+	int columnCount(const QModelIndex& parent = QModelIndex()) const override;
+	QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+	QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
+
+	void refreshData();
+
+private:
+	DebugInterface& m_cpu;
+};

--- a/pcsx2-qt/Debugger/ModuleView.cpp
+++ b/pcsx2-qt/Debugger/ModuleView.cpp
@@ -19,6 +19,7 @@ ModuleView::ModuleView(const DebuggerViewParameters& parameters)
 	connect(m_ui.moduleList, &QTableView::customContextMenuRequested, this, &ModuleView::openContextMenu);
 	connect(m_ui.moduleList, &QTableView::doubleClicked, this, &ModuleView::onDoubleClick);
 
+	m_ui.moduleList->verticalHeader()->setSectionResizeMode(QHeaderView::ResizeMode::ResizeToContents);
 	for (std::size_t i = 0; auto mode : ModuleModel::HeaderResizeModes)
 	{
 		m_ui.moduleList->horizontalHeader()->setSectionResizeMode(i, mode);

--- a/pcsx2-qt/Debugger/ModuleView.cpp
+++ b/pcsx2-qt/Debugger/ModuleView.cpp
@@ -26,6 +26,11 @@ ModuleView::ModuleView(const DebuggerViewParameters& parameters)
 		i++;
 	}
 
+	receiveEvent<DebuggerEvents::Refresh>([this](const DebuggerEvents::Refresh& event) -> bool {
+		m_model->refreshData();
+		return true;
+	});
+
 	receiveEvent<DebuggerEvents::VMUpdate>([this](const DebuggerEvents::VMUpdate& event) -> bool {
 		m_model->refreshData();
 		return true;

--- a/pcsx2-qt/Debugger/ModuleView.cpp
+++ b/pcsx2-qt/Debugger/ModuleView.cpp
@@ -27,7 +27,8 @@ ModuleView::ModuleView(const DebuggerViewParameters& parameters)
 	}
 
 	receiveEvent<DebuggerEvents::Refresh>([this](const DebuggerEvents::Refresh& event) -> bool {
-		m_model->refreshData();
+		if (!QtHost::IsVMPaused())
+			m_model->refreshData();
 		return true;
 	});
 

--- a/pcsx2-qt/Debugger/ModuleView.cpp
+++ b/pcsx2-qt/Debugger/ModuleView.cpp
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "ModuleView.h"
+
+#include "QtUtils.h"
+
+#include <QtGui/QClipboard>
+#include <QtWidgets/QMenu>
+
+ModuleView::ModuleView(const DebuggerViewParameters& parameters)
+	: DebuggerView(parameters, MONOSPACE_FONT)
+	, m_model(new ModuleModel(cpu()))
+{
+	m_ui.setupUi(this);
+	m_ui.moduleList->setModel(m_model);
+
+	m_ui.moduleList->setContextMenuPolicy(Qt::CustomContextMenu);
+	connect(m_ui.moduleList, &QTableView::customContextMenuRequested, this, &ModuleView::openContextMenu);
+	connect(m_ui.moduleList, &QTableView::doubleClicked, this, &ModuleView::onDoubleClick);
+
+	for (std::size_t i = 0; auto mode : ModuleModel::HeaderResizeModes)
+	{
+		m_ui.moduleList->horizontalHeader()->setSectionResizeMode(i, mode);
+		i++;
+	}
+
+	receiveEvent<DebuggerEvents::VMUpdate>([this](const DebuggerEvents::VMUpdate& event) -> bool {
+		m_model->refreshData();
+		return true;
+	});
+}
+
+void ModuleView::openContextMenu(QPoint pos)
+{
+	if (!m_ui.moduleList->selectionModel()->hasSelection())
+		return;
+
+	QMenu* menu = new QMenu(m_ui.moduleList);
+	menu->setAttribute(Qt::WA_DeleteOnClose);
+
+	QAction* copy = menu->addAction(tr("Copy"));
+	connect(copy, &QAction::triggered, [this]() {
+		const QItemSelectionModel* selection_model = m_ui.moduleList->selectionModel();
+		if (!selection_model->hasSelection())
+			return;
+
+		QGuiApplication::clipboard()->setText(m_model->data(selection_model->currentIndex()).toString());
+	});
+
+	menu->addSeparator();
+
+	QAction* copy_all_as_csv = menu->addAction(tr("Copy all as CSV"));
+	connect(copy_all_as_csv, &QAction::triggered, [this]() {
+		QGuiApplication::clipboard()->setText(QtUtils::AbstractItemModelToCSV(m_ui.moduleList->model()));
+	});
+
+	menu->popup(m_ui.moduleList->viewport()->mapToGlobal(pos));
+}
+
+void ModuleView::onDoubleClick(const QModelIndex& index)
+{
+	switch (index.column())
+	{
+		case ModuleModel::ModuleColumns::ENTRY:
+		{
+			goToInDisassembler(m_model->data(index, Qt::UserRole).toUInt(), true);
+			break;
+		}
+		case ModuleModel::ModuleColumns::GP:
+		{
+			goToInMemoryView(m_model->data(index, Qt::UserRole).toUInt(), true);
+			break;
+		}
+		case ModuleModel::ModuleColumns::TEXT_SECTION:
+		{
+			goToInDisassembler(m_model->data(index, Qt::UserRole).toUInt(), true);
+			break;
+		}
+		case ModuleModel::ModuleColumns::DATA_SECTION:
+		{
+			goToInMemoryView(m_model->data(index, Qt::UserRole).toUInt(), true);
+			break;
+		}
+		case ModuleModel::ModuleColumns::BSS_SECTION:
+		{
+			auto data = m_model->data(index, Qt::UserRole).toUInt();
+			if (data)
+			{
+				goToInMemoryView(data, true);
+			}
+			break;
+		}
+		default:
+		{
+			break;
+		}
+	}
+}

--- a/pcsx2-qt/Debugger/ModuleView.h
+++ b/pcsx2-qt/Debugger/ModuleView.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#pragma once
+
+#include "ui_ModuleView.h"
+
+#include "DebuggerView.h"
+#include "ModuleModel.h"
+
+#include <QtCore/QSortFilterProxyModel>
+
+class ModuleView final : public DebuggerView
+{
+	Q_OBJECT
+
+public:
+	ModuleView(const DebuggerViewParameters& parameters);
+
+	void openContextMenu(QPoint pos);
+	void onDoubleClick(const QModelIndex& index);
+
+private:
+	Ui::ModuleView m_ui;
+
+	ModuleModel* m_model;
+};

--- a/pcsx2-qt/Debugger/ModuleView.ui
+++ b/pcsx2-qt/Debugger/ModuleView.ui
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ModuleView</class>
+ <widget class="QWidget" name="ModuleView">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Modules</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QTableView" name="moduleList"/>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/pcsx2-qt/Debugger/ThreadModel.cpp
+++ b/pcsx2-qt/Debugger/ThreadModel.cpp
@@ -23,13 +23,11 @@ int ThreadModel::columnCount(const QModelIndex&) const
 
 QVariant ThreadModel::data(const QModelIndex& index, int role) const
 {
-	const std::vector<std::unique_ptr<BiosThread>> threads = m_cpu.GetThreadList();
-
 	size_t row = static_cast<size_t>(index.row());
-	if (row >= threads.size())
+	if (row >= m_threads.size())
 		return QVariant();
 
-	const BiosThread* thread = threads[row].get();
+	const BiosThread* thread = m_threads[row].get();
 
 	if (role == Qt::DisplayRole)
 	{
@@ -128,5 +126,6 @@ QVariant ThreadModel::headerData(int section, Qt::Orientation orientation, int r
 void ThreadModel::refreshData()
 {
 	beginResetModel();
+	m_threads = m_cpu.GetThreadList();
 	endResetModel();
 }

--- a/pcsx2-qt/Debugger/ThreadModel.h
+++ b/pcsx2-qt/Debugger/ThreadModel.h
@@ -88,4 +88,5 @@ private:
 	};
 
 	DebugInterface& m_cpu;
+	std::vector<std::unique_ptr<BiosThread>> m_threads;
 };

--- a/pcsx2-qt/Debugger/ThreadView.cpp
+++ b/pcsx2-qt/Debugger/ThreadView.cpp
@@ -32,7 +32,8 @@ ThreadView::ThreadView(const DebuggerViewParameters& parameters)
 	}
 
 	receiveEvent<DebuggerEvents::Refresh>([this](const DebuggerEvents::Refresh& event) -> bool {
-		m_model->refreshData();
+		if (!QtHost::IsVMPaused())
+			m_model->refreshData();
 		return true;
 	});
 

--- a/pcsx2-qt/Debugger/ThreadView.cpp
+++ b/pcsx2-qt/Debugger/ThreadView.cpp
@@ -31,6 +31,11 @@ ThreadView::ThreadView(const DebuggerViewParameters& parameters)
 		i++;
 	}
 
+	receiveEvent<DebuggerEvents::Refresh>([this](const DebuggerEvents::Refresh& event) -> bool {
+		m_model->refreshData();
+		return true;
+	});
+
 	receiveEvent<DebuggerEvents::VMUpdate>([this](const DebuggerEvents::VMUpdate& event) -> bool {
 		m_model->refreshData();
 		return true;

--- a/pcsx2-qt/Debugger/ThreadView.cpp
+++ b/pcsx2-qt/Debugger/ThreadView.cpp
@@ -24,6 +24,7 @@ ThreadView::ThreadView(const DebuggerViewParameters& parameters)
 	m_ui.threadList->setModel(m_proxy_model);
 	m_ui.threadList->setSortingEnabled(true);
 	m_ui.threadList->sortByColumn(ThreadModel::ThreadColumns::ID, Qt::SortOrder::AscendingOrder);
+	m_ui.threadList->verticalHeader()->setSectionResizeMode(QHeaderView::ResizeMode::ResizeToContents);
 	for (std::size_t i = 0; auto mode : ThreadModel::HeaderResizeModes)
 	{
 		m_ui.threadList->horizontalHeader()->setSectionResizeMode(i, mode);

--- a/pcsx2-qt/Debugger/ThreadView.cpp
+++ b/pcsx2-qt/Debugger/ThreadView.cpp
@@ -9,7 +9,7 @@
 #include <QtWidgets/QMenu>
 
 ThreadView::ThreadView(const DebuggerViewParameters& parameters)
-	: DebuggerView(parameters, NO_DEBUGGER_FLAGS)
+	: DebuggerView(parameters, MONOSPACE_FONT)
 	, m_model(new ThreadModel(cpu()))
 	, m_proxy_model(new QSortFilterProxyModel())
 {

--- a/pcsx2-qt/pcsx2-qt.vcxproj
+++ b/pcsx2-qt/pcsx2-qt.vcxproj
@@ -121,6 +121,8 @@
     <ClCompile Include="Debugger\StackView.cpp" />
     <ClCompile Include="Debugger\ThreadModel.cpp" />
     <ClCompile Include="Debugger\ThreadView.cpp" />
+    <ClCompile Include="Debugger\ModuleModel.cpp" />
+    <ClCompile Include="Debugger\ModuleView.cpp" />
     <ClCompile Include="Debugger\Breakpoints\BreakpointDialog.cpp" />
     <ClCompile Include="Debugger\Breakpoints\BreakpointModel.cpp" />
     <ClCompile Include="Debugger\Breakpoints\BreakpointView.cpp" />
@@ -235,6 +237,8 @@
     <QtMoc Include="Debugger\RegisterView.h" />
     <QtMoc Include="Debugger\StackModel.h" />
     <QtMoc Include="Debugger\StackView.h" />
+    <QtMoc Include="Debugger\ModuleModel.h" />
+    <QtMoc Include="Debugger\ModuleView.h" />
     <QtMoc Include="Debugger\ThreadModel.h" />
     <QtMoc Include="Debugger\ThreadView.h" />
     <ClInclude Include="Debugger\DebuggerSettingsManager.h" />
@@ -309,6 +313,8 @@
     <ClCompile Include="$(IntDir)Debugger\moc_RegisterView.cpp" />
     <ClCompile Include="$(IntDir)Debugger\moc_StackModel.cpp" />
     <ClCompile Include="$(IntDir)Debugger\moc_StackView.cpp" />
+    <ClCompile Include="$(IntDir)Debugger\moc_ModuleModel.cpp" />
+    <ClCompile Include="$(IntDir)Debugger\moc_ModuleView.cpp" />
     <ClCompile Include="$(IntDir)Debugger\moc_ThreadModel.cpp" />
     <ClCompile Include="$(IntDir)Debugger\moc_ThreadView.cpp" />
     <ClCompile Include="$(IntDir)Debugger\Breakpoints\moc_BreakpointDialog.cpp" />
@@ -368,6 +374,7 @@
     <QtUi Include="Debugger\StackView.ui" />
     <QtUi Include="Debugger\SymbolTree\NewSymbolDialog.ui" />
     <QtUi Include="Debugger\SymbolTree\SymbolTreeView.ui" />
+    <QtUi Include="Debugger\ModuleView.ui" />
     <QtUi Include="Debugger\ThreadView.ui" />
     <QtUi Include="GameList\EmptyGameListWidget.ui" />
     <QtUi Include="GameList\GameListWidget.ui" />

--- a/pcsx2/DebugTools/BiosDebugData.cpp
+++ b/pcsx2/DebugTools/BiosDebugData.cpp
@@ -69,3 +69,29 @@ std::vector<std::unique_ptr<BiosThread>> getIOPThreads()
 
 	return threads;
 }
+
+std::vector<IopMod> getIOPModules()
+{
+	u32 maddr = iopMemRead32(CurrentBiosInformation.iopModListAddr);
+	std::vector<IopMod> modlist;
+
+	while (maddr != 0)
+	{
+		IopMod mod;
+
+		mod.name = iopMemReadString(iopMemRead32(maddr + 4));
+		mod.version = iopMemRead16(maddr + 8);
+		mod.entry = iopMemRead32(maddr + 0x10);
+		mod.gp = iopMemRead32(maddr + 0x14);
+		mod.text_addr = iopMemRead32(maddr + 0x18);
+		mod.text_size = iopMemRead32(maddr + 0x1c);
+		mod.data_size = iopMemRead32(maddr + 0x20);
+		mod.bss_size = iopMemRead32(maddr + 0x24);
+
+		modlist.push_back(mod);
+
+		maddr = iopMemRead32(maddr);
+	}
+
+	return modlist;
+}

--- a/pcsx2/DebugTools/BiosDebugData.cpp
+++ b/pcsx2/DebugTools/BiosDebugData.cpp
@@ -74,10 +74,24 @@ std::vector<IopMod> getIOPModules()
 {
 	u32 maddr = iopMemRead32(CurrentBiosInformation.iopModListAddr);
 	std::vector<IopMod> modlist;
+	int i = 0;
 
 	while (maddr != 0)
 	{
 		IopMod mod;
+
+		if (maddr >= 0x200000)
+		{
+			// outside of memory
+			// change if we ever support IOP ram extension
+			return {};
+		}
+
+		if (i > 200)
+		{
+			// 200 modules? unlikely
+			return {};
+		}
 
 		u32 nstr = iopMemRead32(maddr + 4);
 		if (nstr)
@@ -100,6 +114,7 @@ std::vector<IopMod> getIOPModules()
 		modlist.push_back(mod);
 
 		maddr = iopMemRead32(maddr);
+		i++;
 	}
 
 	return modlist;

--- a/pcsx2/DebugTools/BiosDebugData.cpp
+++ b/pcsx2/DebugTools/BiosDebugData.cpp
@@ -79,7 +79,16 @@ std::vector<IopMod> getIOPModules()
 	{
 		IopMod mod;
 
-		mod.name = iopMemReadString(iopMemRead32(maddr + 4));
+		u32 nstr = iopMemRead32(maddr + 4);
+		if (nstr)
+		{
+			mod.name = iopMemReadString(iopMemRead32(maddr + 4));
+		}
+		else
+		{
+			mod.name = "(NULL)";
+		}
+
 		mod.version = iopMemRead16(maddr + 8);
 		mod.entry = iopMemRead32(maddr + 0x10);
 		mod.gp = iopMemRead32(maddr + 0x14);

--- a/pcsx2/DebugTools/BiosDebugData.h
+++ b/pcsx2/DebugTools/BiosDebugData.h
@@ -178,5 +178,18 @@ private:
 	IOPInternalThread data;
 };
 
+struct IopMod
+{
+	std::string name;
+	u16 version;
+	u32 text_addr;
+	u32 entry;
+	u32 gp;
+	u32 text_size;
+	u32 data_size;
+	u32 bss_size;
+};
+
 std::vector<std::unique_ptr<BiosThread>> getIOPThreads();
+std::vector<IopMod> getIOPModules();
 std::vector<std::unique_ptr<BiosThread>> getEEThreads();

--- a/pcsx2/DebugTools/DebugInterface.cpp
+++ b/pcsx2/DebugTools/DebugInterface.cpp
@@ -734,6 +734,11 @@ std::vector<std::unique_ptr<BiosThread>> R5900DebugInterface::GetThreadList() co
 	return getEEThreads();
 }
 
+std::vector<IopMod> R5900DebugInterface::GetModuleList() const
+{
+	return {};
+}
+
 //
 // R3000DebugInterface
 //
@@ -1060,6 +1065,11 @@ SymbolImporter* R3000DebugInterface::GetSymbolImporter() const
 std::vector<std::unique_ptr<BiosThread>> R3000DebugInterface::GetThreadList() const
 {
 	return getIOPThreads();
+}
+
+std::vector<IopMod> R3000DebugInterface::GetModuleList() const
+{
+	return getIOPModules();
 }
 
 ElfMemoryReader::ElfMemoryReader(const ccc::ElfFile& elf)

--- a/pcsx2/DebugTools/DebugInterface.h
+++ b/pcsx2/DebugTools/DebugInterface.h
@@ -90,6 +90,7 @@ public:
 	virtual SymbolGuardian& GetSymbolGuardian() const = 0;
 	virtual SymbolImporter* GetSymbolImporter() const = 0;
 	virtual std::vector<std::unique_ptr<BiosThread>> GetThreadList() const = 0;
+	virtual std::vector<IopMod> GetModuleList() const = 0;
 
 	bool isAlive();
 	bool isCpuPaused();
@@ -151,6 +152,7 @@ public:
 	SymbolGuardian& GetSymbolGuardian() const override;
 	SymbolImporter* GetSymbolImporter() const override;
 	std::vector<std::unique_ptr<BiosThread>> GetThreadList() const override;
+	std::vector<IopMod> GetModuleList() const override;
 
 	std::string disasm(u32 address, bool simplify) override;
 	bool isValidAddress(u32 address) override;
@@ -194,6 +196,7 @@ public:
 	SymbolGuardian& GetSymbolGuardian() const override;
 	SymbolImporter* GetSymbolImporter() const override;
 	std::vector<std::unique_ptr<BiosThread>> GetThreadList() const override;
+	std::vector<IopMod> GetModuleList() const override;
 
 	std::string disasm(u32 address, bool simplify) override;
 	bool isValidAddress(u32 address) override;

--- a/pcsx2/IopBios.cpp
+++ b/pcsx2/IopBios.cpp
@@ -1055,27 +1055,22 @@ namespace R3000A
 
 		u32 GetModList(u32 a0reg)
 		{
-			u32 lcptr = iopMemRead32(0x3f0);
-			u32 lcstring = irxFindLoadcore(lcptr);
-			u32 list = 0;
+			/* Loadcore puts a pointer to a static array at 0x3f0 */
+			u32 bootmodes_ptr = iopMemRead32(0x3f0);
+			/* Search for the main loadcore struct from there */
+			u32 lcstring = irxFindLoadcore(bootmodes_ptr);
+			u32 lc_struct = 0;
 
 			if (lcstring == 0)
 			{
-				list = lcptr - 0x20;
+				lc_struct = bootmodes_ptr - 0x20;
 			}
 			else
 			{
-				list = lcstring + 0x18;
+				lc_struct = lcstring + 0x18;
 			}
 
-			u32 mod = iopMemRead32(list);
-
-			while (mod != 0)
-			{
-				mod = iopMemRead32(mod);
-			}
-
-			return list;
+			return lc_struct + 0x10;
 		}
 
 		// Gets the thread list ptr from thbase


### PR DESCRIPTION
![Screenshot_20250520_193501](https://github.com/user-attachments/assets/82250df3-56dc-4f28-8a39-90be8fcd0f1b)

(oops, text section end is broken in screenshot but fixed in pr)

### Description of Changes
Find and display the list of loaded modules by inspecting `loadcore`.

### Rationale behind Changes
It's nice for debugging to be able to quickly figure out what code is running.

### Suggested Testing Steps
Just open the list on whatever game/thing you can think of.

I'm quite worried about the loadcore detection and list traversal breaking if there is some possible struct layout that I didn't account for, or on something weird that doesn't have loadcore at all.

### Did you use AI to help find, test, or implement this issue or feature?
No
