### PR TITLE
GS: Better texture dump directory handling

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureReplacements.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureReplacements.cpp
@@ -289,37 +289,38 @@ std::string GSTextureReplacements::GetDumpFilename(const TextureName& name, u32 
 	{
 		if (name.HasPalette())
 		{
-			filename = (level > 0) ?
-						   StringUtil::StdStringFromFormat(TEXTURE_FILENAME_REGION_CLUT_FORMAT_STRING "-mip%u.png",
-							   name.TEX0Hash, name.CLUTHash, name.region_width, name.region_height, name.bits, level) :
-						   StringUtil::StdStringFromFormat(TEXTURE_FILENAME_REGION_CLUT_FORMAT_STRING ".png",
-							   name.TEX0Hash, name.CLUTHash, name.region_width, name.region_height, name.bits);
+			filename = (level > 0)
+				? StringUtil::StdStringFromFormat(TEXTURE_FILENAME_REGION_CLUT_FORMAT_STRING "-mip%u.png",
+					name.TEX0Hash, name.CLUTHash, name.region_width, name.region_height, name.bits, level)
+				: StringUtil::StdStringFromFormat(TEXTURE_FILENAME_REGION_CLUT_FORMAT_STRING ".png",
+					name.TEX0Hash, name.CLUTHash, name.region_width, name.region_height, name.bits);
 		}
 		else
 		{
-			filename = (level > 0) ? StringUtil::StdStringFromFormat(
-										 TEXTURE_FILENAME_REGION_FORMAT_STRING "-mip%u.png", name.TEX0Hash,
-										 name.region_width, name.region_height, name.bits, level) :
-									 StringUtil::StdStringFromFormat(
-										 TEXTURE_FILENAME_REGION_FORMAT_STRING ".png", name.TEX0Hash,
-										 name.region_width, name.region_height, name.bits);
+			filename = (level > 0)
+				? StringUtil::StdStringFromFormat(TEXTURE_FILENAME_REGION_FORMAT_STRING "-mip%u.png",
+					name.TEX0Hash, name.region_width, name.region_height, name.bits, level)
+				: StringUtil::StdStringFromFormat(TEXTURE_FILENAME_REGION_FORMAT_STRING ".png",
+					name.TEX0Hash, name.region_width, name.region_height, name.bits);
 		}
 	}
 	else
 	{
 		if (name.HasPalette())
 		{
-			filename = (level > 0) ? StringUtil::StdStringFromFormat(TEXTURE_FILENAME_CLUT_FORMAT_STRING "-mip%u.png",
-										 name.TEX0Hash, name.CLUTHash, name.bits, level) :
-									 StringUtil::StdStringFromFormat(TEXTURE_FILENAME_CLUT_FORMAT_STRING ".png",
-										 name.TEX0Hash, name.CLUTHash, name.bits);
+			filename = (level > 0)
+				? StringUtil::StdStringFromFormat(TEXTURE_FILENAME_CLUT_FORMAT_STRING "-mip%u.png",
+				                                  name.TEX0Hash, name.CLUTHash, name.bits, level)
+				: StringUtil::StdStringFromFormat(TEXTURE_FILENAME_CLUT_FORMAT_STRING ".png",
+				                                  name.TEX0Hash, name.CLUTHash, name.bits);
 		}
 		else
 		{
-			filename = (level > 0) ? StringUtil::StdStringFromFormat(
-										 TEXTURE_FILENAME_FORMAT_STRING "-mip%u.png", name.TEX0Hash, name.bits, level) :
-									 StringUtil::StdStringFromFormat(
-										 TEXTURE_FILENAME_FORMAT_STRING ".png", name.TEX0Hash, name.bits);
+			filename = (level > 0)
+				? StringUtil::StdStringFromFormat(TEXTURE_FILENAME_FORMAT_STRING "-mip%u.png",
+				                                  name.TEX0Hash, name.bits, level)
+				: StringUtil::StdStringFromFormat(TEXTURE_FILENAME_FORMAT_STRING ".png",
+				                                  name.TEX0Hash, name.bits);
 		}
 	}
 

--- a/pcsx2/GS/Renderers/HW/GSTextureReplacements.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureReplacements.cpp
@@ -270,19 +270,19 @@ std::string GSTextureReplacements::GetDumpFilename(const TextureName& name, u32 
 		return ret;
 
 	const std::string game_dir(GetGameTextureDirectory());
-	if (!FileSystem::DirectoryExists(game_dir.c_str()))
+	const std::string game_subdir(Path::Combine(game_dir, TEXTURE_DUMP_SUBDIRECTORY_NAME));
+
+	if (!FileSystem::DirectoryExists(game_subdir.c_str()))
 	{
 		// create both dumps and replacements
 		if (!FileSystem::CreateDirectoryPath(game_dir.c_str(), false) ||
-			!FileSystem::EnsureDirectoryExists(Path::Combine(game_dir, "dumps").c_str(), false) ||
-			!FileSystem::EnsureDirectoryExists(Path::Combine(game_dir, "replacements").c_str(), false))
+			!FileSystem::EnsureDirectoryExists(game_subdir.c_str(), false) ||
+			!FileSystem::EnsureDirectoryExists(Path::Combine(game_dir, TEXTURE_REPLACEMENT_SUBDIRECTORY_NAME).c_str(), false))
 		{
 			// if it fails to create, we're not going to be able to use it anyway
 			return ret;
 		}
 	}
-
-	const std::string game_subdir(Path::Combine(game_dir, TEXTURE_DUMP_SUBDIRECTORY_NAME));
 
 	std::string filename;
 	if (name.HasRegion())


### PR DESCRIPTION
### Description of Changes
Previously, the emulator would only create the texture dump directory if the *game dir* didn't exist.  If someone grabbed a texture pack online and installed it, dumping would not work because there was a game dir but no dump dir.

In addition, some texture pack creators seem to be renaming their texture packs' replacement directories with capital letters.  This adds a warning if any case mismatches are found.  Hopefully this will both (A) deter renaming of texture replacements and (B) notify users on case sensitive filesystems that they need to rename the folder to use the texture pack.

### Rationale behind Changes
So users don't spend like a week and a half of getting frustrated trying to figure out why their texture packs are broken.

### Suggested Testing Steps
- Try to dump textures with a game folder but no dump folder
  - This should work
- Rename `replacements` in a texture pack to `Replacements`
  - This should display a warning on both case sensitive and case insensitive filesystems

### Did you use AI to help find, test, or implement this issue or feature?
No
