### PR TITLE
Debugger: Add Follow Address option in memory view

### DIFF
--- a/pcsx2-qt/Debugger/Memory/MemoryView.cpp
+++ b/pcsx2-qt/Debugger/Memory/MemoryView.cpp
@@ -565,8 +565,11 @@ void MemoryView::openContextMenu(QPoint pos)
 		return std::optional(event);
 	});
 
-	QAction* go_to_address_action = menu->addAction(tr("Go to address"));
+	QAction* go_to_address_action = menu->addAction(tr("Go to Address"));
 	connect(go_to_address_action, &QAction::triggered, this, [this]() { contextGoToAddress(); });
+
+	QAction* follow_address_action = menu->addAction(tr("Follow Address"));
+	connect(follow_address_action, &QAction::triggered, this, [this]() { contextFollowAddress(); });
 
 	menu->addSeparator();
 
@@ -664,6 +667,16 @@ void MemoryView::contextGoToAddress()
 	}
 
 	gotoAddress(static_cast<u32>(address));
+}
+
+void MemoryView::contextFollowAddress()
+{
+	bool valid;
+	u32 address = cpu().read32(m_table.selectedAddress & ~3, valid);
+	if (!valid)
+		return;
+
+	gotoAddress(address);
 }
 
 void MemoryView::mouseDoubleClickEvent(QMouseEvent* event)

--- a/pcsx2-qt/Debugger/Memory/MemoryView.h
+++ b/pcsx2-qt/Debugger/Memory/MemoryView.h
@@ -126,6 +126,7 @@ public slots:
 	void openContextMenu(QPoint pos);
 
 	void contextGoToAddress();
+	void contextFollowAddress();
 	void contextCopyByte();
 	void contextCopySegment();
 	void contextCopyCharacter();


### PR DESCRIPTION
### Description of Changes
Adds a Follow Address menu option to the memory view.

### Rationale behind Changes
Parity with the wxWidgets debugger, fixes one of the issues mentioned in #12691.

### Suggested Testing Steps
Make sure the new menu option works.

### Did you use AI to help find, test, or implement this issue or feature?
No.
