### PR TITLE
GS/HW: Clear matched target on HW Move

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -55561,7 +55561,8 @@ SLPS-20489:
   name-en: "Simple 2000 Series Vol. 114 - The Onna Okappichi Torimonochou - Oharu-chan GoGoGo!"
   region: "NTSC-J"
   gsHWFixes:
-    getSkipCount: "GSC_Simple2000Vol114"
+    halfPixelOffset: 5 # Fixes DoF alignment.
+    nativeScaling: 1 # Corrects DoF.
 SLPS-20490:
   name: "パチスロ倶楽部コレクション アイムジャグラーEX～ジャグラーセレクション～"
   name-sort: "ぱちすろくらぶこれくしょん あいむじゃぐらーEX じゃぐらーせれくしょん"

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -557,26 +557,6 @@ bool GSHwHack::GSC_TalesofSymphonia(GSRendererHW& r, int& skip)
 	return true;
 }
 
-bool GSHwHack::GSC_Simple2000Vol114(GSRendererHW& r, int& skip)
-{
-	if (skip == 0)
-	{
-		if (!s_nativeres && RTME == 0 && (RFBP == 0x1500) && (RTBP0 == 0x2c97 || RTBP0 == 0x2ace || RTBP0 == 0x03d0 || RTBP0 == 0x2448) && (RFBMSK == 0x0000))
-		{
-			// Don't enable hack on native res if crc is below aggressive.
-			// Upscaling issues, removes glow/blur effect which fixes ghosting.
-			skip = 1;
-		}
-		if (RTME && (RFBP == 0x0e00) && (RTBP0 == 0x1000) && (RFBMSK == 0x0000))
-		{
-			// Depth shadows.
-			skip = 1;
-		}
-	}
-
-	return true;
-}
-
 bool GSHwHack::GSC_UrbanReign(GSRendererHW& r, int& skip)
 {
 	if (skip == 0)
@@ -1419,7 +1399,6 @@ const GSHwHack::Entry<GSRendererHW::GSC_Ptr> GSHwHack::s_get_skip_count_function
 	CRC_F(GSC_SacredBlaze),
 	CRC_F(GSC_GuitarHero),
 	CRC_F(GSC_SakuraWarsSoLongMyLove),
-	CRC_F(GSC_Simple2000Vol114),
 	CRC_F(GSC_SFEX3),
 	CRC_F(GSC_DTGames),
 	CRC_F(GSC_TalesOfLegendia),

--- a/pcsx2/GS/Renderers/HW/GSHwHack.h
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.h
@@ -21,7 +21,6 @@ public:
 	static bool GSC_SakuraWarsSoLongMyLove(GSRendererHW& r, int& skip);
 	static bool GSC_UltramanFightingEvolution(GSRendererHW& r, int& skip);
 	static bool GSC_TalesofSymphonia(GSRendererHW& r, int& skip);
-	static bool GSC_Simple2000Vol114(GSRendererHW& r, int& skip);
 	static bool GSC_UrbanReign(GSRendererHW& r, int& skip);
 	static bool GSC_SteambotChronicles(GSRendererHW& r, int& skip);
 	static bool GSC_BlueTongueGames(GSRendererHW& r, int& skip);

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -4808,7 +4808,16 @@ bool GSTextureCache::Move(u32 SBP, u32 SBW, u32 SPSM, int sx, int sy, u32 DBP, u
 		if (!dst)
 			dst = CreateTarget(new_TEX0, target_size, target_size, src->m_scale, src->m_type);
 		else // Expand if necessary (Silent hill 4 takes an old target which is smaller).
+		{
 			dst->ResizeTexture(std::max(dst->m_unscaled_size.x, target_size.x), std::max(dst->m_unscaled_size.y, target_size.y));
+
+			// If it was matched to an old target, make sure to clear the other type and update its information.
+			if (dst->m_was_dst_matched)
+			{
+				g_texture_cache->InvalidateVideoMemType(GSTextureCache::DepthStencil - dst->m_type, dst->m_TEX0.TBP0);
+				dst->m_TEX0 = new_TEX0;
+			}
+		}
 
 		if (!dst)
 			return false;


### PR DESCRIPTION
### Description of Changes
Clear any matched targets which exist on a hardware move to avoid it taking precedence.

Removes the CRC hack for Simple 2000 Series Vol. 114 - The Onna Okappichi Torimonochou - Oharu-chan GoGoGo! and fixes the shadows

### Rationale behind Changes
The move was being ignored as this was considered the copy.

### Suggested Testing Steps
Test Simple 2000 Series Vol. 114 - The Onna Okappichi Torimonochou - Oharu-chan GoGoGo!

### Did you use AI to help find, test, or implement this issue or feature?
No

Simple 2000 Series Vol. 114 - The Onna Okappichi Torimonochou - Oharu-chan GoGoGo!:
Master:
![mastercompare](https://github.com/user-attachments/assets/2028f284-cde3-4165-b1a7-d8fa5e3936ba)
PR:
![prcompare](https://github.com/user-attachments/assets/be451c29-c894-4715-9667-3e65f125d8d9)

