### PR TITLE
Debugger: Allow default layouts to be defined with different groups

### DIFF
--- a/pcsx2-qt/Debugger/Docking/DockLayout.cpp
+++ b/pcsx2-qt/Debugger/Docking/DockLayout.cpp
@@ -872,8 +872,7 @@ void DockLayout::setupDefaultLayout()
 
 	for (const DockTables::DefaultDockWidgetDescription& dock_description : base_layout->widgets)
 	{
-		const DockTables::DefaultDockGroupDescription& group =
-			base_layout->groups[static_cast<u32>(dock_description.group)];
+		const DockTables::DefaultDockGroupDescription& group = base_layout->groups.at(dock_description.group);
 
 		DebuggerView* widget = nullptr;
 		for (auto& [unique_name, test_widget] : m_widgets)
@@ -887,19 +886,19 @@ void DockLayout::setupDefaultLayout()
 			KDDockWidgets::Config::self().viewFactory()->createDockWidget(widget->uniqueName()));
 		view->setWidget(widget);
 
-		if (!groups[static_cast<u32>(dock_description.group)])
+		if (!groups.at(dock_description.group))
 		{
 			KDDockWidgets::QtWidgets::DockWidget* parent = nullptr;
-			if (group.parent != DockTables::DefaultDockGroup::ROOT)
-				parent = groups[static_cast<u32>(group.parent)];
+			if (group.parent >= 0 && group.parent < static_cast<s32>(groups.size()))
+				parent = groups.at(group.parent);
 
 			g_debugger_window->addDockWidget(view, group.location, parent);
 
-			groups[static_cast<u32>(dock_description.group)] = view;
+			groups.at(dock_description.group) = view;
 		}
 		else
 		{
-			groups[static_cast<u32>(dock_description.group)]->addDockWidgetAsTab(view);
+			groups.at(dock_description.group)->addDockWidgetAsTab(view);
 		}
 	}
 

--- a/pcsx2-qt/Debugger/Docking/DockTables.cpp
+++ b/pcsx2-qt/Debugger/Docking/DockTables.cpp
@@ -45,12 +45,12 @@ const std::map<std::string, DockTables::DebuggerViewDescription> DockTables::DEB
 	DEBUGGER_VIEW(LocalVariableTreeView, QT_TRANSLATE_NOOP("DebuggerView", "Locals"), BOTTOM_MIDDLE),
 	DEBUGGER_VIEW(MemorySearchView, QT_TRANSLATE_NOOP("DebuggerView", "Memory Search"), TOP_LEFT),
 	DEBUGGER_VIEW(MemoryView, QT_TRANSLATE_NOOP("DebuggerView", "Memory"), BOTTOM_MIDDLE),
+	DEBUGGER_VIEW(ModuleView, QT_TRANSLATE_NOOP("DebuggerView", "Modules"), BOTTOM_MIDDLE),
 	DEBUGGER_VIEW(ParameterVariableTreeView, QT_TRANSLATE_NOOP("DebuggerView", "Parameters"), BOTTOM_MIDDLE),
 	DEBUGGER_VIEW(RegisterView, QT_TRANSLATE_NOOP("DebuggerView", "Registers"), TOP_LEFT),
 	DEBUGGER_VIEW(SavedAddressesView, QT_TRANSLATE_NOOP("DebuggerView", "Saved Addresses"), BOTTOM_MIDDLE),
 	DEBUGGER_VIEW(StackView, QT_TRANSLATE_NOOP("DebuggerView", "Stack"), BOTTOM_MIDDLE),
 	DEBUGGER_VIEW(ThreadView, QT_TRANSLATE_NOOP("DebuggerView", "Threads"), BOTTOM_MIDDLE),
-	DEBUGGER_VIEW(ModuleView, QT_TRANSLATE_NOOP("DebuggerView", "Modules"), BOTTOM_MIDDLE),
 };
 
 #undef DEBUGGER_VIEW

--- a/pcsx2-qt/Debugger/Docking/DockTables.h
+++ b/pcsx2-qt/Debugger/Docking/DockTables.h
@@ -30,18 +30,23 @@ namespace DockTables
 
 	extern const std::map<std::string, DebuggerViewDescription> DEBUGGER_VIEWS;
 
-	enum class DefaultDockGroup
+	using DockGroup = s32;
+
+	namespace DefaultDockGroup
 	{
-		ROOT = -1,
-		TOP_RIGHT = 0,
-		BOTTOM = 1,
-		TOP_LEFT = 2
-	};
+		enum
+		{
+			ROOT = -1,
+			TOP_RIGHT = 0,
+			BOTTOM = 1,
+			TOP_LEFT = 2
+		};
+	}
 
 	struct DefaultDockGroupDescription
 	{
 		KDDockWidgets::Location location;
-		DefaultDockGroup parent;
+		DockGroup parent;
 	};
 
 	extern const std::vector<DefaultDockGroupDescription> DEFAULT_DOCK_GROUPS;
@@ -49,7 +54,7 @@ namespace DockTables
 	struct DefaultDockWidgetDescription
 	{
 		std::string type;
-		DefaultDockGroup group;
+		DockGroup group;
 	};
 
 	struct DefaultDockLayout


### PR DESCRIPTION
### Description of Changes
Use an integer index to refer to dock groups instead of an enum.

### Rationale behind Changes
This was a small oversight when designing the docking system, each default dock layout previously had to have the same dock groups.

### Suggested Testing Steps
Make sure the debugger dock layouts still work as expected.

### Did you use AI to help find, test, or implement this issue or feature?
No.
