### PR TITLE
Qt: Better handle multi monitor setups with different DPIs

### DIFF
--- a/pcsx2-qt/CoverDownloadDialog.cpp
+++ b/pcsx2-qt/CoverDownloadDialog.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0+
 
 #include "CoverDownloadDialog.h"
+#include "QtUtils.h"
 
 #include "pcsx2/GameList.h"
 
@@ -11,7 +12,7 @@ CoverDownloadDialog::CoverDownloadDialog(QWidget* parent /*= nullptr*/)
 	: QDialog(parent)
 {
 	m_ui.setupUi(this);
-	m_ui.coverIcon->setPixmap(QIcon::fromTheme("artboard-2-line").pixmap(32));
+	QtUtils::SetScalableIcon(m_ui.coverIcon, QIcon::fromTheme(QStringLiteral("artboard-2-line")), QSize(32, 32));
 	updateEnabled();
 
 	connect(m_ui.start, &QPushButton::clicked, this, &CoverDownloadDialog::onStartClicked);

--- a/pcsx2-qt/DisplayWidget.cpp
+++ b/pcsx2-qt/DisplayWidget.cpp
@@ -52,12 +52,12 @@ DisplayWidget::~DisplayWidget()
 
 int DisplayWidget::scaledWindowWidth() const
 {
-	return std::max(static_cast<int>(std::ceil(static_cast<qreal>(width()) * QtUtils::GetDevicePixelRatioForWidget(this))), 1);
+	return std::max(static_cast<int>(std::ceil(static_cast<qreal>(width()) * devicePixelRatioF())), 1);
 }
 
 int DisplayWidget::scaledWindowHeight() const
 {
-	return std::max(static_cast<int>(std::ceil(static_cast<qreal>(height()) * QtUtils::GetDevicePixelRatioForWidget(this))), 1);
+	return std::max(static_cast<int>(std::ceil(static_cast<qreal>(height()) * devicePixelRatioF())), 1);
 }
 
 std::optional<WindowInfo> DisplayWidget::getWindowInfo()
@@ -268,7 +268,7 @@ bool DisplayWidget::event(QEvent* event)
 
 			if (!m_relative_mouse_enabled)
 			{
-				const qreal dpr = QtUtils::GetDevicePixelRatioForWidget(this);
+				const qreal dpr = devicePixelRatioF();
 				const QPoint mouse_pos = mouse_event->pos();
 
 				const float scaled_x = static_cast<float>(static_cast<qreal>(mouse_pos.x()) * dpr);
@@ -355,7 +355,7 @@ bool DisplayWidget::event(QEvent* event)
 		{
 			QWidget::event(event);
 
-			const float dpr = QtUtils::GetDevicePixelRatioForWidget(this);
+			const float dpr = devicePixelRatioF();
 			const u32 scaled_width = static_cast<u32>(std::max(static_cast<int>(std::ceil(static_cast<qreal>(width()) * dpr)), 1));
 			const u32 scaled_height = static_cast<u32>(std::max(static_cast<int>(std::ceil(static_cast<qreal>(height()) * dpr)), 1));
 

--- a/pcsx2-qt/DisplayWidget.cpp
+++ b/pcsx2-qt/DisplayWidget.cpp
@@ -349,8 +349,7 @@ bool DisplayWidget::event(QEvent* event)
 			return true;
 		}
 
-		// According to https://bugreports.qt.io/browse/QTBUG-95925 the recommended practice for handling DPI change is responding to paint events
-		case QEvent::Paint:
+		case QEvent::DevicePixelRatioChange:
 		case QEvent::Resize:
 		{
 			QWidget::event(event);

--- a/pcsx2-qt/GameList/GameListModel.h
+++ b/pcsx2-qt/GameList/GameListModel.h
@@ -43,7 +43,7 @@ public:
 	static QIcon getIconForType(GameList::EntryType type);
 	static QIcon getIconForRegion(GameList::Region region);
 
-	GameListModel(float cover_scale, bool show_cover_titles, QObject* parent = nullptr);
+	GameListModel(float cover_scale, bool show_cover_titles, qreal dpr, QObject* parent = nullptr);
 	~GameListModel();
 
 	int rowCount(const QModelIndex& parent = QModelIndex()) const override;
@@ -71,6 +71,8 @@ public:
 	void refreshCovers();
 	void updateCacheSize(int width, int height);
 
+	void setDevicePixelRatio(qreal dpr);
+
 Q_SIGNALS:
 	void coverScaleChanged();
 
@@ -94,6 +96,7 @@ private:
 	std::array<QPixmap, static_cast<u32>(GameList::Region::Count)> m_region_pixmaps;
 	QPixmap m_placeholder_pixmap;
 	QPixmap m_loading_pixmap;
+	qreal m_dpr;
 
 	std::array<QPixmap, static_cast<int>(GameList::CompatibilityRatingCount)> m_compatibility_pixmaps;
 	mutable LRUCache<std::string, QPixmap> m_cover_pixmap_cache;

--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -181,7 +181,7 @@ void GameListWidget::initialize()
 {
 	const float cover_scale = Host::GetBaseFloatSettingValue("UI", "GameListCoverArtScale", 0.45f);
 	const bool show_cover_titles = Host::GetBaseBoolSettingValue("UI", "GameListShowCoverTitles", true);
-	m_model = new GameListModel(cover_scale, show_cover_titles, this);
+	m_model = new GameListModel(cover_scale, show_cover_titles, devicePixelRatioF(), this);
 	m_model->updateCacheSize(width(), height());
 
 	m_sort_model = new GameListSortModel(m_model);
@@ -557,6 +557,18 @@ void GameListWidget::resizeEvent(QResizeEvent* event)
 	QWidget::resizeEvent(event);
 	resizeTableViewColumnsToFit();
 	m_model->updateCacheSize(width(), height());
+}
+
+bool GameListWidget::event(QEvent* event)
+{
+	if (event->type() == QEvent::DevicePixelRatioChange)
+	{
+		m_model->setDevicePixelRatio(devicePixelRatioF());
+		QWidget::event(event);
+		return true;
+	}
+
+	return QWidget::event(event);
 }
 
 void GameListWidget::resizeTableViewColumnsToFit()

--- a/pcsx2-qt/GameList/GameListWidget.h
+++ b/pcsx2-qt/GameList/GameListWidget.h
@@ -93,6 +93,7 @@ public Q_SLOTS:
 
 protected:
 	void resizeEvent(QResizeEvent* event);
+	bool event(QEvent* event) override;
 
 private:
 	void loadTableViewColumnVisibilitySettings();

--- a/pcsx2-qt/QtUtils.cpp
+++ b/pcsx2-qt/QtUtils.cpp
@@ -254,15 +254,6 @@ namespace QtUtils
 		widget->resize(width, height);
 	}
 
-	qreal GetDevicePixelRatioForWidget(const QWidget* widget)
-	{
-		const QScreen* screen_for_ratio = widget->screen();
-		if (!screen_for_ratio)
-			screen_for_ratio = QGuiApplication::primaryScreen();
-
-		return screen_for_ratio ? screen_for_ratio->devicePixelRatio() : static_cast<qreal>(1);
-	}
-
 	std::optional<WindowInfo> GetWindowInfoForWidget(QWidget* widget)
 	{
 		WindowInfo wi;
@@ -303,7 +294,7 @@ namespace QtUtils
 		}
 #endif
 
-		const qreal dpr = GetDevicePixelRatioForWidget(widget);
+		const qreal dpr = widget->devicePixelRatioF();
 		wi.surface_width = static_cast<u32>(static_cast<qreal>(widget->width()) * dpr);
 		wi.surface_height = static_cast<u32>(static_cast<qreal>(widget->height()) * dpr);
 		wi.surface_scale = static_cast<float>(dpr);

--- a/pcsx2-qt/QtUtils.cpp
+++ b/pcsx2-qt/QtUtils.cpp
@@ -374,4 +374,37 @@ namespace QtUtils
 
 		return true;
 	}
+
+	class IconVariableDpiFilter : QObject
+	{
+	public:
+		explicit IconVariableDpiFilter(QLabel* lbl, const QIcon& icon, const QSize& size, QObject* parent = nullptr)
+			: QObject(parent)
+			, m_lbl{lbl}
+			, m_icn{icon}
+			, m_size{size}
+		{
+			lbl->installEventFilter(this);
+			m_lbl->setPixmap(m_icn.pixmap(m_size, m_lbl->devicePixelRatioF()));
+		}
+
+	protected:
+		bool eventFilter(QObject* object, QEvent* event) override
+		{
+			if (object == m_lbl && event->type() == QEvent::DevicePixelRatioChange)
+				m_lbl->setPixmap(m_icn.pixmap(m_size, m_lbl->devicePixelRatioF()));
+			// Don't block the event
+			return false;
+		}
+
+	private:
+		QLabel* m_lbl;
+		QIcon m_icn;
+		QSize m_size;
+	};
+
+	void SetScalableIcon(QLabel* lbl, const QIcon& icon, const QSize& size)
+	{
+		new IconVariableDpiFilter(lbl, icon, size, lbl);
+	}
 } // namespace QtUtils

--- a/pcsx2-qt/QtUtils.h
+++ b/pcsx2-qt/QtUtils.h
@@ -83,9 +83,6 @@ namespace QtUtils
 	/// Adjusts the fixed size for a window if it's not resizeable.
 	void ResizePotentiallyFixedSizeWindow(QWidget* widget, int width, int height);
 
-	/// Returns the pixel ratio/scaling factor for a widget.
-	qreal GetDevicePixelRatioForWidget(const QWidget* widget);
-
 	/// Returns the common window info structure for a Qt widget.
 	std::optional<WindowInfo> GetWindowInfoForWidget(QWidget* widget);
 

--- a/pcsx2-qt/QtUtils.h
+++ b/pcsx2-qt/QtUtils.h
@@ -20,6 +20,7 @@ class QAction;
 class QComboBox;
 class QFileInfo;
 class QFrame;
+class QIcon;
 class QLabel;
 class QKeyEvent;
 class QSlider;
@@ -102,4 +103,8 @@ namespace QtUtils
 	bool IsLightTheme(const QPalette& palette);
 
 	bool IsCompositorManagerRunning();
+
+	/// Sets the scalable icon to a given label (svg icons, or icons with multiple size pixmaps)
+	/// The icon will then be reloaded on DPR changes using an event filter
+	void SetScalableIcon(QLabel* lbl, const QIcon& icon, const QSize& size);
 } // namespace QtUtils

--- a/pcsx2-qt/Settings/AchievementLoginDialog.cpp
+++ b/pcsx2-qt/Settings/AchievementLoginDialog.cpp
@@ -3,6 +3,7 @@
 
 #include "AchievementLoginDialog.h"
 #include "QtHost.h"
+#include "QtUtils.h"
 
 #include "pcsx2/Achievements.h"
 
@@ -15,7 +16,7 @@ AchievementLoginDialog::AchievementLoginDialog(QWidget* parent, Achievements::Lo
 	, m_reason(reason)
 {
 	m_ui.setupUi(this);
-	m_ui.loginIcon->setPixmap(QIcon::fromTheme("login-box-line").pixmap(32));
+	QtUtils::SetScalableIcon(m_ui.loginIcon, QIcon::fromTheme(QStringLiteral("login-box-line")), QSize(32, 32));
 	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
 	// Adjust text if needed based on reason.
@@ -116,7 +117,6 @@ void AchievementLoginDialog::processLoginResult(bool result, const QString& mess
 				g_emu_thread->resetVM();
 			}
 		}
-
 	}
 
 	done(0);

--- a/pcsx2-qt/Settings/AudioSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.cpp
@@ -342,7 +342,7 @@ void AudioSettingsWidget::onExpansionSettingsClicked()
 	QDialog dlg(QtUtils::GetRootWidget(this));
 	Ui::AudioExpansionSettingsDialog dlgui;
 	dlgui.setupUi(&dlg);
-	dlgui.icon->setPixmap(QIcon::fromTheme(QStringLiteral("volume-up-line")).pixmap(32, 32));
+	QtUtils::SetScalableIcon(dlgui.icon, QIcon::fromTheme(QStringLiteral("volume-up-line")), QSize(32, 32));
 
 	SettingsInterface* sif = m_dialog->getSettingsInterface();
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, dlgui.blockSize, "SPU2/Output", "ExpandBlockSize",
@@ -431,7 +431,7 @@ void AudioSettingsWidget::onStretchSettingsClicked()
 	QDialog dlg(QtUtils::GetRootWidget(this));
 	Ui::AudioStretchSettingsDialog dlgui;
 	dlgui.setupUi(&dlg);
-	dlgui.icon->setPixmap(QIcon::fromTheme(QStringLiteral("volume-up-line")).pixmap(32, 32));
+	QtUtils::SetScalableIcon(dlgui.icon, QIcon::fromTheme(QStringLiteral("volume-up-line")), QSize(32, 32));
 
 	SettingsInterface* sif = m_dialog->getSettingsInterface();
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, dlgui.sequenceLength, "SPU2/Output", "StretchSequenceLengthMS",

--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
@@ -170,7 +170,7 @@ ControllerMouseSettingsDialog::ControllerMouseSettingsDialog(QWidget* parent, Co
 
 	SettingsInterface* sif = dialog->getProfileSettingsInterface();
 
-	m_ui.icon->setPixmap(QIcon::fromTheme(QStringLiteral("mouse-line")).pixmap(32, 32));
+	QtUtils::SetScalableIcon(m_ui.icon, QIcon::fromTheme(QStringLiteral("mouse-line")), QSize(32, 32));
 
 	ControllerSettingWidgetBinder::BindWidgetToInputProfileFloat(sif, m_ui.pointerXSpeedSlider, "Pad", "PointerXSpeed", 40.0f);
 	ControllerSettingWidgetBinder::BindWidgetToInputProfileFloat(sif, m_ui.pointerYSpeedSlider, "Pad", "PointerYSpeed", 40.0f);
@@ -202,11 +202,10 @@ ControllerMappingSettingsDialog::ControllerMappingSettingsDialog(ControllerSetti
 
 	SettingsInterface* sif = parent->getProfileSettingsInterface();
 
-	m_ui.icon->setPixmap(QIcon::fromTheme(QStringLiteral("settings-3-line")).pixmap(32, 32));
+	QtUtils::SetScalableIcon(m_ui.icon, QIcon::fromTheme(QStringLiteral("settings-3-line")), QSize(32, 32));
 
 	ControllerSettingWidgetBinder::BindWidgetToInputProfileBool(sif, m_ui.ignoreInversion, "InputSources", "IgnoreInversion", false);
 
 	connect(m_ui.buttonBox->button(QDialogButtonBox::Close), &QPushButton::clicked, this, &QDialog::accept);
 }
-
 ControllerMappingSettingsDialog::~ControllerMappingSettingsDialog() = default;

--- a/pcsx2-qt/Settings/MemoryCardCreateDialog.cpp
+++ b/pcsx2-qt/Settings/MemoryCardCreateDialog.cpp
@@ -9,6 +9,7 @@
 #include <QtWidgets/QPushButton>
 
 #include "Settings/MemoryCardCreateDialog.h"
+#include "QtUtils.h"
 
 #include "pcsx2/SIO/Memcard/MemoryCardFile.h"
 
@@ -16,7 +17,7 @@ MemoryCardCreateDialog::MemoryCardCreateDialog(QWidget* parent /* = nullptr */)
 	: QDialog(parent)
 {
 	m_ui.setupUi(this);
-	m_ui.icon->setPixmap(QIcon::fromTheme("memcard-line").pixmap(m_ui.icon->width()));
+	QtUtils::SetScalableIcon(m_ui.icon, QIcon::fromTheme(QStringLiteral("memcard-line")), QSize(m_ui.icon->width(), m_ui.icon->width()));
 
 	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 


### PR DESCRIPTION
### Description of Changes
Fix DPR handling in Game-list flags/icons.
Fix icons in setting dialogs  being drawn at a higher DPR then needed for the current screen.
Remove seemingly redundant method
Use DPR changed event instead of paint event to detect DPR changes in display widget

### Rationale behind Changes
Most of the icons corrected here where drawn at highest DPR of all connected monitors, rather then the monitor the window was visible on, while the stars are drawn at a DPR of 1.

For icons being rendered from SVGs, upscaling/downscaling artefacts can be noticeable
This was moreso for stars as they where upscaled, flags and various setting dialog icons where less noticible as these got downscaled.

The existing `GetDevicePixelRatioForWidget()` appears redundant and I couldn't see a reason for not just using `QWidget.devicePixelRatioF()`. 
Might be a holdover from older Qt versions, as was the case for the use of `QEvent::Paint` to detect DPR changes.

### Suggested Testing Steps
Have 2 monitors with differing DPI ratios
Take a close look at the icons in the gamelist on those different DPI monitors
Take a close look at the icon on the AchievementLogin/AudioExpansion/Controller*SettingsDialog/MemoryCardCreate dialogs on different DPI monitors.

### Did you use AI to help find, test, or implement this issue or feature?
Nay