### PR TITLE
GS/TC: On clear delete overlapping depth targets

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -3940,7 +3940,7 @@ void GSTextureCache::InvalidateContainedTargets(u32 start_bp, u32 end_bp, u32 wr
 
 			const u32 offset = (std::abs(static_cast<int>(start_bp - t->m_TEX0.TBP0)) >> 5) % std::max(1U, t->m_TEX0.TBW);
 			// If not fully contained but they are aligned and or clean, just dirty the area.
-			if (start_bp != t->m_TEX0.TBP0 && (t->m_TEX0.TBP0 < start_bp || t->UnwrappedEndBlock() > end_bp) && (offset == 0 || t->m_dirty.size() == 0))
+			if (type != DepthStencil && start_bp != t->m_TEX0.TBP0 && (t->m_TEX0.TBP0 < start_bp || t->UnwrappedEndBlock() > end_bp) && (offset == 0 || t->m_dirty.size() == 0))
 			{
 				if (write_bw == t->m_TEX0.TBW && GSLocalMemory::m_psm[t->m_TEX0.PSM].bpp == GSLocalMemory::m_psm[write_psm].bpp)
 				{


### PR DESCRIPTION
### Description of Changes
Always deletes depth targets on clear overlap

### Rationale behind Changes
This was the behaviour from before RT in RT, however when I allowed partial invalidations I didn't limit it to render targets, this changes that.

### Suggested Testing Steps
Test Ace Coimbat Squadron Leader/The Belkin War (just in case) and WWE Smackdown Vs RAW 2006 

### Did you use AI to help find, test, or implement this issue or feature?
If you mean Actual Insanity, yes, if you mean Artificial Intelligence, no.

WWE SvR 2006:
Master:
![image](https://github.com/user-attachments/assets/c1304089-7dca-4e25-8583-d72afbceb5da)
PR:
![image](https://github.com/user-attachments/assets/eb9113f8-73b8-4a35-8279-816eebd49151)

