### PR TITLE
Debugger: Update search results when we are _not_ going to remove them

### DIFF
--- a/pcsx2-qt/Debugger/Memory/MemorySearchView.cpp
+++ b/pcsx2-qt/Debugger/Memory/MemorySearchView.cpp
@@ -311,7 +311,7 @@ void searchWorker(DebugInterface* cpu, std::vector<SearchResult>& searchResults,
 			const auto readValue = readValueAtAddress<T>(cpu, addr);
 
 			const bool doesMatch = handleSearchComparison(searchComparison, addr, &searchResult, searchValue, readValue);
-			if (!doesMatch)
+			if (doesMatch)
 				searchResult = MemorySearchView::SearchResult(addr, QVariant::fromValue(readValue), searchType);
 
 			return !doesMatch;


### PR DESCRIPTION
### Description of Changes
When we discard the search result when it doesn't match the search criteria we were updating the result with the new value only then. This was the opposite of what we want. If you do a "changed" search, you want the "old" value for the next search to be the latest value read by the search system.

### Rationale behind Changes
This should hopefully fix #12058 

### Suggested Testing Steps
See if you can reproduce https://github.com/PCSX2/pcsx2/issues/12058

### Did you use AI to help find, test, or implement this issue or feature?
No