### PR TITLE
Qt/Debugger: Remove text display for breakpoint enabled state

### DIFF
--- a/pcsx2-qt/Debugger/Breakpoints/BreakpointModel.cpp
+++ b/pcsx2-qt/Debugger/Breakpoints/BreakpointModel.cpp
@@ -72,7 +72,7 @@ QVariant BreakpointModel::data(const QModelIndex& index, int role) const
 			switch (index.column())
 			{
 				case BreakpointColumns::ENABLED:
-					return (bp->enabled) ? tr("Enabled") : tr("Disabled");
+					return "";
 				case BreakpointColumns::TYPE:
 					return tr("Execute");
 				case BreakpointColumns::OFFSET:
@@ -95,7 +95,7 @@ QVariant BreakpointModel::data(const QModelIndex& index, int role) const
 			switch (index.column())
 			{
 				case BreakpointColumns::ENABLED:
-					return (mc->result & MEMCHECK_BREAK) ? tr("Enabled") : tr("Disabled");
+					return "";
 				case BreakpointColumns::TYPE:
 				{
 					QString type("");


### PR DESCRIPTION
### Description of Changes
Removed the Breakpoint Enabled/Disabled Text

### Rationale behind Changes
Fixes #12049 , also not needed as the [X] is sufficient

### Suggested Testing Steps
Load up a game, and set a breakpoint in the debugger

### Did you use AI to help find, test, or implement this issue or feature?
No
