### PR TITLE
UI: Fix Discord Rich Presence not activating in FSUI

### DIFF
--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3559,7 +3559,7 @@ void FullscreenUI::DrawInterfaceSettingsPage()
 
 	MenuHeading(FSUI_CSTR("Integration"));
 	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_USER_CIRCLE, "Enable Discord Presence"),
-		FSUI_CSTR("Shows the game you are currently playing as part of your profile on Discord."), "UI", "DiscordPresence", false);
+		FSUI_CSTR("Shows the game you are currently playing as part of your profile on Discord."), "EmuCore", "EnableDiscordPresence", false);
 
 	MenuHeading(FSUI_CSTR("Game Display"));
 	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_TV, "Start Fullscreen"),

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1898,6 +1898,7 @@ Pcsx2Config::Pcsx2Config()
 	UseSavestateSelector = true;
 	BackupSavestate = true;
 	WarnAboutUnsafeSettings = true;
+	EnableDiscordPresence = false;
 	ManuallySetRealTimeClock = false;
 
 	// To be moved to FileMemoryCard pluign (someday)


### PR DESCRIPTION
### Description of Changes
FSUI was sending this option to the shadow realm by sending it to the [UI] section (whereas it's under [EmuCore] in the Qt settings) and calling it "DiscordPresence" instead of "EnableDiscordPresence".

### Rationale behind Changes
This should hopefully fix Discord Rich Presence in the FSUI. I can't test because Discord Rich Presence has been broken for me on PCSX2 for a long time.

### Suggested Testing Steps
1) Open FSUI
2) Simultaneously open `Settings` > `Interface`.
3) Make sure that when you check and uncheck `Enable Discord Presence` in the Qt UI that the corresponding slider in the FSUI moves along with it.

### Did you use AI to help find, test, or implement this issue or feature?
I have no mouth and I must eat spaghetti
