### PR TITLE
Deps: Specify minimum version of KDDockWidgets in cmake file

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -120,7 +120,7 @@ add_subdirectory(3rdparty/demangler EXCLUDE_FROM_ALL)
 add_subdirectory(3rdparty/ccc EXCLUDE_FROM_ALL)
 
 # The docking system for the debugger.
-find_package(KDDockWidgets-qt6 REQUIRED)
+find_package(KDDockWidgets-qt6 2.0.0 REQUIRED)
 # Add an extra include path to work around a broken include directive.
 # TODO: Remove this the next time we update KDDockWidgets.
 get_target_property(KDDOCKWIDGETS_INCLUDE_DIRECTORY KDAB::kddockwidgets INTERFACE_INCLUDE_DIRECTORIES)

--- a/pcsx2-qt/Debugger/Docking/DropIndicators.cpp
+++ b/pcsx2-qt/Debugger/Docking/DropIndicators.cpp
@@ -10,6 +10,7 @@
 
 #include <kddockwidgets/Config.h>
 #include <kddockwidgets/core/Group.h>
+#include <kddockwidgets/core/Platform.h>
 #include <kddockwidgets/core/indicators/SegmentedDropIndicatorOverlay.h>
 #include <kddockwidgets/qtwidgets/ViewFactory.h>
 


### PR DESCRIPTION
### Description of Changes
- Specify the minimum version of KDDockWidgets supported (2.0.0) in the cmake file.
- Add a missing include that's required to actually get it building with 2.0.0.

### Rationale behind Changes
Friendlier build error for users trying to build against KDDockWidgets 1.x (e.g. #12778). 2.x is majorly different so this won't work.

### Suggested Testing Steps
Make sure it builds against different supported versions of KDDockWidgets.

### Did you use AI to help find, test, or implement this issue or feature?
No.
