### PR TITLE
GitHub: Add types to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/app_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/app_bug_report.yaml
@@ -3,6 +3,7 @@ name: Application Bug Report
 description: Found a problem with the application itself (ie. bad file path handling, UX issue)? Help us improve it.
 title: "[BUG]: "
 labels: [Bug]
+type: [Bug]
 # assignees:
 #   - octocat
 body:

--- a/.github/ISSUE_TEMPLATE/emu_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/emu_bug_report.yaml
@@ -3,6 +3,7 @@ name: Emulation Bug Report
 description: Problem in a game (ie. graphical artifacts, crashes)? Help us improve it.
 title: "[BUG]: "
 labels: [Bug]
+type: [Bug]
 # assignees:
 #   - octocat
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -3,6 +3,7 @@ name: Feature request
 description: Suggest a new feature or improve an existing one
 title: "[Feature Request]: "
 labels: ["Enhancement / Feature Request", "FR: Awaiting Consideration"]
+type: [Enhancement]
 # assignees:
 #   - octocat
 body:


### PR DESCRIPTION
### Description of Changes
Added `type` key to issue templates.

### Rationale behind Changes
Thought this can improve QoL for searching issues.

### Suggested Testing Steps
Not sure, can anyone suggest?

### Did you use AI to help find, test, or implement this issue or feature?
No.
