### PR TITLE
Debugger: Allow debugging before first frame

### DIFF
--- a/pcsx2/DebugTools/DebugInterface.cpp
+++ b/pcsx2/DebugTools/DebugInterface.cpp
@@ -44,7 +44,7 @@ bool DebugInterface::m_pause_on_entry = false;
 
 bool DebugInterface::isAlive()
 {
-	return VMManager::HasValidVM() && g_FrameCount > 0;
+	return VMManager::HasValidVM();
 }
 
 bool DebugInterface::isCpuPaused()


### PR DESCRIPTION
### Description of Changes
Remove the frame count check in DebugInterface::isAlive()

### Rationale behind Changes
This prevented you from debugging the early bios boot code.

### Suggested Testing Steps
Idk, just make sure normal debugger work doesn't break.

### Did you use AI to help find, test, or implement this issue or feature?
no
