### PR TITLE
GS/HW: Fix temp z and clear detection regression

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2972,6 +2972,22 @@ bool GSState::TrianglesAreQuads(bool shuffle_check)
 		}
 		else if (m_index.tail == 6)
 		{
+			bool shared_vert_found = false;
+			for (int i = 0; i < 3; i++)
+			{
+				for (int j = 3; j < 6; j++)
+					if (m_vertex.buff[m_index.buff[i]].XYZ.X == m_vertex.buff[m_index.buff[j]].XYZ.X &&
+						m_vertex.buff[m_index.buff[i]].XYZ.Y == m_vertex.buff[m_index.buff[j]].XYZ.Y)
+					{
+						shared_vert_found = true;
+						break;
+					}
+			}
+			
+			// At least one vert should be shared across otherwise it's 2 separate triangles (false positive from Tales of Destiny).
+			if (!shared_vert_found)
+				return false;
+
 			const int first_X = m_vertex.buff[m_index.buff[0]].XYZ.X;
 			const int first_Y = m_vertex.buff[m_index.buff[0]].XYZ.Y;
 			const int second_X = m_vertex.buff[m_index.buff[1]].XYZ.X;


### PR DESCRIPTION
### Description of Changes
Fixes an issue with temporarily offset Z and a clear misdetection.

### Rationale behind Changes
Offset Z in Time Crisis 3 was detecting a channel shuffle (which was technically correct) and not copying the Z correctly to the new position, it now properly detects this situation.

Tales of Destiny does 2 triangles across the screen to do a cool effect at the end of of a battle, but this was being detected as a clear with quad. The code now checks for at least one shared vertex in this case.

From here on the GT3 demo (possibly the full game) may require high blending if it doesn't already to stop the left/right buttons in the car select from flickering. This was an issue before RT in RT but due to the false clear, it kind of "fixed" it.

### Suggested Testing Steps
Test Tales of Destiny and Time Crisis 3 (visible in menu demos).  Can also check Black, Burnout 3, GT 3, MGS 3, Tekken Tag, as they show up in the results.

### Did you use AI to help find, test, or implement this issue or feature?
No

Fixes #12966
Fixes #12965

Tales of Destiny:
Master:
![image](https://github.com/user-attachments/assets/5e88c889-e8b4-4cb0-ab53-c3675e8f9150)
PR:
![image](https://github.com/user-attachments/assets/76c720b7-42ab-4439-ade1-dfc30e94cfb7)

Time Crisis 3 (There was also some stripes which are now also gone):
Master:
![image](https://github.com/user-attachments/assets/85d4e510-ce7b-45f4-ae8c-717e36f0c49e)
PR:
![image](https://github.com/user-attachments/assets/229f4b1e-235b-4297-8742-8b6c0e87089f)
