### PR TITLE
GameDB: Remove Ineffective Sorting Title for Disney/Pixar The Incredibles - Rise of the Underminer

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -69074,7 +69074,6 @@ SLUS-21216:
     nativeScaling: 2 # Fixes misaligned bloom.
 SLUS-21217:
   name: "Disney/Pixar The Incredibles - Rise of the Underminer"
-  name-sort: "Disney/Pixar Incredibles, The - Rise of the Underminer"
   region: "NTSC-U"
   compat: 5
   gsHWFixes:

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -23004,7 +23004,6 @@ SLES-53471:
   region: "PAL-M5"
 SLES-53473:
   name: "Disney/Pixar The Incredibles - Rise of the Underminer"
-  name-sort: "Disney/Pixar Incredibles, The - Rise of the Underminer"
   region: "PAL-M3"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes building shade and shadows.
@@ -23012,7 +23011,6 @@ SLES-53473:
     nativeScaling: 2 # Fixes post effects.
 SLES-53474:
   name: "Disney/Pixar The Incredibles - Rise of the Underminer"
-  name-sort: "Disney/Pixar Incredibles, The - Rise of the Underminer"
   region: "PAL-M3"
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes building shade and shadows.


### PR DESCRIPTION
### Description of Changes
removed name-sort from SLUS-21217, SLES-53473, and SLES-53474

### Rationale behind Changes
removing this allows users to set their own title in the ui - e.g. removing "Disney/Pixar"

### Suggested Testing Steps
n/a

### Did you use AI to help find, test, or implement this issue or feature?
no
