### PR TITLE
FSUI: Add Save State Incompatible Warning

### DIFF
--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -6220,10 +6220,30 @@ void FullscreenUI::DrawResumeStateSelector()
 
 void FullscreenUI::DoLoadState(std::string path)
 {
-	Host::RunOnCPUThread([boot_path = s_save_state_selector_game_path, path = std::move(path)]() {
+	Host::RunOnCPUThread([path = std::move(path)]()
+	{
+		const std::string boot_path = s_save_state_selector_game_path;
 		if (VMManager::HasValidVM())
 		{
-			VMManager::LoadState(path.c_str());
+			Error error;
+			if (!SaveState_UnzipFromDisk(path, &error))
+			{
+				if (error.GetDescription().find("outdated") != std::string::npos)
+				{
+					Host::RunOnCPUThread([error_desc = error.GetDescription()]()
+					{
+						ImGuiFullscreen::OpenInfoMessageDialog(
+							FSUI_ICONSTR(ICON_FA_EXCLAMATION_TRIANGLE, "Incompatible Save State"),
+							FSUI_STR(error_desc));
+					});
+				}
+				else
+				{
+					Host::ReportErrorAsync(TRANSLATE_SV("VMManager", "Failed to load save state"), error.GetDescription());
+				}
+				return;
+			}
+
 			if (!boot_path.empty() && VMManager::GetDiscPath() != boot_path)
 				VMManager::ChangeDisc(CDVD_SourceType::Iso, std::move(boot_path));
 		}


### PR DESCRIPTION
### Description of Changes
This pull request adds an explicit warning in Fullscreen UI when a user attempts to load a save state that is incompatible or outdated.

### Rationale behind Changes
Previously, if a user tried to load an incompatible (e.g., outdated) save state, they may not have received a clear or user-friendly message showed why the operation failed in a FSUI window it was linked to Qt before so it makes it easier when someone is on Big Picture Mode on a PC on their TV they don't have to pull out a Mouse to click Ok. 

### Suggested Testing Steps
1. [ ] Attempt to load a save state created from an older/different version of PCSX2 in Fullscreen UI.
    - You should see a warning dialog indicating the save state is incompatible or outdated in ImGui **not** Qt.
2. [ ] Attempt to load a valid save state.
    - The save state should load as expected.

### Did you use AI to help find, test, or implement this issue or feature?
I did not use it for my code but it did help me with grammar and better helping understand why this should be added