### PR TITLE
Debugger: Fix crash when breakpoint is hit before createMenuBar call

### DIFF
--- a/pcsx2-qt/Debugger/Docking/DockManager.cpp
+++ b/pcsx2-qt/Debugger/Docking/DockManager.cpp
@@ -142,12 +142,12 @@ void DockManager::switchToLayout(DockLayout::Index layout_index, bool blink_tab)
 			layout.thaw();
 
 			int tab_index = static_cast<int>(layout_index);
-			if (m_menu_bar && tab_index >= 0)
+			if (tab_index >= 0 && m_menu_bar)
 				m_menu_bar->onCurrentLayoutChanged(layout_index);
 		}
 	}
 
-	if (blink_tab)
+	if (blink_tab && m_menu_bar)
 		m_menu_bar->startBlink(m_current_layout);
 }
 
@@ -512,7 +512,8 @@ void DockManager::newLayoutClicked()
 {
 	// The plus button has just been made the current tab, so set it back to the
 	// one corresponding to the current layout again.
-	m_menu_bar->onCurrentLayoutChanged(m_current_layout);
+	if (m_menu_bar)
+		m_menu_bar->onCurrentLayoutChanged(m_current_layout);
 
 	auto name_validator = [this](const QString& name) {
 		return !hasNameConflict(name, DockLayout::INVALID_INDEX);


### PR DESCRIPTION
### Description of Changes
Previously the debugger would crash when receiving a breakpoint in its constructor immediately while it was being created since it would try to start the blinking animation even though the menu bar hadn't been created yet.

### Rationale behind Changes
Fixes #12847.

### Suggested Testing Steps
Try to reproduce the steps in #12847.

### Did you use AI to help find, test, or implement this issue or feature?
No.