### PR TITLE
CI/Linux: Link ffmpeg for the appimage

### DIFF
--- a/.github/workflows/linux_build_qt.yml
+++ b/.github/workflows/linux_build_qt.yml
@@ -144,6 +144,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DENABLE_SETCAP=OFF \
             -DDISABLE_ADVANCE_SIMD=TRUE \
+            -DUSE_LINKED_FFMPEG=ON \
             -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON \
             $ADDITIONAL_CMAKE_ARGS
 


### PR DESCRIPTION
### Description of Changes
Links ffmpeg for the appimage to allow video recording by default.

### Rationale behind Changes
Having this feature be broken for a lot of users to save 40MB of space doesn't really make sense so let's fix that.

### Suggested Testing Steps
Make sure the CI still passes and video recording works with the appimage.

### Did you use AI to help find, test, or implement this issue or feature?
No
