### PR TITLE
GS/HW: Add CRC for Sand Grain Games palette shuffle effect.

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -24330,6 +24330,7 @@ SLES-53804:
     nativeScaling: 1 # Fixes depth intensity.
     textureInsideRT: 1 # Fixes depth blur.
     estimateTextureRegion: 1 # Massively improves performance in certain situations.
+    getSkipCount: "GSC_SandGrainGames"
 SLES-53805:
   name: "Cocoto Funfair"
   region: "PAL-M5"
@@ -26906,6 +26907,8 @@ SLES-54653:
 SLES-54655:
   name: "Cabela's African Safari"
   region: "PAL-A"
+  gsHWFixes:
+    getSkipCount: "GSC_SandGrainGames"
 SLES-54656:
   name: "EyeToy - Bob the Builder"
   region: "PAL-E"
@@ -28470,9 +28473,12 @@ SLES-55102:
     halfPixelOffset: 5 # Fixes depth alignment.
     nativeScaling: 1 # Fixes depth intensity.
     textureInsideRT: 1 # Fixes depth blur.
+    getSkipCount: "GSC_SandGrainGames"
 SLES-55103:
   name: "Cabela's Big Game Hunter [2007]"
   region: "PAL-E"
+  gsHWFixes:
+    getSkipCount: "GSC_SandGrainGames"
 SLES-55104:
   name: "UEFA Euro 2008 - Austria-Switzerland"
   region: "PAL-E"
@@ -37279,6 +37285,8 @@ SLPM-62286:
   name-sort: "もんすたーばす"
   name-en: "Monster Bass"
   region: "NTSC-J"
+  gsHWFixes:
+    getSkipCount: "GSC_SandGrainGames"
 SLPM-62287:
   name: "ファイヤープロレスリングZ 闘辞苑 同梱BOX"
   name-sort: "ふぁいやーぷろれすりんぐZ とうじえん どうこんBOX"
@@ -69748,6 +69756,7 @@ SLUS-21289:
     nativeScaling: 1 # Fixes depth intensity.
     textureInsideRT: 1 # Fixes depth blur.
     estimateTextureRegion: 1 # Massively improves performance in certain situations.
+    getSkipCount: "GSC_SandGrainGames"
 SLUS-21290:
   name: "Ford Street Racing"
   region: "NTSC-U"
@@ -70375,6 +70384,8 @@ SLUS-21379:
   name: "Cabela's African Safari"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_SandGrainGames"
 SLUS-21380:
   name: "Snoopy vs. the Red Baron"
   region: "NTSC-U"
@@ -71733,10 +71744,14 @@ SLUS-21624:
   name: "Cabela's Trophy Bucks"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_SandGrainGames"
 SLUS-21625:
   name: "Cabela's Big Game Hunter [2007]"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_SandGrainGames"
 SLUS-21626:
   name: "Stuntman - Ignition"
   region: "NTSC-U"
@@ -72216,6 +72231,7 @@ SLUS-21712:
     halfPixelOffset: 5 # Fixes depth alignment.
     nativeScaling: 1 # Fixes depth intensity.
     textureInsideRT: 1 # Fixes depth blur.
+    getSkipCount: "GSC_SandGrainGames"
 SLUS-21713:
   name: "Winter Sports 2008 - The Ultimate Challenge"
   region: "NTSC-U"
@@ -72233,6 +72249,8 @@ SLUS-21715:
   name: "Cabela's Monster Bass"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_SandGrainGames"
 SLUS-21716:
   name: "The Spiderwick Chronicles"
   name-sort: "Spiderwick Chronicles, The"
@@ -72675,6 +72693,8 @@ SLUS-21789:
   name: "Cabela's Legendary Adventures"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    getSkipCount: "GSC_SandGrainGames"
 SLUS-21790:
   name: "DreamWorks Shrek's Carnival Craze - Party Games"
   region: "NTSC-U"

--- a/pcsx2/GS/Renderers/HW/GSHwHack.h
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.h
@@ -12,6 +12,7 @@ public:
 	static bool GSC_SFEX3(GSRendererHW& r, int& skip);
 	static bool GSC_DTGames(GSRendererHW& r, int& skip);
 	static bool GSC_NamcoGames(GSRendererHW& r, int& skip);
+	static bool GSC_SandGrainGames(GSRendererHW& r, int& skip);
 	static bool GSC_BurnoutGames(GSRendererHW& r, int& skip);
 	static bool GSC_BlackAndBurnoutSky(GSRendererHW& r, int& skip);
 	static bool GSC_MidnightClub3(GSRendererHW& r, int& skip);


### PR DESCRIPTION
### Description of Changes
Adds CRC for Sand Grain Games games.

### Rationale behind Changes
We have no way to do this effect directly without having 50-100 readbacks per frame, which is very very slow, this emulates the effect they're trying to achieve (G->A shuffle with palette)

### Suggested Testing Steps
Test Cabela's African Safari, The History Channel - Battle for the Pacific, SeaWorld Adventure Parks - Shamu's Deep Sea Adventure

If you have other Cabela games, it would be interesting to know if any of them have a lot of readbacks and also require this, I don't have them to check, but I don't suspect they all do and don't want to blindly add it.  Keep in mind it may only be the pause screen.

Edit: Added the following games:
Cabela's Big Game Hunter 2007
Cabela's Legendary Adventures
Cabela's Monster Bass
Cabela's Trophy Bucks

### Did you use AI to help find, test, or implement this issue or feature?
No.

### Newly fixed/changes:

Expecting performance to be considerably higher on affected games.

## Stat changes:

Cabela's African Safari:
Draw Calls: -156 [318=>162]
Render Passes: -156 [176=>20]
Copies: -52 [57=>5]
Readbacks: -52 [53=>1]

Cabela's Big Game Hunter [2007]:
Draw Calls: -104 [376=>272]
Render Passes: -104 [123=>19]
Copies: -35 [41=>6]
Uploads: -18 [45=>27]
Readbacks: -35 [36=>1]

Cabela's Legendary Adventures:
Stats are missing in dump run likey due to threading hazard, but assume losing a whole ton of readbacks and draws.

Cabela's Monster Bass:
Draw Calls: -208 [987=>779]
Render Passes: -208 [251=>43]
Copies: -69 [83=>14]
Uploads: -5 [21=>16]
Readbacks: -70 [71=>1]

Cabela's Trophy Bucks:
Stats are missing in dump run likey due to threading hazard, but assume losing a whole ton of readbacks and draws.

History Channel - Battle for the Pacific (These stats might be also because I had it set to "full" blending, which is recommended, but the drop is true):
Draw Calls: -3940 [7150=>3210]
Render Passes: -207 [242=>35]
Barriers: -3876 [6573=>2697]
Copies: -68 [82=>14]
Uploads: -19 [42=>23]
Readbacks: -70 [71=>1]


## Comparison Shots:

Cabela's Big Game Hunter 2007:
Master:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/990a9c71-05a7-4af6-8893-10f1675d2b2b" />
PR:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/9fe5babe-9dda-43f1-9520-d301187becdd" />

Cabela's Legendary Adventures:
Master:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/b5ed3157-29d4-4530-9829-5afd1c77dc91" />
PR:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/c38d11e4-9a31-4e51-a070-8f6bd29b363d" />

Cabela's Trophy Bucks:
Master:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/707dcddf-8526-414f-835d-33d5f5ddd35d" />
PR:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/3c1f3d02-29ba-4d6c-b4b1-f6e82afea03b" />
