### PR TITLE
MemoryCardFile: Fix memory card sorting on Linux

### DIFF
--- a/pcsx2/SIO/Memcard/MemoryCardFile.cpp
+++ b/pcsx2/SIO/Memcard/MemoryCardFile.cpp
@@ -887,6 +887,7 @@ std::vector<AvailableMcdInfo> FileMcd_GetAvailableCards(bool include_in_use_card
 		}
 	}
 
+	std::sort(mcds.begin(), mcds.end(), [](auto& a, auto& b) { return a.name < b.name; });
 	return mcds;
 }
 


### PR DESCRIPTION
### Description of Changes
Fixes memory card alphabetical ordering on Linux when using btrfs.

### Rationale behind Changes
On Linux in some situations memory cards did not return alphabetically this should fix it.

### Suggested Testing Steps
Make sure in those same situations memory cards return alphabetically.

### Did you use AI to help find, test, or implement this issue or feature?
No.
