### PR TITLE
Update pcsx2-qt_lv-LV.ts

### DIFF
--- a/pcsx2-qt/Translations/pcsx2-qt_lv-LV.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_lv-LV.ts
@@ -414,9 +414,9 @@ Pieslēgšānās žetons ģenerēts šeit:</translation>
       <location filename="../Settings/AchievementSettingsWidget.cpp" line="184"/>
       <source>%n seconds</source>
       <translation>
-        <numerusform>%n sekundes</numerusform>
         <numerusform>%n sekunde</numerusform>
         <numerusform>%n sekundes</numerusform>
+        <numerusform>%n sekunde</numerusform>
       </translation>
     </message>
     <message>
@@ -11674,9 +11674,9 @@ graphical quality, but this will increase system requirements.</translation>
       <location filename="../../pcsx2/GameList.cpp" line="1200"/>
       <source>%n hours</source>
       <translation>
-        <numerusform>%n stundas</numerusform>
         <numerusform>%n stunda</numerusform>
         <numerusform>%n stundas</numerusform>
+        <numerusform>%n stunda</numerusform>
       </translation>
     </message>
     <message numerus="yes">
@@ -11684,9 +11684,9 @@ graphical quality, but this will increase system requirements.</translation>
       <location filename="../../pcsx2/GameList.cpp" line="1202"/>
       <source>%n minutes</source>
       <translation>
-        <numerusform>%n minūtes</numerusform>
         <numerusform>%n minūte</numerusform>
         <numerusform>%n minūtes</numerusform>
+        <numerusform>%n minūte</numerusform>
       </translation>
     </message>
     <message>


### PR DESCRIPTION
### Description of Changes
Fixed the plural and singulars in playtime being inverted

### Rationale behind Changes
Fixes a bug in the translation leading to plurals and singular of playtime

### Suggested Testing Steps
Test playtime using the Latvian language setting.

### Did you use AI to help find, test, or implement this issue or feature?
No. No google translate either, only native Latvian skill.