### PR TITLE
PINE: Give the server thread a name

### DIFF
--- a/pcsx2/PINE.cpp
+++ b/pcsx2/PINE.cpp
@@ -8,6 +8,7 @@
 #include "Elfheader.h"
 #include "PINE.h"
 #include "VMManager.h"
+#include "common/Threading.h"
 
 #include <atomic>
 #include <cstdio>
@@ -392,6 +393,8 @@ bool PINEServer::AcceptClient()
 
 void PINEServer::MainLoop()
 {
+	Threading::SetNameOfCurrentThread("PINE Server");
+
 	while (!m_end.load(std::memory_order_acquire))
 	{
 		if (!AcceptClient())


### PR DESCRIPTION
### Description of Changes
Give the PINE server thread a name.

### Rationale behind Changes
Previously it showed up as "CPU Thread" in gdb, was kinda confusing.

### Suggested Testing Steps
- Open PCSX2 under gdb.
- Make sure PINE is enabled.
- Use the command: `info threads`

### Did you use AI to help find, test, or implement this issue or feature?
ⓃⓄ
