### PR TITLE
BPM: Fix CTD when exiting BPM in No GUI mode

### DIFF
--- a/pcsx2-qt/LogWindow.cpp
+++ b/pcsx2-qt/LogWindow.cpp
@@ -43,7 +43,7 @@ void LogWindow::updateSettings()
 {
 	std::unique_lock lock(s_log_mutex);
 
-	const bool new_enabled = Host::GetBaseBoolSettingValue("Logging", "EnableLogWindow", false) && !QtHost::InNoGUIMode();
+	const bool new_enabled = Host::GetBaseBoolSettingValue("Logging", "EnableLogWindow", false) && !Host::InNoGUIMode();
 	const bool attach_to_main = Host::GetBaseBoolSettingValue("Logging", "AttachLogWindowToMainWindow", true);
 	const bool curr_enabled = Log::IsHostOutputEnabled();
 

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1130,7 +1130,7 @@ bool MainWindow::shouldHideMainWindow() const
 	// NOTE: We can't use isRenderingToMain() here, because this happens post-fullscreen-switch.
 	return (Host::GetBoolSettingValue("UI", "HideMainWindowWhenRunning", false) && !g_emu_thread->shouldRenderToMain()) ||
 		   (g_emu_thread->shouldRenderToMain() && (isRenderingFullscreen() || m_is_temporarily_windowed)) ||
-		   QtHost::InNoGUIMode();
+		   Host::InNoGUIMode();
 }
 
 bool MainWindow::shouldMouseLock() const
@@ -1306,7 +1306,7 @@ bool MainWindow::requestShutdown(bool allow_confirm, bool allow_save_to_state, b
 	// reshow the main window during display updates, because otherwise fullscreen transitions and renderer switches
 	// would briefly show and then hide the main window. So instead, we do it on shutdown, here. Except if we're in
 	// batch mode, when we're going to exit anyway.
-	if (!isRenderingToMain() && isHidden() && !QtHost::InBatchMode() && !g_emu_thread->isRunningFullscreenUI())
+	if (!isRenderingToMain() && isHidden() && !Host::InBatchMode() && !g_emu_thread->isRunningFullscreenUI())
 		updateWindowState(true);
 
 	// Clear the VM valid state early. That way we can't do anything in the UI if we take a while to shut down.
@@ -2060,7 +2060,7 @@ void MainWindow::onVMStopped()
 	updateInputRecordingActions(false);
 
 	// If we're closing or in batch mode, quit the whole application now.
-	if (m_is_closing || QtHost::InBatchMode())
+	if (m_is_closing || Host::InBatchMode())
 	{
 		quit();
 		return;

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -602,7 +602,7 @@ void Host::CheckForSettingsChanges(const Pcsx2Config& old_config)
 
 bool EmuThread::shouldRenderToMain() const
 {
-	return !Host::GetBoolSettingValue("UI", "RenderToSeparateWindow", false) && !QtHost::InNoGUIMode();
+	return !Host::GetBoolSettingValue("UI", "RenderToSeparateWindow", false) && !Host::InNoGUIMode();
 }
 
 void EmuThread::toggleSoftwareRendering()
@@ -1268,7 +1268,7 @@ void Host::RequestVMShutdown(bool allow_confirm, bool allow_save_state, bool def
 
 		// This will probably call shutdownVM() again, but by the time it runs, we'll have already shut down
 		// and it'll be a noop.
-		if (QtHost::InBatchMode())
+		if (Host::InBatchMode())
 			QMetaObject::invokeMethod(g_main_window, "requestExit", Qt::QueuedConnection, Q_ARG(bool, false));
 	}
 }
@@ -1437,12 +1437,12 @@ void Host::CommitBaseSettingChanges()
 	}
 }
 
-bool QtHost::InBatchMode()
+bool Host::InBatchMode()
 {
 	return s_batch_mode;
 }
 
-bool QtHost::InNoGUIMode()
+bool Host::InNoGUIMode()
 {
 	return s_nogui_mode;
 }

--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -245,12 +245,6 @@ namespace QtHost
 	/// Sets the icon theme, based on the current style (light/dark).
 	void SetIconThemeFromStyle();
 
-	/// Sets batch mode (exit after game shutdown).
-	bool InBatchMode();
-
-	/// Sets NoGUI mode (implys batch mode, does not display main window, exits on shutdown).
-	bool InNoGUIMode();
-
 	/// Returns true if the calling thread is the UI thread.
 	bool IsOnUIThread();
 

--- a/pcsx2/Host.h
+++ b/pcsx2/Host.h
@@ -67,6 +67,12 @@ namespace Host
 	bool ConfirmMessage(const std::string_view title, const std::string_view message);
 	bool ConfirmFormattedMessage(const std::string_view title, const char* format, ...);
 
+	/// Sets batch mode (exit after game shutdown).
+	bool InBatchMode();
+
+	/// Sets NoGUI mode (implys batch mode, does not display main window, exits on shutdown).
+	bool InNoGUIMode();
+
 	/// Opens a URL, using the default application.
 	void OpenURL(const std::string_view url);
 

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -1602,7 +1602,7 @@ void FullscreenUI::DrawExitWindow()
 
 	ImGui::PushStyleColor(ImGuiCol_Text, UIBackgroundTextColor);
 
-	if (BeginHorizontalMenu("exit_window", menu_pos, menu_size, 3))
+	if (BeginHorizontalMenu("exit_window", menu_pos, menu_size, (Host::InNoGUIMode()) ? 2 : 3))
 	{
 		ResetFocusHere();
 
@@ -1621,10 +1621,13 @@ void FullscreenUI::DrawExitWindow()
 			DoRequestExit();
 		}
 
-		if (HorizontalMenuItem(GetCachedTexture("fullscreenui/desktop-mode.png"), FSUI_CSTR("Desktop Mode"),
-				FSUI_CSTR("Exits Big Picture mode, returning to the desktop interface.")))
+		if (!Host::InNoGUIMode())
 		{
-			DoDesktopMode();
+			if (HorizontalMenuItem(GetCachedTexture("fullscreenui/desktop-mode.png"), FSUI_CSTR("Desktop Mode"),
+				FSUI_CSTR("Exits Big Picture mode, returning to the desktop interface.")))
+			{
+				DoDesktopMode();
+			}
 		}
 	}
 	EndHorizontalMenu();

--- a/tests/ctest/core/StubHost.cpp
+++ b/tests/ctest/core/StubHost.cpp
@@ -56,6 +56,16 @@ void Host::OpenURL(const std::string_view url)
 {
 }
 
+bool Host::InBatchMode()
+{
+	return false;
+}
+
+bool Host::InNoGUIMode()
+{
+	return false;
+}
+
 bool Host::CopyTextToClipboard(const std::string_view text)
 {
 	return false;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
This PR fixes a crash to desktop when you are trying to Exit to Desktop while running in No GUI mode.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Less crashing more goodie

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Launch PCSX2 with `-fullscreen -bigpicture -nogui`
![image](https://github.com/user-attachments/assets/61fa7db4-7ba1-4e2a-833d-a0cd2c1fe67e)

PCSX2 should no longer shows the exit to desktop button.

Test both normal and no GUI mode.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
gak