### PR TITLE
GS/HW: Adjust SpriteNoGaps check for vertical strips

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -3140,7 +3140,8 @@ bool GSState::SpriteDrawWithoutGaps()
 			}
 			else
 			{
-				if ((std::abs(dpX - first_dpX) >= 16 && (i + 2) < m_vertex.next) || std::abs(this_start_X - last_pX) >= 16)
+				const int dpY = v[i + 1].XYZ.Y - v[i].XYZ.Y;
+				if ((std::abs(dpY - first_dpY) >= 16 && (i + 2) < m_vertex.next) || std::abs(this_start_X - last_pX) >= 16)
 					return false;
 			}
 		}


### PR DESCRIPTION
### Description of Changes
Allows the strips to be of any size, as long as the last one is butted up against the current one and the height matches.

### Rationale behind Changes
Some games like Prince of Persia do a tiny strip, followed by a bunch of normal ones, but this was enough to throw off the "no gaps" check, making native scaling fail to happen on some draws. That said I didn't really notice any changes outside that series

### Suggested Testing Steps
Test the lighting with high upscales in the prince of persia games vs master.

### Did you use AI to help find, test, or implement this issue or feature?
Nope.

Sands of Time:
Master:
![image](https://github.com/user-attachments/assets/9d3eda13-8317-4d24-899e-8feefbae54f2)

PR:
![image](https://github.com/user-attachments/assets/4c7a8c37-d1aa-4ae6-adfd-0025977cd93f)
