### PR TITLE
Qt/ImGui: Fix settings not syncing from FullscreenUI to Qt widgets

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1349,6 +1349,14 @@ void MainWindow::checkForSettingChanges()
 	LogWindow::updateSettings();
 }
 
+void MainWindow::refreshSettings()
+{
+	if (SettingsWindow* sw = getSettingsWindow())
+	{
+		sw->onExternalSettingsChanged();
+	}
+}
+
 std::optional<WindowInfo> MainWindow::getWindowInfo()
 {
 	if (!m_display_widget || isRenderingToMain())

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -116,6 +116,7 @@ public Q_SLOTS:
 	void reportError(const QString& title, const QString& message);
 	bool confirmMessage(const QString& title, const QString& message);
 	void onStatusMessage(const QString& message);
+	void refreshSettings();
 
 	void runOnUIThread(const std::function<void()>& func);
 	void requestReset();

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -1480,6 +1480,16 @@ bool Host::RequestResetSettings(bool folders, bool core, bool controllers, bool 
 	return true;
 }
 
+void Host::OnSettingsChangedExternally()
+{
+	QtHost::RunOnUIThread([]() {
+		if (g_main_window)
+		{
+			g_main_window->refreshSettings();
+		}
+	});
+}
+
 QString QtHost::GetAppNameAndVersion()
 {
 	return QString("PCSX2 %1").arg(BuildVersion::GitRev);

--- a/pcsx2-qt/Settings/AchievementSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AchievementSettingsWidget.cpp
@@ -97,6 +97,21 @@ AchievementSettingsWidget::AchievementSettingsWidget(SettingsWindow* dialog, QWi
 	updateEnableState();
 	onAchievementsNotificationDurationSliderChanged();
 	onLeaderboardsNotificationDurationSliderChanged();
+
+	connect(dialog, &SettingsWindow::externalSettingsChanged, this, [this]() {
+		// Refresh achievement states and notification durations
+		m_ui.enable->setChecked(m_dialog->getEffectiveBoolValue("Achievements", "Enabled", false));
+		m_ui.hardcoreMode->setChecked(m_dialog->getEffectiveBoolValue("Achievements", "ChallengeMode", false));
+		m_ui.achievementNotifications->setChecked(m_dialog->getEffectiveBoolValue("Achievements", "Notifications", true));
+		m_ui.leaderboardNotifications->setChecked(m_dialog->getEffectiveBoolValue("Achievements", "LeaderboardNotifications", true));
+		
+		updateEnableState();
+		onAchievementsNotificationDurationSliderChanged();
+		onLeaderboardsNotificationDurationSliderChanged();
+		
+		if (!m_dialog->isPerGameSettings())
+			updateLoginState();
+	});
 }
 
 AchievementSettingsWidget::~AchievementSettingsWidget() = default;

--- a/pcsx2-qt/Settings/AdvancedSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AdvancedSettingsWidget.cpp
@@ -153,6 +153,13 @@ AdvancedSettingsWidget::AdvancedSettingsWidget(SettingsWindow* dialog, QWidget* 
 	dialog->registerWidgetHelp(m_ui.backupSaveStates, tr("Create Save State Backups"), tr("Checked"),
 		//: Do not translate the ".backup" extension.
 		tr("Creates a backup copy of a save state if it already exists when the save is created. The backup copy has a .backup suffix."));
+
+	connect(dialog, &SettingsWindow::externalSettingsChanged, this, [this]() {
+		// Refresh clamping mode dropdowns
+		m_ui.eeClampMode->setCurrentIndex(getClampingModeIndex(-1));
+		m_ui.vu0ClampMode->setCurrentIndex(getClampingModeIndex(0));
+		m_ui.vu1ClampMode->setCurrentIndex(getClampingModeIndex(1));
+	});
 }
 
 AdvancedSettingsWidget::~AdvancedSettingsWidget() = default;

--- a/pcsx2-qt/Settings/AudioSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.cpp
@@ -125,6 +125,12 @@ AudioSettingsWidget::AudioSettingsWidget(SettingsWindow* dialog, QWidget* parent
 	dialog->registerWidgetHelp(m_ui.resetFastForwardVolume, tr("Reset Fast Forward Volume"), tr("N/A"),
 		m_dialog->isPerGameSettings() ? tr("Resets fast forward volume back to the global/inherited setting.") :
 										tr("Resets fast forward volume back to the default."));
+	
+	connect(dialog, &SettingsWindow::externalSettingsChanged, this, [this]() {
+		updateLatencyLabel();
+		updateVolumeLabel();
+		updateDriverNames();
+	});					
 }
 
 AudioSettingsWidget::~AudioSettingsWidget() = default;

--- a/pcsx2-qt/Settings/BIOSSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/BIOSSettingsWidget.cpp
@@ -41,6 +41,11 @@ BIOSSettingsWidget::BIOSSettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	connect(m_ui.refresh, &QPushButton::clicked, this, &BIOSSettingsWidget::refreshList);
 	connect(m_ui.fileList, &QTreeWidget::currentItemChanged, this, &BIOSSettingsWidget::listItemChanged);
 	connect(m_ui.fastBoot, &QCheckBox::checkStateChanged, this, &BIOSSettingsWidget::fastBootChanged);
+
+	connect(dialog, &SettingsWindow::externalSettingsChanged, this, [this]() {
+		refreshList();
+		fastBootChanged();
+	});
 }
 
 BIOSSettingsWidget::~BIOSSettingsWidget() = default;

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
@@ -191,6 +191,11 @@ DEV9SettingsWidget::DEV9SettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	SettingWidgetBinder::SettingAccessor<QSpinBox>::connectValueChanged(m_ui.hddSizeSpinBox, [&]() { onHddSizeAccessorSpin(); });
 
 	connect(m_ui.hddCreate, &QPushButton::clicked, this, &DEV9SettingsWidget::onHddCreateClicked);
+
+	connect(dialog, &SettingsWindow::externalSettingsChanged, this, [this]() {
+		LoadAdapters();
+		UpdateHddSizeUIValues();
+	});
 }
 
 void DEV9SettingsWidget::onEthEnabledChanged(Qt::CheckState state)

--- a/pcsx2-qt/Settings/DebugSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DebugSettingsWidget.cpp
@@ -159,6 +159,15 @@ DebugSettingsWidget::DebugSettingsWidget(SettingsWindow* dialog, QWidget* parent
 #else
 	m_ui.debugTabs->removeTab(m_ui.debugTabs->indexOf(m_ui.traceLogTabWidget));
 #endif
+
+	connect(dialog, &SettingsWindow::externalSettingsChanged, this, [this]() {
+		// Refresh draw dumping and logging states
+		m_ui.dumpGSData->setChecked(m_dialog->getEffectiveBoolValue("EmuCore/GS", "DumpGSData", false));
+		m_ui.saveRT->setChecked(m_dialog->getEffectiveBoolValue("EmuCore/GS", "SaveRT", false));
+		m_ui.saveFrame->setChecked(m_dialog->getEffectiveBoolValue("EmuCore/GS", "SaveFrame", false));
+		m_ui.saveTexture->setChecked(m_dialog->getEffectiveBoolValue("EmuCore/GS", "SaveTexture", false));
+		m_ui.saveDepth->setChecked(m_dialog->getEffectiveBoolValue("EmuCore/GS", "SaveDepth", false));
+	});
 }
 
 DebugSettingsWidget::~DebugSettingsWidget() = default;

--- a/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
@@ -170,6 +170,11 @@ EmulationSettingsWidget::EmulationSettingsWidget(SettingsWindow* dialog, QWidget
 
 	updateOptimalFramePacing();
 	updateUseVSyncForTimingEnabled();
+
+	connect(dialog, &SettingsWindow::externalSettingsChanged, this, [this]() {
+		updateOptimalFramePacing();
+		updateUseVSyncForTimingEnabled();
+	});
 }
 
 EmulationSettingsWidget::~EmulationSettingsWidget() = default;

--- a/pcsx2-qt/Settings/FolderSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/FolderSettingsWidget.cpp
@@ -20,6 +20,9 @@ FolderSettingsWidget::FolderSettingsWidget(SettingsWindow* dialog, QWidget* pare
 	SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.covers, m_ui.coversBrowse, m_ui.coversOpen, m_ui.coversReset, "Folders", "Covers", Path::Combine(EmuFolders::DataRoot, "covers"));
 	SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.snapshots, m_ui.snapshotsBrowse, m_ui.snapshotsOpen, m_ui.snapshotsReset, "Folders", "Snapshots", Path::Combine(EmuFolders::DataRoot, "snaps"));
 	SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.saveStates, m_ui.saveStatesBrowse, m_ui.saveStatesOpen, m_ui.saveStatesReset, "Folders", "SaveStates", Path::Combine(EmuFolders::DataRoot, "sstates"));
+	
+	connect(dialog, &SettingsWindow::externalSettingsChanged, this, [this]() {
+	});
 }
 
 FolderSettingsWidget::~FolderSettingsWidget() = default;

--- a/pcsx2-qt/Settings/GameListSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GameListSettingsWidget.cpp
@@ -53,6 +53,11 @@ GameListSettingsWidget::GameListSettingsWidget(SettingsWindow* dialog, QWidget* 
 
 	refreshDirectoryList();
 	refreshExclusionList();
+
+	connect(dialog, &SettingsWindow::externalSettingsChanged, this, [this]() {
+		refreshDirectoryList();
+		refreshExclusionList();
+	});
 }
 
 GameListSettingsWidget::~GameListSettingsWidget() = default;

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -874,6 +874,15 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 			   "Can result in a large speed boost on slower systems, at the cost of many broken graphical effects. "
 			   "If games are broken and you have this option enabled, please disable it first."));
 	}
+
+	connect(dialog, &SettingsWindow::externalSettingsChanged, this, [this]() {
+		onShadeBoostChanged();
+		onMessagesPosChanged();
+		onPerformancePosChanged();
+		onTrilinearFilteringChanged();
+		onCPUSpriteRenderBWChanged();
+		onGpuPaletteConversionChanged(m_ui.gpuPaletteConversion->checkState());
+	});
 }
 
 GraphicsSettingsWidget::~GraphicsSettingsWidget() = default;

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -183,6 +183,10 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsWindow* dialog, QWidget
 		tr("Prevents the main window from being resized."));
 
 	onRenderToSeparateWindowChanged();
+
+	connect(dialog, &SettingsWindow::externalSettingsChanged, this, [this]() {
+		onRenderToSeparateWindowChanged();
+	});
 }
 
 InterfaceSettingsWidget::~InterfaceSettingsWidget() = default;

--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
@@ -64,6 +64,10 @@ MemoryCardSettingsWidget::MemoryCardSettingsWidget(SettingsWindow* dialog, QWidg
 		tr("Checked"),
 		tr("(Folder type only / Card size: Auto) Loads only the relevant booted game saves, ignoring others. Avoids "
 		   "running out of space for saves."));
+
+	connect(dialog, &SettingsWindow::externalSettingsChanged, this, [this]() {
+		refresh();
+	});
 }
 
 MemoryCardSettingsWidget::~MemoryCardSettingsWidget() = default;

--- a/pcsx2-qt/Settings/SettingsWindow.cpp
+++ b/pcsx2-qt/Settings/SettingsWindow.cpp
@@ -693,3 +693,8 @@ void SettingsWindow::closeGamePropertiesDialogs()
 		dialog->deleteLater();
 	}
 }
+
+void SettingsWindow::onExternalSettingsChanged()
+{
+	emit externalSettingsChanged();
+}

--- a/pcsx2-qt/Settings/SettingsWindow.h
+++ b/pcsx2-qt/Settings/SettingsWindow.h
@@ -96,8 +96,12 @@ public:
 	void removeSettingValue(const char* section, const char* key);
 	void saveAndReloadGameSettings();
 
+public Q_SLOTS:
+	void onExternalSettingsChanged();
+
 Q_SIGNALS:
 	void discSerialChanged();
+	void externalSettingsChanged();
 
 private Q_SLOTS:
 	void onCategoryCurrentRowChanged(int row);

--- a/pcsx2/Host.h
+++ b/pcsx2/Host.h
@@ -124,6 +124,7 @@ namespace Host
 	bool ContainsBaseSettingValue(const char* section, const char* key);
 	void RemoveBaseSettingValue(const char* section, const char* key);
 	void CommitBaseSettingChanges();
+	void OnSettingsChangedExternally();
 
 	/// Settings access, thread-safe.
 	std::string GetStringSettingValue(const char* section, const char* key, const char* default_value = "");

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -1693,6 +1693,8 @@ void FullscreenUI::SetSettingsChanged(SettingsInterface* bsi)
 		s_game_settings_changed.store(true, std::memory_order_release);
 	else
 		s_settings_changed.store(true, std::memory_order_release);
+
+	Host::OnSettingsChangedExternally();
 }
 
 bool FullscreenUI::GetEffectiveBoolSetting(SettingsInterface* bsi, const char* section, const char* key, bool default_value)

--- a/tests/ctest/core/StubHost.cpp
+++ b/tests/ctest/core/StubHost.cpp
@@ -17,6 +17,10 @@ void Host::CommitBaseSettingChanges()
 {
 }
 
+void Host::OnSettingsChangedExternally()
+{
+}
+
 void Host::LoadSettings(SettingsInterface& si, std::unique_lock<std::mutex>& lock)
 {
 }


### PR DESCRIPTION
Fixes #12750

https://github.com/user-attachments/assets/72ab268b-33d6-45a4-b79c-810fc1600c98

### Description of Changes
Enables two-way synchronization of settings between the ImGui FullscreenUI and the Qt settings dialogs:

1. Adds a new notification entry point in `Host` (`OnSettingsChangedExternally`) and calls it from FullscreenUI.  
2. Exposes and wires up Qt handlers to refresh every settings widget when that notification fires.

### Rationale behind Changes
The existing settings system had one-way communication: Qt UI changes would reflect in FSUI, but FSUI changes would not reflect back to Qt UI widgets. This created an inconsistent user experience where:

- Changing "Maximum Frame Latency" from 2 to 3 in Qt immediately showed in FSUI
- Changing "Maximum Frame Latency" from 2 to 3 in FSUI did NOT show in Qt

1. **New Host Notification System**
- Added `Host::OnSettingsChangedExternally()` notification entry point in `QtHost.cpp`
- This function runs on the UI thread and notifies the settings window of external changes

2. **FullscreenUI Integration**  
- FullscreenUI setting change handlers now invoke the new notification system
- Ensures Qt widgets are refreshed whenever settings change in FullscreenUI

3. **Qt Widget Auto-Refresh**
- Connected all settings widgets to the `externalSettingsChanged` signal
- Each widget now automatically refreshes its state when external changes occur
- Added refresh logic for each settings page:

### Suggested Testing Steps
1. Open both UIs:
   - Launch PCSX2 and open a Qt settings window (e.g., Emulation settings)
   - Go into FSUI

2. Test FSUI -> Qt sync:
   - Change a setting in FSUI (e.g., "Maximum Frame Latency" from default to a different value)
   - Verify the Qt settings window automatically updates to show the new value

3. Test Qt -> FSUI sync (already working):
   - Change a setting in Qt UI
   - Verify FSUI shows the updated value

4. Test multiple settings:
   - Repeat with other settings like vsync, aspect ratio, etc.
   - Verify bidirectional sync works for all tested settings

### Did you use AI to help find, test, or implement this issue or feature?
I did not use it for my code but it did help me with grammar and better helping understand why this should be added