### PR TITLE
ImGuiOverlays: Internal FPS stat regression fix

### DIFF
--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -1054,8 +1054,14 @@ void EmuThread::updatePerformanceMetrics(bool force)
 
 		if (gfps != m_last_game_fps || force)
 		{
+			QString text;
+			if (gfps == 0)
+				text = tr("FPS: N/A");
+			else
+				text = tr("FPS: %1").arg(gfps, 0, 'f', 0);
+
 			QMetaObject::invokeMethod(g_main_window->getStatusFPSWidget(), "setText", Qt::QueuedConnection,
-				Q_ARG(const QString&, tr("FPS: %1").arg(gfps, 0, 'f', 0)));
+				Q_ARG(const QString&, text));
 			m_last_game_fps = gfps;
 		}
 

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -221,18 +221,16 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 			switch (PerformanceMetrics::GetInternalFPSMethod())
 			{
 				case PerformanceMetrics::InternalFPSMethod::GSPrivilegedRegister:
-					text.append_format("FPS: {:.2f} [P]", PerformanceMetrics::GetInternalFPS(),
-						PerformanceMetrics::GetFPS());
+					text.append_format("FPS: {:.2f} [P]", PerformanceMetrics::GetInternalFPS());
 					break;
 
 				case PerformanceMetrics::InternalFPSMethod::DISPFBBlit:
-					text.append_format("FPS: {:.2f} [B]", PerformanceMetrics::GetInternalFPS(),
-						PerformanceMetrics::GetFPS());
+					text.append_format("FPS: {:.2f} [B]", PerformanceMetrics::GetInternalFPS());
 					break;
 
 				case PerformanceMetrics::InternalFPSMethod::None:
 				default:
-					text.append_format("FPS: {:.2f}", PerformanceMetrics::GetFPS());
+					text.append("FPS: N/A");
 					break;
 			}
 			first = false;


### PR DESCRIPTION
### Description of Changes
Fixes the overlay showing VPS when there was no FPS detection taking place.

### Rationale behind Changes
Previously when there was no way to detect the internal FPS it would show the stat for VPS while the host window status bar would show 0. This has been changed to show N/A on both when no internal FPS method can be used.

### Suggested Testing Steps
Make sure FPS detection works correctly in a variety of situations.

### Did you use AI to help find, test, or implement this issue or feature?
I used Kam does that count?
