### PR TITLE
Docs: Add missing third party license for KDBindings

### DIFF
--- a/bin/docs/ThirdPartyLicenses.html
+++ b/bin/docs/ThirdPartyLicenses.html
@@ -24,6 +24,7 @@
 <li><a href="#googletest">GoogleTest</a></li>
 <li><a href="#harfbuzz">HarfBuzz</a></li>
 <li><a href="#jsonformoderncpp">JSON for Modern C++</a></li>
+<li><a href="#kdbindings">KDBindings</a></li>
 <li><a href="#kddockwidgets">KDDockWidgets</a></li>
 <li><a href="#kissfft">kissfft</a></li>
 <li><a href="#libbacktrace">libbacktrace</a></li>
@@ -1910,6 +1911,7 @@ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 </pre>
 </div>
 
+<!-- Transitive dependency of KDDockWidgets. -->
 <div id="jsonformoderncpp">
 <h3>JSON for Modern C++ - <a href="https://json.nlohmann.me">https://json.nlohmann.me</a></h3>
 <pre>
@@ -1934,6 +1936,34 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+</pre>
+</div>
+
+<!-- Transitive dependency of KDDockWidgets. -->
+<div id="kdbindings">
+<h3>KDBindings - <a href="https://github.com/KDAB/KDBindings">https://github.com/KDAB/KDBindings</a></h3>
+<pre>
+MIT License
+
+Copyright 2021 Klarälvdalens Datakonsult AB, a KDAB Group company &lt;info@kdab.com&gt;
+Copyright 2021 Jeremy Burns
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the &quot;Software&quot;), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 </pre>
 </div>
 


### PR DESCRIPTION
### Description of Changes
This adds a third party license for KDBindings, a transitive dependency of KDDockWidgets.

### Rationale behind Changes
Comply with the attribution clause of the license.

The exact text I'm adding isn't present all in one piece in the KDBindings repository, it seems they use a tool to generate their licensing information (REUSE.TOML). I asked the KDDW dev about this and he gave me the exact text to use for the copyright lines, so I think this should be good.

### Suggested Testing Steps
N/A

### Did you use AI to help find, test, or implement this issue or feature?
ＮＥＧＡＴＩＶＥ