### PR TITLE
GameDB: Xenosaga Episode III fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -2409,6 +2409,7 @@ SCAJ-20179:
     autoFlush: 1 # Fixes shadows.
     halfPixelOffset: 4 # Fixes lighting misalignment.
     nativeScaling: 2 # Fixes lighting smoothness.
+    textureInsideRT: 1 # Fixes broken crystalline surface textures.
 SCAJ-20180:
   name: "Xenosaga Episode III - Also Sprach Zarathustra [Disc 2 of 2]"
   region: "NTSC-Unk"
@@ -2416,6 +2417,7 @@ SCAJ-20180:
     autoFlush: 1 # Fixes shadows.
     halfPixelOffset: 4 # Fixes lighting misalignment.
     nativeScaling: 2 # Fixes lighting smoothness.
+    textureInsideRT: 1 # Fixes broken crystalline surface textures.
 SCAJ-20181:
   name: "Minna no Tennis"
   region: "NTSC-Unk"
@@ -35734,6 +35736,7 @@ SLPM-61147:
     autoFlush: 1 # Fixes shadows.
     halfPixelOffset: 4 # Fixes lighting misalignment.
     nativeScaling: 2 # Fixes lighting smoothness.
+    textureInsideRT: 1 # Fixes broken crystalline surface textures.
 SLPM-61148:
   name: "グローランサーⅤ ジェネレーションズ [体験版]"
   name-sort: "ぐろーらんさー5 じぇねれーしょんず [たいけんばん]"
@@ -59562,6 +59565,7 @@ SLPS-25640:
     autoFlush: 1 # Fixes shadows.
     halfPixelOffset: 4 # Fixes lighting misalignment.
     nativeScaling: 2 # Fixes lighting smoothness.
+    textureInsideRT: 1 # Fixes broken crystalline surface textures.
   memcardFilters: # Allows import of Xenosaga II save data.
     - "SLPS-25640"
     - "SLPS-25368"
@@ -59575,6 +59579,7 @@ SLPS-25641:
     autoFlush: 1 # Fixes shadows.
     halfPixelOffset: 4 # Fixes lighting misalignment.
     nativeScaling: 2 # Fixes lighting smoothness.
+    textureInsideRT: 1 # Fixes broken crystalline surface textures.
   memcardFilters:
     - "SLPS-25640"
     - "SLPS-25368"
@@ -70356,6 +70361,7 @@ SLUS-21389:
     autoFlush: 1 # Fixes shadows.
     halfPixelOffset: 4 # Fixes lighting misalignment.
     nativeScaling: 2 # Fixes lighting smoothness.
+    textureInsideRT: 1 # Fixes broken crystalline surface textures.
   memcardFilters: # Allows import of Xenosaga II save data.
     - "SLUS-21389"
     - "SLUS-20892"
@@ -70525,6 +70531,7 @@ SLUS-21417:
     autoFlush: 1 # Fixes shadows.
     halfPixelOffset: 4 # Fixes lighting misalignment.
     nativeScaling: 2 # Fixes lighting smoothness.
+    textureInsideRT: 1 # Fixes broken crystalline surface textures.
   memcardFilters:
     - "SLUS-21389"
     - "SLUS-20892"


### PR DESCRIPTION
### Description of Changes
Re adds tex in rt to fix broken textures on crystal surfaces. This previously made people bald which was bad.

Without:
![Xenosaga Episode III - Also Sprach Zarathustra  Disc 2 of 2 _SLUS-21417_20250622234406](https://github.com/user-attachments/assets/5cb16805-8c2a-48d5-8d8c-83547e57cb82)

With:
![Xenosaga Episode III - Also Sprach Zarathustra  Disc 2 of 2 _SLUS-21417_20250622234413](https://github.com/user-attachments/assets/d6bf813b-31db-44b6-af0c-116cfa70a7c7)

### Rationale behind Changes
Broken games that can be fixed should be fixed.

### Suggested Testing Steps
Make sure CI passes.

### Did you use AI to help find, test, or implement this issue or feature?
Nop
