### PR TITLE
MemoryCard: Fix crash when attempting to save read only file.

### DIFF
--- a/pcsx2/SIO/Memcard/MemoryCardFolder.cpp
+++ b/pcsx2/SIO/Memcard/MemoryCardFolder.cpp
@@ -63,6 +63,12 @@ static std::optional<ryml::Tree> loadYamlFile(const char* filePath)
 static void SaveYAMLToFile(const char* filename, const ryml::NodeRef& node)
 {
 	auto file = FileSystem::OpenCFile(filename, "w");
+	if (!file)
+	{
+		Console.Error(fmt::format("[MemoryCard] Failed to open '{}' for writing: {}.", filename, std::strerror(errno)));
+		return;
+	}
+
 	ryml::emit_yaml(node, file);
 	std::fflush(file);
 	std::fclose(file);


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
MemoryCard: Fix crash when attempting to save read only file.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Crash fix/bugfix.
Fixes https://github.com/PCSX2/pcsx2/issues/12658

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Use folder memory cards, make the location read only, try to save and see if it crashes, see if any log messages appear when failing to save.