### PR TITLE
GS/HW: Remove handling of provoking first vertex in early pipeline.

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -1301,9 +1301,7 @@ VS_OUTPUT vs_main_expand(uint vid : SV_VertexID)
 	uint vid_base = vid >> 2;
 	bool is_bottom = vid & 2;
 	bool is_right = vid & 1;
-	// All lines will be a pair of vertices next to each other
-	// Since DirectX uses provoking vertex first, the bottom point will be the lower of the two
-	uint vid_other = is_bottom ? vid_base + 1 : vid_base - 1;
+	uint vid_other = is_bottom ? vid_base - 1 : vid_base + 1;
 	VS_OUTPUT vtx = vs_main(load_vertex(vid_base));
 	VS_OUTPUT other = vs_main(load_vertex(vid_other));
 

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -174,11 +174,7 @@ void main()
 
 	bool is_bottom = (vid & 2u) != 0u;
 	bool is_right = (vid & 1u) != 0u;
-#ifdef VS_PROVOKING_VERTEX_LAST
 	uint vid_other = is_bottom ? vid_base - 1 : vid_base + 1;
-#else
-	uint vid_other = is_bottom ? vid_base + 1 : vid_base - 1;
-#endif
 	
 	vtx = load_vertex(vid_base);
 	ProcessedVertex other = load_vertex(vid_other);

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -125,6 +125,8 @@ GSState::~GSState()
 {
 	if (m_vertex.buff)
 		_aligned_free(m_vertex.buff);
+	if (m_vertex.buff_copy)
+		_aligned_free(m_vertex.buff_copy);
 	if (m_index.buff)
 		_aligned_free(m_index.buff);
 	if (m_draw_vertex.buff)
@@ -2859,56 +2861,53 @@ void GSState::UpdateVertexKick()
 void GSState::GrowVertexBuffer()
 {
 	const u32 maxcount = std::max<u32>(m_vertex.maxcount * 3 / 2, 10000);
+	const u32 old_vertex_size = sizeof(GSVertex) * m_vertex.tail;
+	const u32 new_vertex_size = sizeof(GSVertex) * maxcount;
+	const u32 old_index_size = sizeof(u16) * m_index.tail;
+	const u32 new_index_size = sizeof(u16) * maxcount * 6; // Worst case index list is a list of points with vs expansion, 6 indices per point
 
-	GSVertex* vertex = static_cast<GSVertex*>(_aligned_malloc(sizeof(GSVertex) * maxcount, 32));
-	GSVertex* draw_vertex = static_cast<GSVertex*>(_aligned_malloc(sizeof(GSVertex) * maxcount, 32));
-	// Worst case index list is a list of points with vs expansion, 6 indices per point
-	u16* index = static_cast<u16*>(_aligned_malloc(sizeof(u16) * maxcount * 6, 32));
-	u16* draw_index = static_cast<u16*>(_aligned_malloc(sizeof(u16) * maxcount * 6, 32));
-
-	if (!vertex || !index)
+	// Structure describing buffers to reallocate
+	struct AllocDesc
 	{
-		const u32 vert_byte_count = sizeof(GSVertex) * maxcount;
-		const u32 idx_byte_count = sizeof(u16) * maxcount * 3;
+		void** pbuff;
+		u32 old_size;
+		u32 new_size;
+	};
+	std::vector<AllocDesc> alloc_desc = {
+		{reinterpret_cast<void**>(&m_vertex.buff),      old_vertex_size, new_vertex_size},
+		// discard contents of buff_copy by setting old_size = 0
+		{reinterpret_cast<void**>(&m_vertex.buff_copy), 0,               new_vertex_size},
+		{reinterpret_cast<void**>(&m_draw_vertex.buff), old_vertex_size, new_vertex_size},
+		{reinterpret_cast<void**>(&m_index.buff),       old_index_size,  new_index_size},
+		{reinterpret_cast<void**>(&m_draw_index.buff),  old_index_size,  new_index_size}
+	};
 
-		Console.Error("GS: failed to allocate %zu bytes for vertices and %zu for indices.",
-			vert_byte_count, idx_byte_count);
-		pxFailRel("Memory allocation failed");
+	// For logging
+	u32 total_size = 0;
+	for (const auto& desc : alloc_desc)
+		total_size += desc.new_size;
+
+	// Reallocate each of the needed buffers
+	for (const auto [pbuff, old_size, new_size] : alloc_desc)
+	{
+		void* new_buff = _aligned_malloc(new_size, 32);
+		if (!new_buff)
+		{
+			Console.Error("GS: failed to allocate %zu bytes for vertices and indices.", total_size);
+			pxFailRel("Memory allocation failed");
+		}
+		if (*pbuff)
+		{
+			if (old_size)
+			{
+				std::memcpy(new_buff, *pbuff, old_size);
+			}
+			_aligned_free(*pbuff);
+		}
+		*pbuff = new_buff;
 	}
 
-	if (m_vertex.buff)
-	{
-		std::memcpy(vertex, m_vertex.buff, sizeof(GSVertex) * m_vertex.tail);
-
-		_aligned_free(m_vertex.buff);
-	}
-
-	if (m_index.buff)
-	{
-		std::memcpy(index, m_index.buff, sizeof(u16) * m_index.tail);
-
-		_aligned_free(m_index.buff);
-	}
-
-	if (m_draw_vertex.buff)
-	{
-		std::memcpy(draw_vertex, m_draw_vertex.buff, sizeof(GSVertex) * m_vertex.tail);
-
-		_aligned_free(m_draw_vertex.buff);
-	}
-
-	if (m_draw_index.buff)
-	{
-		std::memcpy(draw_index, m_draw_index.buff, sizeof(u16) * m_index.tail);
-
-		_aligned_free(m_draw_index.buff);
-	}
-
-	m_draw_vertex.buff = draw_vertex;
-	m_draw_index.buff = draw_index;
-	m_vertex.buff = vertex;
 	m_vertex.maxcount = maxcount - 3; // -3 to have some space at the end of the buffer before DrawingKick can grow it
-	m_index.buff = index;
 }
 
 bool GSState::TrianglesAreQuads(bool shuffle_check)

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -38,8 +38,8 @@ private:
 	void GIFPackedRegHandlerSTQ(const GIFPackedReg* RESTRICT r);
 	void GIFPackedRegHandlerUV(const GIFPackedReg* RESTRICT r);
 	void GIFPackedRegHandlerUV_Hack(const GIFPackedReg* RESTRICT r);
-	template<u32 prim, u32 adc, bool auto_flush, bool index_swap> void GIFPackedRegHandlerXYZF2(const GIFPackedReg* RESTRICT r);
-	template<u32 prim, u32 adc, bool auto_flush, bool index_swap> void GIFPackedRegHandlerXYZ2(const GIFPackedReg* RESTRICT r);
+	template<u32 prim, u32 adc, bool auto_flush> void GIFPackedRegHandlerXYZF2(const GIFPackedReg* RESTRICT r);
+	template<u32 prim, u32 adc, bool auto_flush> void GIFPackedRegHandlerXYZ2(const GIFPackedReg* RESTRICT r);
 	void GIFPackedRegHandlerFOG(const GIFPackedReg* RESTRICT r);
 	void GIFPackedRegHandlerA_D(const GIFPackedReg* RESTRICT r);
 	void GIFPackedRegHandlerNOP(const GIFPackedReg* RESTRICT r);
@@ -55,8 +55,8 @@ private:
 	GIFPackedRegHandlerC m_fpGIFPackedRegHandlerSTQRGBAXYZF2[8] = {};
 	GIFPackedRegHandlerC m_fpGIFPackedRegHandlerSTQRGBAXYZ2[8] = {};
 
-	template<u32 prim, bool auto_flush, bool index_swap> void GIFPackedRegHandlerSTQRGBAXYZF2(const GIFPackedReg* RESTRICT r, u32 size);
-	template<u32 prim, bool auto_flush, bool index_swap> void GIFPackedRegHandlerSTQRGBAXYZ2(const GIFPackedReg* RESTRICT r, u32 size);
+	template<u32 prim, bool auto_flush> void GIFPackedRegHandlerSTQRGBAXYZF2(const GIFPackedReg* RESTRICT r, u32 size);
+	template<u32 prim, bool auto_flush> void GIFPackedRegHandlerSTQRGBAXYZ2(const GIFPackedReg* RESTRICT r, u32 size);
 	void GIFPackedRegHandlerNOP(const GIFPackedReg* RESTRICT r, u32 size);
 
 	template<int i> void ApplyTEX0(GIFRegTEX0& TEX0);
@@ -68,8 +68,8 @@ private:
 	void GIFRegHandlerST(const GIFReg* RESTRICT r);
 	void GIFRegHandlerUV(const GIFReg* RESTRICT r);
 	void GIFRegHandlerUV_Hack(const GIFReg* RESTRICT r);
-	template<u32 prim, u32 adc, bool auto_flush, bool index_swap> void GIFRegHandlerXYZF2(const GIFReg* RESTRICT r);
-	template<u32 prim, u32 adc, bool auto_flush, bool index_swap> void GIFRegHandlerXYZ2(const GIFReg* RESTRICT r);
+	template<u32 prim, u32 adc, bool auto_flush> void GIFRegHandlerXYZF2(const GIFReg* RESTRICT r);
+	template<u32 prim, u32 adc, bool auto_flush> void GIFRegHandlerXYZ2(const GIFReg* RESTRICT r);
 	template<int i> void GIFRegHandlerTEX0(const GIFReg* RESTRICT r);
 	template<int i> void GIFRegHandlerCLAMP(const GIFReg* RESTRICT r);
 	void GIFRegHandlerFOG(const GIFReg* RESTRICT r);
@@ -102,8 +102,7 @@ private:
 	void GIFRegHandlerTRXDIR(const GIFReg* RESTRICT r);
 	void GIFRegHandlerHWREG(const GIFReg* RESTRICT r);
 
-	template<bool auto_flush, bool index_swap>
-	void SetPrimHandlers();
+	template<bool auto_flush> void SetPrimHandlers();
 
 	struct GSTransferBuffer
 	{
@@ -171,12 +170,10 @@ protected:
 
 	void GrowVertexBuffer();
 	bool IsAutoFlushDraw(u32 prim);
-	template<u32 prim, bool index_swap>
-	void HandleAutoFlush();
+	template<u32 prim> void HandleAutoFlush();
 	void CheckCLUTValidity(u32 prim);
 
-	template <u32 prim, bool auto_flush, bool index_swap>
-	void VertexKick(u32 skip);
+	template <u32 prim, bool auto_flush> void VertexKick(u32 skip);
 
 	// following functions need m_vt to be initialized
 

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -136,6 +136,7 @@ protected:
 	struct
 	{
 		GSVertex* buff;
+		GSVertex* buff_copy;            // same size buffer to copy/modify the original buffer
 		u32 head, tail, next, maxcount; // head: first vertex, tail: last vertex + 1, next: last indexed + 1
 		u32 xy_tail;
 		GSVector4i xy[4];

--- a/pcsx2/GS/Renderers/Common/GSVertexTrace.cpp
+++ b/pcsx2/GS/Renderers/Common/GSVertexTrace.cpp
@@ -7,10 +7,10 @@
 
 #include "common/Console.h"
 
-GSVertexTrace::GSVertexTrace(const GSState* state, bool provoking_vertex_first)
+GSVertexTrace::GSVertexTrace(const GSState* state)
 	: m_state(state)
 {
-	MULTI_ISA_SELECT(GSVertexTracePopulateFunctions)(*this, provoking_vertex_first);
+	MULTI_ISA_SELECT(GSVertexTracePopulateFunctions)(*this);
 }
 
 void GSVertexTrace::Update(const void* vertex, const u16* index, int v_count, int i_count, GS_PRIM_CLASS primclass)

--- a/pcsx2/GS/Renderers/Common/GSVertexTrace.h
+++ b/pcsx2/GS/Renderers/Common/GSVertexTrace.h
@@ -15,7 +15,7 @@ class GSState;
 class GSVertexTrace;
 
 MULTI_ISA_DEF(class GSVertexTraceFMM;)
-MULTI_ISA_DEF(void GSVertexTracePopulateFunctions(GSVertexTrace& vt, bool provoking_vertex_first);)
+MULTI_ISA_DEF(void GSVertexTracePopulateFunctions(GSVertexTrace& vt);)
 
 class alignas(32) GSVertexTrace final : public GSAlignedClass<32>
 {
@@ -63,7 +63,7 @@ public:
 	GSVector2 m_lod = {}; // x = min, y = max
 
 public:
-	GSVertexTrace(const GSState* state, bool provoking_vertex_first);
+	GSVertexTrace(const GSState* state);
 
 	void Update(const void* vertex, const u16* index, int v_count, int i_count, GS_PRIM_CLASS primclass);
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -92,6 +92,7 @@ private:
 	void DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Target* ds, GSTextureCache::Source* tex, const TextureMinMaxResult& tmm);
 
 	void ResetStates();
+	void HandleProvokingVertexFirst();
 	void SetupIA(float target_scale, float sx, float sy, bool req_vert_backup);
 	void EmulateTextureShuffleAndFbmask(GSTextureCache::Target* rt, GSTextureCache::Source* tex);
 	bool EmulateChannelShuffle(GSTextureCache::Target* src, bool test_only, GSTextureCache::Target* rt = nullptr);

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -233,9 +233,7 @@ vertex MainVSOut vs_main_expand(
 			uint vid_base = vid >> 2;
 			bool is_bottom = vid & 2;
 			bool is_right = vid & 1;
-			// All lines will be a pair of vertices next to each other
-			// Since Metal uses provoking vertex first, the bottom point will be the lower of the two
-			uint vid_other = is_bottom ? vid_base + 1 : vid_base - 1;
+			uint vid_other = is_bottom ? vid_base - 1 : vid_base + 1;
 			MainVSOut point = vs_main_run(load_vertex(vertices[vid_base]), cb);
 			MainVSOut other = vs_main_run(load_vertex(vertices[vid_other]), cb);
 

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 68;
+static constexpr u32 SHADER_CACHE_VERSION = 69;


### PR DESCRIPTION
### Description of Changes
Remove the handling of provoking first vertex in early pipeline GSState and GSVertexTrace (and other helper classes) and move it later pipeline GSRendererHW. This is mainly for DX11-12, Vulkan (when it doesn't support fast vertex provoking), and Metal. It should not affect OGL.

### Rationale behind Changes
There is unnecessary code complexity added early in the pipeline in GSState/GSVertexTrace (e.g., keeping track of when vertices are swapped in primitives and when not). Since provoking first vertex is a graphics API quirk, it is better to handle it in lower level code in GSRendererHW.

Also, the way provoking first vertex was implemented gave incorrect results in some cases since it swapped vertices in the draw. This could cause incorrect drawing of line primitives since lines may (and are usually) not drawn the same when interchanging the two endpoints. Affects DX11-12 and possibly Vulkan/Metal. See examples below.

Finally, the code paths that would actually be affected by the provoking first vertex behavior seem to rare (i.e., it only applies to flat shaded triangles/lines, among other criteria) so there is no point in handling it early in the pipeline (even though it may be cheaper to do so). Handling it later may have a small perf impact because the entire vertex buffer may need to be copied. However, I did a simple analysis of the ~2000 GS dumps in the testing collection and it seems that on average < 0.5% of draws actually use this path.

### Suggested Testing Steps
Tested this by doing a GS dump run with DX11. I have not tested on upscaling so that would be very helpful (must be tested eventually because upscaling shaders in DX11-12 were modified). Comparing between DX11-12/Vulkan/Metal and OGL could be helpful since OGL should not be affected by this PR. Testing random games would also work.

Some fixes for DX11 (PR left, master right):

![007](https://github.com/user-attachments/assets/a92be573-06f7-4f85-83ce-bcf5bedcaa85)
GS dump: "007 - Everything or Nothing_SLUS-20751_20240622211641.gs.xz"

![thx](https://github.com/user-attachments/assets/c0e00651-271b-4301-adc1-338a857e5a98)
GS dump from this issue: https://github.com/PCSX2/pcsx2/issues/12825.

### Did you use AI to help find, test, or implement this issue or feature?
GitHub Copilot.