### PR TITLE
FSUI: Change to constant string literal in FullscreenUI

### DIFF
--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -7287,7 +7287,7 @@ void FullscreenUI::DrawAchievementsLoginWindow()
 
 		ImGui::PushTextWrapPos(content_width);
 		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.8f, 0.8f, 0.8f, 1.0f));
-		ImGui::TextWrapped(FSUI_CSTR("Please enter your user name and password for retroachievements.org below. Your password will not be saved in PCSX2, an access token will be generated and used instead."));
+		ImGui::TextWrapped("%s", FSUI_CSTR("Please enter your user name and password for retroachievements.org below. \n\n Your password will not be saved in PCSX2, an access token will be generated and used instead."));
 		ImGui::PopStyleColor();
 		ImGui::PopTextWrapPos();
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Changes string to const string literal

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Avoids security warnings and errors in linux environments with Werror and Wformat-security

```
/home/musungo/.cache/paru/clone/pcsx2-git/src/pcsx2/pcsx2/ImGui/FullscreenUI.cpp:7290:22: error: format string is not a string literal (potentially insecure) [-Werror,-Wformat-security]
 7290 |                 ImGui::TextWrapped(FSUI_CSTR("Please enter your user name and password for retroachievements.org below. Your password will not be saved in PCSX2, an access token will be generated and used instead."));
      |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/musungo/.cache/paru/clone/pcsx2-git/src/pcsx2/pcsx2/ImGui/FullscreenUI.cpp:78:24: note: expanded from macro 'FSUI_CSTR'
   78 | #define FSUI_CSTR(str) Host::TranslateToCString(TR_CONTEXT, str)
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/musungo/.cache/paru/clone/pcsx2-git/src/pcsx2/pcsx2/ImGui/FullscreenUI.cpp:7290:22: note: treat the string as an argument to avoid this
 7290 |                 ImGui::TextWrapped(FSUI_CSTR("Please enter your user name and password for retroachievements.org below. Your password will not be saved in PCSX2, an access token will be generated and used instead."));
      |                                    ^
      |                                    "%s", 
/home/musungo/.cache/paru/clone/pcsx2-git/src/pcsx2/pcsx2/ImGui/FullscreenUI.cpp:78:24: note: expanded from macro 'FSUI_CSTR'
   78 | #define FSUI_CSTR(str) Host::TranslateToCString(TR_CONTEXT, str)
      |                        ^
6 warnings and 1 error generated.
[795/888] Linking CXX static library tests/ctest/core/libcore_test_avx2.a
ninja: build stopped: subcommand failed.
==> ERROR: A failure occurred in build().
```

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

Build in environments with Werror and Wformat-security, see that it builds

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No. 