### PR TITLE
GS/HW: Invalidate single columns on format mismatch

### DIFF
--- a/pcsx2/GS/GSLocalMemory.cpp
+++ b/pcsx2/GS/GSLocalMemory.cpp
@@ -70,6 +70,7 @@ GSLocalMemory::GSLocalMemory()
 		psm.wfa = &GSLocalMemory::WritePixel32;
 		psm.bpp = psm.trbpp = 32;
 		psm.pal = 0;
+		psm.cs = GSVector2i(8, 2);
 		psm.bs = GSVector2i(8, 8);
 		psm.pgs = GSVector2i(64, 32);
 		psm.msk = 0xff;
@@ -197,6 +198,11 @@ GSLocalMemory::GSLocalMemory()
 	m_psm[PSMCT16].fmt = m_psm[PSMZ16].fmt = PSM_FMT_16;
 	m_psm[PSMCT16S].fmt = m_psm[PSMZ16S].fmt = PSM_FMT_16;
 
+	m_psm[PSGPU24].cs = GSVector2i(16, 2);
+	m_psm[PSMCT16].cs = m_psm[PSMCT16S].bs = GSVector2i(16, 2);
+	m_psm[PSMT8].cs = GSVector2i(16, 4);
+	m_psm[PSMT4].cs = GSVector2i(32, 4);
+	m_psm[PSMZ16].cs = m_psm[PSMZ16S].bs = GSVector2i(16, 2);
 
 	m_psm[PSGPU24].bs = GSVector2i(16, 8);
 	m_psm[PSMCT16].bs = m_psm[PSMCT16S].bs = GSVector2i(16, 8);

--- a/pcsx2/GS/GSLocalMemory.h
+++ b/pcsx2/GS/GSLocalMemory.h
@@ -460,7 +460,7 @@ public:
 		readTexture rtx, rtxP;
 		readTextureBlock rtxb, rtxbP;
 		u16 bpp, trbpp, pal, fmt;
-		GSVector2i bs, pgs;
+		GSVector2i cs, bs, pgs;
 		u8 msk, depth;
 		u32 fmsk;
 	};

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -621,9 +621,12 @@ void GSTextureCache::DirtyRectByPage(u32 sbp, u32 spsm, u32 sbw, Target* t, GSVe
 	if (!(src_info->bpp == dst_info->bpp))
 	{
 		const int src_bpp = src_info->bpp;
+		const bool column_align = !block_offset && src_r.z <= src_info->cs.x && src_r.w <= src_info->cs.y && src_info->depth == dst_info->depth;
 
 		if (block_offset)
 			in_rect = in_rect.ralign<Align_Outside>(src_info->bs);
+		else if (column_align)
+			in_rect = in_rect.ralign<Align_Outside>(src_info->cs);
 		else
 			in_rect = in_rect.ralign<Align_Outside>(src_info->pgs);
 
@@ -639,7 +642,10 @@ void GSTextureCache::DirtyRectByPage(u32 sbp, u32 spsm, u32 sbw, Target* t, GSVe
 
 		// Translate back to the new(dst) format.
 		in_rect = GSVector4i(in_pages.x * src_info->pgs.x, in_pages.y * src_info->pgs.y, in_pages.z * src_info->pgs.x, in_pages.w * src_info->pgs.y);
-		in_rect += GSVector4i(in_blocks.x * src_info->bs.x, in_blocks.y * src_info->bs.y, in_blocks.z * src_info->bs.x, in_blocks.w * src_info->bs.y);
+		if (column_align)
+			in_rect += GSVector4i(in_blocks.x * src_info->cs.x, in_blocks.y * src_info->cs.y, in_blocks.z * src_info->cs.x, in_blocks.w * src_info->cs.y);
+		else
+			in_rect += GSVector4i(in_blocks.x * src_info->bs.x, in_blocks.y * src_info->bs.y, in_blocks.z * src_info->bs.x, in_blocks.w * src_info->bs.y);
 
 		if (in_rect.rempty())
 			return;


### PR DESCRIPTION
### Description of Changes
Invalidate by column if in the first block when formats do not match but the size of the invalidation is less than/equal to the size of a column

### Rationale behind Changes
This should be safe to do as the storage size of a column is the same on every format, and the first column of the first block in a page is always in the same place.  Katamari Damacy overwrites this with a palette, for some reason, I guess they thought it'd be hidden by overscan, but we were nuking the entire first page before to be safe, leaving a very obvious black square in the corner.

### Suggested Testing Steps
Check Katamari Damacy 2 player mode, not much else affected.

### Did you use AI to help find, test, or implement this issue or feature?
No

Fixes #8353

Katamari Damacy:
Master:
![image](https://github.com/user-attachments/assets/623fd363-d03e-48f7-a1e0-15b4703e1b8d)
PR (Software looks identical):
![image](https://github.com/user-attachments/assets/7c7f7772-6c2a-4763-9b13-ce2476d6cec3)
