### PR TITLE
GS/HW: Remove channel shuffle override from Namco CRC hack

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -184,40 +184,6 @@ bool GSHwHack::GSC_NamcoGames(GSRendererHW& r, int& skip)
 {
 	if (skip == 0)
 	{
-		if (r.IsPossibleChannelShuffle() && !(RTBP0 & 31))
-		{
-			GSVertex* v = &r.m_vertex.buff[0];
-
-			// Make sure we're detecting the right effect.
-			if (((v[1].XYZ.X - v[0].XYZ.X) >> 4) != 8 || ((v[1].XYZ.Y - v[0].XYZ.Y) >> 4) != 14)
-				return false;
-
-			GSTextureCache::Target* rt = g_texture_cache->LookupTarget(GIFRegTEX0::Create(RTBP0, RFBW, RFPSM),
-				GSVector2i(1, 1), r.GetTextureScaleFactor(), GSTextureCache::RenderTarget);
-			if (!rt)
-				return false;
-
-			GL_INS("GSC_NamcoGames(): HLE channel shuffle");
-
-			// have to set up the palette ourselves too, since GSC executes before it does
-			r.m_mem.m_clut.Read32(RTEX0, r.m_draw_env->TEXA);
-			std::shared_ptr<GSTextureCache::Palette> palette =
-				g_texture_cache->LookupPaletteObject(r.m_mem.m_clut, GSLocalMemory::m_psm[RTEX0.PSM].pal, true);
-			if (!palette)
-				return false;
-
-			GSHWDrawConfig& conf = r.BeginHLEHardwareDraw(
-				rt->GetTexture(), nullptr, rt->GetScale(), rt->GetTexture(), rt->GetScale(), rt->GetUnscaledRect());
-			conf.pal = palette->GetPaletteGSTexture();
-			conf.ps.channel = ChannelFetch_RGB;
-			conf.colormask.wa = false;
-			r.EndHLEHardwareDraw(false);
-
-			// 12 pages: 2 calls by channel, 3 channels, 1 blit
-			skip = 12 * (3 + 3 + 1);
-			return true;
-		}
-
 		if (!s_nativeres && r.PRIM->PRIM == GS_SPRITE && RTME && RTEX0.TFX == 1 && RFPSM == RTPSM && RTPSM == PSMCT32 && RFBMSK == 0xFF000000 && r.m_index.tail > 2)
 		{
 			GSVertex* v = &r.m_vertex.buff[0];


### PR DESCRIPTION
### Description of Changes
Removes the Channel Shuffle portion of the CRC hack override from the Namco CRC hack, which is currently used for Tekken 5, Death by Degrees, Tales of the Abyss and some (if not all) Taiko no Tatsujin games.

### Rationale behind Changes
This was implemented before RT in RT was a thing mainly for Tekken 5, so it couldn't be done by conventional methods, but now it can, and this override was causing problems with Death by Degrees, which just got moved over to the namco CRC, but has a more complex channel shuffle than was present.

### Suggested Testing Steps
Test the above mentioned games to make sure they're okay. GS Dumps turned out fine.

### Did you use AI to help find, test, or implement this issue or feature?
No,

Death By Degrees:
Master:
![image](https://github.com/user-attachments/assets/025dc00c-75ae-4acb-9f89-0c77227e355a)
PR:
![image](https://github.com/user-attachments/assets/f068ecac-c2e2-4a30-8f6a-7c6857b84f65)
