### PR TITLE
GS/TC: Fine tune Frame buffer conversion.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1588,14 +1588,13 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const bool is_color, const 
 					//	DevCon.Warning("Expected %x Got %x shuffle %d draw %d", psm, t_psm, possible_shuffle, GSState::s_n);
 					if (match)
 					{
-						// It is a complex to convert the code in shader. As a reference, let's do it on the CPU, it will be slow but
-						// 1/ it just works :)
-						// 2/ even with upscaling
-						// 3/ for both Direct3D and OpenGL
-						if (psm == PSMT4 || (GSConfig.UserHacks_CPUFBConversion && psm == PSMT8))
+						// It is a complex to convert the code in shader. As a reference, let's do it on the CPU,
+						// it will be slow but can work even with upscaling, also fine tune it so it's not enabled when not needed.
+						if (psm == PSMT4 || (GSConfig.UserHacks_CPUFBConversion && psm == PSMT8 && (!possible_shuffle || GSLocalMemory::m_psm[t->m_TEX0.PSM].bpp != 32)))
 						{
 							// Forces 4-bit and 8-bit frame buffer conversion to be done on the CPU instead of the GPU, but performance will be slower.
-							// There is no dedicated shader to handle 4-bit conversion (Stuntman has been confirmed to use 4-bit).
+							// There is no dedicated shader to handle 4-bit conversion (Beyond Good and Evil and Stuntman).
+							// Note: Stuntman no longer hits the PSMT4 code path.
 							// Direct3D10/11 and OpenGL support 8-bit fb conversion but don't render some corner cases properly (Harry Potter games).
 							// The hack can fix glitches in some games.
 							if (!t->m_drawn_since_read.rempty())


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/TC: Fine tune Frame buffer conversion.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Make it so Frame buffer conversion isn't enabled when not needed and break things, exclude shuffles or 32bit format.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test games that use frame buffer conversion, see db.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.