### PR TITLE
GS: Update transfer regs out of order if not already started

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -1413,6 +1413,9 @@ void GSState::GIFRegHandlerBITBLTBUF(const GIFReg* RESTRICT r)
 		FlushWrite();
 
 	m_env.BITBLTBUF = r->BITBLTBUF;
+
+	if (m_tr.total == 0 && m_tr.start == m_tr.end)
+		m_tr.Init(m_env.TRXPOS.DSAX, m_env.TRXPOS.DSAY, m_env.BITBLTBUF, m_tr.write);
 }
 
 void GSState::GIFRegHandlerTRXPOS(const GIFReg* RESTRICT r)
@@ -1423,6 +1426,9 @@ void GSState::GIFRegHandlerTRXPOS(const GIFReg* RESTRICT r)
 		FlushWrite();
 
 	m_env.TRXPOS = r->TRXPOS;
+
+	if (m_tr.total == 0 && m_tr.start == m_tr.end)
+		m_tr.Init(m_env.TRXPOS.DSAX, m_env.TRXPOS.DSAY, m_env.BITBLTBUF, m_tr.write);
 }
 
 void GSState::GIFRegHandlerTRXREG(const GIFReg* RESTRICT r)


### PR DESCRIPTION
### Description of Changes
Allows updating of BLTBLITBUF and TRXPOS registers if TRXDIR (which usually starts a transfer) is done before they are set, but nothing has been transferred.

### Rationale behind Changes
Saishuu Denshia was doing this causing it to not only corrupt the picture, but also crash the emulator due to bad memory access.

It still looks like it's offsetting by 16 or 32 pixels (due to the right column being on the left and down 16 or 32 pixels), that will need to be fixed separately, unless we can work it out before this PR merges.

### Suggested Testing Steps
Test Saishuu Denshia, not sure what else does this cursed nonsense.

### Did you use AI to help find, test, or implement this issue or feature?
No.

Saishuu Denshia:

Master (with crash not pictured here):

![image](https://github.com/user-attachments/assets/b8e23917-d4de-4935-b493-7768911791ec)

PR:

![image](https://github.com/user-attachments/assets/f3c2afb4-ee55-4ef6-b055-2e58c35e172c)
