### PR TITLE
FSUI: Don't attempt to translate input profile names

### DIFF
--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3384,7 +3384,7 @@ void FullscreenUI::DrawSummarySettingsPage()
 
 			for (const std::string& name : Pad::GetInputProfileNames())
 			{
-				options.emplace_back(fmt::format(FSUI_FSTR(name)), (value.has_value() && !value->empty() && value == name) ? true : false);
+				options.emplace_back(name, (value.has_value() && !value->empty() && value == name) ? true : false);
 				names.push_back(std::move(name));
 			}
 


### PR DESCRIPTION
### Description of Changes
Remove FSUI_FSTR (and the associated fmt::format call) when handling an input profile name in BMP game specific settings

### Rationale behind Changes
This didn't look correct.
Other locations didn't seem to translate 

### Suggested Testing Steps
Open BPM
Go to the games properties
Click Input profiles and look at the list of profiles

### Did you use AI to help find, test, or implement this issue or feature?
No
