### PR TITLE
Debugger/Qt: Unlock debugger table view layout

### DIFF
--- a/pcsx2-qt/Debugger/Breakpoints/BreakpointView.cpp
+++ b/pcsx2-qt/Debugger/Breakpoints/BreakpointView.cpp
@@ -21,6 +21,7 @@ BreakpointView::BreakpointView(const DebuggerViewParameters& parameters)
 	connect(m_ui.breakpointList, &QTableView::doubleClicked, this, &BreakpointView::onDoubleClicked);
 
 	m_ui.breakpointList->setModel(m_model);
+	m_ui.breakpointList->horizontalHeader()->setSectionsMovable(true);
 	this->resizeColumns();
 }
 

--- a/pcsx2-qt/Debugger/Memory/SavedAddressesView.cpp
+++ b/pcsx2-qt/Debugger/Memory/SavedAddressesView.cpp
@@ -16,6 +16,7 @@ SavedAddressesView::SavedAddressesView(const DebuggerViewParameters& parameters)
 	m_ui.setupUi(this);
 
 	m_ui.savedAddressesList->setModel(m_model);
+	m_ui.savedAddressesList->horizontalHeader()->setSectionsMovable(true);
 
 	m_ui.savedAddressesList->setContextMenuPolicy(Qt::CustomContextMenu);
 	connect(m_ui.savedAddressesList, &QTableView::customContextMenuRequested,

--- a/pcsx2-qt/Debugger/ModuleView.cpp
+++ b/pcsx2-qt/Debugger/ModuleView.cpp
@@ -14,6 +14,7 @@ ModuleView::ModuleView(const DebuggerViewParameters& parameters)
 {
 	m_ui.setupUi(this);
 	m_ui.moduleList->setModel(m_model);
+	m_ui.moduleList->horizontalHeader()->setSectionsMovable(true);
 
 	m_ui.moduleList->setContextMenuPolicy(Qt::CustomContextMenu);
 	connect(m_ui.moduleList, &QTableView::customContextMenuRequested, this, &ModuleView::openContextMenu);

--- a/pcsx2-qt/Debugger/StackView.cpp
+++ b/pcsx2-qt/Debugger/StackView.cpp
@@ -19,6 +19,7 @@ StackView::StackView(const DebuggerViewParameters& parameters)
 	connect(m_ui.stackList, &QTableView::doubleClicked, this, &StackView::onDoubleClick);
 
 	m_ui.stackList->setModel(m_model);
+	m_ui.stackList->horizontalHeader()->setSectionsMovable(true);
 	for (std::size_t i = 0; auto mode : StackModel::HeaderResizeModes)
 	{
 		m_ui.stackList->horizontalHeader()->setSectionResizeMode(i, mode);

--- a/pcsx2-qt/Debugger/ThreadView.cpp
+++ b/pcsx2-qt/Debugger/ThreadView.cpp
@@ -24,6 +24,7 @@ ThreadView::ThreadView(const DebuggerViewParameters& parameters)
 	m_ui.threadList->setModel(m_proxy_model);
 	m_ui.threadList->setSortingEnabled(true);
 	m_ui.threadList->sortByColumn(ThreadModel::ThreadColumns::ID, Qt::SortOrder::AscendingOrder);
+	m_ui.threadList->horizontalHeader()->setSectionsMovable(true);
 	m_ui.threadList->verticalHeader()->setSectionResizeMode(QHeaderView::ResizeMode::ResizeToContents);
 	for (std::size_t i = 0; auto mode : ThreadModel::HeaderResizeModes)
 	{


### PR DESCRIPTION
### Description of Changes
Unlocks the layout of the tables in the debugger.

### Rationale behind Changes
to make the debugger view even more comfortable by adjusting the rows

### Suggested Testing Steps
open the debugger, go to e.g. stack view and try to move the columns

### Did you use AI to help find, test, or implement this issue or feature?
no