### PR TITLE
FSUI: Fix save state duplicate entry

### DIFF
--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -5738,9 +5738,12 @@ u32 FullscreenUI::PopulateSaveStateListEntries(const std::string& title, const s
 		if (InitializeSaveStateListEntry(&li, title, serial, crc, i) || !s_save_state_selector_loading)
 			s_save_state_selector_slots.push_back(std::move(li));
 
-		SaveStateListEntry bli;
-		if (InitializeSaveStateListEntry(&bli, title, serial, crc, i, true) || !s_save_state_selector_loading)
-			s_save_state_selector_slots.push_back(std::move(bli));
+		if (s_save_state_selector_loading)
+		{
+			SaveStateListEntry bli;
+			if (InitializeSaveStateListEntry(&bli, title, serial, crc, i, true))
+				s_save_state_selector_slots.push_back(std::move(bli));
+		}
 	}
 
 	return static_cast<u32>(s_save_state_selector_slots.size());


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
This PR fixes savestates entry duplicating due to backup states.

Before:
![Screenshot_20250525_081602](https://github.com/user-attachments/assets/446540c7-6c3c-49c4-ac90-df4462cb46f2)

After:
![Screenshot_20250525_080735](https://github.com/user-attachments/assets/32dab61e-4201-4e4a-b1f2-75f162cb0882)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Less brokee, more goodee.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
When running a game, go to the Save state menu on BPM and see if the entry are duplicated.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
Nggak