### PR TITLE
UI: Standardize order of option groups

### DIFF
--- a/pcsx2-qt/MainWindow.ui
+++ b/pcsx2-qt/MainWindow.ui
@@ -103,9 +103,9 @@
     <addaction name="actionMemoryCardSettings"/>
     <addaction name="actionDEV9Settings"/>
     <addaction name="actionFolderSettings"/>
+    <addaction name="actionAchievementSettings"/>
     <addaction name="actionControllerSettings"/>
     <addaction name="actionHotkeySettings"/>
-    <addaction name="actionAchievementSettings"/>
     <addaction name="separator"/>
     <addaction name="actionAddGameDirectory"/>
     <addaction name="actionScanForNewGames"/>

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -203,10 +203,10 @@ namespace FullscreenUI
 		Graphics,
 		Audio,
 		MemoryCard,
+		Folders,
+		Achievements,
 		Controller,
 		Hotkey,
-		Achievements,
-		Folders,
 		Advanced,
 		Patches,
 		Cheats,
@@ -322,10 +322,10 @@ namespace FullscreenUI
 	static void DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_advanced_settings);
 	static void DrawAudioSettingsPage();
 	static void DrawMemoryCardSettingsPage();
+	static void DrawFoldersSettingsPage();
+	static void DrawAchievementsSettingsPage(std::unique_lock<std::mutex>& settings_lock);
 	static void DrawControllerSettingsPage();
 	static void DrawHotkeySettingsPage();
-	static void DrawAchievementsSettingsPage(std::unique_lock<std::mutex>& settings_lock);
-	static void DrawFoldersSettingsPage();
 	static void DrawAdvancedSettingsPage();
 	static void DrawPatchesOrCheatsSettingsPage(bool cheats);
 	static void DrawGameFixesSettingsPage();
@@ -3067,10 +3067,10 @@ void FullscreenUI::DrawSettingsWindow()
 			ICON_PF_PICTURE,
 			ICON_PF_SOUND,
 			ICON_PF_MEMORY_CARD,
+			ICON_FA_FOLDER_OPEN,
+			ICON_FA_TROPHY,
 			ICON_PF_GAMEPAD_ALT,
 			ICON_PF_KEYBOARD_ALT,
-			ICON_FA_TROPHY,
-			ICON_FA_FOLDER_OPEN,
 			ICON_FA_EXCLAMATION_TRIANGLE,
 		};
 		static constexpr const char* per_game_icons[] = {
@@ -3090,10 +3090,10 @@ void FullscreenUI::DrawSettingsWindow()
 			SettingsPage::Graphics,
 			SettingsPage::Audio,
 			SettingsPage::MemoryCard,
+			SettingsPage::Folders,
+			SettingsPage::Achievements,
 			SettingsPage::Controller,
 			SettingsPage::Hotkey,
-			SettingsPage::Achievements,
-			SettingsPage::Folders,
 			SettingsPage::Advanced,
 		};
 		static constexpr SettingsPage per_game_pages[] = {
@@ -3114,10 +3114,10 @@ void FullscreenUI::DrawSettingsWindow()
 			FSUI_NSTR("Graphics Settings"),
 			FSUI_NSTR("Audio Settings"),
 			FSUI_NSTR("Memory Card Settings"),
+			FSUI_NSTR("Folder Settings"),
+			FSUI_NSTR("Achievements Settings"),
 			FSUI_NSTR("Controller Settings"),
 			FSUI_NSTR("Hotkey Settings"),
-			FSUI_NSTR("Achievements Settings"),
-			FSUI_NSTR("Folder Settings"),
 			FSUI_NSTR("Advanced Settings"),
 			FSUI_NSTR("Patches"),
 			FSUI_NSTR("Cheats"),
@@ -3240,20 +3240,20 @@ void FullscreenUI::DrawSettingsWindow()
 				DrawMemoryCardSettingsPage();
 				break;
 
-			case SettingsPage::Controller:
-				DrawControllerSettingsPage();
-				break;
-
-			case SettingsPage::Hotkey:
-				DrawHotkeySettingsPage();
+			case SettingsPage::Folders:
+				DrawFoldersSettingsPage();
 				break;
 
 			case SettingsPage::Achievements:
 				DrawAchievementsSettingsPage(lock);
 				break;
 
-			case SettingsPage::Folders:
-				DrawFoldersSettingsPage();
+			case SettingsPage::Controller:
+				DrawControllerSettingsPage();
+				break;
+
+			case SettingsPage::Hotkey:
+				DrawHotkeySettingsPage();
 				break;
 
 			case SettingsPage::Patches:
@@ -7900,10 +7900,10 @@ TRANSLATE_NOOP("FullscreenUI", "Emulation Settings");
 TRANSLATE_NOOP("FullscreenUI", "Graphics Settings");
 TRANSLATE_NOOP("FullscreenUI", "Audio Settings");
 TRANSLATE_NOOP("FullscreenUI", "Memory Card Settings");
+TRANSLATE_NOOP("FullscreenUI", "Folder Settings");
+TRANSLATE_NOOP("FullscreenUI", "Achievements Settings");
 TRANSLATE_NOOP("FullscreenUI", "Controller Settings");
 TRANSLATE_NOOP("FullscreenUI", "Hotkey Settings");
-TRANSLATE_NOOP("FullscreenUI", "Achievements Settings");
-TRANSLATE_NOOP("FullscreenUI", "Folder Settings");
 TRANSLATE_NOOP("FullscreenUI", "Advanced Settings");
 TRANSLATE_NOOP("FullscreenUI", "Patches");
 TRANSLATE_NOOP("FullscreenUI", "Cheats");


### PR DESCRIPTION
### Description of Changes
Standardizes the ordering of the options in 1) the Qt UI widget, 2) the 'Settings' dropdown menu, and 3) the FSUI navbar. This PR doesn't add any options where they already aren't to avoid an omnibus; it simply reorders them where they already exist to conform to a standard order:

1) Interface
2) Game List (not yet implemented in FSUI)
3) BIOS
4) Emulation
5) Graphics
6) Audio
7) Memory Cards
8) Folders
9) Achievements
10) Controllers (part of controllers rather than the Qt settings widget)
11) Hotkeys (part of controllers rather than the Qt settings widget)
12) Advanced (not in the toolbar; very arguably should be)
13) Debug (not yet in toolbar or FSUI; very arguably should be in the former, and I'm planning work toward the latter)

### Rationale behind Changes
The ordering of options is inconsistent between the Qt settings, toolbar, and FSUI for seemingly no reason. Consistency in a UI is almost universally a good thing, especially when it can be done at no cost like this.

### Suggested Testing Steps
Make sure that the toolbar options still take you where they say they do and that the FSUI menus work correctly. This PR doesn't touch the Qt settings widget or the controllers widget.

### Did you use AI to help find, test, or implement this issue or feature?
My brain is powered by ultra-processed foods, making it artificial.
