### PR TITLE
IopBios: truncate printf output if bigger than our buffer

### DIFF
--- a/pcsx2/IopBios.cpp
+++ b/pcsx2/IopBios.cpp
@@ -1026,6 +1026,8 @@ namespace R3000A
 							case 'O':
 							case 'x':
 							case 'X':
+							case 'u':
+							case 'U':
 								printed_bytes = snprintf(ptmp, remaining_buf, tmp2, (u32)iopMemRead32(sp + n * 4));
 								remaining_buf -= printed_bytes;
 								ptmp += printed_bytes;


### PR DESCRIPTION
### Description of Changes
This PR adds bound checking to our kprintf HLE IOP implementation. 
Since we have a set buffer, I also increased the maximum allowed buffer before we truncate as to try to avoid breakage.

### Rationale behind Changes
Buffer overflow bad

### Suggested Testing Steps
Try to do weird printf on IOP, I didn't test it yet myself so help would be appreciated

### Did you use AI to help find, test, or implement this issue or feature?
No
