### PR TITLE
OSD: Fix performance overlay overwriting dump stats when shifted left

### DIFF
--- a/pcsx2/GSDumpReplayer.cpp
+++ b/pcsx2/GSDumpReplayer.cpp
@@ -379,8 +379,8 @@ void GSDumpReplayer::RenderUI()
 	do \
 	{ \
 		text_size = font->CalcTextSizeA(font->FontSize, std::numeric_limits<float>::max(), -1.0f, (text), nullptr, nullptr); \
-		dl->AddText(font, font->FontSize, ImVec2(margin + shadow_offset, position_y + shadow_offset), IM_COL32(0, 0, 0, 100), (text)); \
-		dl->AddText(font, font->FontSize, ImVec2(margin, position_y), color, (text)); \
+		dl->AddText(font, font->FontSize, ImVec2(GSConfig.OsdPerformancePos == OsdOverlayPos::TopLeft ? ImGuiManager::GetWindowWidth() - margin - text_size.x + shadow_offset : margin + shadow_offset, position_y + shadow_offset), IM_COL32(0, 0, 0, 100), (text)); \
+		dl->AddText(font, font->FontSize, ImVec2(GSConfig.OsdPerformancePos == OsdOverlayPos::TopLeft ? ImGuiManager::GetWindowWidth() - margin - text_size.x : margin, position_y), color, (text)); \
 		position_y += text_size.y + spacing; \
 	} while (0)
 


### PR DESCRIPTION
### Description of Changes
Makes it so that the GS run stats flip to the right side if the performance stats are on the left side.

### Rationale behind Changes
Fixes #12706.

### Suggested Testing Steps
Try to repro 12706 (steps there).

### Did you use AI to help find, test, or implement this issue or feature?
Negative. I am a flesh-based organic humanoid much like yourself. beep boop

### Screenshot
![Proper position for dump message with shifted performance metrics](https://github.com/user-attachments/assets/5f9f18b3-0b24-406a-a18f-f7c48d91db98)
