### PR TITLE
GS/HW: When expanding a target for display, expand valid area

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -3850,6 +3850,9 @@ void GSTextureCache::ScaleTargetForDisplay(Target* t, const GIFRegTEX0& dispfb, 
 	{
 		const GSVector4i right(old_width, 0, preload_width, needed_height);
 		const GSVector4i bottom(0, old_height, old_width, needed_height);
+
+		t->UpdateValidity(right.rintersect(bottom));
+
 		AddDirtyRectTarget(t, right, t->m_TEX0.PSM, t->m_TEX0.TBW, rgba);
 		AddDirtyRectTarget(t, bottom, t->m_TEX0.PSM, t->m_TEX0.TBW, rgba);
 	}
@@ -3858,6 +3861,9 @@ void GSTextureCache::ScaleTargetForDisplay(Target* t, const GIFRegTEX0& dispfb, 
 		const GSVector4i newrect = GSVector4i((old_height < new_height) ? 0 : old_width,
 			(old_width < preload_width) ? 0 : old_height,
 			preload_width, needed_height);
+
+		t->UpdateValidity(newrect);
+
 		AddDirtyRectTarget(t, newrect, t->m_TEX0.PSM, t->m_TEX0.TBW, rgba);
 	}
 


### PR DESCRIPTION
### Description of Changes
Updates the valid size if the display expands it

### Rationale behind Changes
Recent changes restricted the valid sizes to their actual sizes, and this became a problem if the screen size changed. So it now updates the valid size if the screen expands, so the dirty target added is not ignored.

### Suggested Testing Steps
Test MLB 11 The Show, maybe Megaman X8

### Did you use AI to help find, test, or implement this issue or feature?
No

Megaman X8:
Master:'
![image](https://github.com/user-attachments/assets/f8968a85-b705-45f4-95f1-da16176b0c1b)
PR:
![image](https://github.com/user-attachments/assets/a6509b55-45c9-47fb-9c63-0bc814d3a037)

MLB 11:
Master:
![MLB 11 - The Show_SCUS-97657_20250624213827](https://github.com/user-attachments/assets/444236ae-f5f1-4aef-a48a-2e500dabf152)
PR:
![MLB 11 - The Show_SCUS-97657_20250624213836](https://github.com/user-attachments/assets/a01539b5-1cfb-4aae-be34-d4f29509f632)
