### PR TITLE
Debugger: Improve DockTabBar ownership workaround

### DIFF
--- a/pcsx2-qt/Debugger/Docking/DockViews.cpp
+++ b/pcsx2-qt/Debugger/Docking/DockViews.cpp
@@ -149,7 +149,9 @@ DockTabBar::DockTabBar(KDDockWidgets::Core::TabBar* controller, QWidget* parent)
 	// that ends up taking ownerhsip of the style for the entire application!
 	if (QProxyStyle* proxy_style = qobject_cast<QProxyStyle*>(style()))
 	{
-		proxy_style->baseStyle()->setParent(qApp);
+		if (proxy_style->baseStyle() == qApp->style())
+			proxy_style->baseStyle()->setParent(qApp);
+
 		proxy_style->setBaseStyle(QStyleFactory::create(qApp->style()->name()));
 	}
 }


### PR DESCRIPTION
### Description of Changes
Check if the version of KDDockWidgets in use has a certain hack in place before trying to work around it.

I'd like to get this in before 2.4.

### Rationale behind Changes
This may prevent a memory leak in the case that someone wants to build an older version of PCSX2 against a newer version of KDDockWidgets where [this hack might work differently](https://github.com/KDAB/KDDockWidgets/pull/636).

### Suggested Testing Steps
Try changing between different themes on Windows.

### Did you use AI to help find, test, or implement this issue or feature?
No.
