### PR TITLE
Debugger: Fix copying out of sorted thread view

### DIFF
--- a/pcsx2-qt/Debugger/ThreadView.cpp
+++ b/pcsx2-qt/Debugger/ThreadView.cpp
@@ -58,7 +58,8 @@ void ThreadView::openContextMenu(QPoint pos)
 		if (!selection_model->hasSelection())
 			return;
 
-		QGuiApplication::clipboard()->setText(m_model->data(selection_model->currentIndex()).toString());
+		auto real_index = m_proxy_model->mapToSource(selection_model->currentIndex());
+		QGuiApplication::clipboard()->setText(m_model->data(real_index).toString());
 	});
 
 	menu->addSeparator();


### PR DESCRIPTION
### Description of Changes
Fix copying out of the thread view by looking up the real index of the selected line through the sorted proxy model.

### Rationale behind Changes
Fixes #13029 

### Suggested Testing Steps
Copy items out of the thread view and make sure they match the selection.

### Did you use AI to help find, test, or implement this issue or feature?
No
