### PR TITLE
GS/HW: Restore old coverage after updating mip layers.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3803,6 +3803,9 @@ void GSRendererHW::Draw()
 			const GSVector4 tmin = m_vt.m_min.t;
 			const GSVector4 tmax = m_vt.m_max.t;
 
+			// Backup original coverage.
+			const GSVector4i coverage = tmm.coverage;
+
 			for (int layer = m_lod.x + 1; layer <= m_lod.y; layer++)
 			{
 				const GIFRegTEX0 MIP_TEX0(GetTex0Layer(layer));
@@ -3824,6 +3827,9 @@ void GSRendererHW::Draw()
 			src->m_texture->ClearMipmapGenerationFlag();
 			m_vt.m_min.t = tmin;
 			m_vt.m_max.t = tmax;
+
+			// Restore original coverage.
+			tmm.coverage = coverage;
 		}
 	}
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/HW: Restore old coverage after updating mip layers.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Bugfix, fixes https://github.com/PCSX2/pcsx2/issues/12730
https://github.com/PCSX2/pcsx2/pull/12662 exposed a bug with tmm coverage.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test https://github.com/PCSX2/pcsx2/issues/12730

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.