### PR TITLE
Memcard: Remove a buggy assertion

### DIFF
--- a/pcsx2/SIO/Memcard/MemoryCardFile.cpp
+++ b/pcsx2/SIO/Memcard/MemoryCardFile.cpp
@@ -655,9 +655,6 @@ static bool FileMcd_IsAutoEjecting()
 
 void FileMcd_Swap()
 {
-	//Assert that this is called on the CPU thread
-	pxAssert(Host::RunOnCPUThread([]() { return true; }, true) && "FileMcd_Swap must be called under Host::RunOnCPUThread"); 
-
 	if (MemcardBusy::IsBusy())
 	{
 		Host::AddIconOSDMessage("MemoryCardSwap_Busy", ICON_PF_MEMORY_CARD, TRANSLATE_SV("MemoryCardSwap_Busy", "Memory cards are busy. Can't swap right now."));


### PR DESCRIPTION
### Description of Changes
Remove a broken assertion statement in FileMcd_Swap.

### Rationale behind Changes
It broke the build.

This new hotkey seems to crash PCSX2 when I press it, someone more experienced with the memory card stuff should probably look into that (update: actually it looks like it might be to do with STL iterators in the InputManager, so maybe it only happens on Linux). This is just a quick fix for now.

### Suggested Testing Steps
Try compiling a debug build.

### Did you use AI to help find, test, or implement this issue or feature?
No.
