### PR TITLE
GS: Add hotkey for cycling TV shaders

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1213,6 +1213,31 @@ BEGIN_HOTKEY_LIST(g_gs_hotkeys){"Screenshot", TRANSLATE_NOOP("Hotkeys", "Graphic
 
 			MTGS::RunOnGSThread([new_mode]() { GSConfig.InterlaceMode = new_mode; });
 		}},
+	{"CycleTVShader", TRANSLATE_NOOP("Hotkeys", "Graphics"), TRANSLATE_NOOP("Hotkeys", "Cycle TV Shader"),
+		[](s32 pressed) {
+			if (pressed)
+				return;
+
+			static constexpr std::array<const char*, 8> option_names = {{
+				TRANSLATE_NOOP("Hotkeys", "None (Default)"),
+				TRANSLATE_NOOP("Hotkeys", "Scanline Filter"),
+				TRANSLATE_NOOP("Hotkeys", "Diagonal Filter"),
+				TRANSLATE_NOOP("Hotkeys", "Triangular Filter"),
+				TRANSLATE_NOOP("Hotkeys", "Wave Filter"),
+				TRANSLATE_NOOP("Hotkeys", "Lottes CRT"),
+				TRANSLATE_NOOP("Hotkeys", "4xRGSS"),
+				TRANSLATE_NOOP("Hotkeys", "NxAGSS"),
+			}};
+
+			const u32 new_shader = (EmuConfig.GS.TVShader + 1) % 8;
+			Host::AddKeyedOSDMessage("CycleTVShader",
+				fmt::format(
+					TRANSLATE_FS("Hotkeys", "TV shader set to '{}'."), option_names[new_shader]),
+				Host::OSD_QUICK_DURATION);
+			EmuConfig.GS.TVShader = new_shader;
+
+			MTGS::RunOnGSThread([new_shader]() { GSConfig.TVShader = new_shader; });
+		}},
 	{"ToggleTextureDumping", TRANSLATE_NOOP("Hotkeys", "Graphics"), TRANSLATE_NOOP("Hotkeys", "Toggle Texture Dumping"),
 		[](s32 pressed) {
 			if (!pressed)

--- a/pcsx2/SIO/Pad/Pad.cpp
+++ b/pcsx2/SIO/Pad/Pad.cpp
@@ -223,6 +223,7 @@ void Pad::SetDefaultHotkeyConfig(SettingsInterface& si)
 	// PCSX2 Controller Settings - Hotkeys - Graphics
 	si.SetStringValue("Hotkeys", "CycleAspectRatio", "Keyboard/F6");
 	si.SetStringValue("Hotkeys", "CycleInterlaceMode", "Keyboard/F5");
+	// si.SetStringValue("Hotkeys", "CycleTVShader", "Keyboard/"); TBD
 	si.SetStringValue("Hotkeys", "ToggleMipmapMode", "Keyboard/Insert");
 	//	si.SetStringValue("Hotkeys", "DecreaseUpscaleMultiplier", "Keyboard"); TBD
 	//	si.SetStringValue("Hotkeys", "IncreaseUpscaleMultiplier", "Keyboard"); TBD


### PR DESCRIPTION
### Description of Changes
(for you @Mrlinkwii) 
Adds a new hotkey `CycleTVShader` that allows users to cycle through all 8 TV shader options during gameplay.

### Rationale behind Changes
This was a user requested feature to have quick access to TV shader settings without needing to navigate through menus during gameplay

### Suggested Testing Steps
- Make custom keybind
- Verify shader cycles through all 8 options
- Check that OSD message appears showing current shader name
- Verify hotkey setting appears in Settings -> Controllers -> Hotkeys -> Graphics section
- Confirm custom key bindings can be set and work correctly
- Test in both Qt interface and FullscreenUI

### Did you use AI to help find, test, or implement this issue or feature?
nuh uh