### PR TITLE
Qt: Fix selected gamelist icons being wrong colour after theme switch

### DIFF
--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -138,15 +138,14 @@ namespace
 			if (option.state & QStyle::State_Selected)
 			{
 				// See QItemDelegate::selectedPixmap()
-				QString key = QString::fromStdString(fmt::format("{:016X}-{:d}", pix.cacheKey(), enabled));
+				QColor color = option.palette.color(enabled ? QPalette::Normal : QPalette::Disabled, QPalette::Highlight);
+				color.setAlphaF(0.3f);
+
+				QString key = QString::fromStdString(fmt::format("{:016X}-{:d}-{:08X}", pix.cacheKey(), enabled, color.rgba()));
 				QPixmap pm;
 				if (!QPixmapCache::find(key, &pm))
 				{
 					QImage img = pix.toImage().convertToFormat(QImage::Format_ARGB32_Premultiplied);
-
-					QColor color = option.palette.color(enabled ? QPalette::Normal : QPalette::Disabled,
-						QPalette::Highlight);
-					color.setAlphaF(0.3f);
 
 					QPainter tinted_painter(&img);
 					tinted_painter.setCompositionMode(QPainter::CompositionMode_SourceAtop);

--- a/pcsx2-qt/Themes.cpp
+++ b/pcsx2-qt/Themes.cpp
@@ -10,6 +10,7 @@
 
 #include <QtCore/QFile>
 #include <QtGui/QPalette>
+#include <QtGui/QPixmapCache>
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QStyle>
 #include <QtWidgets/QStyleFactory>
@@ -43,6 +44,12 @@ void QtHost::UpdateApplicationTheme()
 
 	SetStyleFromSettings();
 	SetIconThemeFromStyle();
+
+	// Qt generates tinted versions of icons and stores them in QPixmapCache
+	// The key used does not seem to include the theme (or tint colour).
+	// This can cause icons tinted for wrong theme to be used for selected/disabled.
+	// As a workaround, reset the pixmap cache to clear icons tinted for the old theme.
+	QPixmapCache::clear();
 }
 
 bool QtHost::IsDarkApplicationTheme()


### PR DESCRIPTION
### Description of Changes
Include tint colour in cache key for selected icons generated for stars/flags.

### Rationale behind Changes
When switching themes, the tinted star for the wrong theme could be used for selected items.

### Suggested Testing Steps
Select a game on the gamelist
Change to a different theme
Select a game on the gamelist and check that the colour the stars are tinted to
Restart PCSX2
Select a game on the gamelist and check that the colour the stars are tinted to, the before restart tint should match this

### Did you use AI to help find, test, or implement this issue or feature?
Negative
