### PR TITLE
GS/DX12: Fix HDR copy scissor area

### DIFF
--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -3849,7 +3849,7 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 			colclip_rt->TransitionToState(D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
 
 			draw_rt = static_cast<GSTexture12*>(config.rt);
-			OMSetRenderTargets(draw_rt, draw_ds, config.scissor);
+			OMSetRenderTargets(draw_rt, draw_ds, config.colclip_update_area);
 
 			// if this target was cleared and never drawn to, perform the clear as part of the resolve here.
 			BeginRenderPass(GetLoadOpForTexture(draw_rt), D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE,
@@ -4038,6 +4038,7 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 	// rt -> colclip hw blit if enabled
 	if (colclip_rt && (config.colclip_mode == GSHWDrawConfig::ColClipMode::ConvertOnly || config.colclip_mode == GSHWDrawConfig::ColClipMode::ConvertAndResolve) && config.rt->GetState() == GSTexture::State::Dirty)
 	{
+		OMSetRenderTargets(draw_rt, draw_ds, GSVector4i::loadh(rtsize));
 		SetUtilityTexture(static_cast<GSTexture12*>(config.rt), m_point_sampler_cpu);
 		SetPipeline(m_colclip_setup_pipelines[pipe.ds].get());
 
@@ -4047,8 +4048,10 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 		g_perfmon.Put(GSPerfMon::TextureCopies, 1);
 
 		GL_POP();
-	}
 
+		// Restore original scissor, not sure if needed since the render pass has already been started. But to be safe.
+		OMSetRenderTargets(draw_rt, draw_ds, config.scissor);
+	}
 	// VB/IB upload, if we did DATE setup and it's not colclip hw this has already been done
 	SetPrimitiveTopology(s_primitive_topology_mapping[static_cast<u8>(config.topology)]);
 	if (!date_image || colclip_rt)
@@ -4111,7 +4114,7 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 			colclip_rt->TransitionToState(D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
 
 			draw_rt = static_cast<GSTexture12*>(config.rt);
-			OMSetRenderTargets(draw_rt, draw_ds, config.scissor);
+			OMSetRenderTargets(draw_rt, draw_ds, config.colclip_update_area);
 
 			// if this target was cleared and never drawn to, perform the clear as part of the resolve here.
 			BeginRenderPass(GetLoadOpForTexture(draw_rt), D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE,


### PR DESCRIPTION
### Description of Changes
Fixes the scissor size for copying the HDR texture to/from the RT

### Rationale behind Changes
Was overlooked/broken in #12254

### Suggested Testing Steps
Test HDR games mentioned in the above PR with DX12 make sure they look okay.

### Did you use AI to help find, test, or implement this issue or feature?
No

Master:
![image](https://github.com/user-attachments/assets/e4bfb9c5-df4a-45f9-872e-f8bfa5aa7884)
PR:
![image](https://github.com/user-attachments/assets/80f27127-8332-47e6-ab83-36828889c574)
