### PR TITLE
Qt: Add security warning to setup wizard

### DIFF
--- a/pcsx2-qt/SetupWizardDialog.ui
+++ b/pcsx2-qt/SetupWizardDialog.ui
@@ -629,7 +629,7 @@
        <item>
         <widget class="QLabel" name="label_9">
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;h1 style=&quot; margin-top:18px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:xx-large; font-weight:700;&quot;&gt;Setup Complete!&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;You are now ready to run games.&lt;/p&gt;&lt;p&gt;Further options are available under the settings menu. You can also use the Big Picture UI for navigation entirely with a gamepad.&lt;/p&gt;&lt;p&gt;We hope you enjoy using PCSX2.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;h1 style=&quot; margin-top:18px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:xx-large; font-weight:700;&quot;&gt;Setup Complete!&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;You are now ready to run games.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Warning: Do not run untrusted programs in PCSX2. It is not a sandbox and cannot protect your computer from malicious software.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Further options are available under the settings menu. You can also use the Big Picture UI for navigation entirely with a gamepad.&lt;/p&gt;&lt;p&gt;We hope you enjoy using PCSX2.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>


### PR DESCRIPTION
### Description of Changes
Adds a security warning to the setup wizard clarifying that PCSX2 is not a sandbox.

![Screenshot_20250623_203324](https://github.com/user-attachments/assets/7919e5c7-f857-49da-b40d-68e07e1f3b69)

### Rationale behind Changes
It seems to me that a lot of people assume that PCSX2 is completely secure in the same way that a commercial-grade VM is, which anyone who's worked on it knows is not true. I think we should be more upfront about that fact.

I brought this up with some of the other developers a couple days ago, and they seemed to generally agree with my idea, although there was a concern that if we just put a notice on the website that no one would read it. So, I thought we should put it in the setup wizard.

### Suggested Testing Steps
Run the setup wizard, read the text:
```
pcsx2-qt -setupwizard
```

### Did you use AI to help find, test, or implement this issue or feature?
No.
