### PR TITLE
GameDB/Misc: Add memcardFilters to Armored Core: Last Raven NTSC-U SLUS-21338

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -69979,7 +69979,6 @@ SLUS-21338:
     - "SLUS-21200"
     - "SLUS-20986"
     - "SLUS-21079"
-
 SLUS-21339:
   name: "Puzzle Challenge - Crosswords and More!"
   region: "NTSC-U"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -69974,6 +69974,12 @@ SLUS-21338:
     halfPixelOffset: 2 # Corrects shadow alignment and reduces blurriness.
     recommendedBlendingLevel: 3 # Fixes level and map menu brightness.
     preloadFrameData: 1 # Fixes glowing emblems.
+  memcardFilters: # Convert savegames from AC: Nexus and AC: Nine Breaker.
+    - "SLUS-21338"
+    - "SLUS-21200"
+    - "SLUS-20986"
+    - "SLUS-21079"
+
 SLUS-21339:
   name: "Puzzle Challenge - Crosswords and More!"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Added memcardFilter entries to allow importing Nine Breaker and Nexus (NTSC-U) saves into Last Raven (NTSC-U).

### Rationale behind Changes
The NTSC-J version of Last Raven has memcardFilter entries set, but not NTSC-U, and otherwise couldn't import saves from my Folder memory card.

### Suggested Testing Steps
Works with no obvious issues on Linux Flatpak PCSX2 v2.3.436. Last Raven detects and imports saves from Nine Breaker and Nexus successfully using a Folder memory card, and did not before.

### Did you use AI to help find, test, or implement this issue or feature?
No.