### PR TITLE
GS: Min alpha for AA1 is 0, not 128

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -4237,7 +4237,10 @@ void GSState::CalcAlphaMinMax(const int tex_alpha_min, const int tex_alpha_max)
 
 	if (IsCoverageAlpha())
 	{
-		min = 128;
+		// HW renderer doesn't currently support AA, so its min is 128.
+		// If we add AA support to the HW renderer, this will need to be changed.
+		// (Will probably only be supported with ROV/FBFetch so we would want to check for that.)
+		min = GSIsHardwareRenderer() ? 128 : 0;
 		max = 128;
 	}
 	else


### PR DESCRIPTION
### Description of Changes
Sets the minimum alpha to 0 when AA1 is enabled.  This isn't great for the HW renderer, since it doesn't implement AA, and previously could pretend that alpha would always be 128, but is required for the SW renderer to not pretend that alpha is always 128 when it shouldn't be, causing it to optimize out alpha testing.

### Rationale behind Changes
More accurate SW renderer

### Suggested Testing Steps
Test [JonnyMoseleyDebug.gs.xz.zip](https://github.com/user-attachments/files/20851016/JonnyMoseleyDebug.gs.xz.zip) in the software renderer

### Did you use AI to help find, test, or implement this issue or feature?
No
