### PR TITLE
Bundle Qt and SDL Windows Symbols

### DIFF
--- a/.github/workflows/scripts/windows/build-dependencies.bat
+++ b/.github/workflows/scripts/windows/build-dependencies.bat
@@ -254,8 +254,8 @@ if %DEBUG%==1 (
   set KDDOCKWIDGETSBUILDSPEC=-DCMAKE_CONFIGURATION_TYPES="Release;Debug" -DCMAKE_CROSS_CONFIGS=all -DCMAKE_DEFAULT_BUILD_TYPE=Release -DCMAKE_DEFAULT_CONFIGS=all -G "Ninja Multi-Config"
 ) else (
   rem kddockwidgets slightly changes the name of the dll depending on if CMAKE_BUILD_TYPE or CMAKE_CONFIGURATION_TYPES is used
-  rem The dll name being kddockwidgets-qt62.dll or kddockwidgets-qt62.dll respectively
-  rem Always use CMAKE_CONFIGURATION_TYPES to give consistant naming
+  rem The dll name being kddockwidgets-qt62.dll or kddockwidgets-qt6.dll respectively
+  rem Always use CMAKE_CONFIGURATION_TYPES to give consistent naming
   set KDDOCKWIDGETSBUILDSPEC=-DCMAKE_CONFIGURATION_TYPES=Release -DCMAKE_CROSS_CONFIGS=all -DCMAKE_DEFAULT_BUILD_TYPE=Release -DCMAKE_DEFAULT_CONFIGS=Release -G "Ninja Multi-Config"
 )
 

--- a/.github/workflows/scripts/windows/build-dependencies.bat
+++ b/.github/workflows/scripts/windows/build-dependencies.bat
@@ -90,7 +90,7 @@ if %DEBUG%==1 (
   echo Building release libraries...
 )
 
-set FORCEPDB=-DCMAKE_SHARED_LINKER_FLAGS_RELEASE="/DEBUG"
+set FORCEPDB=-DCMAKE_SHARED_LINKER_FLAGS_RELEASE="/DEBUG" -DCMAKE_MODULE_LINKER_FLAGS_RELEASE="/DEBUG"
 
 echo Building Zlib...
 rmdir /S /Q "zlib-%ZLIB%"

--- a/common/vsprops/LinkPCSX2Deps.props
+++ b/common/vsprops/LinkPCSX2Deps.props
@@ -26,6 +26,12 @@
     <DepsDLLs Include="$(DepsBinDir)plutovg.dll" />
     <DepsDLLs Include="$(DepsBinDir)plutosvg.dll" />
   </ItemGroup>
+  <Target Name="DepsListPDBs"
+    AfterTargets="Build">
+    <ItemGroup>
+      <DepsPDBs Include="@(DepsDLLs -> '%(RelativeDir)%(Filename).pdb')" Condition="Exists('%(RelativeDir)%(Filename).pdb')" />
+    </ItemGroup>
+  </Target>
   <Target Name="DepsCopyDLLs"
     AfterTargets="Build"
     Inputs="@(DepsDLLs)"
@@ -33,6 +39,17 @@
     <Message Text="Copying Dependency DLLs" Importance="High" />
     <Copy
       SourceFiles="@(DepsDLLs)"
+      DestinationFolder="$(OutDir)"
+      SkipUnchangedFiles="true"
+    />
+  </Target>
+  <Target Name="DepsCopyPDB"
+    AfterTargets="Build"
+    Inputs="@(DepsPDBs)"
+    Outputs="@(DepsPDBs -> '$(OutDir)%(RecursiveDir)%(Filename)%(Extension)')">
+    <Message Text="Copying Dependency PDBs" Importance="High" />
+    <Copy
+      SourceFiles="@(DepsPDBs)"
       DestinationFolder="$(OutDir)"
       SkipUnchangedFiles="true"
     />

--- a/common/vsprops/QtCompile.props
+++ b/common/vsprops/QtCompile.props
@@ -138,11 +138,17 @@
   <ItemGroup>
     <QtLibNames Include="Qt6Core$(QtLibSuffix);Qt6Gui$(QtLibSuffix);Qt6Widgets$(QtLibSuffix);Qt6Svg$(QtLibSuffix);Qt6Concurrent$(QtLibSuffix)" />
     <QtDlls Include="@(QtLibNames -> '$(QtBinDir)%(Identity).dll')" />
+    <QtPDBs Include="@(QtLibNames -> '$(QtBinDir)%(Identity).pdb')" />
     <!--Filter plugins to copy based on the observation that all debug versions end in "d"-->
     <QtAllPlugins Include="$(QtPluginsDir)**\*$(QtLibSuffix).dll" />
     <QtPlugins Condition="$(Configuration.Contains(Debug))" Include="@(QtAllPlugins)" />
     <QtPlugins Condition="!$(Configuration.Contains(Debug))" Exclude="$(QtPluginsDir)**\*$(QtDebugSuffix).dll" Include="@(QtAllPlugins)" />
     <QtPluginsDest Include="@(QtPlugins -> '$(QtBinaryOutputDir)$(QtPluginFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <!--And again for PDBs-->
+    <QtAllPluginPDBs Include="$(QtPluginsDir)**\*$(QtLibSuffix).pdb" />
+    <QtPluginPDBs Condition="$(Configuration.Contains(Debug))" Include="@(QtAllPluginPDBs)" />
+    <QtPluginPDBs Condition="!$(Configuration.Contains(Debug))" Exclude="$(QtPluginsDir)**\*$(QtDebugSuffix).pdb" Include="@(QtAllPluginPDBs)" />
+    <QtPluginPDBsDest Include="@(QtPluginPDBs -> '$(QtBinaryOutputDir)$(QtPluginFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
   </ItemGroup>
   <PropertyGroup>
     <QtConfFile>$(QtBinaryOutputDir)qt.conf</QtConfFile>
@@ -160,6 +166,22 @@
     <Copy
       SourceFiles="@(QtPlugins)"
       DestinationFiles="@(QtPluginsDest)"
+      SkipUnchangedFiles="true"
+    />
+  </Target>
+    <Target Name="QtCopyPDBs"
+    AfterTargets="Build"
+    Inputs="@(QtPDBs);@(QtPluginPDBs)"
+    Outputs="@(QtPDBs -> '$(QtBinaryOutputDir)%(RecursiveDir)%(Filename)%(Extension)');@(QtPluginPDBsDest)">
+    <Message Text="Copying Qt .pdbs" Importance="High" />
+    <Copy
+      SourceFiles="@(QtPDBs)"
+      DestinationFolder="$(QtBinaryOutputDir)"
+      SkipUnchangedFiles="true"
+    />
+    <Copy
+      SourceFiles="@(QtPluginPDBs)"
+      DestinationFiles="@(QtPluginPDBsDest)"
       SkipUnchangedFiles="true"
     />
   </Target>

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1302,8 +1302,14 @@ function(setup_main_executable target)
 			install(FILES "${DEPS_BINDIR}/${DEP_TO_COPY}" DESTINATION "${CMAKE_SOURCE_DIR}/bin")
 		endforeach()
 
+		set(SYMBOLS_TO_COPY ${DEPS_TO_COPY})
+		list(TRANSFORM SYMBOLS_TO_COPY REPLACE "[.]dll" ".pdb")
+		foreach(SYMBOL_TO_COPY ${SYMBOLS_TO_COPY})
+			install(FILES "${DEPS_BINDIR}/${SYMBOL_TO_COPY}" DESTINATION "${CMAKE_SOURCE_DIR}/bin" OPTIONAL)
+		endforeach()
+
 		get_target_property(WINDEPLOYQT_EXE Qt6::windeployqt IMPORTED_LOCATION)
-		install(CODE "execute_process(COMMAND \"${WINDEPLOYQT_EXE}\" \"${CMAKE_SOURCE_DIR}/bin/$<TARGET_FILE_NAME:${target}>\" --plugindir \"${CMAKE_SOURCE_DIR}/bin/QtPlugins\" --no-compiler-runtime --no-system-d3d-compiler --no-system-dxc-compiler --no-translations COMMAND_ERROR_IS_FATAL ANY)")
+		install(CODE "execute_process(COMMAND \"${WINDEPLOYQT_EXE}\" \"${CMAKE_SOURCE_DIR}/bin/$<TARGET_FILE_NAME:${target}>\" --plugindir \"${CMAKE_SOURCE_DIR}/bin/QtPlugins\" --pdb --no-compiler-runtime --no-system-d3d-compiler --no-system-dxc-compiler --no-translations COMMAND_ERROR_IS_FATAL ANY)")
 		install(CODE "file(WRITE \"${CMAKE_SOURCE_DIR}/bin/qt.conf\" \"[Paths]\\nPlugins = ./QtPlugins\")")
 	endif()
 


### PR DESCRIPTION
### Description of Changes
Bundle Qt & SDL symbols
Force Qt plugin symbols

### Rationale behind Changes
The Windows deps script force enables Qt and SDL symbols, it seems reasonable to also bundle them in our symbols archive.
Qt plugins are now force enabled to align with the rest of Qt.

### Suggested Testing Steps
Download symbols and see if they get loaded when debugging the build.

### Did you use AI to help find, test, or implement this issue or feature?
Negative
