### PR TITLE
Fix invalid comparator in FullscreenUI game list sort

### DIFF
--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -6286,7 +6286,7 @@ void FullscreenUI::PopulateGameListEntryList()
 				case 4: // CRC
 				{
 					if (lhs->crc != rhs->crc)
-						return reverse ? (lhs->crc >= rhs->crc) : (lhs->crc < rhs->crc);
+						return reverse ? (lhs->crc > rhs->crc) : (lhs->crc < rhs->crc);
 				}
 				break;
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Fix an issue in the game list sorting comparator where the use of >= violated the requirements of a strict weak ordering when sorting by CRC in descending order. The comparison now uses > instead to restore correct comparator behavior and prevent undefined behavior during sorting.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
According to the C++ standard, comparators used in std::sort must establish a strict weak ordering. This includes being irreflexive, meaning comp(x, x) must always return false. Using >= violated this rule when two elements were equal, causing both comp(a, b) and comp(b, a) to return true. This could lead to incorrect sort results and potentially undefined behavior such as segmentation faults. Replacing >= with > ensures compliance with the standard and improves stability.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No
