### PR TITLE
GS/HW: Fix region area on new source + valid on clear

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2041,11 +2041,29 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const bool is_color, const 
 			{
 				rect.y /= 2;
 				rect.w /= 2;
+
+				if (region.HasY())
+				{
+					const u32 min_y = region.GetMinY() / 2;
+					const u32 max_y = region.GetMaxY() / 2;
+
+					region.ClearY();
+					region.SetY(min_y, max_y);
+				}
 			}
 			else
 			{
 				rect.x /= 2;
 				rect.z /= 2;
+
+				if (region.HasX())
+				{
+					const u32 min_x = region.GetMinX() / 2;
+					const u32 max_x = region.GetMaxX() / 2;
+
+					region.ClearX();
+					region.SetX(min_x, max_x);
+				}
 			}
 			if (TEX0.TBP0 == frame.Block())
 			{

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -45,6 +45,9 @@ public:
 		bool HasY() const { return static_cast<u32>(bits >> 32) != 0; }
 		bool HasEither() const { return (bits != 0); }
 
+		void ClearX() { bits &= ~0xFFFFFFFFULL; }
+		void ClearY() { bits &= 0xFFFFFFFFULL; }
+
 		void SetX(s32 min, s32 max) { bits |= (static_cast<u64>(static_cast<u16>(min)) | (static_cast<u64>(static_cast<u16>(max) << 16))); }
 		void SetY(s32 min, s32 max) { bits |= ((static_cast<u64>(static_cast<u16>(min)) << 32) | (static_cast<u64>(static_cast<u16>(max)) << 48)); }
 


### PR DESCRIPTION
### Description of Changes
Fixes the region area of a new source on a shuffle, if there is one.
Resize the valid area to the size of the draw if it is a clear which covers most of the valid area (within 1 page of height)

### Rationale behind Changes
Okami (source fix) regressed from my new source on shuffle checks due to missing the extra information.
Prince of Persia depth (valid size change) was still making its target too big by just a few pixels and ruining the clear check, something I previously tried to fix and evidently missed some scenarios.

### Suggested Testing Steps
Test Prince of Persia Warrior Within and Okami (loading screens and maybe smoke test the game).
Smoke test random stuff, maybe 007 - From Russia with Love, Ace Combat 04 - Shattered Skies, Crash Bandicoot - The Wrath of Cortex (Underwater stages), as these come up in the GS dump run but nothing visibly changed.

### Did you use AI to help find, test, or implement this issue or feature?
No.

Okami:
Master:
![image](https://github.com/user-attachments/assets/a8b67042-835f-4ce4-8a27-833fc282523d)
PR:
![image](https://github.com/user-attachments/assets/a9102f83-df88-4ef2-9cee-e39c519e7352)

Prince of Persia - Warrior Within:
Master:
![image](https://github.com/user-attachments/assets/e175d031-8b8d-4fd0-bf0d-7f2c8be9a279)
PR:
![image](https://github.com/user-attachments/assets/536e1986-a3f2-4bdc-8465-488f5d385a75)

