### PR TITLE
GS: Avoid shader_draw_parameters

### DIFF
--- a/bin/resources/shaders/opengl/tfx_vgs.glsl
+++ b/bin/resources/shaders/opengl/tfx_vgs.glsl
@@ -112,11 +112,7 @@ struct ProcessedVertex
 
 ProcessedVertex load_vertex(uint index)
 {
-#if defined(GL_ARB_shader_draw_parameters) && GL_ARB_shader_draw_parameters
-	RawVertex rvtx = vertex_buffer[index + gl_BaseVertexARB];
-#else
 	RawVertex rvtx = vertex_buffer[index];
-#endif
 
 	vec2 i_st = rvtx.ST;
 	vec4 i_c = vec4(uvec4(bitfieldExtract(rvtx.RGBA, 0, 8), bitfieldExtract(rvtx.RGBA, 8, 8),
@@ -158,11 +154,7 @@ void main()
 {
 	ProcessedVertex vtx;
 
-#if defined(GL_ARB_shader_draw_parameters) && GL_ARB_shader_draw_parameters
-	uint vid = uint(gl_VertexID - gl_BaseVertexARB);
-#else
 	uint vid = uint(gl_VertexID);
-#endif
 
 #if VS_EXPAND == 1 // Point
 

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -113,7 +113,7 @@ struct ProcessedVertex
 
 ProcessedVertex load_vertex(uint index)
 {
-	RawVertex rvtx = vertex_buffer[gl_BaseVertexARB + index];
+	RawVertex rvtx = vertex_buffer[index];
 
 	vec2 a_st = rvtx.ST;
 	uvec4 a_c = uvec4(bitfieldExtract(rvtx.RGBA, 0, 8), bitfieldExtract(rvtx.RGBA, 8, 8),
@@ -159,7 +159,7 @@ ProcessedVertex load_vertex(uint index)
 void main()
 {
 	ProcessedVertex vtx;
-	uint vid = uint(gl_VertexIndex - gl_BaseVertexARB);
+	uint vid = uint(gl_VertexIndex);
 
 #if VS_EXPAND == 1 // Point
 

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -757,6 +757,32 @@ struct alignas(16) GSHWDrawConfig
 	GSVector4i colclip_update_area; ///< Area in the framebuffer which colclip will modify;
 };
 
+static inline u32 GetExpansionFactor(GSHWDrawConfig::VSExpand expand)
+{
+	switch (expand)
+	{
+		case GSHWDrawConfig::VSExpand::Point:
+		case GSHWDrawConfig::VSExpand::Line:
+			return 4;
+		case GSHWDrawConfig::VSExpand::Sprite:
+			return 2;
+		default:
+			return 1;
+	}
+}
+
+static inline u32 GetVertexAlignment(GSHWDrawConfig::VSExpand expand)
+{
+	switch (expand)
+	{
+		case GSHWDrawConfig::VSExpand::Sprite:
+			// Sprite expand does a 2-4 expansion, and relies on the low bit of the vertex ID to figure out if it's the first or second coordinate.
+			return 2;
+		default:
+			return 1;
+	}
+}
+
 class GSDevice : public GSAlignedClass<32>
 {
 public:

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -594,20 +594,6 @@ void GSDevice11::SetFeatures(IDXGIAdapter1* adapter)
 	m_features.vs_expand = (!GSConfig.DisableVertexShaderExpand && m_feature_level >= D3D_FEATURE_LEVEL_11_0);
 	m_features.cas_sharpening = (m_feature_level >= D3D_FEATURE_LEVEL_11_0);
 
-	// NVIDIA GPUs prior to Kepler appear to have broken vertex shader buffer loading.
-	if (m_features.vs_expand && (D3D::GetVendorID(adapter) == D3D::VendorID::Nvidia))
-	{
-		// There's nothing Fermi specific which we can query in DX11. Closest we have is typed UAV loads,
-		// which is Kepler+. Anyone using Kepler should be using Vulkan anyway.
-		D3D11_FEATURE_DATA_D3D11_OPTIONS2 options;
-		if (SUCCEEDED(m_dev->CheckFeatureSupport(D3D11_FEATURE_D3D11_OPTIONS2, &options, sizeof(options))) &&
-			!options.TypedUAVLoadAdditionalFormats)
-		{
-			Console.Warning("D3D11: Disabling VS expand due to potentially buggy NVIDIA driver.");
-			m_features.vs_expand = false;
-		}
-	}
-
 	m_max_texture_size = (m_feature_level >= D3D_FEATURE_LEVEL_11_0) ?
 							 D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION :
 							 D3D10_REQ_TEXTURE2D_U_OR_V_DIMENSION;

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -741,20 +741,12 @@ bool GSDeviceOGL::CheckFeatures(bool& buggy_pbo)
 	m_features.stencil_buffer = true;
 	m_features.test_and_sample_depth = m_features.texture_barrier;
 
-	// NVIDIA GPUs prior to Kepler appear to have broken vertex shader buffer loading.
-	// Use bindless textures (introduced in Kepler) to differentiate.
-	const bool buggy_vs_expand =
-		vendor_id_nvidia && (!GLAD_GL_ARB_bindless_texture && !GLAD_GL_NV_bindless_texture);
-	if (buggy_vs_expand)
-		Console.Warning("GL: Disabling vertex shader expand due to broken NVIDIA driver.");
-
 	if (GLAD_GL_ARB_shader_storage_buffer_object)
 	{
 		GLint max_vertex_ssbos = 0;
 		glGetIntegerv(GL_MAX_VERTEX_SHADER_STORAGE_BLOCKS, &max_vertex_ssbos);
 		DevCon.WriteLn("GL_MAX_VERTEX_SHADER_STORAGE_BLOCKS: %d", max_vertex_ssbos);
-		m_features.vs_expand = (!GSConfig.DisableVertexShaderExpand && !buggy_vs_expand && max_vertex_ssbos > 0 &&
-								GLAD_GL_ARB_gpu_shader5);
+		m_features.vs_expand = (!GSConfig.DisableVertexShaderExpand && max_vertex_ssbos > 0 && GLAD_GL_ARB_gpu_shader5);
 	}
 	if (!m_features.vs_expand)
 		Console.Warning("GL: Vertex expansion is not supported. This will reduce performance.");

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -336,7 +336,7 @@ public:
 
 	void IASetVAO(GLuint vao);
 	void IASetPrimitiveTopology(GLenum topology);
-	void IASetVertexBuffer(const void* vertices, size_t count);
+	void IASetVertexBuffer(const void* vertices, size_t count, size_t align_multiplier = 1);
 	void IASetIndexBuffer(const void* index, size_t count);
 
 	void PSSetShaderResource(int i, GSTexture* sr);

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -401,14 +401,6 @@ bool GSDeviceVK::SelectDeviceExtensions(ExtensionList* extension_list, bool enab
 			return false;
 	}
 
-	// MoltenVK does not support VK_EXT_line_rasterization. We want it for other platforms,
-	// but on Mac, the implicit line rasterization apparently matches Bresenham anyway.
-#ifdef __APPLE__
-	static constexpr bool require_line_rasterization = false;
-#else
-	static constexpr bool require_line_rasterization = true;
-#endif
-
 	m_optional_extensions.vk_ext_provoking_vertex = SupportsExtension(VK_EXT_PROVOKING_VERTEX_EXTENSION_NAME, false);
 	m_optional_extensions.vk_ext_memory_budget = SupportsExtension(VK_EXT_MEMORY_BUDGET_EXTENSION_NAME, false);
 	m_optional_extensions.vk_ext_calibrated_timestamps =
@@ -417,8 +409,7 @@ bool GSDeviceVK::SelectDeviceExtensions(ExtensionList* extension_list, bool enab
 		SupportsExtension(VK_EXT_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_EXTENSION_NAME, false);
 	m_optional_extensions.vk_ext_attachment_feedback_loop_layout =
 		SupportsExtension(VK_EXT_ATTACHMENT_FEEDBACK_LOOP_LAYOUT_EXTENSION_NAME, false);
-	m_optional_extensions.vk_ext_line_rasterization = SupportsExtension(VK_EXT_LINE_RASTERIZATION_EXTENSION_NAME,
-		require_line_rasterization);
+	m_optional_extensions.vk_ext_line_rasterization = SupportsExtension(VK_EXT_LINE_RASTERIZATION_EXTENSION_NAME, false);
 	m_optional_extensions.vk_khr_driver_properties = SupportsExtension(VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME, false);
 
 	// glslang generates debug info instructions before phi nodes at the beginning of blocks when non-semantic debug info
@@ -764,15 +755,10 @@ bool GSDeviceVK::ProcessDeviceExtensions()
 		return false;
 	}
 
-	if (!line_rasterization_feature.bresenhamLines)
+	if (m_optional_extensions.vk_ext_line_rasterization && !line_rasterization_feature.bresenhamLines)
 	{
-		// See note in SelectDeviceExtensions().
-		Console.Error("VK: bresenhamLines is not supported.");
-#ifndef __APPLE__
-		return false;
-#else
+		Console.Warning("VK: bresenhamLines is not supported.");
 		m_optional_extensions.vk_ext_line_rasterization = false;
-#endif
 	}
 
 	// VK_EXT_calibrated_timestamps checking

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -554,7 +554,7 @@ public:
 	void SetupDATE(GSTexture* rt, GSTexture* ds, SetDATM datm, const GSVector4i& bbox);
 	GSTextureVK* SetupPrimitiveTrackingDATE(GSHWDrawConfig& config);
 
-	void IASetVertexBuffer(const void* vertex, size_t stride, size_t count);
+	void IASetVertexBuffer(const void* vertex, size_t stride, size_t count, size_t align_multiplier = 1);
 	void IASetIndexBuffer(const void* index, size_t count);
 
 	void PSSetShaderResource(int i, GSTexture* sr, bool check_state);

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 67;
+static constexpr u32 SHADER_CACHE_VERSION = 68;


### PR DESCRIPTION
### Description of Changes
Scales vertex base to avoid the need for GL_ARB_shader_draw_parameters on OGL and VK_KHR_shader_draw_parameters on Vulkan

### Rationale behind Changes
Some older Nvidia GPUs break when you use it

### Suggested Testing Steps
Test OGL and Vk
Test OGL and Vk on Kepler and Maxwell GPUs (I've tested on a 750M and it works now, someone should test Maxwell)

### Did you use AI to help find, test, or implement this issue or feature?
No
