### PR TITLE
USB: Dual Cursor Lightgun

### DIFF
--- a/pcsx2/ImGui/ImGuiManager.cpp
+++ b/pcsx2/ImGui/ImGuiManager.cpp
@@ -1221,9 +1221,7 @@ void ImGuiManager::SetSoftwareCursor(u32 index, std::string image_path, float im
 	// Also, need to make it run on the GSthread to ensure thread safety or OpenGL renderer will have race conditions due to not creating texture without a valid accompanying context.
 	if (MTGS::IsOpen())
 	{
-		MTGS::RunOnGSThread([index]() {
-			UpdateSoftwareCursorTexture(index);
-		});
+		UpdateSoftwareCursorTexture(index); // Since the entire lambda MTGS::RunOnGSThread([index, image_path = ...]() { ... }); is already executing on the GS thread, the UpdateSoftwareCursorTexture(index) call within it is also on the GS thread. Therefore, it doesn't strictly need its own separate MTGS::RunOnGSThread wrapper around it. If you do call MTGS it will lock up Big Picture Mode (FSUI).
 	}
 
 	// If showing or hiding the cursor for Player 1 (index 0), update the host mouse mode


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
There seems to be an issue with how the MTGS handles the enumeration and drawing, updating for the replaced crosshairs icons that the users provides like in a .png format. Master would be random but tends to only show USB Device 1 crosshair. But now 2 at same time should work. Hopefully gets rid of https://github.com/PCSX2/pcsx2/issues/11423
![2025-05-23_03-36](https://github.com/user-attachments/assets/c42e1eeb-09fe-4a23-b5eb-14355de71483)
![2025-05-23_03-35](https://github.com/user-attachments/assets/311a20a5-4efe-456d-b026-7aa606bdf320)
![2025-05-23_04-28](https://github.com/user-attachments/assets/ec26bd44-1cd5-445b-a0f7-4effa1f1d5c3)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
The niche lightgun users also using niche dual replaced icons was certainly a bug as you get ghost inputs if not the texture was carefully drawn.
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Normal games work, but best in any game that uses GunCon2 aka lightgun games.
### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No, this mess is my own.