### PR TITLE
GS/HW: Don't resize target if only writing to alpha when RGB is valid

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4039,7 +4039,8 @@ void GSRendererHW::Draw()
 		bool valid_width_change = false;
 		if (rt && ((!is_possible_mem_clear || blending_cd) || rt->m_TEX0.PSM != FRAME_TEX0.PSM) && !m_in_target_draw)
 		{
-			valid_width_change = rt->m_TEX0.TBW != FRAME_TEX0.TBW;
+			const u32 frame_mask = (m_cached_ctx.FRAME.FBMSK & frame_psm.fmsk);
+			valid_width_change = rt->m_TEX0.TBW != FRAME_TEX0.TBW && (frame_mask != (frame_psm.fmsk & 0x00FFFFFF) || rt->m_valid_rgb == false);
 			if (valid_width_change && !m_cached_ctx.ZBUF.ZMSK && (m_cached_ctx.FRAME.FBMSK & 0xFF000000))
 			{
 				// Alpha could be a font, and since the width is changing it's no longer valid.


### PR DESCRIPTION
### Description of Changes
Doesn't resize a target if writing a different width to the alpha channel

### Rationale behind Changes
A bunch of games will write data to the alpha channel (such as shadows) in a different width to the colour component, which might be the main frame for the game, this changes it so it doesn't alter the width on these writes if there is valid colour.

Ideally, we would need to have a separate "TEX0" texture information for the alpha channel as well as the colour so these could be stored appropriately in these cases, but that's a big chunk of reworking I'm not willing to do.

### Suggested Testing Steps
Test any of the games listed below, smoke test others, especially japanese games, they love storing the font in the alpha channel of a different width.

### Did you use AI to help find, test, or implement this issue or feature?
No

Fixes Freedom Fighters when shadows are on screen.
Fixes some bad lighting which happens on 007 From Russia with Love

007 From Russia With Love:
Master:
![image](https://github.com/user-attachments/assets/01eb55d0-5fef-4a5a-826e-6ba344a1692c)
PR:
![image](https://github.com/user-attachments/assets/f995f1bd-44d9-4da7-a9d1-fdcf7f514c5c)

Freedom Fighters:
Master:
![image](https://github.com/user-attachments/assets/7ea3e489-9e11-4dbc-aab3-8c22628e5a6f)
PR:
![image](https://github.com/user-attachments/assets/cc7ee9f5-2eb3-4462-bc5e-42fa7396024d)

