### PR TITLE
CI: Restore repository check in Flathub publish action

### DIFF
--- a/.github/workflows/cron_publish_flatpak.yml
+++ b/.github/workflows/cron_publish_flatpak.yml
@@ -43,6 +43,8 @@ jobs:
     # and: https://github.com/orgs/community/discussions/57480
 
 #   if: fromJson(needs.check.outputs.FLATHUB_RELEASE) < fromJson(needs.check.outputs.PCSX2_RELEASE)
+    # As the check step is disabled, perform repository check here
+    if: github.repository == 'PCSX2/pcsx2'
     name: "Build and publish Flatpak"
     uses: ./.github/workflows/linux_build_flatpak.yml
     with:


### PR DESCRIPTION
### Description of Changes
Restores the check for the repository in the Flathub publish action

### Rationale behind Changes
This check got removed when disabling a different non-functional version check
Without forks configuring their own flathub secrets, this action will fail anytime its run.

### Suggested Testing Steps
Cherry pick the commit onto a fork, and run the flatpak publish action on the related branch to see if the build/publish gets skipped.
Make sure it doesn’t break the action when its supposed to run.

### Did you use AI to help find, test, or implement this issue or feature?
No
