### PR TITLE
GameList: Fix region flag icons for non-English languages and more

### DIFF
--- a/pcsx2-qt/GameList/GameListModel.cpp
+++ b/pcsx2-qt/GameList/GameListModel.cpp
@@ -440,7 +440,7 @@ bool GameListModel::titlesLessThan(int left_row, int right_row) const
 	const GameList::Entry* left = GameList::GetEntryByIndex(left_row);
 	const GameList::Entry* right = GameList::GetEntryByIndex(right_row);
 	return QtHost::LocaleSensitiveCompare(QString::fromStdString(left->GetTitleSort(m_prefer_english_titles)),
-	                                      QString::fromStdString(right->GetTitleSort(m_prefer_english_titles))) < 0;
+			   QString::fromStdString(right->GetTitleSort(m_prefer_english_titles))) < 0;
 }
 
 bool GameListModel::lessThan(const QModelIndex& left_index, const QModelIndex& right_index, int column) const
@@ -569,7 +569,7 @@ QIcon GameListModel::getIconForType(GameList::EntryType type)
 QIcon GameListModel::getIconForRegion(GameList::Region region)
 {
 	return QIcon(
-		QStringLiteral("%1/icons/flags/%2.svg").arg(QtHost::GetResourcesBasePath()).arg(GameList::RegionToString(region)));
+		QStringLiteral("%1/icons/flags/%2.svg").arg(QtHost::GetResourcesBasePath()).arg(GameList::RegionToString(region, false)));
 }
 
 void GameListModel::loadThemeSpecificImages()

--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -133,7 +133,7 @@ namespace
 			const QPoint p = QPoint((r.width() - pix_width) / 2, (r.height() - pix_height) / 2);
 			if (option.state & QStyle::State_Selected)
 			{
-				// See QItemDelegate::selectedPixmap()		
+				// See QItemDelegate::selectedPixmap()
 				QString key = QString::fromStdString(fmt::format("{:016X}-{:d}", pix.cacheKey(), enabled));
 				QPixmap pm;
 				if (!QPixmapCache::find(key, &pm))
@@ -184,12 +184,12 @@ void GameListWidget::initialize()
 	for (u32 type = 0; type < static_cast<u32>(GameList::EntryType::Count); type++)
 	{
 		m_ui.filterType->addItem(GameListModel::getIconForType(static_cast<GameList::EntryType>(type)),
-			qApp->translate("GameList", GameList::EntryTypeToDisplayString(static_cast<GameList::EntryType>(type))));
+			GameList::EntryTypeToString(static_cast<GameList::EntryType>(type), true));
 	}
 	for (u32 region = 0; region < static_cast<u32>(GameList::Region::Count); region++)
 	{
 		m_ui.filterRegion->addItem(GameListModel::getIconForRegion(static_cast<GameList::Region>(region)),
-			qApp->translate("GameList", GameList::RegionToString(static_cast<GameList::Region>(region))));
+			GameList::RegionToString(static_cast<GameList::Region>(region), true));
 	}
 
 	connect(m_ui.viewGameList, &QPushButton::clicked, this, &GameListWidget::showGameList);

--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -181,11 +181,16 @@ void GameListWidget::initialize()
 	m_sort_model->setSourceModel(m_model);
 
 	m_ui.setupUi(this);
+
 	for (u32 type = 0; type < static_cast<u32>(GameList::EntryType::Count); type++)
 	{
-		m_ui.filterType->addItem(GameListModel::getIconForType(static_cast<GameList::EntryType>(type)),
-			GameList::EntryTypeToString(static_cast<GameList::EntryType>(type), true));
+		if (type != static_cast<u32>(GameList::EntryType::Invalid))
+		{
+			m_ui.filterType->addItem(GameListModel::getIconForType(static_cast<GameList::EntryType>(type)),
+				GameList::EntryTypeToString(static_cast<GameList::EntryType>(type), true));
+		}
 	}
+
 	for (u32 region = 0; region < static_cast<u32>(GameList::Region::Count); region++)
 	{
 		m_ui.filterRegion->addItem(GameListModel::getIconForRegion(static_cast<GameList::Region>(region)),

--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -128,6 +128,10 @@ namespace
 			const int pix_width = static_cast<int>(pix.width() / pix.devicePixelRatio());
 			const int pix_height = static_cast<int>(pix.height() / pix.devicePixelRatio());
 
+			// Clip the pixmaps so they don't extend outside the column
+			painter->save();
+			painter->setClipRect(option.rect);
+
 			// Draw the icon, using code derived from QItemDelegate::drawDecoration()
 			const bool enabled = option.state & QStyle::State_Enabled;
 			const QPoint p = QPoint((r.width() - pix_width) / 2, (r.height() - pix_height) / 2);
@@ -159,6 +163,9 @@ namespace
 			{
 				painter->drawPixmap(r.topLeft() + p, pix);
 			}
+
+			// Restore the old clip path.
+			painter->restore();
 		}
 	};
 } // namespace

--- a/pcsx2-qt/Settings/GameSummaryWidget.cpp
+++ b/pcsx2-qt/Settings/GameSummaryWidget.cpp
@@ -33,7 +33,7 @@ GameSummaryWidget::GameSummaryWidget(const GameList::Entry* entry, SettingsWindo
 	for (int i = 0; i < m_ui.region->count(); i++)
 	{
 		m_ui.region->setItemIcon(i,
-			QIcon(QStringLiteral("%1/icons/flags/%2.svg").arg(base_path).arg(GameList::RegionToString(static_cast<GameList::Region>(i)))));
+			QIcon(QStringLiteral("%1/icons/flags/%2.svg").arg(base_path).arg(GameList::RegionToString(static_cast<GameList::Region>(i), false))));
 	}
 
 	m_entry_path = entry->path;
@@ -73,16 +73,17 @@ void GameSummaryWidget::populateDetails(const GameList::Entry* entry)
 	m_ui.type->setCurrentIndex(static_cast<int>(entry->type));
 	m_ui.region->setCurrentIndex(static_cast<int>(entry->region));
 	//: First arg is a GameList compat; second is a string with space followed by star rating OR empty if Unknown compat
-	m_ui.compatibility->setText(tr("%0%1")
-		.arg(GameList::EntryCompatibilityRatingToString(entry->compatibility_rating))
-		.arg([entry]() {
-			if (entry->compatibility_rating == GameList::CompatibilityRating::Unknown)
-				return QStringLiteral("");
+	m_ui.compatibility->setText(
+		tr("%0%1")
+			.arg(GameList::EntryCompatibilityRatingToString(entry->compatibility_rating, true))
+			.arg([entry]() {
+				if (entry->compatibility_rating == GameList::CompatibilityRating::Unknown)
+					return QStringLiteral("");
 
-			const qsizetype compatibility_value = static_cast<qsizetype>(entry->compatibility_rating);
-			//: First arg is filled-in stars for game compatibility; second is empty stars; should be swapped for RTL languages
-			return tr(" %0%1").arg(QStringLiteral("★").repeated(compatibility_value - 1)).arg(QStringLiteral("☆").repeated(6 - compatibility_value));
-		}()));
+				const qsizetype compatibility_value = static_cast<qsizetype>(entry->compatibility_rating);
+				//: First arg is filled-in stars for game compatibility; second is empty stars; should be swapped for RTL languages
+				return tr(" %0%1").arg(QStringLiteral("★").repeated(compatibility_value - 1)).arg(QStringLiteral("☆").repeated(6 - compatibility_value));
+			}()));
 
 	int row = 0;
 	m_ui.detailsFormLayout->getWidgetPosition(m_ui.titleSort, &row, nullptr);
@@ -156,7 +157,7 @@ void GameSummaryWidget::onDiscPathChanged(const QString& value)
 
 	// force rescan of elf to update the serial
 	g_main_window->rescanFile(m_entry_path);
-	
+
 	auto lock = GameList::GetLock();
 	const GameList::Entry* entry = GameList::GetEntryForPath(m_entry_path.c_str());
 	if (entry)

--- a/pcsx2/GameList.cpp
+++ b/pcsx2/GameList.cpp
@@ -91,42 +91,98 @@ static std::recursive_mutex s_mutex;
 static GameList::CacheMap s_cache_map;
 static std::FILE* s_cache_write_stream = nullptr;
 
-const char* GameList::EntryTypeToString(EntryType type)
+const char* GameList::EntryTypeToString(EntryType type, bool translate)
 {
-	static std::array<const char*, static_cast<int>(EntryType::Count)> names = {{"PS2Disc", "PS1Disc", "ELF"}};
-	return names[static_cast<int>(type)];
+	static constexpr std::array<const char*, static_cast<int>(EntryType::Count)> names = {
+		TRANSLATE_NOOP("GameList", "PS2 Disc"),
+		TRANSLATE_NOOP("GameList", "PS1 Disc"),
+		TRANSLATE_NOOP("GameList", "ELF"),
+		TRANSLATE_NOOP("GameList", "Invalid"),
+	};
+
+	const char* name = names.at(static_cast<int>(type));
+	if (translate)
+		name = TRANSLATE("GameList", name);
+
+	return name;
 }
 
-const char* GameList::EntryTypeToDisplayString(EntryType type)
+const char* GameList::RegionToString(Region region, bool translate)
 {
-	static std::array<const char*, static_cast<int>(EntryType::Count)> names = {{TRANSLATE("GameList", "PS2 Disc"), TRANSLATE("GameList", "PS1 Disc"), TRANSLATE("GameList", "ELF")}};
-	return names[static_cast<int>(type)];
+	static constexpr std::array<const char*, static_cast<int>(Region::Count)> names = {
+		TRANSLATE_NOOP("GameList", "NTSC-B"),
+		TRANSLATE_NOOP("GameList", "NTSC-C"),
+		TRANSLATE_NOOP("GameList", "NTSC-HK"),
+		TRANSLATE_NOOP("GameList", "NTSC-J"),
+		TRANSLATE_NOOP("GameList", "NTSC-K"),
+		TRANSLATE_NOOP("GameList", "NTSC-T"),
+		TRANSLATE_NOOP("GameList", "NTSC-U"),
+		TRANSLATE_NOOP("GameList", "Other"),
+		TRANSLATE_NOOP("GameList", "PAL-A"),
+		TRANSLATE_NOOP("GameList", "PAL-AF"),
+		TRANSLATE_NOOP("GameList", "PAL-AU"),
+		TRANSLATE_NOOP("GameList", "PAL-BE"),
+		TRANSLATE_NOOP("GameList", "PAL-E"),
+		TRANSLATE_NOOP("GameList", "PAL-F"),
+		TRANSLATE_NOOP("GameList", "PAL-FI"),
+		TRANSLATE_NOOP("GameList", "PAL-G"),
+		TRANSLATE_NOOP("GameList", "PAL-GR"),
+		TRANSLATE_NOOP("GameList", "PAL-I"),
+		TRANSLATE_NOOP("GameList", "PAL-IN"),
+		TRANSLATE_NOOP("GameList", "PAL-M"),
+		TRANSLATE_NOOP("GameList", "PAL-NL"),
+		TRANSLATE_NOOP("GameList", "PAL-NO"),
+		TRANSLATE_NOOP("GameList", "PAL-P"),
+		TRANSLATE_NOOP("GameList", "PAL-PL"),
+		TRANSLATE_NOOP("GameList", "PAL-R"),
+		TRANSLATE_NOOP("GameList", "PAL-S"),
+		TRANSLATE_NOOP("GameList", "PAL-SC"),
+		TRANSLATE_NOOP("GameList", "PAL-SW"),
+		TRANSLATE_NOOP("GameList", "PAL-SWI"),
+		TRANSLATE_NOOP("GameList", "PAL-UK"),
+	};
+
+	const char* name = names.at(static_cast<int>(region));
+	if (translate)
+		name = TRANSLATE("GameList", name);
+
+	return name;
 }
 
-const char* GameList::RegionToString(Region region)
+const char* GameList::EntryCompatibilityRatingToString(CompatibilityRating rating, bool translate)
 {
-	static std::array<const char*, static_cast<int>(Region::Count)> names = {{"NTSC-B", "NTSC-C", "NTSC-HK", "NTSC-J", "NTSC-K", "NTSC-T",
-		"NTSC-U", TRANSLATE("GameList", "Other"), "PAL-A", "PAL-AF", "PAL-AU", "PAL-BE", "PAL-E", "PAL-F", "PAL-FI", "PAL-G", "PAL-GR", "PAL-I", "PAL-IN", "PAL-M",
-		"PAL-NL", "PAL-NO", "PAL-P", "PAL-PL", "PAL-R", "PAL-S", "PAL-SC", "PAL-SW", "PAL-SWI", "PAL-UK"}};
-
-	return names[static_cast<int>(region)];
-}
-
-const char* GameList::EntryCompatibilityRatingToString(CompatibilityRating rating)
-{
-	// clang-format off
+	const char* name = "";
 	switch (rating)
 	{
-		case CompatibilityRating::Unknown:  return TRANSLATE("GameList", "Unknown");
-		case CompatibilityRating::Nothing:  return TRANSLATE("GameList", "Nothing");
-		case CompatibilityRating::Intro:    return TRANSLATE("GameList", "Intro");
-		case CompatibilityRating::Menu:     return TRANSLATE("GameList", "Menu");
-		case CompatibilityRating::InGame:   return TRANSLATE("GameList", "In-Game");
-		case CompatibilityRating::Playable: return TRANSLATE("GameList", "Playable");
-		case CompatibilityRating::Perfect:  return TRANSLATE("GameList", "Perfect");
-		default: return "";
+		case CompatibilityRating::Unknown:
+			name = TRANSLATE_NOOP("GameList", "Unknown");
+			break;
+		case CompatibilityRating::Nothing:
+			name = TRANSLATE_NOOP("GameList", "Nothing");
+			break;
+		case CompatibilityRating::Intro:
+			name = TRANSLATE_NOOP("GameList", "Intro");
+			break;
+		case CompatibilityRating::Menu:
+			name = TRANSLATE_NOOP("GameList", "Menu");
+			break;
+		case CompatibilityRating::InGame:
+			name = TRANSLATE_NOOP("GameList", "In-Game");
+			break;
+		case CompatibilityRating::Playable:
+			name = TRANSLATE_NOOP("GameList", "Playable");
+			break;
+		case CompatibilityRating::Perfect:
+			name = TRANSLATE_NOOP("GameList", "Perfect");
+			break;
+		default:
+			return "";
 	}
-	// clang-format on
+
+	if (translate)
+		name = TRANSLATE("GameList", name);
+
+	return name;
 }
 
 bool GameList::IsScannableFilename(const std::string_view path)
@@ -591,15 +647,18 @@ void GameList::ScanDirectory(const char* path, bool recursive, bool only_cache, 
 	Console.WriteLn("Scanning %s%s", path, recursive ? " (recursively)" : "");
 
 	progress->PushState();
-	progress->SetStatusText(fmt::format(
-		recursive ? TRANSLATE_FS("GameList", "Scanning directory {} (recursively)...") :
-		            TRANSLATE_FS("GameList", "Scanning directory {}..."),
-		path).c_str());
+
+	if (recursive)
+		progress->SetStatusText(
+			fmt::format(TRANSLATE_FS("GameList", "Scanning directory {} (recursively)..."), path).c_str());
+	else
+		progress->SetStatusText(
+			fmt::format(TRANSLATE_FS("GameList", "Scanning directory {}..."), path).c_str());
 
 	FileSystem::FindResultsArray files;
 	FileSystem::FindFiles(path, "*",
 		recursive ? (FILESYSTEM_FIND_FILES | FILESYSTEM_FIND_HIDDEN_FILES | FILESYSTEM_FIND_RECURSIVE) :
-		            (FILESYSTEM_FIND_FILES | FILESYSTEM_FIND_HIDDEN_FILES),
+					(FILESYSTEM_FIND_FILES | FILESYSTEM_FIND_HIDDEN_FILES),
 		&files, progress);
 
 	u32 files_scanned = 0;
@@ -622,7 +681,7 @@ void GameList::ScanDirectory(const char* path, bool recursive, bool only_cache, 
 		}
 
 		const std::string_view filename = Path::GetFileName(ffd.FileName);
-		progress->SetStatusText(fmt::format(TRANSLATE_FS("GameList","Scanning {}..."), filename.data()).c_str());
+		progress->SetStatusText(fmt::format(TRANSLATE_FS("GameList", "Scanning {}..."), filename.data()).c_str());
 		ScanFile(std::move(ffd.FileName), ffd.ModificationTime, lock, played_time_map, custom_attributes_ini);
 		progress->SetProgressValue(files_scanned);
 	}
@@ -1300,7 +1359,7 @@ bool GameList::DownloadCovers(const std::vector<std::string>& url_templates, boo
 				continue;
 			}
 
-			progress->SetStatusText(fmt::format(TRANSLATE_FS("GameList","Downloading cover for {0} [{1}]..."), entry->title, entry->serial).c_str());
+			progress->SetStatusText(fmt::format(TRANSLATE_FS("GameList", "Downloading cover for {0} [{1}]..."), entry->title, entry->serial).c_str());
 		}
 
 		// we could actually do a few in parallel here...

--- a/pcsx2/GameList.h
+++ b/pcsx2/GameList.h
@@ -104,10 +104,9 @@ namespace GameList
 		__fi bool IsDisc() const { return (type == EntryType::PS1Disc || type == EntryType::PS2Disc); }
 	};
 
-	const char* EntryTypeToString(EntryType type);
-	const char* EntryTypeToDisplayString(EntryType type);
-	const char* RegionToString(Region region);
-	const char* EntryCompatibilityRatingToString(CompatibilityRating rating);
+	const char* EntryTypeToString(EntryType type, bool translate);
+	const char* RegionToString(Region region, bool translate);
+	const char* EntryCompatibilityRatingToString(CompatibilityRating rating, bool translate);
 
 	/// Fills in boot parameters (iso or elf) based on the game list entry.
 	void FillBootParametersForEntry(VMBootParameters* params, const Entry* entry);

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3316,15 +3316,15 @@ void FullscreenUI::DrawSummarySettingsPage()
 			CopyTextToClipboard(FSUI_STR("Game serial copied to clipboard."), s_game_settings_entry->serial);
 		if (MenuButton(FSUI_ICONSTR(ICON_FA_CODE, "CRC"), fmt::format("{:08X}", s_game_settings_entry->crc).c_str(), true))
 			CopyTextToClipboard(FSUI_STR("Game CRC copied to clipboard."), fmt::format("{:08X}", s_game_settings_entry->crc));
-		if (MenuButton(FSUI_ICONSTR(ICON_FA_BOX, "Type"), GameList::EntryTypeToDisplayString(s_game_settings_entry->type), true))
-			CopyTextToClipboard(FSUI_STR("Game type copied to clipboard."), GameList::EntryTypeToDisplayString(s_game_settings_entry->type));
-		if (MenuButton(FSUI_ICONSTR(ICON_FA_GLOBE, "Region"), GameList::RegionToString(s_game_settings_entry->region), true))
-			CopyTextToClipboard(FSUI_STR("Game region copied to clipboard."), GameList::RegionToString(s_game_settings_entry->region));
+		if (MenuButton(FSUI_ICONSTR(ICON_FA_BOX, "Type"), GameList::EntryTypeToString(s_game_settings_entry->type, true), true))
+			CopyTextToClipboard(FSUI_STR("Game type copied to clipboard."), GameList::EntryTypeToString(s_game_settings_entry->type, true));
+		if (MenuButton(FSUI_ICONSTR(ICON_FA_GLOBE, "Region"), GameList::RegionToString(s_game_settings_entry->region, true), true))
+			CopyTextToClipboard(FSUI_STR("Game region copied to clipboard."), GameList::RegionToString(s_game_settings_entry->region, true));
 		if (MenuButton(FSUI_ICONSTR(ICON_FA_STAR, "Compatibility Rating"),
-				GameList::EntryCompatibilityRatingToString(s_game_settings_entry->compatibility_rating), true))
+				GameList::EntryCompatibilityRatingToString(s_game_settings_entry->compatibility_rating, true), true))
 		{
 			CopyTextToClipboard(FSUI_STR("Game compatibility copied to clipboard."),
-				GameList::EntryCompatibilityRatingToString(s_game_settings_entry->compatibility_rating));
+				GameList::EntryCompatibilityRatingToString(s_game_settings_entry->compatibility_rating, true));
 		}
 		if (MenuButton(FSUI_ICONSTR(ICON_FA_FOLDER_OPEN, "Path"), s_game_settings_entry->path.c_str(), true))
 			CopyTextToClipboard(FSUI_STR("Game path copied to clipboard."), s_game_settings_entry->path);
@@ -6459,9 +6459,9 @@ void FullscreenUI::DrawGameList(const ImVec2& heading_size)
 
 			summary.clear();
 			if (entry->serial.empty())
-				fmt::format_to(std::back_inserter(summary), "{} - ", GameList::RegionToString(entry->region));
+				fmt::format_to(std::back_inserter(summary), "{} - ", GameList::RegionToString(entry->region, true));
 			else
-				fmt::format_to(std::back_inserter(summary), "{} - {} - ", entry->serial, GameList::RegionToString(entry->region));
+				fmt::format_to(std::back_inserter(summary), "{} - {} - ", entry->serial, GameList::RegionToString(entry->region, true));
 
 			const std::string_view filename(Path::GetFileName(entry->path));
 			summary.append(filename);
@@ -6563,12 +6563,12 @@ void FullscreenUI::DrawGameList(const ImVec2& heading_size)
 
 			// region
 			{
-				std::string flag_texture(fmt::format("icons/flags/{}.svg", GameList::RegionToString(selected_entry->region)));
+				std::string flag_texture(fmt::format("icons/flags/{}.svg", GameList::RegionToString(selected_entry->region, false)));
 				ImGui::TextUnformatted(FSUI_CSTR("Region: "));
 				ImGui::SameLine();
 				DrawCachedSvgTextureAsync(flag_texture, LayoutScale(23.0f, 16.0f), SvgScaling::Fit);
 				ImGui::SameLine();
-				ImGui::Text(" (%s)", GameList::RegionToString(selected_entry->region));
+				ImGui::Text(" (%s)", GameList::RegionToString(selected_entry->region, true));
 			}
 
 			// compatibility
@@ -6579,7 +6579,7 @@ void FullscreenUI::DrawGameList(const ImVec2& heading_size)
 				DrawSvgTexture(s_game_compatibility_textures[static_cast<u32>(selected_entry->compatibility_rating) - 1].get(), LayoutScale(64.0f, 16.0f));
 				ImGui::SameLine();
 			}
-			ImGui::Text(" (%s)", GameList::EntryCompatibilityRatingToString(selected_entry->compatibility_rating));
+			ImGui::Text(" (%s)", GameList::EntryCompatibilityRatingToString(selected_entry->compatibility_rating, true));
 
 			// play time
 			ImGui::TextUnformatted(
@@ -7305,7 +7305,7 @@ void FullscreenUI::DrawAchievementsSettingsPage(std::unique_lock<std::mutex>& se
 			};
 			OpenFileSelector(FSUI_ICONSTR(ICON_FA_FOLDER_OPEN, "Select Leaderboard Submit Sound"), false, std::move(callback), GetAudioFileFilters());
 		}
-		
+
 		MenuHeading(FSUI_CSTR("Account"));
 		if (bsi->ContainsValue("Achievements", "Token"))
 		{


### PR DESCRIPTION
### Description of Changes
- The file paths for the region flag icons are no longer translated incorrectly.
- Various strings are no longer translated twice.
- The `GameList::EntryTypeToString`, `GameList::RegionToString` and `GameList::EntryCompatibilityRatingToString` functions have been refactored so that they can return a translated or non-translated string depending on the value of the new `translate` parameter.
- The `GameList::ScanDirectory` function has been very slightly modified to make clang-format happy.
- Prevent the `GameList::EntryType::Invalid` option from appearing in the filter box in the GUI.
- Clip the flag and compatibility rating pixmaps to the available space.

### Rationale behind Changes
- The region flag icons were broken for non-English languages.
- Strings shouldn't be translated twice.
- The `EntryTypeToString` function was missing support for the `Invalid` option.
- Adding the `translate` parameter keeps the translation context all in one source file.
- `GameList::EntryType::Invalid` appears to be an internal thing.
- The flag and compatiblity rating pixmaps previously would extend outside the column they were supposed to be in.

### Suggested Testing Steps
Make sure the entry type (PS2 disc vs PS1 disc vs ELF), the region icons, and the compatibility ratings still show up correctly for both the Qt UI and the fullscreen UI.

The region flag issue can be reproduced with the fa-IR language setting.

### Did you use AI to help find, test, or implement this issue or feature?
I did not use AI, I did not. Oh hi Mark.
