### PR TITLE
USB: Throttle the Buzz data packets

### DIFF
--- a/pcsx2/USB/usb-pad/usb-buzz.h
+++ b/pcsx2/USB/usb-pad/usb-buzz.h
@@ -75,7 +75,7 @@ namespace usb_pad
 			u8 player4_blue : 1;
 
 			u8 tail : 4;
-		} data = {};
+		} data = {}, lastData = {};
 		#pragma pack(pop)
 	};
 


### PR DESCRIPTION
### Description of Changes
Throttle the Buzz data packets, which should should resolve the problem with ghost inputs

### Rationale behind Changes
Closes #4990, closes #8393, closes #9898

### Suggested Testing Steps
Buzz
