### PR TITLE
FSUI: Centre disc/exe icon in game list selected preview

### DIFF
--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -7009,6 +7009,9 @@ void FullscreenUI::DrawGameCover(const GameList::Entry* entry, const ImVec2& siz
 		const ImVec2 image_square(min_size, min_size);
 		GSTexture* const icon_texture = GetTextureForGameListEntryType(entry->type, image_square);
 
+		const ImRect image_rect(CenterImage(size, image_square));
+
+		ImGui::SetCursorPos(origin + image_rect.Min);
 		DrawSvgTexture(icon_texture, image_square);
 	}
 	// Pretend the image we drew was the the size passed to us
@@ -7050,6 +7053,9 @@ void FullscreenUI::DrawFallbackCover(const ImVec2& size)
 	const ImVec2 image_square(min_size, min_size);
 	GSTexture* const icon_texture = GetTextureForGameListEntryType(GameList::EntryType::PS2Disc, image_square);
 
+	const ImRect image_rect(CenterImage(size, image_square));
+
+	ImGui::SetCursorPos(origin + image_rect.Min);
 	DrawSvgTexture(icon_texture, image_square);
 
 	// Pretend the image we drew was the the size passed to us


### PR DESCRIPTION
### Description of Changes
Adds missing logic to centre the disc/gear icon in the preview panel in the BPM games list.

### Rationale behind Changes
Regression from #12875

Master on left, PR on right
![image](https://github.com/user-attachments/assets/d7424433-d9ec-4fab-810e-dd28ae93ef0c)

### Suggested Testing Steps
Look at the preview panel in the BPM games list.

### Did you use AI to help find, test, or implement this issue or feature?
No
