### PR TITLE
GS/HW: Don't look up block offset targets on Exact target lookup

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -5188,7 +5188,7 @@ GSTextureCache::Target* GSTextureCache::GetExactTarget(u32 BP, u32 BW, int type,
 	{
 		Target* t = *it;
 		const u32 tgt_bw = std::max(t->m_TEX0.TBW, 1U);
-		if ((t->m_TEX0.TBP0 == BP || (GSConfig.UserHacks_TextureInsideRt >= GSTextureInRtMode::InsideTargets && t->m_TEX0.TBP0 < BP && (((BP - t->m_TEX0.TBP0) >> 5) % tgt_bw) == 0)) && tgt_bw == BW && t->UnwrappedEndBlock() >= end_bp)
+		if ((t->m_TEX0.TBP0 == BP || (GSConfig.UserHacks_TextureInsideRt >= GSTextureInRtMode::InsideTargets && t->m_TEX0.TBP0 < BP && !(BP & 0x1f) && (((BP - t->m_TEX0.TBP0) >> 5) % tgt_bw) == 0)) && tgt_bw == BW && t->UnwrappedEndBlock() >= end_bp)
 		{
 			rts.MoveFront(it.Index());
 			return t;


### PR DESCRIPTION
### Description of Changes
If the requested block address is offset inside a page on lookup, don't allow "inside" target.

### Rationale behind Changes
regression from RT in RT, this doesn't work great and would need a lot of work, I think it's only Snowblind games that do it.

### Suggested Testing Steps
Test Baldur's Gate games.

### Did you use AI to help find, test, or implement this issue or feature?
No

Baldur's Gate - Dark Alliance - look at the torch smoke:
Master:
![image](https://github.com/user-attachments/assets/ba7095dc-fb26-4efa-aa15-eb489316d846)
PR:
![image](https://github.com/user-attachments/assets/a9d734b8-5216-4c3d-8605-e85732021e9c)

GS Dump for testing: 
[Baldur's Gate - Dark Alliance_SLES-50672_smoke_garbage_PR12731.gs.zip](https://github.com/user-attachments/files/20616558/Baldur.s.Gate.-.Dark.Alliance_SLES-50672_smoke_garbage_PR12731.gs.zip)
