### PR TITLE
SaveState: Improve version incompatibility error message

### DIFF
--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -1101,11 +1101,16 @@ static bool CheckVersion(const std::string& filename, zip_t* zf, Error* error)
 	// than the emulator recognizes.  99% chance that trying to load it will just corrupt emulation or crash.
 	if (savever > g_SaveVersion || (savever >> 16) != (g_SaveVersion >> 16))
 	{
-		Error::SetString(error, fmt::format(TRANSLATE_FS("SaveState","This save state is outdated and is no longer compatible "
-											"with the current version of PCSX2.\n\n"
-											"If you have any unsaved progress on this save state, you can download the compatible version (PCSX2 {}) "
+		std::string current_emulator_version = BuildVersion::GitTag;
+		if (current_emulator_version.empty())
+		{
+			current_emulator_version = "Unknown";
+		}
+		Error::SetString(error, fmt::format(TRANSLATE_FS("SaveState","This save state was created with PCSX2 version {0}. It is no longer compatible "
+											"with your current PCSX2 version {1}.\n\n"
+											"If you have any unsaved progress on this save state, you can download the compatible PCSX2 version {0} "
 											"from pcsx2.net, load the save state, and save your progress to the memory card."),
-											version_string));
+											version_string, current_emulator_version));
 		return false;
 	}
 


### PR DESCRIPTION
I did it because of this now closed issue https://github.com/PCSX2/pcsx2/issues/12753

Before:
![image](https://github.com/user-attachments/assets/15173fcb-a82c-4a6f-9fdb-7ba025fd12de)

After:
![image](https://github.com/user-attachments/assets/e3f453f3-09d3-42d3-b1fa-1b9173a16a57)

### Description of Changes
Added version information to save state error messages to show users exactly which version of PCSX2 created the save state and which version they need to recover it. The error message now includes both the original version that created the save state and the current version being used.

### Rationale behind Changes
Currently, when users try to load an incompatible save state, they have to guess which version of PCSX2 they need to recover their saves. By showing the exact version information, users can easily get the correct version of PCSX2 to recover their save states and transfer their progress to memory cards. This improves the user experience by removing the guesswork from save state recovery.

### Suggested Testing Steps
1. Create a save state using the current version of PCSX2
2. Try to load this save state in a different version of PCSX2
3. Verify that the error message shows:
* The version that created the save state
* The current version being used
* Clear instructions about which version to download to recover the save

### Did you use AI to help find, test, or implement this issue or feature?
I did not use it for my code but it did help me with grammar and better helping understand why this should be added