### PR TITLE
MacOS: Add pnach definition to Info.plist

### DIFF
--- a/pcsx2/Resources/Info.plist.in
+++ b/pcsx2/Resources/Info.plist.in
@@ -45,6 +45,46 @@
 	<string>public.app-category.games</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>public.ini</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.plain-text</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Configuration File</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>ini</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>net.pcsx2.pnach</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.ini</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>PCSX2 Game Patch</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>pnach</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
 	<key>CFBundleLocalizations</key>
 	<array>${PCSX2_MACOS_LOCALIZATIONS}
 	</array>


### PR DESCRIPTION
### Description of Changes
Ensures macOS treats it as a known file type, so it doesn't try to prevent users from adding it as a file extension

Side note, we could also add a custom icon for pnach files this way, but I don't feel like making icon artwork so I'm leaving it default.

### Rationale behind Changes
Currently, when users try to rename text files to pnach files, macOS leaves the .txt extension and hides it instead of adding the new extension.

### Suggested Testing Steps
- Try to rename a .txt file to .pnach in Finder with after unzipping PR's PCSX2.  It should rename it without sneakily adding a hidden .txt
- Look at a .pnach file.  It should have a text-document-looking icon with PNACH over it, instead of a blank generic unknown file icon.

### Did you use AI to help find, test, or implement this issue or feature?
No
