### PR TITLE
GS/DX11/GL: Fix more hazard warnings on dx11, tweak primid checks on dx11/gl.

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -325,6 +325,7 @@ public:
 	void PSSetShaderResource(int i, GSTexture* sr);
 	void PSSetShader(ID3D11PixelShader* ps, ID3D11Buffer* ps_cb);
 	void PSUpdateShaderState();
+	void PSUnbindConflictingSRVs(GSTexture* rt, GSTexture* ds);
 	void PSSetSamplerState(ID3D11SamplerState* ss0);
 
 	void OMSetDepthStencilState(ID3D11DepthStencilState* dss, u8 sref);

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -3903,7 +3903,7 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 		config.rt = backup_rt;
 		if (!date_image)
 		{
-			Console.WriteLn("D3D12: Failed to allocate DATE image, aborting draw.");
+			Console.Warning("D3D12: Failed to allocate DATE image, aborting draw.");
 			return;
 		}
 	}

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -2475,7 +2475,7 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 			primid_texture = InitPrimDateTexture(colclip_rt ? colclip_rt : config.rt, config.drawarea, config.datm);
 			if (!primid_texture)
 			{
-				Console.WriteLn("GL: Failed to allocate DATE image, aborting draw.");
+				Console.Warning("GL: Failed to allocate DATE image, aborting draw.");
 				return;
 			}
 			break;
@@ -2607,7 +2607,7 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 		}
 	}
 
-	if (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking)
+	if (primid_texture)
 	{
 		GL_PUSH("Destination Alpha PrimID Init");
 

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -5630,7 +5630,7 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 		date_image = SetupPrimitiveTrackingDATE(config);
 		if (!date_image)
 		{
-			Console.WriteLn("VK: Failed to allocate DATE image, aborting draw.");
+			Console.Warning("VK: Failed to allocate DATE image, aborting draw.");
 			return;
 		}
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/DX11: Make sure no SRVs are bound using the same texture before binding it to a RTV.
Fixes api hazard warnings.

GS/DX11/GL: Check if primid texture exists instead if it's a primid draw.
Makes local testing easier to null out primid tex.
Also match naming between gl and dx11.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Follow up from https://github.com/PCSX2/pcsx2/pull/12600
Fixes hazard warnings on dx11.
Example:
```
[28236] D3D11 WARNING: ID3D11DeviceContext::OMSetRenderTargets: Resource being set to OM RenderTarget slot 0 is still bound on input! [ STATE_SETTING WARNING #9: DEVICE_OMSETRENDERTARGETS_HAZARD]
[28236] D3D11 WARNING: ID3D11DeviceContext::OMSetRenderTargets[AndUnorderedAccessViews]: Forcing PS shader resource slot 0 to NULL. [ STATE_SETTING WARNING #7: DEVICE_PSSETSHADERRESOURCES_HAZARD]
[28236] D3D11 WARNING: ID3D11DeviceContext::PSSetShaderResources: Resource being set to PS shader resource slot 0 is still bound on output! Forcing to NULL. [ STATE_SETTING WARNING #7: DEVICE_PSSETSHADERRESOURCES_HAZARD]
```

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Dump run on dx11 is ok besides false positives.
Test Sly2 as well as other games, see if any similar api warnings pop up using debug device and a debug output program such as DebugView, Renderdoc and such, see if anything broke.
Smoke test PrimID date games such as Sly 2, Amagami on GL/DX11, I smoke tested Sly 2 and Amagami but make sure.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.
