### PR TITLE
GS: Store entire GS transfer state at TRXDIR write

### DIFF
--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -108,15 +108,19 @@ private:
 	struct GSTransferBuffer
 	{
 		int x = 0, y = 0;
+		int w = 0, h = 0;
 		int start = 0, end = 0, total = 0;
 		u8* buff = nullptr;
+		GSVector4i rect = GSVector4i::zero();
 		GIFRegBITBLTBUF m_blit = {};
+		GIFRegTRXPOS m_pos = {};
+		GIFRegTRXREG m_reg = {};
 		bool write = false;
 
 		GSTransferBuffer();
 		~GSTransferBuffer();
 
-		void Init(int tx, int ty, const GIFRegBITBLTBUF& blit, bool write);
+		void Init(GIFRegTRXPOS& TRXPOS, GIFRegTRXREG& TRXREG, const GIFRegBITBLTBUF& blit, bool is_write);
 		bool Update(int tw, int th, int bpp, int& len);
 
 	} m_tr;

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -21,7 +21,7 @@ public:
 	GSState();
 	virtual ~GSState();
 
-	static constexpr int GetSaveStateSize();
+	static constexpr int GetSaveStateSize(int version);
 
 private:
 	// RESTRICT prevents multiple loads of the same part of the register when accessing its bitfields (the compiler is happy to know that memory writes in-between will not go there)
@@ -263,7 +263,7 @@ public:
 	static int s_last_transfer_draw_n;
 	static int s_transfer_n;
 
-	static constexpr u32 STATE_VERSION = 8;
+	static constexpr u32 STATE_VERSION = 9;
 
 	enum REG_DIRTY
 	{


### PR DESCRIPTION
### Description of Changes
Stores the GS Transfer registers in our internal state on TRXDIR write (transfer start), as the registers can be updated after this and have no effect on the current transfer.

### Rationale behind Changes
Saishuu Densha was doing this causing it to not only corrupt the picture and offset it by 16x16 pixels, but also crash the emulator due to bad memory access.

### Suggested Testing Steps
Test Saishuu Densha, not sure what else does this cursed nonsense.

### Did you use AI to help find, test, or implement this issue or feature?
No.

Saishuu Densha:

Master (with crash not pictured here):

![image](https://github.com/user-attachments/assets/003fc8fc-3666-427a-a3bd-069d6656cafe)

PR:

![image](https://github.com/user-attachments/assets/5d1ffb32-7bcb-444c-b0f5-ca0cfabe7c87)