### PR TITLE
Qt: Add option to start in Big Picture Mode from settings.

### DIFF
--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -2413,8 +2413,8 @@ int main(int argc, char* argv[])
 		g_main_window->activateWindow();
 	}
 
-	// Initialize big picture mode if requested.
-	if (s_start_fullscreen_ui)
+	// Initialize big picture mode if requested by command line or settings.
+	if (s_start_fullscreen_ui || Host::GetBaseBoolSettingValue("UI", "StartBigPictureMode", false))
 		g_emu_thread->startFullscreenUI(s_start_fullscreen_ui_fullscreen);
 
 	if (s_boot_and_debug || DebuggerWindow::shouldShowOnStartup())

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -98,6 +98,7 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsWindow* dialog, QWidget
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.renderToSeparateWindow, "UI", "RenderToSeparateWindow", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.hideMainWindow, "UI", "HideMainWindowWhenRunning", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.disableWindowResizing, "UI", "DisableWindowResize", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.startFullscreenUI, "UI", "StartBigPictureMode", false);
 	connect(m_ui.renderToSeparateWindow, &QCheckBox::checkStateChanged, this, &InterfaceSettingsWidget::onRenderToSeparateWindowChanged);
 
 	SettingWidgetBinder::BindWidgetToEnumSetting(sif, m_ui.theme, "UI", "Theme", THEME_NAMES, THEME_VALUES,
@@ -181,6 +182,9 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsWindow* dialog, QWidget
 	dialog->registerWidgetHelp(
 		m_ui.disableWindowResizing, tr("Disable Window Resizing"), tr("Unchecked"),
 		tr("Prevents the main window from being resized."));
+	dialog->registerWidgetHelp(
+		m_ui.startFullscreenUI, tr("Start Big Picture Mode"), tr("Unchecked"),
+		tr("Automatically starts Big Picture Mode instead of the regular Qt interface when PCSX2 launches."));
 
 	onRenderToSeparateWindowChanged();
 }

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
@@ -129,6 +129,13 @@
         </property>
        </widget>
       </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="startFullscreenUI">
+         <property name="text">
+          <string>Start Big Picture UI</string>
+         </property>
+        </widget>
+       </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
Fixes #12857
### Description of Changes
Adds a new setting in Qt Interface Settings to automatically start PCSX2 in Big Picture Mode (FullscreenUI) instead of the Qt UI.

### Rationale behind Changes
- New "Start Big Picture" checkbox in Interface Settings -> Game Display section
- Setting is stored as "StartBigPictureMode" in the "UI" configuration section
- Changed QtHost.cpp to check both command line (-bigpicture) and the new setting

### Suggested Testing Steps
Users who primarily use PCSX2 in BPM had to manually switch to it every time they launched the application, or remember to use the `-bigpicture` cli option . This was inconvenient for users who prefer the BPM interface as their default experience.

### Did you use AI to help find, test, or implement this issue or feature?
nuh uh