### PR TITLE
Hotkeys: Better organize hotkeys page

### DIFF
--- a/pcsx2-qt/Settings/HotkeySettingsWidget.cpp
+++ b/pcsx2-qt/Settings/HotkeySettingsWidget.cpp
@@ -53,16 +53,24 @@ void HotkeySettingsWidget::createButtons()
 		auto iter = m_categories.find(category);
 		if (iter == m_categories.end())
 		{
+			// Top line
+			QLabel* top_line = new QLabel(m_container);
+			top_line->setFrameShape(QFrame::HLine);
+			top_line->setFixedHeight(12);
+			m_layout->addWidget(top_line);
+
+			// Category label
 			QLabel* label = new QLabel(category, m_container);
 			QFont label_font(label->font());
 			label_font.setPointSizeF(14.0f);
 			label->setFont(label_font);
 			m_layout->addWidget(label);
 
-			QLabel* line = new QLabel(m_container);
-			line->setFrameShape(QFrame::HLine);
-			line->setFixedHeight(4);
-			m_layout->addWidget(line);
+			// Bottom line
+			QLabel* bottom_line = new QLabel(m_container);
+			bottom_line->setFrameShape(QFrame::HLine);
+			bottom_line->setFixedHeight(12);
+			m_layout->addWidget(bottom_line);
 
 			QGridLayout* layout = new QGridLayout();
 			layout->setContentsMargins(0, 0, 0, 0);

--- a/pcsx2/Hotkeys.cpp
+++ b/pcsx2/Hotkeys.cpp
@@ -113,32 +113,37 @@ static bool UseSavestateSelector()
 }
 
 BEGIN_HOTKEY_LIST(g_common_hotkeys)
-DEFINE_HOTKEY("OpenPauseMenu", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Open Pause Menu"),
+DEFINE_HOTKEY("ToggleFullscreen", TRANSLATE_NOOP("Hotkeys", "Navigation"), TRANSLATE_NOOP("Hotkeys", "Toggle Fullscreen"),
+	[](s32 pressed) {
+		if (!pressed)
+			Host::SetFullscreen(!Host::IsFullscreen());
+	})
+DEFINE_HOTKEY("OpenPauseMenu", TRANSLATE_NOOP("Hotkeys", "Navigation"), TRANSLATE_NOOP("Hotkeys", "Open Pause Menu"),
 	[](s32 pressed) {
 		if (!pressed && VMManager::HasValidVM() && CanPause())
 			FullscreenUI::OpenPauseMenu();
 	})
-DEFINE_HOTKEY("OpenAchievementsList", TRANSLATE_NOOP("Hotkeys", "System"),
+DEFINE_HOTKEY("OpenAchievementsList", TRANSLATE_NOOP("Hotkeys", "Navigation"),
 	TRANSLATE_NOOP("Hotkeys", "Open Achievements List"), [](s32 pressed) {
 		if (!pressed && CanPause())
 			FullscreenUI::OpenAchievementsWindow();
 	})
-DEFINE_HOTKEY("OpenLeaderboardsList", TRANSLATE_NOOP("Hotkeys", "System"),
+DEFINE_HOTKEY("OpenLeaderboardsList", TRANSLATE_NOOP("Hotkeys", "Navigation"),
 	TRANSLATE_NOOP("Hotkeys", "Open Leaderboards List"), [](s32 pressed) {
 		if (!pressed && CanPause())
 			FullscreenUI::OpenLeaderboardsWindow();
 	})
 DEFINE_HOTKEY(
-	"TogglePause", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Toggle Pause"), [](s32 pressed) {
+	"TogglePause", TRANSLATE_NOOP("Hotkeys", "Speed"), TRANSLATE_NOOP("Hotkeys", "Toggle Pause"), [](s32 pressed) {
 		if (!pressed && VMManager::HasValidVM() && CanPause())
 			VMManager::SetPaused(VMManager::GetState() != VMState::Paused);
 	})
-DEFINE_HOTKEY("ToggleFullscreen", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Toggle Fullscreen"),
-	[](s32 pressed) {
-		if (!pressed)
-			Host::SetFullscreen(!Host::IsFullscreen());
+DEFINE_HOTKEY(
+	"FrameAdvance", TRANSLATE_NOOP("Hotkeys", "Speed"), TRANSLATE_NOOP("Hotkeys", "Frame Advance"), [](s32 pressed) {
+		if (!pressed && VMManager::HasValidVM())
+			VMManager::FrameAdvance(1);
 	})
-DEFINE_HOTKEY("ToggleFrameLimit", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Toggle Frame Limit"),
+DEFINE_HOTKEY("ToggleFrameLimit", TRANSLATE_NOOP("Hotkeys", "Speed"), TRANSLATE_NOOP("Hotkeys", "Toggle Frame Limit"),
 	[](s32 pressed) {
 		if (!pressed && VMManager::HasValidVM())
 		{
@@ -147,7 +152,7 @@ DEFINE_HOTKEY("ToggleFrameLimit", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE
 										  LimiterModeType::Nominal);
 		}
 	})
-DEFINE_HOTKEY("ToggleTurbo", TRANSLATE_NOOP("Hotkeys", "System"),
+DEFINE_HOTKEY("ToggleTurbo", TRANSLATE_NOOP("Hotkeys", "Speed"),
 	TRANSLATE_NOOP("Hotkeys", "Toggle Turbo / Fast Forward"), [](s32 pressed) {
 		if (!pressed && VMManager::HasValidVM())
 		{
@@ -155,15 +160,7 @@ DEFINE_HOTKEY("ToggleTurbo", TRANSLATE_NOOP("Hotkeys", "System"),
 				(VMManager::GetLimiterMode() != LimiterModeType::Turbo) ? LimiterModeType::Turbo : LimiterModeType::Nominal);
 		}
 	})
-DEFINE_HOTKEY("ToggleSlowMotion", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Toggle Slow Motion"),
-	[](s32 pressed) {
-		if (!pressed && VMManager::HasValidVM())
-		{
-			VMManager::SetLimiterMode(
-				(VMManager::GetLimiterMode() != LimiterModeType::Slomo) ? LimiterModeType::Slomo : LimiterModeType::Nominal);
-		}
-	})
-DEFINE_HOTKEY("HoldTurbo", TRANSLATE_NOOP("Hotkeys", "System"),
+DEFINE_HOTKEY("HoldTurbo", TRANSLATE_NOOP("Hotkeys", "Speed"),
 	TRANSLATE_NOOP("Hotkeys", "Turbo / Fast Forward (Hold)"), [](s32 pressed) {
 		if (!VMManager::HasValidVM())
 			return;
@@ -180,34 +177,23 @@ DEFINE_HOTKEY("HoldTurbo", TRANSLATE_NOOP("Hotkeys", "System"),
 			s_limiter_mode_prior_to_hold_interaction.reset();
 		}
 	})
-DEFINE_HOTKEY("IncreaseSpeed", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Increase Target Speed"),
+DEFINE_HOTKEY("ToggleSlowMotion", TRANSLATE_NOOP("Hotkeys", "Speed"), TRANSLATE_NOOP("Hotkeys", "Toggle Slow Motion"),
+	[](s32 pressed) {
+		if (!pressed && VMManager::HasValidVM())
+		{
+			VMManager::SetLimiterMode(
+				(VMManager::GetLimiterMode() != LimiterModeType::Slomo) ? LimiterModeType::Slomo : LimiterModeType::Nominal);
+		}
+	})
+DEFINE_HOTKEY("IncreaseSpeed", TRANSLATE_NOOP("Hotkeys", "Speed"), TRANSLATE_NOOP("Hotkeys", "Increase Target Speed"),
 	[](s32 pressed) {
 		if (!pressed && VMManager::HasValidVM())
 			HotkeyAdjustTargetSpeed(0.1);
 	})
-DEFINE_HOTKEY("DecreaseSpeed", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Decrease Target Speed"),
+DEFINE_HOTKEY("DecreaseSpeed", TRANSLATE_NOOP("Hotkeys", "Speed"), TRANSLATE_NOOP("Hotkeys", "Decrease Target Speed"),
 	[](s32 pressed) {
 		if (!pressed && VMManager::HasValidVM())
 			HotkeyAdjustTargetSpeed(-0.1);
-	})
-DEFINE_HOTKEY("IncreaseVolume", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Increase Volume"),
-	[](s32 pressed) {
-		if (!pressed && VMManager::HasValidVM())
-			HotkeyAdjustVolume(-1, 5);
-	})
-DEFINE_HOTKEY("DecreaseVolume", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Decrease Volume"),
-	[](s32 pressed) {
-		if (!pressed && VMManager::HasValidVM())
-			HotkeyAdjustVolume(-1, -5);
-	})
-DEFINE_HOTKEY("Mute", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Toggle Mute"), [](s32 pressed) {
-	if (!pressed && VMManager::HasValidVM())
-		HotkeyAdjustVolume((SPU2::GetOutputVolume() == 0) ? SPU2::GetResetVolume() : 0, 0);
-})
-DEFINE_HOTKEY(
-	"FrameAdvance", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Frame Advance"), [](s32 pressed) {
-		if (!pressed && VMManager::HasValidVM())
-			VMManager::FrameAdvance(1);
 	})
 DEFINE_HOTKEY("ShutdownVM", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Shut Down Virtual Machine"),
 	[](s32 pressed) {
@@ -219,17 +205,17 @@ DEFINE_HOTKEY("ResetVM", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Ho
 		if (!pressed && VMManager::HasValidVM())
 			VMManager::Reset();
 	})
-DEFINE_HOTKEY("InputRecToggleMode", TRANSLATE_NOOP("Hotkeys", "System"),
-	TRANSLATE_NOOP("Hotkeys", "Toggle Input Recording Mode"), [](s32 pressed) {
-		if (!pressed && VMManager::HasValidVM())
-			g_InputRecording.getControls().toggleRecordMode();
-	})
 DEFINE_HOTKEY("SwapMemCards", TRANSLATE_NOOP("Hotkeys", "System"),
 	TRANSLATE_NOOP("Hotkeys", "Swap Memory Cards"), [](s32 pressed) {
 		if (!pressed && VMManager::HasValidVM())
 			Host::RunOnCPUThread([]() {
 				FileMcd_Swap();
 			});
+	})
+DEFINE_HOTKEY("InputRecToggleMode", TRANSLATE_NOOP("Hotkeys", "System"),
+	TRANSLATE_NOOP("Hotkeys", "Toggle Input Recording Mode"), [](s32 pressed) {
+		if (!pressed && VMManager::HasValidVM())
+			g_InputRecording.getControls().toggleRecordMode();
 	})
 DEFINE_HOTKEY("PreviousSaveStateSlot", TRANSLATE_NOOP("Hotkeys", "Save States"),
 	TRANSLATE_NOOP("Hotkeys", "Select Previous Save Slot"), [](s32 pressed) {
@@ -305,4 +291,18 @@ DEFINE_HOTKEY_SAVESTATE_X(10, TRANSLATE_NOOP("Hotkeys", "Save State To Slot 10")
 DEFINE_HOTKEY_LOADSTATE_X(10, TRANSLATE_NOOP("Hotkeys", "Load State From Slot 10"))
 #undef DEFINE_HOTKEY_SAVESTATE_X
 #undef DEFINE_HOTKEY_LOADSTATE_X
+DEFINE_HOTKEY("Mute", TRANSLATE_NOOP("Hotkeys", "Audio"), TRANSLATE_NOOP("Hotkeys", "Toggle Mute"), [](s32 pressed) {
+	if (!pressed && VMManager::HasValidVM())
+		HotkeyAdjustVolume((SPU2::GetOutputVolume() == 0) ? SPU2::GetResetVolume() : 0, 0);
+})
+DEFINE_HOTKEY("IncreaseVolume", TRANSLATE_NOOP("Hotkeys", "Audio"), TRANSLATE_NOOP("Hotkeys", "Increase Volume"),
+	[](s32 pressed) {
+		if (!pressed && VMManager::HasValidVM())
+			HotkeyAdjustVolume(-1, 5);
+	})
+DEFINE_HOTKEY("DecreaseVolume", TRANSLATE_NOOP("Hotkeys", "Audio"), TRANSLATE_NOOP("Hotkeys", "Decrease Volume"),
+	[](s32 pressed) {
+		if (!pressed && VMManager::HasValidVM())
+			HotkeyAdjustVolume(-1, -5);
+	})
 END_HOTKEY_LIST()


### PR DESCRIPTION
### Description of Changes
Splits the overloaded `System` hotkey header into `System`, `Navigation`, `Speed`, and `Audio`. Within those headers, sorts the hotkeys so that related ones are closer together (e.g. `Toggle Pause` is now adjacent to `Frame Advance`, as they're used in conjunction). In order, the headers are:

* Navigation (menus, VM shutdown, etc.; anything that navigates you through the UI)
* Speed (anything that changes the speed of the VM)
* System (due to `Graphics` having a hold on screenshot/video capture, the best solution was to keep `System` and keep memcard swap and input recording mode in it)
* Save States (untouched by this PR)
* Audio (intuitively coupled with graphics)
* Graphics (untouched by this PR)

### Rationale behind Changes
Currently, the `System` section is a 19-item landfill of items that, yes, are related to the "system", but to an end user, that distinction means almost nothing, and the `System` section instead feels incoherent. That is, a bunch of items in `System` are completely divorced from each other.

* Accessibility – Clear headers make this easier for the visually impaired to give them a narrower area to search in. Dividing a large wall of text likely also makes this easier for those with dyslexia.
* Aesthetics(bility) – Breaks up a monotonous wall of options.
* Explorability – Users are more likely to explore what hotkeys we have available for them if the menu doesn't look like an amorphous mass of options that makes their eyes glaze over.
* Intuitivity – Everyday users who already know exactly what hotkey they want are likely to find this experience faster. Almost nobody remembers specific positions, so it's a linear scan to find it again from whatever header they start at. Like a filesystem, to a point creating less generic folders will aid in traversal speed. I've used PCSX2 since before this version of the menu has existed, and I still find this much more intuitive.
* Maintainability – Potential future hotkeys can easily be elegantly slotted in alongside similar hotkeys.

### Potential Problems
* Is the `System` section an appropriate name for what's effectively `Miscellaneous` now?
* Should `Audio` be below `Save States` in order to be paired with `Graphics` at the cost of having to scroll through `Save States`?

### Suggested Testing Steps
* Check if it looks and feel nicer to you *and especially* if you think it would look and feel nicer to a typical user who isn't already familiar with PCSX2 beyond what 99.99% of users ever will be. Try to test specific hotkey options to see how that experience feels. I guess too make sure I didn't somehow remove a hotkey? That'd be embarrassing.

### Did you use AI to help find, test, or implement this feature?
I see you have asked me if I used AI in order to find, test, or implement this issue or feature. While there may be valid reasons to use an AI in order to find, test, or implement features in software projects, I did not use AI to develop this feature. If you would like me to clarify the pros and cons of using AI for software development, please feel free to ask! Otherwise, we can move on to discussing the pull request.

### Screenshots
<img width="1083" height="953" alt="image" src="https://github.com/user-attachments/assets/a6a2e8df-c904-4265-bf12-80dfa6673566" />

<img width="1082" height="952" alt="image" src="https://github.com/user-attachments/assets/a653c2f7-d18c-4d0a-a9f2-6e6bcc8f0139" />

<img width="1084" height="722" alt="image" src="https://github.com/user-attachments/assets/8bd35d7e-d090-4311-9dc9-7acd10832865" />
