### PR TITLE
CI: Fix flathub versioning on tagless commits

### DIFF
--- a/.github/workflows/cron_publish_flatpak.yml
+++ b/.github/workflows/cron_publish_flatpak.yml
@@ -6,36 +6,43 @@ on:
   workflow_dispatch: # As well as manually.
 
 jobs:
-  check:
-    if: github.repository == 'PCSX2/pcsx2'
-    name: "Check if release is needed"
-    runs-on: ubuntu-latest
-    timeout-minutes: 180
-    outputs:
-      PCSX2_RELEASE: ${{ steps.getinfo.outputs.PCSX2_RELEASE }}
-      FLATHUB_RELEASE: ${{ steps.getinfo.outputs.FLATHUB_RELEASE }}
-    steps:
-      - name: Get latest tag and Flathub release
-        id: getinfo
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          PCSX2_RELEASE=$(gh api -H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28' /repos/PCSX2/pcsx2/releases | jq -r '.[0].tag_name')
-          FLATHUB_RELEASE=$(curl -L -s https://flathub.org/api/v2/appstream/net.pcsx2.PCSX2 | jq -r '.releases | max_by(.version) | .version')
-          echo "Latest PCSX2 release is: '${PCSX2_RELEASE}'"
-          echo "Latest Flathub release is: '${FLATHUB_RELEASE}'"
-          PCSX2_RELEASE=$(echo $PCSX2_RELEASE | sed 's/[^0-9]*//g')
-          FLATHUB_RELEASE=$(echo $FLATHUB_RELEASE | sed 's/[^0-9]*//g')
-          echo "PCSX2_RELEASE=${PCSX2_RELEASE}" >> "$GITHUB_OUTPUT"
-          echo "FLATHUB_RELEASE=${FLATHUB_RELEASE}" >> "$GITHUB_OUTPUT"
+
+# check is disabled as the flathub api does not give us beta repository information
+# Alternatively we can "flatpak remote-info or parse the appstream directly for the beta repo"
+# Maybe in the future if we don't want to publish the same version twice if we get no commits
+# for 24 hours.
+
+#  check:
+#    if: github.repository == 'PCSX2/pcsx2'
+#    name: "Check if release is needed"
+#    runs-on: ubuntu-latest
+#    timeout-minutes: 180
+#    outputs:
+#      PCSX2_RELEASE: ${{ steps.getinfo.outputs.PCSX2_RELEASE }}
+#      FLATHUB_RELEASE: ${{ steps.getinfo.outputs.FLATHUB_RELEASE }}
+#    steps:
+#      - name: Get latest tag and Flathub release
+#        id: getinfo
+#        env:
+#          GH_TOKEN: ${{ github.token }}
+#        run: |
+#          PCSX2_RELEASE=$(gh api -H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28' /repos/PCSX2/pcsx2/releases | jq -r '.[0].tag_name')
+#          FLATHUB_RELEASE=$(curl -L -s https://flathub.org/api/v2/appstream/net.pcsx2.PCSX2 | jq -r '.releases | max_by(.version) | .version')
+#          echo "Latest PCSX2 release is: '${PCSX2_RELEASE}'"
+#          echo "Latest Flathub release is: '${FLATHUB_RELEASE}'"
+#          PCSX2_RELEASE=$(echo $PCSX2_RELEASE | sed 's/[^0-9]*//g')
+#          FLATHUB_RELEASE=$(echo $FLATHUB_RELEASE | sed 's/[^0-9]*//g')
+#          echo "PCSX2_RELEASE=${PCSX2_RELEASE}" >> "$GITHUB_OUTPUT"
+#          echo "FLATHUB_RELEASE=${FLATHUB_RELEASE}" >> "$GITHUB_OUTPUT"
 
   build:
-    needs: check
+#    needs: check
     # outputs are automatically compared as strings. This doesn't work in our favour
     # Use fromJson() to convert them to proper integers...
     # see: https://github.com/github/docs/pull/25870
     # and: https://github.com/orgs/community/discussions/57480
-    #if: fromJson(needs.check.outputs.FLATHUB_RELEASE) < fromJson(needs.check.outputs.PCSX2_RELEASE)
+
+#   if: fromJson(needs.check.outputs.FLATHUB_RELEASE) < fromJson(needs.check.outputs.PCSX2_RELEASE)
     name: "Build and publish Flatpak"
     uses: ./.github/workflows/linux_build_flatpak.yml
     with:

--- a/.github/workflows/linux_build_flatpak.yml
+++ b/.github/workflows/linux_build_flatpak.yml
@@ -54,18 +54,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           set-safe-directory: ${{ env.GITHUB_WORKSPACE }}
+          # 10 here, since the odds of having 10 untagged commits in a row should be slim to none
+          # This is required for the tagging logic in generate-metainfo.sh
+          fetch-depth: 10
+          fetch-tags: true
 
       # Work around container ownership issue
       - name: Set Safe Directory
         shell: bash
         run: git config --global --add safe.directory "*"
-
-      # Hackity hack. When running the workflow on a schedule, we don't have the tag,
-      # it doesn't fetch tags, therefore we don't get a version. So grab them manually.
-      # actions/checkout elides tags, fetch them primarily for releases
-      - name: Fetch tags
-        if: ${{ inputs.fetchTags }}
-        run: git fetch --tags --no-recurse-submodules
 
       - name: Add stable release identifier file
         if: ${{ inputs.stableBuild == true || inputs.stableBuild == 'true' }}
@@ -125,7 +122,7 @@ jobs:
           cache: true
           restore-cache: true
           cache-key: ${{ inputs.os }} ${{ inputs.platform }} ${{ inputs.compiler }} flatpak ${{ hashFiles('.github/workflows/scripts/linux/flatpak/**/*.json') }}
-  
+
       #- name: Validate build
       #  run: |
       #    flatpak-builder-lint repo repo


### PR DESCRIPTION
### Description of Changes
We have an option to make commits not trigger our actions scripts (ci skip).

When we merge one of these into our master branch, it doesn't get a tag assigned to it.

When the Flatpak cron job would run, it would shallow clone (only the latest commit was pulled), look for a tag to get a version, and never see the latest tag (despite us fetching all the tags? idk). The resulting Flathub version would end up being the entire SHA of the commit, which is not desired.

This PR makes the script checkout with a depth of 10 .
We also have two different fallback options now.

If we are on the master branch, we pull the abbreviated description of the closest tag ie:
v2.3.420

If we are not on the master branch, the logic is the same, it's not abbreviated ie:
v2.3.420-1-g10dc1a2da

### Rationale behind Changes
Having our Flathub releases be an entire commit SHA isn't great, this fixes that.

### Suggested Testing Steps
Testing it here:
https://github.com/PCSX2/pcsx2/actions/runs/15666366758

### Did you use AI to help find, test, or implement this issue or feature?
I have copilot enabled, and it auto-completed some bash portion which I tested locally.
