### PR TITLE
Core: FTOI optimizations

### DIFF
--- a/pcsx2/FPU.cpp
+++ b/pcsx2/FPU.cpp
@@ -249,7 +249,6 @@ void CTC1() {
 
 void CVT_S() {
 	_FdValf_ = (float)_FsValSl_;
-	_FdValf_ = fpuDouble( _FdValUl_ );
 }
 
 void CVT_W() {

--- a/pcsx2/VUops.cpp
+++ b/pcsx2/VUops.cpp
@@ -879,12 +879,10 @@ static __fi u32 floatToInt(u32 uvalue)
 	float fvalue = std::bit_cast<float>(uvalue);
 	if (Offset)
 		fvalue *= std::bit_cast<float>(0x3f800000 + (Offset << 23));
-	s32 svalue = std::bit_cast<s32>(fvalue);
+	uvalue = std::bit_cast<u32>(fvalue);
 
-	if (svalue >= static_cast<s32>(0x4f000000))
-		return 0x7fffffff;
-	else if (svalue <= static_cast<s32>(0xcf000000))
-		return 0x80000000;
+	if ((uvalue & 0x7f800000) >= 0x4f000000)
+		return (uvalue & 0x80000000) ? 0x80000000 : 0x7fffffff;
 	else
 		return static_cast<u32>(static_cast<s32>(fvalue));
 }

--- a/pcsx2/x86/microVU_Misc.h
+++ b/pcsx2/x86/microVU_Misc.h
@@ -42,6 +42,7 @@ struct mVU_Globals
 	u32   E4      [4] = __four(0x3933e553);
 	u32   E5      [4] = __four(0x36b63510);
 	u32   E6      [4] = __four(0x353961ac);
+	u32   I32MAXF [4] = __four(0x4effffff);
 	float FTOI_4  [4] = __four(16.0);
 	float FTOI_12 [4] = __four(4096.0);
 	float FTOI_15 [4] = __four(32768.0);


### PR DESCRIPTION
### Description of Changes
Slightly faster FTOI implementation
I also removed the FPUd implementation, since it was identical to the normal one
Also I totally broke FTOI on negative numbers in the interpreter in #12324, this fixes that

### Rationale behind Changes
Faster yay

### Suggested Testing Steps
Test games
<details>
<summary>Run this program</summary>

```cpp
int main(int argc, const char* argv[]) {
	u32 i = 0;
	do {
		if ((i & 0xfffffff) == 0)
			printf("%08x\n", i);
		u32 cop1, cop2;
		asm(
			"qmtc2 %[reg], $vf1\n\t"
			"mtc1  %[reg], $f1 \n\t"
			"vftoi0  $vf2, $vf1\n\t"
			"cvt.w.s $f2,  $f1 \n\t"
			"qmfc2 %[c2],  $vf2\n\t"
			"mfc1  %[c1],  $f2 \n\t"
			"addiu %[c2],  0   \n\t"
			: [c1]"=r"(cop1), [c2]"=r"(cop2)
			: [reg]"r"(i)
			: "f1", "f2"
		);
		u32 exponent = (i >> 23) & 0xff;
		u32 expected;
		if (exponent >= 158) {
			expected = (i & 0x80000000) ? 0x80000000 : 0x7fffffff;
		} else if (exponent < 127) {
			expected = 0;
		} else {
			u32 mantissa = (i & 0x7fffff) | 0x800000;
			if (exponent >= 150)
				expected = mantissa << (exponent - 150);
			else
				expected = mantissa >> (150 - exponent);
			if (i & 0x80000000)
				expected = -expected;
		}

		if (cop1 != expected)
			printf("int(%08x) = %08x[COP1] != %08x[Expected]\n", i, cop1, expected);
		if (cop2 != expected)
			printf("int(%08x) = %08x[COP2] != %08x[Expected]\n", i, cop2, expected);
	} while (++i);
	printf("Sleeping\n");
	SleepThread();
}
```
</details>

### Did you use AI to help find, test, or implement this issue or feature?

No