### PR TITLE
Misc: Fix changing console log file.

### DIFF
--- a/common/Console.cpp
+++ b/common/Console.cpp
@@ -335,7 +335,7 @@ bool Log::SetFileOutputLevel(LOGLEVEL level, std::string path)
 
 	const bool was_enabled = (s_file_level > LOGLEVEL_NONE);
 	const bool new_enabled = (level > LOGLEVEL_NONE && !path.empty());
-	if (was_enabled != new_enabled || (new_enabled && path == s_file_path))
+	if (was_enabled != new_enabled || (new_enabled && path != s_file_path))
 	{
 		if (new_enabled)
 		{


### PR DESCRIPTION
### Description of Changes
Console logging file should be updated whenever it is not equal to the old file. The test to check this was inverted.

### Rationale behind Changes
To allow changing the log file location when running the gsrunner.

### Suggested Testing Steps
Run the gsrunner with the -logfile option and see if it log to the specified file.

### Did you use AI to help find, test, or implement this issue or feature?
Github copilot.
