### PR TITLE
Tools: Small fix to gsrunner args.

### DIFF
--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -534,7 +534,7 @@ bool GSRunner::ParseCommandLineArgs(int argc, char* argv[], VMBootParameters& pa
 			{
 				std::string str(argv[++i]);
 
-				s_settings_interface.SetBoolValue("EmuCore/GS", "dump", true);
+				s_settings_interface.SetBoolValue("EmuCore/GS", "DumpGSData", true);
 
 				if (str.find("rt") != std::string::npos)
 					s_settings_interface.SetBoolValue("EmuCore/GS", "SaveRT", true);
@@ -766,7 +766,7 @@ bool GSRunner::ParseCommandLineArgs(int argc, char* argv[], VMBootParameters& pa
 		return false;
 	}
 
-	if (s_settings_interface.GetBoolValue("EmuCore/GS", "dump") && !dumpdir.empty())
+	if (s_settings_interface.GetBoolValue("EmuCore/GS", "DumpGSData") && !dumpdir.empty())
 	{
 		if (s_settings_interface.GetStringValue("EmuCore/GS", "HWDumpDirectory").empty())
 			s_settings_interface.SetStringValue("EmuCore/GS", "HWDumpDirectory", dumpdir.c_str());


### PR DESCRIPTION
### Description of Changes
Fixes to commandline args for gsrunner.

### Rationale behind Changes
Needed for dumping from commandline to work properly.

### Suggested Testing Steps
Build pcsx2-gsrunner and run with the -dump argument.

### Did you use AI to help find, test, or implement this issue or feature?
Yes, I use GitHub copilot for autocompletion sometimes.
