### PR TITLE
GS/DX11: Cache shader resources and sampler.

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -145,9 +145,11 @@ private:
 		ID3D11VertexShader* vs;
 		ID3D11Buffer* vs_cb;
 		std::array<ID3D11ShaderResourceView*, MAX_TEXTURES> ps_sr_views;
+		std::array<ID3D11ShaderResourceView*, MAX_TEXTURES> ps_cached_sr_views;
 		ID3D11PixelShader* ps;
 		ID3D11Buffer* ps_cb;
 		std::array<ID3D11SamplerState*, MAX_SAMPLERS> ps_ss;
+		std::array<ID3D11SamplerState*, MAX_SAMPLERS> ps_cached_ss;
 		GSVector2i viewport;
 		GSVector4i scissor;
 		u32 vb_stride;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/DX11: Cache shader resources and sampler.
Might help speed things up, requires srv and rtv conflicts to be resolved.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Speed.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test various games, see if there's any speed difference if it's worth adding.
Games that do many things like Sly2, gt4, hitman, primid date, sw blending, tex is fb, tex is ds and such.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.