### PR TITLE
GS/HW: Improvements to HW moving (C<->Z)

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -2557,8 +2557,6 @@ SCAJ-25012:
 SCAJ-25026:
   name: "Kunoichi Shinobi"
   region: "NTSC-Unk"
-  gsHWFixes:
-    getSkipCount: "GSC_Kunoichi"
 SCAJ-25034:
   name: "Sakura Taisen Monogatari"
   region: "NTSC-Unk"
@@ -12878,8 +12876,6 @@ SLAJ-25023:
 SLAJ-25026:
   name: "Kunoichi Shinobi"
   region: "NTSC-Unk"
-  gsHWFixes:
-    getSkipCount: "GSC_Kunoichi"
 SLAJ-25027:
   name: "Sonic Heroes"
   region: "NTSC-Unk"
@@ -12894,8 +12890,6 @@ SLAJ-25030:
 SLAJ-25031:
   name: "Kunoichi - Shinobu"
   region: "NTSC-C-J"
-  gsHWFixes:
-    getSkipCount: "GSC_Kunoichi"
 SLAJ-25033:
   name: "Puyo Puyo Fever"
   region: "NTSC-Unk"
@@ -19388,8 +19382,6 @@ SLES-52238:
   name: "Nightshade"
   region: "PAL-M5"
   compat: 5
-  gsHWFixes:
-    getSkipCount: "GSC_Kunoichi"
 SLES-52240:
   name: "International Pool Championship"
   region: "PAL-M5"
@@ -30958,8 +30950,6 @@ SLKA-25135:
   name: "Kunoichi"
   region: "NTSC-K"
   compat: 5
-  gsHWFixes:
-    getSkipCount: "GSC_Kunoichi"
 SLKA-25136:
   name: "Need for Speed - Underground"
   region: "NTSC-K"
@@ -32524,8 +32514,6 @@ SLKA-35004:
   name: "Sakura Wars 5 So Long My Love"
   region: "NTSC-K"
   compat: 5
-  gsHWFixes:
-    getSkipCount: "GSC_SakuraWarsSoLongMyLove"
 SLKA-35005:
   name: "Jin Samguk Mussang 5 - Special"
   region: "NTSC-K"
@@ -35219,8 +35207,6 @@ SLPM-61059:
   name-sort: "くのいち -しのび- [たいけんばん]"
   name-en: "Kunoichi -Shinobi- [Trial]"
   region: "NTSC-J"
-  gsHWFixes:
-    getSkipCount: "GSC_Kunoichi"
 SLPM-61060:
   name: "BUSIN 0 ～Wizardry Alternative NEO～ [体験版]"
   name-sort: "ぶしん ぜろ ～うぃざーどりぃ おるたなてぃぶ ねお～ [たいけんばん]"
@@ -42475,8 +42461,6 @@ SLPM-65447:
   name-en: "Kunoichi -Shinobi-"
   region: "NTSC-J"
   compat: 5
-  gsHWFixes:
-    getSkipCount: "GSC_Kunoichi"
 SLPM-65448:
   name: "カンブリアンQTS ～化石になっても～"
   name-sort: "かんぶりあんQTS ～かせきになっても～"
@@ -66542,8 +66526,6 @@ SLUS-20810:
   name: "Nightshade"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    getSkipCount: "GSC_Kunoichi"
 SLUS-20811:
   name: "Need for Speed - Underground"
   region: "NTSC-U"
@@ -73139,8 +73121,6 @@ SLUS-21927:
   name: "Sakura Wars - So Long, My Love [English - Disc 1]"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    getSkipCount: "GSC_SakuraWarsSoLongMyLove"
 SLUS-21928:
   name: "Scooby-Doo! and the Spooky Swamp"
   region: "NTSC-U"
@@ -73157,8 +73137,6 @@ SLUS-21930:
   name: "Sakura Wars - So Long, My Love [Japanese - Disc 2]"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    getSkipCount: "GSC_SakuraWarsSoLongMyLove"
 SLUS-21931:
   name: "Disney/Pixar Toy Story 3"
   region: "NTSC-U"

--- a/pcsx2/GS/GSLocalMemory.cpp
+++ b/pcsx2/GS/GSLocalMemory.cpp
@@ -446,6 +446,13 @@ std::vector<GSVector2i>* GSLocalMemory::GetPage2TileMap(const GIFRegTEX0& TEX0)
 	return p2t;
 }
 
+u32 GSLocalMemory::IsPageAlignedMasked(u32 psm, const GSVector4i& rc)
+{
+	const psm_t& psm_s = m_psm[psm];
+	const GSVector4i pgmsk = GSVector4i(psm_s.pgs).xyxy() - GSVector4i(1);
+	return ((rc & pgmsk) == GSVector4i::zero()).mask();
+}
+
 bool GSLocalMemory::IsPageAligned(u32 psm, const GSVector4i& rc)
 {
 	const psm_t& psm_s = m_psm[psm];

--- a/pcsx2/GS/GSLocalMemory.h
+++ b/pcsx2/GS/GSLocalMemory.h
@@ -524,6 +524,7 @@ public:
 	GSPixelOffset4* GetPixelOffset4(const GIFRegFRAME& FRAME, const GIFRegZBUF& ZBUF);
 	std::vector<GSVector2i>* GetPage2TileMap(const GIFRegTEX0& TEX0);
 	static bool HasOverlap(u32 src_bp, u32 src_bw, u32 src_psm, GSVector4i src_rect, u32 dst_bp, u32 dst_bw, u32 dst_psm, GSVector4i dst_rect);
+	static u32 IsPageAlignedMasked(u32 psm, const GSVector4i& rc);
 	static bool IsPageAligned(u32 psm, const GSVector4i& rc);
 	static u32 GetStartBlockAddress(u32 bp, u32 bw, u32 psm, GSVector4i rect);
 	static u32 GetEndBlockAddress(u32 bp, u32 bw, u32 psm, GSVector4i rect);

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -431,31 +431,6 @@ bool GSHwHack::GSC_TalesOfLegendia(GSRendererHW& r, int& skip)
 	return true;
 }
 
-bool GSHwHack::GSC_Kunoichi(GSRendererHW& r, int& skip)
-{
-	if (skip == 0)
-	{
-		if (!RTME && (RFBP == 0x0 || RFBP == 0x00700 || RFBP == 0x00800) && RFPSM == PSMCT32 && RFBMSK == 0x00FFFFFF)
-		{
-			// Removes depth effects(shadows) not rendered correctly on all renders.
-			skip = 3;
-		}
-		if (RTME && (RFBP == 0x0700 || RFBP == 0) && RTBP0 == 0x0e00 && RTPSM == 0 && RFBMSK == 0)
-		{
-			skip = 1; // Removes black screen (not needed anymore maybe)?
-		}
-	}
-	else
-	{
-		if (RTME && (RFBP == 0x0e00) && RFPSM == PSMCT32 && RFBMSK == 0xFF000000)
-		{
-			skip = 0;
-		}
-	}
-
-	return true;
-}
-
 bool GSHwHack::GSC_ZettaiZetsumeiToshi2(GSRendererHW& r, int& skip)
 {
 	if (skip == 0)
@@ -499,27 +474,6 @@ bool GSHwHack::GSC_ZettaiZetsumeiToshi2(GSRendererHW& r, int& skip)
 		if (RTME && RTPSM == PSMCT16S && (RFBP == 0x1180))
 		{
 			skip = 2;
-		}
-	}
-
-	return true;
-}
-
-bool GSHwHack::GSC_SakuraWarsSoLongMyLove(GSRendererHW& r, int& skip)
-{
-	if (skip == 0)
-	{
-		if (RTME == 0 && RFBP != RTBP0 && RTBP0 && RFBMSK == 0x00FFFFFF)
-		{
-			skip = 3; // Remove darkness
-		}
-		else if (RTME == 0 && RFBP == RTBP0 && (RTBP0 == 0x1200 || RTBP0 == 0x1180 || RTBP0 == 0) && RFBMSK == 0x00FFFFFF)
-		{
-			skip = 3; // Remove darkness
-		}
-		else if (RTME && (RFBP == 0 || RFBP == 0x1180) && RFPSM == PSMCT32 && RTBP0 == 0x3F3F && RTPSM == PSMT8)
-		{
-			skip = 1; // Floodlight
 		}
 	}
 
@@ -1393,12 +1347,10 @@ bool GSHwHack::MV_Ico(GSRendererHW& r)
 #define CRC_F(name) { #name, &GSHwHack::name }
 
 const GSHwHack::Entry<GSRendererHW::GSC_Ptr> GSHwHack::s_get_skip_count_functions[] = {
-	CRC_F(GSC_Kunoichi),
 	CRC_F(GSC_Manhunt2),
 	CRC_F(GSC_MidnightClub3),
 	CRC_F(GSC_SacredBlaze),
 	CRC_F(GSC_GuitarHero),
-	CRC_F(GSC_SakuraWarsSoLongMyLove),
 	CRC_F(GSC_SFEX3),
 	CRC_F(GSC_DTGames),
 	CRC_F(GSC_TalesOfLegendia),

--- a/pcsx2/GS/Renderers/HW/GSHwHack.h
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.h
@@ -16,9 +16,7 @@ public:
 	static bool GSC_BlackAndBurnoutSky(GSRendererHW& r, int& skip);
 	static bool GSC_MidnightClub3(GSRendererHW& r, int& skip);
 	static bool GSC_TalesOfLegendia(GSRendererHW& r, int& skip);
-	static bool GSC_Kunoichi(GSRendererHW& r, int& skip);
 	static bool GSC_ZettaiZetsumeiToshi2(GSRendererHW& r, int& skip);
-	static bool GSC_SakuraWarsSoLongMyLove(GSRendererHW& r, int& skip);
 	static bool GSC_UltramanFightingEvolution(GSRendererHW& r, int& skip);
 	static bool GSC_TalesofSymphonia(GSRendererHW& r, int& skip);
 	static bool GSC_UrbanReign(GSRendererHW& r, int& skip);

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -3543,11 +3543,11 @@ bool GSTextureCache::PreloadTarget(GIFRegTEX0 TEX0, const GSVector2i& size, cons
 							continue;
 						}
 
-						const int height_adjust = (((dst_end_block - t->m_TEX0.TBP0) >> 5) / std::max(t->m_TEX0.TBW, 1U)) * GSLocalMemory::m_psm[t->m_TEX0.PSM].pgs.y;
+						const int height_adjust = ((((dst_end_block + 31) - t->m_TEX0.TBP0) >> 5) / std::max(t->m_TEX0.TBW, 1U)) * GSLocalMemory::m_psm[t->m_TEX0.PSM].pgs.y;
 
 						if (height_adjust < t->m_unscaled_size.y)
 						{
-							t->m_TEX0.TBP0 = dst_end_block;
+							t->m_TEX0.TBP0 = GSLocalMemory::GetStartBlockAddress(t->m_TEX0.TBP0, t->m_TEX0.TBW, t->m_TEX0.PSM, GSVector4i(0, height_adjust, t->m_valid.z, t->m_valid.w));
 							t->m_valid.w -= height_adjust;
 							t->ResizeValidity(t->m_valid);
 

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -5188,7 +5188,7 @@ GSTextureCache::Target* GSTextureCache::GetExactTarget(u32 BP, u32 BW, int type,
 	{
 		Target* t = *it;
 		const u32 tgt_bw = std::max(t->m_TEX0.TBW, 1U);
-		if ((t->m_TEX0.TBP0 == BP || (GSConfig.UserHacks_TextureInsideRt >= GSTextureInRtMode::InsideTargets && t->m_TEX0.TBP0 < BP && (((BP - t->m_TEX0.TBP0) >> 5) % tgt_bw) == 0)) && tgt_bw == BW && t->UnwrappedEndBlock() >= end_bp)
+		if ((t->m_TEX0.TBP0 == BP || (GSConfig.UserHacks_TextureInsideRt >= GSTextureInRtMode::InsideTargets && t->m_TEX0.TBP0 < BP && !(BP & 0x1f) && (((BP - t->m_TEX0.TBP0) >> 5) % tgt_bw) == 0)) && tgt_bw == BW && t->UnwrappedEndBlock() >= end_bp)
 		{
 			rts.MoveFront(it.Index());
 			return t;


### PR DESCRIPTION
### Description of Changes
Makes improvements to the hardware level moving between targets, namely between colour and depth targets.

Also added fixes for moving and invalidating/translating inside block offsets.

### Rationale behind Changes
While not always 100% correct, in most cases they copy with the respective formats so the swizzling is correct, so we can get away with it, and this fixes a bunch of behaviours.

Block offsets were also not working correctly which caused issues in some transfers/invalidation, which has also been fixed by this PR.

### Suggested Testing Steps
Test the games listed below with screenshots, but also just check the following as they showed differences is numbers only, but be sure nothing broke:

Armored Core 2 & 3,  Astro Boy, Baldurs Gate DA 1 & 2, Critical Velocity (watch out for seizures during videos), Dark Chronicle/Dark Cloud 2, Devil May Cry, Dog's Life, FIFA 2002, Flower Sun and Rain, Ghost in the Shell, Gradius V, Hokuto no Ken, Justice League Heroes, Kenran Butousai, Warship Gunner 2, Sakura Taisen/Wars games, Star Wars Racer (vs master, might be broken anyway), Street Fighter 3 3rd Strike, Thrilleville, Transformers The Game, True Crime NYC, Ultraman Fighting Evolution 2.

Also check the Baldur's Gate games and Total Immersion Racing for the block offset fix.

### Did you use AI to help find, test, or implement this issue or feature?
No.

Fixes #3988 shadows for Kunoichi/Nightshade and removes the need for a CRC for the Sakura Wars games.
Fixes #12785 Star Trek Shattered Universe rendering.


Kunoichi:

Master:
![image](https://github.com/user-attachments/assets/e1e9ea19-5c1f-4e4b-94d9-8e3734f875e4)

PR:
![image](https://github.com/user-attachments/assets/55a757c6-f878-4f06-8ed9-3e04f55741e9)


Star Trek - Shattered Universe:

Master:
![image](https://github.com/user-attachments/assets/5104b2af-2f77-43e3-9d6d-256af439ecf0)

PR:
![image](https://github.com/user-attachments/assets/9be984e7-2554-405c-ac47-a9414873c343)


Bonus:
Kenran Butousai when upscaled: Ignore the speed, that's just because of how I was taking the screenshots, it'll be faster if anything.

Master:
![image](https://github.com/user-attachments/assets/1f7e6622-6aee-43f6-85fa-1ffc605da265)

PR:
![image](https://github.com/user-attachments/assets/de5bd3cd-0653-4d01-845e-95b30a551c47)

Software for reference:
![image](https://github.com/user-attachments/assets/a6ea3552-d53c-41bb-94d7-08ab965c73a6)

Baldur's Gate Dark Aliiance:
Master:
![image](https://github.com/user-attachments/assets/39b65ced-d632-4b69-895f-3c963356522d)
PR:
![image](https://github.com/user-attachments/assets/daeca606-3a0f-4815-b54a-953e3a1c7c29)
