### PR TITLE
GS: Treat Q == 0 in STQ as FLT_MIN

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -575,7 +575,7 @@ void GSState::GIFPackedRegHandlerSTQ(const GIFPackedReg* RESTRICT r)
 
 	// Vexx (character shadow)
 	// q = 0 (st also 0 on the first 16 vertices), setting it to 1.0f to avoid div by zero later
-	q = q.blend8(GSVector4i::cast(GSVector4::m_one), q == GSVector4i::zero());
+	q = q.blend8(GSVector4i::cast(GSVector4(FLT_MIN)), q == GSVector4i::zero());
 
 	// Suikoden 4
 	// creates some nan for Q. Let's avoid undefined behavior (See GIFRegHandlerRGBAQ)
@@ -671,7 +671,7 @@ void GSState::GIFPackedRegHandlerSTQRGBAXYZF2(const GIFPackedReg* RESTRICT r, u3
 		GSVector4i q = GSVector4i::loadl(&r[0].U64[1]);
 		const GSVector4i rgba = (GSVector4i::load<false>(&r[1]) & GSVector4i::x000000ff()).ps32().pu16();
 
-		q = q.blend8(GSVector4i::cast(GSVector4::m_one), q == GSVector4i::zero()); // see GIFPackedRegHandlerSTQ
+		q = q.blend8(GSVector4i::cast(GSVector4(FLT_MIN)), q == GSVector4i::zero()); // see GIFPackedRegHandlerSTQ
 
 		m_v.m[0] = st.upl64(rgba.upl32(q)); // TODO: only store the last one
 
@@ -705,7 +705,7 @@ void GSState::GIFPackedRegHandlerSTQRGBAXYZ2(const GIFPackedReg* RESTRICT r, u32
 		GSVector4i q = GSVector4i::loadl(&r[0].U64[1]);
 		const GSVector4i rgba = (GSVector4i::load<false>(&r[1]) & GSVector4i::x000000ff()).ps32().pu16();
 
-		q = q.blend8(GSVector4i::cast(GSVector4::m_one), q == GSVector4i::zero()); // see GIFPackedRegHandlerSTQ
+		q = q.blend8(GSVector4i::cast(GSVector4(FLT_MIN)), q == GSVector4i::zero()); // see GIFPackedRegHandlerSTQ
 
 		m_v.m[0] = st.upl64(rgba.upl32(q)); // TODO: only store the last one
 


### PR DESCRIPTION
### Description of Changes
Changes Q == 0 handling to change Q to FLT_MIN instead of 1.0

### Rationale behind Changes
Cold Winter abuses this for shadow draw occlusion by setting Q to zero, which would cause a divide by zero (in theory), so previously we set it to 1.0, but this then causes it to draw the shadow in places it shouldn't. On the real hardware, due to GS conversion this will likely end up closer to FLT_MIN, so it's better we do that (until someone does proper hardware tests lol)

### Suggested Testing Steps
Test Cold Winter, Psychonauts and some random games, Futurama showed up as well with differences to the face shadow because of how the game draws it, it could be arguably better, but it isn't better or worse in practice.

### Did you use AI to help find, test, or implement this issue or feature?
No

Fixes #3881

Cold Winter (Shadow on far wall):
Master:
![image](https://github.com/user-attachments/assets/e02c6e86-669e-4643-aee1-3c5fc45260a7)
PR:
![image](https://github.com/user-attachments/assets/aa1a4ce2-03e2-4750-83c5-47d2dd43bc2e)

Futurama (little HUD picture in top left):
Master:
![image](https://github.com/user-attachments/assets/8b833aed-1e2a-4ba3-a265-27c24b22f29b)
PR:
![image](https://github.com/user-attachments/assets/74ebc15e-000c-4a31-b0ed-54a873beaf30)

Psychonauts (Garbage, this may still not be 100% correct, but not tested on PS2, but looks better that garbage):
Master:
![image](https://github.com/user-attachments/assets/56a611cd-7ec7-48d0-93ad-e59379aacd04)
PR:
![image](https://github.com/user-attachments/assets/7347aee8-161a-4d42-9038-82150ceddf9e)