### PR TITLE
GS/Qt: Implement option for organizing screenshots in folders by game name

### DIFF
--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -274,6 +274,7 @@ private:
 	void setGameListEntryCoverImage(const GameList::Entry* entry);
 	void clearGameListEntryPlayTime(const GameList::Entry* entry);
 	void goToWikiPage(const GameList::Entry* entry);
+	void openScreenshotsFolderForGame(const GameList::Entry* entry);
 
 	std::optional<bool> promptForResumeState(const QString& save_state_path);
 	void loadSaveStateSlot(s32 slot, bool load_backup = false);

--- a/pcsx2-qt/Settings/FolderSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/FolderSettingsWidget.cpp
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: GPL-3.0+
 
 #include <QtWidgets/QMessageBox>
+#include <algorithm>
 
 #include "FolderSettingsWidget.h"
+#include "pcsx2/GS/GS.h"
 #include "SettingWidgetBinder.h"
 #include "SettingsWindow.h"
 
@@ -18,8 +20,14 @@ FolderSettingsWidget::FolderSettingsWidget(SettingsWindow* dialog, QWidget* pare
 	SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.cheats, m_ui.cheatsBrowse, m_ui.cheatsOpen, m_ui.cheatsReset, "Folders", "Cheats", Path::Combine(EmuFolders::DataRoot, "cheats"));
 	SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.covers, m_ui.coversBrowse, m_ui.coversOpen, m_ui.coversReset, "Folders", "Covers", Path::Combine(EmuFolders::DataRoot, "covers"));
 	SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.snapshots, m_ui.snapshotsBrowse, m_ui.snapshotsOpen, m_ui.snapshotsReset, "Folders", "Snapshots", Path::Combine(EmuFolders::DataRoot, "snaps"));
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.organizeScreenshotsByGame, "EmuCore/GS", "OrganizeScreenshotsByGame", false);
+	connect(m_ui.organizeScreenshotsByGame, &QCheckBox::checkStateChanged, this, [](int state) {
+		GSConfig.OrganizeScreenshotsByGame = (state == Qt::Checked);
+	});
 	SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.saveStates, m_ui.saveStatesBrowse, m_ui.saveStatesOpen, m_ui.saveStatesReset, "Folders", "SaveStates", Path::Combine(EmuFolders::DataRoot, "sstates"));
 	SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.videoDumpingDirectory, m_ui.videoDumpingDirectoryBrowse, m_ui.videoDumpingDirectoryOpen, m_ui.videoDumpingDirectoryReset, "Folders", "Videos", Path::Combine(EmuFolders::DataRoot, "videos"));
+	dialog->registerWidgetHelp(m_ui.organizeScreenshotsByGame, tr("Organize Screenshots by Game"), tr("Unchecked"),
+		tr("When enabled, screenshots will be saved in a folder with the game's name, instead of all being saved in the Snapshots folder"));
 }
 
 FolderSettingsWidget::~FolderSettingsWidget() = default;

--- a/pcsx2-qt/Settings/FolderSettingsWidget.ui
+++ b/pcsx2-qt/Settings/FolderSettingsWidget.ui
@@ -175,12 +175,19 @@
           </item>
           <item row="0" column="0" colspan="4">
            <widget class="QLabel" name="snaphotsLabel">
-            <property name="text">
-             <string>Used for screenshots and saving GS dumps.</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
+        <property name="text">
+         <string>Used for screenshots and saving GS dumps.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="4">
+       <widget class="QCheckBox" name="organizeScreenshotsByGame">
+        <property name="text">
+         <string>Save Screenshots in Game-Specific Folders</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
         </widget>
        </item>
        <item row="3" column="0">

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -781,7 +781,8 @@ struct Pcsx2Config
 					EnableVideoCaptureParameters : 1,
 					VideoCaptureAutoResolution : 1,
 					EnableAudioCapture : 1,
-					EnableAudioCaptureParameters : 1;
+					EnableAudioCaptureParameters : 1,
+					OrganizeScreenshotsByGame : 1;
 			};
 		};
 

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -876,7 +876,30 @@ static std::string GSGetBaseFilename()
 std::string GSGetBaseSnapshotFilename()
 {
 	// prepend snapshots directory
-	return Path::Combine(EmuFolders::Snapshots, GSGetBaseFilename());
+	std::string base_path = EmuFolders::Snapshots;
+
+	// If organize by game is enabled, create a game-specific folder
+	if (GSConfig.OrganizeScreenshotsByGame)
+	{
+		std::string game_name = VMManager::GetTitle(true);
+		if (!game_name.empty())
+		{
+			Path::SanitizeFileName(&game_name);
+			if (game_name.length() > 219)
+			{
+				game_name.resize(219);
+			}
+			const std::string game_dir = Path::Combine(base_path, game_name);
+			if (!FileSystem::DirectoryExists(game_dir.c_str()))
+			{
+				FileSystem::CreateDirectoryPath(game_dir.c_str(), false);
+			}
+
+			base_path = game_dir;
+		}
+	}
+
+	return Path::Combine(base_path, GSGetBaseFilename());
 }
 
 std::string GSGetBaseVideoFilename()

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -920,6 +920,7 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapIntEnumEx(ScreenshotSize, "ScreenshotSize");
 	SettingsWrapIntEnumEx(ScreenshotFormat, "ScreenshotFormat");
 	SettingsWrapEntry(ScreenshotQuality);
+	SettingsWrapBitBool(OrganizeScreenshotsByGame);
 	SettingsWrapEntry(StretchY);
 	SettingsWrapEntryEx(Crop[0], "CropLeft");
 	SettingsWrapEntryEx(Crop[1], "CropTop");


### PR DESCRIPTION
### Description of Changes
Allows the organize screenshots made with the emulator. Fixes #10913

### Rationale behind Changes
Having the screenshots more organized, especially when u have and do a lot screenshots

### Suggested Testing Steps
Go to settings, graphics, and select *Save screenshots in game-specific folders* and make a screenshot. It should now have its own folder

### Did you use AI to help find, test, or implement this issue or feature?
no