### PR TITLE
GS/DX: Don't output color for datm/stencil date shaders.

### DIFF
--- a/bin/resources/shaders/dx11/convert.fx
+++ b/bin/resources/shaders/dx11/convert.fx
@@ -110,48 +110,24 @@ uint ps_convert_rgba8_16bits(PS_INPUT input) : SV_Target0
 	return ((i.x & 0x00F8u) >> 3) | ((i.y & 0x00F8u) << 2) | ((i.z & 0x00f8u) << 7) | ((i.w & 0x80u) << 8);
 }
 
-PS_OUTPUT ps_datm1(PS_INPUT input)
+void ps_datm1(PS_INPUT input)
 {
-	PS_OUTPUT output;
-	
 	clip(sample_c(input.t).a - 127.5f / 255); // >= 0x80 pass
-	
-	output.c = 0;
-
-	return output;
 }
 
-PS_OUTPUT ps_datm0(PS_INPUT input)
+void ps_datm0(PS_INPUT input)
 {
-	PS_OUTPUT output;
-	
 	clip(127.5f / 255 - sample_c(input.t).a); // < 0x80 pass (== 0x80 should not pass)
-	
-	output.c = 0;
-
-	return output;
 }
 
-PS_OUTPUT ps_datm1_rta_correction(PS_INPUT input)
+void ps_datm1_rta_correction(PS_INPUT input)
 {
-	PS_OUTPUT output;
-
 	clip(sample_c(input.t).a - 254.5f / 255); // >= 0x80 pass
-
-	output.c = 0;
-
-	return output;
 }
 
-PS_OUTPUT ps_datm0_rta_correction(PS_INPUT input)
+void ps_datm0_rta_correction(PS_INPUT input)
 {
-	PS_OUTPUT output;
-
 	clip(254.5f / 255 - sample_c(input.t).a); // < 0x80 pass (== 0x80 should not pass)
-
-	output.c = 0;
-
-	return output;
 }
 
 PS_OUTPUT ps_rta_correction(PS_INPUT input)

--- a/bin/resources/shaders/vulkan/convert.glsl
+++ b/bin/resources/shaders/vulkan/convert.glsl
@@ -104,7 +104,6 @@ void ps_datm1()
 {
 	if(sample_c(v_tex).a < (127.5f / 255.0f)) // >= 0x80 pass
 		discard;
-
 }
 #endif
 

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 66;
+static constexpr u32 SHADER_CACHE_VERSION = 67;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/DX: Don't output color for datm/stencil date shaders.
RTV(Render target view) is not bound so no need to output anything, just clip/discard if needed.
Fixes dx11 api warning that pixel shader writes color output but no rtv is bound.
Note: We already do this for gl/vk/metal.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Fixes dx11 api warning:
`D3D11 WARNING: ID3D11DeviceContext::Draw: The Pixel Shader expects a Render Target View bound to slot 0, but none is bound. This is OK, as writes of an unbound Render Target View are discarded. It is also possible the developer knows the data will not be used anyway. This is only a problem if the developer actually intended to bind a Render Target View here. [ EXECUTION WARNING #3146081: DEVICE_DRAW_RENDERTARGETVIEW_NOT_SET]`

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Didn't see any differences on dx11 dump run, smoke tested dx11 and 12 on a few dumps.
Test games that use stencil date, persona 3/4 shadows, gt4 shadows, sly 2 shadows and health bar and anything else you can think of, test only dx11/12.
Test if the api arning is fixed on dx11.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.
