### PR TITLE
Add listings for PSX Update Disc to the GameDB.

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1219,6 +1219,26 @@ PKP2-00702:
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Vertical and horizontal lines in FMV.
+PSXC-00201:
+  name: "DESR-7000/DESR-5000 専用:PSXアップデートディスク Version 1.10"
+  name-sort: "でえする-7000/でえする-5000 せんよう:PSXあっぷでーとでぃす うえるしぉん 1.10"
+  name-en: "PSX Update Disc Version 1.10"
+  region: "NTSC-J"
+PSXC-00202:
+  name: "DESR-7000/DESR-5000 専用:PSXアップデートディスク Version 1.20"
+  name-sort: "でえする-7000/でえする-5000 せんよう:PSXあっぷでーとでぃす うえるしぉん 1.20"
+  name-en: "PSX Update Disc Version 1.20"
+  region: "NTSC-J"
+PSXC-00203:
+  name: "DESR-7000/DESR-5000 専用:PSXアップデートディスク Version 1.31"
+  name-sort: "でえする-7000/でえする-5000 せんよう:PSXあっぷでーとでぃす うえるしぉん 1.31"
+  name-en: "PSX Update Disc Version 1.31"
+  region: "NTSC-J"
+PSXC-00204:
+  name: "DESR-7000/DESR-5000 専用:PSXアップデートディスク Version 2.11"
+  name-sort: "でえする-7000/でえする-5000 せんよう:PSXあっぷでーとでぃす うえるしぉん 2.11"
+  name-en: "PSX Update Disc Version 2.11"
+  region: "NTSC-J"
 PUPX-93033:
   name: "PlayStation Seizou Kensa-you Disc 3 CD-ROM US-ban Ver1.1"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Adds the 4 versions of [PSX Update Disc](https://wiki.pcsx2.net/PSX_Update_Disc) to the index.

### Rationale behind Changes
I had pondered for a couple months now how to make the PCSX2 menu show the PSX Update Discs with a Japanese flag by default (as opposed to having to change the flag manually in PCSX2's game settings), and gradually found the Game Index system, which I'm now hoping to add the disc infos to.

### Suggested Testing Steps
1. Have any of the PSX Update Disc versions show up in the game list of a PCSX2 instance.
2. See that their flags by default show a grey box with a question mark, or no box/flag at all.
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

### Did you use AI to help find, test, or implement this issue or feature?
No.