### PR TITLE
GraphicsSettingsWidget: Correctly set current index

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -55,7 +55,7 @@
    <item>
     <widget class="QTabWidget" name="tabs">
      <property name="currentIndex">
-      <number>7</number>
+      <number>0</number>
      </property>
      <property name="documentMode">
       <bool>true</bool>


### PR DESCRIPTION
### Description of Changes
Fixes the current default section to it's proper tab.

Regression from #12979 

### Rationale behind Changes
This is bad don't be like Red and forget.

### Suggested Testing Steps
NA

### Did you use AI to help find, test, or implement this issue or feature?
No
