### PR TITLE
IopBios: do not overflow snprintf tmp buffer

### DIFF
--- a/pcsx2/IopBios.cpp
+++ b/pcsx2/IopBios.cpp
@@ -929,12 +929,6 @@ namespace R3000A
 	{
 		int Kprintf_HLE()
 		{
-			// Using sprintf here is a bit nasty, but it has a large buffer..
-			// Don't feel like rewriting it.
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#endif
 
 			// Emulate the expected Kprintf functionality:
 			iopMemWrite32(sp, a0);
@@ -1071,10 +1065,6 @@ namespace R3000A
 			iopConLog(ShiftJIS_ConvertString(tmp, 1023));
 
 			return 1;
-
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
 		}
 	} // namespace sysmem
 


### PR DESCRIPTION
We could otherwise overflow as snprintf does not return the number of written bytes but the number of written bytes assuming an infinite buffer.

### Description of Changes
Followup of #12823

### Suggested Testing Steps
IOP kprintf

### Did you use AI to help find, test, or implement this issue or feature?
No
