### PR TITLE
Qt: Move screenshot section to Recording tab

### DIFF
--- a/pcsx2-qt/Settings/AchievementSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AchievementSettingsWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>674</width>
-    <height>481</height>
+    <width>680</width>
+    <height>480</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -32,9 +32,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-2</y>
-        <width>655</width>
-        <height>739</height>
+        <y>0</y>
+        <width>661</width>
+        <height>700</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -187,13 +187,6 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
-           <widget class="QCheckBox" name="overlays">
-            <property name="text">
-             <string>Enable In-Game Overlays</string>
-            </property>
-           </widget>
-          </item>
          </layout>
         </widget>
        </item>
@@ -203,14 +196,7 @@
           <string>Overlay Settings</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_overlay">
-          <item row="0" column="0">
-           <widget class="QLabel" name="overlayPositionLabel">
-            <property name="text">
-             <string>Overlay Position:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
+          <item row="1" column="1">
            <widget class="QComboBox" name="overlayPosition">
             <item>
              <property name="text">
@@ -259,14 +245,14 @@
             </item>
            </widget>
           </item>
-          <item row="1" column="0">
+          <item row="2" column="0">
            <widget class="QLabel" name="notificationPositionLabel">
             <property name="text">
              <string>Notification Position:</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
+          <item row="2" column="1">
            <widget class="QComboBox" name="notificationPosition">
             <item>
              <property name="text">
@@ -320,7 +306,20 @@
             </item>
            </widget>
           </item>
-
+          <item row="1" column="0">
+           <widget class="QLabel" name="overlayPositionLabel">
+            <property name="text">
+             <string>Overlay Position:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="overlays">
+            <property name="text">
+             <string>Enable In-Game Overlays</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/pcsx2-qt/Settings/FolderSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/FolderSettingsWidget.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0+
 
 #include <QtWidgets/QMessageBox>
-#include <algorithm>
 
 #include "FolderSettingsWidget.h"
 #include "SettingWidgetBinder.h"
@@ -20,6 +19,7 @@ FolderSettingsWidget::FolderSettingsWidget(SettingsWindow* dialog, QWidget* pare
 	SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.covers, m_ui.coversBrowse, m_ui.coversOpen, m_ui.coversReset, "Folders", "Covers", Path::Combine(EmuFolders::DataRoot, "covers"));
 	SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.snapshots, m_ui.snapshotsBrowse, m_ui.snapshotsOpen, m_ui.snapshotsReset, "Folders", "Snapshots", Path::Combine(EmuFolders::DataRoot, "snaps"));
 	SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.saveStates, m_ui.saveStatesBrowse, m_ui.saveStatesOpen, m_ui.saveStatesReset, "Folders", "SaveStates", Path::Combine(EmuFolders::DataRoot, "sstates"));
+	SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.videoDumpingDirectory, m_ui.videoDumpingDirectoryBrowse, m_ui.videoDumpingDirectoryOpen, m_ui.videoDumpingDirectoryReset, "Folders", "Videos", Path::Combine(EmuFolders::DataRoot, "videos"));
 }
 
 FolderSettingsWidget::~FolderSettingsWidget() = default;

--- a/pcsx2-qt/Settings/FolderSettingsWidget.ui
+++ b/pcsx2-qt/Settings/FolderSettingsWidget.ui
@@ -10,231 +10,262 @@
     <height>487</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
-    <number>0</number>
-   </property>
-   <item>
-    <widget class="QGroupBox" name="groupBox_3">
-     <property name="title">
-      <string>Cache Directory</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <item row="1" column="0">
-       <widget class="QLineEdit" name="cache"/>
-      </item>
-      <item row="1" column="1">
-       <widget class="QPushButton" name="cacheBrowse">
-        <property name="text">
-         <string>Browse...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QPushButton" name="cacheOpen">
-        <property name="text">
-         <string>Open...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="3">
-       <widget class="QPushButton" name="cacheReset">
-        <property name="text">
-         <string>Reset</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0" colspan="4">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Used for storing shaders, game list, and achievement data.</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
+  <layout class="QGridLayout" name="gridLayout_6">
+   <item row="0" column="0" rowspan="2">
+    <widget class="QScrollArea" name="scrollArea">
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>665</width>
+        <height>600</height>
+       </rect>
+      </property>
+      <layout class="QGridLayout" name="gridLayout_8">
+       <item row="0" column="0">
+        <widget class="QGroupBox" name="cacheGroup">
+         <property name="title">
+          <string>Cache Directory</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_3">
+          <item row="1" column="0">
+           <widget class="QLineEdit" name="cache"/>
+          </item>
+          <item row="1" column="1">
+           <widget class="QPushButton" name="cacheBrowse">
+            <property name="text">
+             <string>Browse...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QPushButton" name="cacheOpen">
+            <property name="text">
+             <string>Open...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="QPushButton" name="cacheReset">
+            <property name="text">
+             <string>Reset</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0" colspan="4">
+           <widget class="QLabel" name="cacheLabel">
+            <property name="text">
+             <string>Used for storing shaders, game list, and achievement data.</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QGroupBox" name="saveStatesGroup">
+         <property name="title">
+          <string>Save States Directory</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_2">
+          <item row="0" column="0" colspan="4">
+           <widget class="QLabel" name="saveStatesLabel">
+            <property name="text">
+             <string>Used for storing save states.</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QPushButton" name="saveStatesBrowse">
+            <property name="text">
+             <string>Browse...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="QPushButton" name="saveStatesReset">
+            <property name="text">
+             <string>Reset</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLineEdit" name="saveStates"/>
+          </item>
+          <item row="1" column="2">
+           <widget class="QPushButton" name="saveStatesOpen">
+            <property name="text">
+             <string>Open...</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QGroupBox" name="cheatsGroup">
+         <property name="title">
+          <string>Cheats Directory</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_5">
+          <item row="1" column="0">
+           <widget class="QLineEdit" name="cheats"/>
+          </item>
+          <item row="1" column="1">
+           <widget class="QPushButton" name="cheatsBrowse">
+            <property name="text">
+             <string>Browse...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QPushButton" name="cheatsOpen">
+            <property name="text">
+             <string>Open...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="QPushButton" name="cheatsReset">
+            <property name="text">
+             <string>Reset</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0" colspan="4">
+           <widget class="QLabel" name="cheatsLabel">
+            <property name="text">
+             <string>Used for storing .pnach files containing game cheats.</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QGroupBox" name="snapshotsGroup">
+         <property name="title">
+          <string>Snapshots Directory</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout">
+          <item row="1" column="0">
+           <widget class="QLineEdit" name="snapshots"/>
+          </item>
+          <item row="1" column="1">
+           <widget class="QPushButton" name="snapshotsBrowse">
+            <property name="text">
+             <string>Browse...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QPushButton" name="snapshotsOpen">
+            <property name="text">
+             <string>Open...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="QPushButton" name="snapshotsReset">
+            <property name="text">
+             <string>Reset</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0" colspan="4">
+           <widget class="QLabel" name="snaphotsLabel">
+            <property name="text">
+             <string>Used for screenshots and saving GS dumps.</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QGroupBox" name="coversGroup">
+         <property name="title">
+          <string>Covers Directory</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_4">
+          <item row="1" column="0">
+           <widget class="QLineEdit" name="covers"/>
+          </item>
+          <item row="1" column="1">
+           <widget class="QPushButton" name="coversBrowse">
+            <property name="text">
+             <string>Browse...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QPushButton" name="coversOpen">
+            <property name="text">
+             <string>Open...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="QPushButton" name="coversReset">
+            <property name="text">
+             <string>Reset</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0" colspan="4">
+           <widget class="QLabel" name="coversLabel">
+            <property name="text">
+             <string>Used for storing covers in the game grid/Big Picture UIs.</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QGroupBox" name="videoDumpDirectory">
+         <property name="title">
+          <string>Video Dumping Directory</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_7">
+          <item row="3" column="2">
+           <widget class="QPushButton" name="videoDumpingDirectoryOpen">
+            <property name="text">
+             <string>Open...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLineEdit" name="videoDumpingDirectory"/>
+          </item>
+          <item row="3" column="1">
+           <widget class="QPushButton" name="videoDumpingDirectoryBrowse">
+            <property name="text">
+             <string>Browse...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="3">
+           <widget class="QPushButton" name="videoDumpingDirectoryReset">
+            <property name="text">
+             <string>Reset</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="videoDumpLabel">
+            <property name="text">
+             <string>Used for storing video captures.</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_5">
-     <property name="title">
-      <string>Cheats Directory</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_5">
-      <item row="1" column="0">
-       <widget class="QLineEdit" name="cheats"/>
-      </item>
-      <item row="1" column="1">
-       <widget class="QPushButton" name="cheatsBrowse">
-        <property name="text">
-         <string>Browse...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QPushButton" name="cheatsOpen">
-        <property name="text">
-         <string>Open...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="3">
-       <widget class="QPushButton" name="cheatsReset">
-        <property name="text">
-         <string>Reset</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0" colspan="4">
-       <widget class="QLabel" name="label_5">
-        <property name="text">
-         <string>Used for storing .pnach files containing game cheats.</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_4">
-     <property name="title">
-      <string>Covers Directory</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_4">
-      <item row="1" column="0">
-       <widget class="QLineEdit" name="covers"/>
-      </item>
-      <item row="1" column="1">
-       <widget class="QPushButton" name="coversBrowse">
-        <property name="text">
-         <string>Browse...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QPushButton" name="coversOpen">
-        <property name="text">
-         <string>Open...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="3">
-       <widget class="QPushButton" name="coversReset">
-        <property name="text">
-         <string>Reset</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0" colspan="4">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Used for storing covers in the game grid/Big Picture UIs.</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>Snapshots Directory</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="1" column="0">
-       <widget class="QLineEdit" name="snapshots"/>
-      </item>
-      <item row="1" column="1">
-       <widget class="QPushButton" name="snapshotsBrowse">
-        <property name="text">
-         <string>Browse...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QPushButton" name="snapshotsOpen">
-        <property name="text">
-         <string>Open...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="3">
-       <widget class="QPushButton" name="snapshotsReset">
-        <property name="text">
-         <string>Reset</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0" colspan="4">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Used for screenshots and saving GS dumps.</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="title">
-      <string>Save States Directory</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="1" column="0">
-       <widget class="QLineEdit" name="saveStates"/>
-      </item>
-      <item row="1" column="1">
-       <widget class="QPushButton" name="saveStatesBrowse">
-        <property name="text">
-         <string>Browse...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QPushButton" name="saveStatesOpen">
-        <property name="text">
-         <string>Open...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="3">
-       <widget class="QPushButton" name="saveStatesReset">
-        <property name="text">
-         <string>Reset</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0" colspan="4">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Used for storing save states.</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>132</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -130,7 +130,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdShowHardwareInfo, "EmuCore/GS", "OsdShowHardwareInfo", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdShowVideoCapture, "EmuCore/GS", "OsdShowVideoCapture", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdShowInputRec, "EmuCore/GS", "OsdShowInputRec", true);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.warnAboutUnsafeSettings, "EmuCore", "WarnAboutUnsafeSettings", true);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdWarnAboutUnsafeSettings, "EmuCore", "osdWarnAboutUnsafeSettings", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.fxaa, "EmuCore/GS", "fxaa", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.shadeBoost, "EmuCore/GS", "ShadeBoost", false);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.shadeBoostBrightness, "EmuCore/GS", "ShadeBoost_Brightness", false);
@@ -409,10 +409,6 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 			m_ui.captureContainer->addItem(name.toUpper(), name);
 		}
 
-		SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.videoDumpingDirectory, m_ui.videoDumpingDirectoryBrowse,
-			m_ui.videoDumpingDirectoryOpen, m_ui.videoDumpingDirectoryReset, "Folders", "Videos",
-			Path::Combine(EmuFolders::DataRoot, "videos"));
-
 		SettingWidgetBinder::BindWidgetToStringSetting(sif, m_ui.captureContainer, "EmuCore/GS", "CaptureContainer");
 		connect(m_ui.captureContainer, &QComboBox::currentIndexChanged, this, &GraphicsSettingsWidget::onCaptureContainerChanged);
 
@@ -451,18 +447,6 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 		onVideoCaptureAutoResolutionChanged();
 		onEnableAudioCaptureChanged();
 		onEnableAudioCaptureArgumentsChanged();
-
-		if (m_dialog->isPerGameSettings())
-		{
-			m_ui.recordingTabLayout->removeWidget(m_ui.videoDumpDirectory);
-			m_ui.videoDumpDirectory->deleteLater();
-			m_ui.videoDumpDirectory = nullptr;
-			m_ui.videoDumpLayout = nullptr;
-			m_ui.videoDumpingDirectory = nullptr;
-			m_ui.videoDumpingDirectoryBrowse = nullptr;
-			m_ui.videoDumpingDirectoryOpen = nullptr;
-			m_ui.videoDumpingDirectoryReset = nullptr;
-		}
 	}
 
 	// Display tab
@@ -506,7 +490,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 
 		dialog->registerWidgetHelp(m_ui.interlacing, tr("Deinterlacing"), tr("Automatic (Default)"), tr("Determines the deinterlacing method to be used on the interlaced screen of the emulated console. Automatic should be able to correctly deinterlace most games, but if you see visibly shaky graphics, try one of the other options."));
 
-		dialog->registerWidgetHelp(m_ui.screenshotSize, tr("Screenshot Size"), tr("Screen Resolution"),
+		dialog->registerWidgetHelp(m_ui.screenshotSize, tr("Screenshot Resolution"), tr("Screen Resolution"),
 			tr("Determines the resolution at which screenshots will be saved. Internal resolutions preserve more detail at the cost of "
 			   "file size."));
 
@@ -799,7 +783,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 		dialog->registerWidgetHelp(m_ui.osdShowHardwareInfo, tr("Show Hardware Info"), tr("Unchecked"),
 			tr("Shows the current system hardware information on the OSD."));
 
-		dialog->registerWidgetHelp(m_ui.warnAboutUnsafeSettings, tr("Warn About Unsafe Settings"), tr("Checked"),
+		dialog->registerWidgetHelp(m_ui.osdWarnAboutUnsafeSettings, tr("Warn About Unsafe Settings"), tr("Checked"),
 			tr("Displays warnings when settings are enabled which may break games."));
 	}
 
@@ -957,7 +941,7 @@ void GraphicsSettingsWidget::onMessagesPosChanged()
 {
 	const bool enabled = m_ui.osdMessagesPos->currentIndex() != (m_dialog->isPerGameSettings() ? 1 : 0);
 
-	m_ui.warnAboutUnsafeSettings->setEnabled(enabled);
+	m_ui.osdWarnAboutUnsafeSettings->setEnabled(enabled);
 }
 
 void GraphicsSettingsWidget::onPerformancePosChanged()

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>720</width>
-    <height>656</height>
+    <height>588</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -235,82 +235,13 @@
         </widget>
        </item>
        <item row="5" column="0">
-        <widget class="QLabel" name="screenshotSizeLabel">
-         <property name="text">
-          <string>Screenshot Size:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <layout class="QHBoxLayout" name="screenshotLayout" stretch="1,0,0,0">
-         <item>
-          <widget class="QComboBox" name="screenshotSize">
-           <item>
-            <property name="text">
-             <string>Window Resolution (Aspect Corrected)</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Internal Resolution (Aspect Corrected)</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Internal Resolution (No Aspect Correction)</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="screenshotFormat">
-           <item>
-            <property name="text">
-             <string>PNG</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>JPEG</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>WebP</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="screenshotQualityLabel">
-           <property name="text">
-            <string>Quality:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QSpinBox" name="screenshotQuality">
-           <property name="suffix">
-            <string>%</string>
-           </property>
-           <property name="minimum">
-            <number>1</number>
-           </property>
-           <property name="maximum">
-            <number>100</number>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item row="6" column="0">
         <widget class="QLabel" name="verticalStretchLabel">
          <property name="text">
           <string>Vertical Stretch:</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="5" column="1">
         <widget class="QSpinBox" name="stretchY">
          <property name="suffix">
           <string extracomment="Percentage sign that shows next to a value. You might want to add a space before if your language requires it.">%</string>
@@ -323,14 +254,14 @@
          </property>
         </widget>
        </item>
-       <item row="7" column="0">
+       <item row="6" column="0">
         <widget class="QLabel" name="cropLabel">
          <property name="text">
           <string>Crop:</string>
          </property>
         </widget>
        </item>
-       <item row="7" column="1">
+       <item row="6" column="1">
         <layout class="QHBoxLayout" name="cropLayout" stretch="0,1,0,1,0,1,0,1">
          <item>
           <widget class="QLabel" name="cropLeftLabel">
@@ -402,7 +333,7 @@
          </item>
         </layout>
        </item>
-       <item row="8" column="0" colspan="2">
+       <item row="7" column="0" colspan="2">
         <layout class="QGridLayout" name="displayGridLayout">
          <item row="1" column="1">
           <widget class="QCheckBox" name="integerScaling">
@@ -465,24 +396,14 @@
        <string>Rendering</string>
       </attribute>
       <layout class="QFormLayout" name="formLayout_4">
-       <item row="0" column="0">
-        <widget class="QLabel" name="internalResLabel">
-         <property name="text">
-          <string>Internal Resolution:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QComboBox" name="upscaleMultiplier"/>
-       </item>
-       <item row="2" column="0">
+       <item row="4" column="0">
         <widget class="QLabel" name="textureFilteringLabel">
          <property name="text">
           <string>Texture Filtering:</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
+       <item row="4" column="1">
         <widget class="QComboBox" name="textureFiltering">
          <item>
           <property name="text">
@@ -506,14 +427,14 @@
          </item>
         </widget>
        </item>
-       <item row="3" column="0">
+       <item row="5" column="0">
         <widget class="QLabel" name="trilinearFilterLabel">
          <property name="text">
           <string>Trilinear Filtering:</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="5" column="1">
         <widget class="QComboBox" name="trilinearFiltering">
          <item>
           <property name="text">
@@ -537,24 +458,24 @@
          </item>
         </widget>
        </item>
-       <item row="4" column="0">
+       <item row="6" column="0">
         <widget class="QLabel" name="anisotropicFilteringLabel">
          <property name="text">
           <string>Anisotropic Filtering:</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="6" column="1">
         <widget class="QComboBox" name="anisotropicFiltering"/>
        </item>
-       <item row="5" column="0">
+       <item row="7" column="0">
         <widget class="QLabel" name="ditheringLabel">
          <property name="text">
           <string>Dithering:</string>
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="7" column="1">
         <widget class="QComboBox" name="dithering">
          <item>
           <property name="text">
@@ -578,14 +499,14 @@
          </item>
         </widget>
        </item>
-       <item row="6" column="0">
+       <item row="8" column="0">
         <widget class="QLabel" name="blendingLabel">
          <property name="text">
           <string>Blending Accuracy:</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="8" column="1">
         <widget class="QComboBox" name="blending">
          <item>
           <property name="text">
@@ -619,7 +540,7 @@
          </item>
         </widget>
        </item>
-       <item row="7" column="0" colspan="2">
+       <item row="9" column="0" colspan="2">
         <layout class="QGridLayout" name="hardwareRenderingOptionsLayout">
          <item row="0" column="1">
           <widget class="QCheckBox" name="enableHWFixes">
@@ -636,6 +557,16 @@
           </widget>
          </item>
         </layout>
+       </item>
+       <item row="3" column="1">
+        <widget class="QComboBox" name="upscaleMultiplier"/>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="internalResLabel">
+         <property name="text">
+          <string>Internal Resolution:</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>
@@ -663,7 +594,7 @@
           </sizepolicy>
          </property>
          <property name="layoutDirection">
-          <enum>Qt::LeftToRight</enum>
+          <enum>Qt::LayoutDirection::LeftToRight</enum>
          </property>
          <item>
           <property name="text">
@@ -702,7 +633,7 @@
         </widget>
        </item>
        <item row="2" column="0" colspan="2">
-        <layout class="QGridLayout" name="gridLayout_2">
+        <layout class="QGridLayout" name="swRenderingLayout">
          <item row="0" column="1">
           <widget class="QCheckBox" name="swMipmap">
            <property name="text">
@@ -1315,7 +1246,7 @@
        <item>
         <spacer name="verticalSpacer_4">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -1333,7 +1264,7 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_5">
        <item>
-        <widget class="QGroupBox" name="groupBox_5">
+        <widget class="QGroupBox" name="sharpeningGrroup">
          <property name="title">
           <string>Sharpening/Anti-Aliasing</string>
          </property>
@@ -1471,7 +1402,20 @@
             <item>
              <spacer name="horizontalSpacer">
               <property name="orientation">
-               <enum>Qt::Vertical</enum>
+               <enum>Qt::Orientation::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Orientation::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -1540,7 +1484,7 @@
        <item>
         <spacer name="verticalSpacer_5">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -1714,7 +1658,7 @@
           <item row="4" column="0" colspan="2">
            <layout class="QGridLayout" name="osdOptionLayout" rowstretch="0,0,0,0,0,0,0,0,0,0,0">
             <property name="sizeConstraint">
-             <enum>QLayout::SetDefaultConstraint</enum>
+             <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
             </property>
             <property name="topMargin">
              <number>10</number>
@@ -1758,7 +1702,7 @@
              </widget>
             </item>
             <item row="10" column="2">
-             <widget class="QCheckBox" name="warnAboutUnsafeSettings">
+             <widget class="QCheckBox" name="osdWarnAboutUnsafeSettings">
               <property name="text">
                <string>Warn About Unsafe Settings</string>
               </property>
@@ -1885,10 +1829,10 @@
           <item row="3" column="0" colspan="2">
            <spacer name="verticalSpacer_7">
             <property name="orientation">
-             <enum>Qt::Vertical</enum>
+             <enum>Qt::Orientation::Vertical</enum>
             </property>
             <property name="sizeType">
-             <enum>QSizePolicy::Fixed</enum>
+             <enum>QSizePolicy::Policy::Fixed</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -1904,10 +1848,10 @@
        <item>
         <spacer name="verticalSpacer_3">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Maximum</enum>
+          <enum>QSizePolicy::Policy::Maximum</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -1921,16 +1865,94 @@
      </widget>
      <widget class="QGroupBox" name="recordingTab">
       <attribute name="title">
-       <string>Recording</string>
+       <string>Media Capture</string>
       </attribute>
       <layout class="QVBoxLayout" name="recordingTabLayout">
+       <item>
+        <widget class="QGroupBox" name="groupBox">
+         <property name="title">
+          <string>Screenshot Capture Setup</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_2">
+          <item row="0" column="0">
+           <layout class="QHBoxLayout" name="screenshotLayout" stretch="0,1,0,0,0">
+            <item>
+             <widget class="QLabel" name="screenshotSizeLabel">
+              <property name="text">
+               <string>Resolution:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="screenshotSize">
+              <item>
+               <property name="text">
+                <string>Window Resolution (Aspect Corrected)</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Internal Resolution (Aspect Corrected)</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Internal Resolution (No Aspect Correction)</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="screenshotFormat">
+              <item>
+               <property name="text">
+                <string>PNG</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>JPEG</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>WebP</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="screenshotQualityLabel">
+              <property name="text">
+               <string>Quality:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="screenshotQuality">
+              <property name="suffix">
+               <string>%</string>
+              </property>
+              <property name="minimum">
+               <number>1</number>
+              </property>
+              <property name="maximum">
+               <number>100</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
        <item>
         <widget class="QGroupBox" name="captureTabGroupBox">
          <property name="statusTip">
           <string>capture</string>
          </property>
          <property name="title">
-          <string>Capture Setup</string>
+          <string>Video Recording Setup</string>
          </property>
          <layout class="QFormLayout" name="captureTabGroupBoxLayout">
           <item row="0" column="0">
@@ -2085,7 +2107,7 @@
                 </widget>
                </item>
                <item row="3" column="1">
-                <layout class="QHBoxLayout" name="horizontalLayout_10" stretch="1,0,1,0">
+                <layout class="QHBoxLayout" name="videoCaptureResolutionLayout" stretch="1,0,1,0">
                  <item>
                   <widget class="QSpinBox" name="videoCaptureWidth">
                    <property name="minimum">
@@ -2160,46 +2182,9 @@
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="videoDumpDirectory">
-         <property name="title">
-          <string>Video Dumping Directory</string>
-         </property>
-         <layout class="QVBoxLayout" name="videoDumpDirectoryLayout">
-          <item>
-           <layout class="QHBoxLayout" name="videoDumpLayout">
-            <item>
-             <widget class="QLineEdit" name="videoDumpingDirectory"/>
-            </item>
-            <item>
-             <widget class="QPushButton" name="videoDumpingDirectoryBrowse">
-              <property name="text">
-               <string>Browse...</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="videoDumpingDirectoryOpen">
-              <property name="text">
-               <string>Open...</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="videoDumpingDirectoryReset">
-              <property name="text">
-               <string>Reset</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
         <spacer name="verticalSpacer_6">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -2280,7 +2265,7 @@
            </widget>
           </item>
           <item row="10" column="0" colspan="2">
-           <layout class="QGridLayout" name="gridLayout_9">
+           <layout class="QGridLayout" name="advancedLayout">
             <item row="1" column="1">
              <widget class="QCheckBox" name="extendedUpscales">
               <property name="text">
@@ -2443,7 +2428,7 @@
        <item>
         <spacer name="verticalSpacer_2">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -2460,7 +2445,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -1264,7 +1264,7 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_5">
        <item>
-        <widget class="QGroupBox" name="sharpeningGrroup">
+        <widget class="QGroupBox" name="sharpeningGroup">
          <property name="title">
           <string>Sharpening/Anti-Aliasing</string>
          </property>
@@ -1277,7 +1277,7 @@
            </widget>
           </item>
           <item row="0" column="1">
-           <layout class="QHBoxLayout" name="horizontalLayout_6">
+           <layout class="QHBoxLayout" name="casLayout">
             <item>
              <widget class="QComboBox" name="casMode">
               <item>
@@ -1298,7 +1298,7 @@
              </widget>
             </item>
             <item>
-             <layout class="QHBoxLayout" name="horizontalLayout_7">
+             <layout class="QHBoxLayout" name="sharpnessLayout">
               <item>
                <widget class="QLabel" name="casSharpnessLabel">
                 <property name="text">
@@ -1334,11 +1334,11 @@
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="groupBox_7">
+        <widget class="QGroupBox" name="filtersLayout">
          <property name="title">
           <string>Filters</string>
          </property>
-         <layout class="QFormLayout" name="formLayout_5">
+         <layout class="QGridLayout" name="gridLayout_4">
           <item row="0" column="0">
            <widget class="QLabel" name="tvShaderLabel">
             <property name="text">
@@ -1398,33 +1398,7 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <layout class="QHBoxLayout" name="horizontalLayout_4">
-            <item>
-             <spacer name="horizontalSpacer">
-              <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer">
-              <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
+           <layout class="QHBoxLayout" name="shadeBoostLayout">
             <item>
              <widget class="QLabel" name="brightnessLabel">
               <property name="text">
@@ -1482,7 +1456,7 @@
         </widget>
        </item>
        <item>
-        <spacer name="verticalSpacer_5">
+        <spacer name="postSpacer">
          <property name="orientation">
           <enum>Qt::Orientation::Vertical</enum>
          </property>
@@ -1507,46 +1481,6 @@
           <string>On-Screen Display</string>
          </property>
          <layout class="QGridLayout" name="gridLayout">
-          <item row="2" column="0">
-           <widget class="QLabel" name="osdPerformancePosLabel">
-            <property name="text">
-             <string>OSD Performance Position:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="osdScaleLabel">
-            <property name="text">
-             <string>OSD Scale:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QSpinBox" name="osdScale">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="suffix">
-             <string>%</string>
-            </property>
-            <property name="minimum">
-             <number>50</number>
-            </property>
-            <property name="maximum">
-             <number>500</number>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="osdMessagesPosLabel">
-            <property name="text">
-             <string>OSD Messages Position:</string>
-            </property>
-           </widget>
-          </item>
           <item row="1" column="1">
            <widget class="QComboBox" name="osdMessagesPos">
             <item>
@@ -1653,6 +1587,46 @@
               <string>Bottom Right</string>
              </property>
             </item>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="osdMessagesPosLabel">
+            <property name="text">
+             <string>OSD Messages Position:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="osdPerformancePosLabel">
+            <property name="text">
+             <string>OSD Performance Position:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="osdScale">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="suffix">
+             <string>%</string>
+            </property>
+            <property name="minimum">
+             <number>50</number>
+            </property>
+            <property name="maximum">
+             <number>500</number>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="osdScaleLabel">
+            <property name="text">
+             <string>OSD Scale:</string>
+            </property>
            </widget>
           </item>
           <item row="4" column="0" colspan="2">
@@ -1804,7 +1778,7 @@
              </widget>
             </item>
             <item row="9" column="2">
-             <widget class="QLabel" name="label_2">
+             <widget class="QLabel" name="osdWarningLabel">
               <property name="text">
                <string>Warnings For User</string>
               </property>
@@ -1827,7 +1801,7 @@
            </layout>
           </item>
           <item row="3" column="0" colspan="2">
-           <spacer name="verticalSpacer_7">
+           <spacer name="osdCheckboxSpacer">
             <property name="orientation">
              <enum>Qt::Orientation::Vertical</enum>
             </property>
@@ -2441,19 +2415,6 @@
       </layout>
      </widget>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Orientation::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>60</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/pcsx2-qt/Settings/SettingsWindow.ui
+++ b/pcsx2-qt/Settings/SettingsWindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>800</width>
-    <height>500</height>
+    <height>450</height>
    </rect>
   </property>
   <property name="sizePolicy">


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
This PR moves the screenshot section from the Display tab over to the Recording tab, then subsequently rename that tab to Capture.

A small followup to #12979
![image](https://github.com/user-attachments/assets/008bcd7e-e9ad-4ef9-adc4-eb44f337609a)

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Better organizations.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
See if the screenshot sections shows up correctly and make sure the option still works.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
Nada