### PR TITLE
GS: Better handle hazards when dx12/vk device creation fails.

### DIFF
--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -703,11 +703,17 @@ bool GSDevice12::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 	if (!AcquireWindow(true) || (m_window_info.type != WindowInfo::Type::Surfaceless && !CreateSwapChain()))
 		return false;
 
+	if (!CreateNullTexture())
+	{
+		Host::ReportErrorAsync("GS", "Failed to create dummy texture");
+		return false;
+	}
+
 	{
 		std::optional<std::string> shader = ReadShaderSource("shaders/dx11/tfx.fx");
 		if (!shader.has_value())
 		{
-			Host::ReportErrorAsync("GS", "Failed to read shaders/dx11/tfx.fxf.");
+			Host::ReportErrorAsync("GS", "Failed to read shaders/dx11/tfx.fx.");
 			return false;
 		}
 
@@ -716,12 +722,6 @@ bool GSDevice12::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 
 	if (!m_shader_cache.Open(m_feature_level, GSConfig.UseDebugDevice))
 		Console.Warning("D3D12: Shader cache failed to open.");
-
-	if (!CreateNullTexture())
-	{
-		Host::ReportErrorAsync("GS", "Failed to create dummy texture");
-		return false;
-	}
 
 	if (!CreateRootSignatures())
 	{


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS: Better handle hazards when dx12/vk device creation fails.
VK/DX12: Move CreateNullTexture before reading shader resource.
Fixes null pointer dereference.
VK: Check if vertex buffer is valid before binding.
Fixes vertex buffer validation error null handle.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Fixes a crash on dx12 when tfx shader is not found, issue was we were trying to unbind null textures when destroying device but since the shader was not found null textures weren't created in the first place leading to dereferencing a null pointer.

Fixes validation error on vk when device creation fails (missing shaders for example) which binded invalid vertex buffer.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Delete the vk and dx12 shaders folders/files, try to boot anything, see if dx12 crashes, see if vk validation error is resolved.
Also smoke test dx12/vk normally.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
Is the GS AI?