### PR TITLE
GS/DX11: Also check DrawMultiStretchRects copy for srv conflicts with rtv.

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -325,7 +325,7 @@ public:
 	void PSSetShaderResource(int i, GSTexture* sr);
 	void PSSetShader(ID3D11PixelShader* ps, ID3D11Buffer* ps_cb);
 	void PSUpdateShaderState();
-	void PSUnbindConflictingSRVs(GSTexture* rt, GSTexture* ds);
+	void PSUnbindConflictingSRVs(GSTexture* tex1 = nullptr, GSTexture* tex2 = nullptr);
 	void PSSetSamplerState(ID3D11SamplerState* ss0);
 
 	void OMSetDepthStencilState(ID3D11DepthStencilState* dss, u8 sref);


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/DX11: Also check DrawMultiStretchRects copy for srv conflicts with rtv.
Also adjust the naming.
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Follow up from https://github.com/PCSX2/pcsx2/pull/12884
Even less api warnings.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test Hitman Blood Money.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.