### PR TITLE
Debugger: Update symbol tree license headers

### DIFF
--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeDelegates.cpp
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeDelegates.cpp
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
-// SPDX-License-Identifier: LGPL-3.0+
+// SPDX-License-Identifier: GPL-3.0+
 
 #include "SymbolTreeDelegates.h"
 

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeDelegates.h
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeDelegates.h
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
-// SPDX-License-Identifier: LGPL-3.0+
+// SPDX-License-Identifier: GPL-3.0+
 
 #pragma once
 

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeLocation.cpp
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeLocation.cpp
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
-// SPDX-License-Identifier: LGPL-3.0+
+// SPDX-License-Identifier: GPL-3.0+
 
 #include "SymbolTreeLocation.h"
 

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeLocation.h
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeLocation.h
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
-// SPDX-License-Identifier: LGPL-3.0+
+// SPDX-License-Identifier: GPL-3.0+
 
 #pragma once
 

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeModel.cpp
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeModel.cpp
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
-// SPDX-License-Identifier: LGPL-3.0+
+// SPDX-License-Identifier: GPL-3.0+
 
 #include "SymbolTreeModel.h"
 

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeModel.h
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeModel.h
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
-// SPDX-License-Identifier: LGPL-3.0+
+// SPDX-License-Identifier: GPL-3.0+
 
 #pragma once
 

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeNode.cpp
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeNode.cpp
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
-// SPDX-License-Identifier: LGPL-3.0+
+// SPDX-License-Identifier: GPL-3.0+
 
 #include "SymbolTreeNode.h"
 

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeNode.h
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeNode.h
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
-// SPDX-License-Identifier: LGPL-3.0+
+// SPDX-License-Identifier: GPL-3.0+
 
 #pragma once
 

--- a/pcsx2-qt/Debugger/SymbolTree/TypeString.cpp
+++ b/pcsx2-qt/Debugger/SymbolTree/TypeString.cpp
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
-// SPDX-License-Identifier: LGPL-3.0+
+// SPDX-License-Identifier: GPL-3.0+
 
 #include "TypeString.h"
 

--- a/pcsx2-qt/Debugger/SymbolTree/TypeString.h
+++ b/pcsx2-qt/Debugger/SymbolTree/TypeString.h
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
-// SPDX-License-Identifier: LGPL-3.0+
+// SPDX-License-Identifier: GPL-3.0+
 
 #pragma once
 


### PR DESCRIPTION
### Description of Changes
Changes the license for the debugger symbol tree sources from LGPL to GPL.

### Rationale behind Changes
It doesn't make sense for these files to be LGPL with the rest of the project being GPL.

I think what happened is I created these files before the license change, but they only got merged after the license change, so they never got updated.

### Suggested Testing Steps
N/A

### Did you use AI to help find, test, or implement this issue or feature?
𝙽𝙴𝙶𝙰𝚃𝙸𝚅𝙴
