### PR TITLE
GS/HW: Add sanity/hazard checks for DATE and Texture barriers.

### DIFF
--- a/pcsx2/GS/GSClut.cpp
+++ b/pcsx2/GS/GSClut.cpp
@@ -462,7 +462,8 @@ void GSClut::GetAlphaMinMax32(int& amin_out, int& amax_out)
 {
 	// call only after Read32
 
-	pxAssert(!m_read.dirty);
+	if (m_read.dirty)
+		GL_INS("GSClut: GetAlphaMinMax32 m_read.dirty");
 
 	if (m_read.adirty)
 	{


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/HW: Add sanity/hazard checks for DATE and Texture barriers.
When checking for full barrier, also check if texture barriers are supported.
Get rid of preprocessSel in DX11, turn off full barrier and related stuff when not supported in rendererhw instead.
Check if StencilDate types are actually enabled, don't want to turn it on for any others.

Bonus:
GSClut: Get rid of m_read.dirty assert in GetAlphaMinMax32.
Replace it with a log.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Hazard checks, these shouldn't be hit but just in case, and makes testing/changing stuff easier.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Quick test on Persona 3/4 shadows, GT4 car reflections with max blending, and some other games.