### PR TITLE
GameDB: Simple 2000 Vol 92 Fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -59136,6 +59136,8 @@ SLPS-25581:
   name-sort: "しんぷる2000しりーず Vol.  92 THE のろいのげーむ"
   name-en: "Simple 2000 Series Vol. 92 - The Game of a Curse"
   region: "NTSC-J"
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes corrupted and missing graphics.
 SLPS-25582:
   name: "アストロ球団 決戦！！ビクトリー球団編"
   name-sort: "あすとろきゅうだん けっせん！！びくとりーきゅうだんへん"


### PR DESCRIPTION
### Description of Changes
Fixes broken and missing graphics in simple series 2000 vol 92.

Fixes #12806
 
### Rationale behind Changes
Game broken bad.

### Suggested Testing Steps
Make sure CI is happy boy.

### Did you use AI to help find, test, or implement this issue or feature?
No.
