### PR TITLE
GameDB: Add native scaling to Scooby-Doo! Unmasked

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -22086,6 +22086,8 @@ SLES-53099:
 SLES-53100:
   name: "Scooby-Doo! Unmasked"
   region: "PAL-M4"
+  gsHWFixes:
+    nativeScaling: 2 # Fixes post processing position.
 SLES-53104:
   name: "Tom Clancy's Rainbow Six - Lockdown"
   region: "PAL-M5"
@@ -68231,6 +68233,8 @@ SLUS-21091:
   name: "Scooby-Doo! Unmasked"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    nativeScaling: 2 # Fixes post processing position.
 SLUS-21093:
   name: "Worms Forts - Under Siege"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Adds native scaling to Scooby-Doo! Unmasked to fix misaligned post-processing effects.

### Rationale behind Changes
This game downscales non-bilinearly, like [Scaler](https://github.com/PCSX2/pcsx2/pull/11514).

### Suggested Testing Steps
Test Scooby-Doo with and without native scaling.

Before:
![Scooby-Doo! Unmasked_SLUS-21091_20250606055808](https://github.com/user-attachments/assets/6bd7c2d5-1258-42b5-824e-ddb374eea079)

After:
![Scooby-Doo! Unmasked_SLUS-21091_20250606060048](https://github.com/user-attachments/assets/164fded0-3af7-4c9d-af17-7373c1ea094a)

### Did you use AI to help find, test, or implement this issue or feature?
No.
