### PR TITLE
GameDB: Kamen Rider Kabuto fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -22205,18 +22205,28 @@ SLES-53142:
 SLES-53143:
   name: "Fantastic 4"
   region: "PAL-E"
+  gsHWFixes:
+    halfPixelOffset: 5 # Fixes large depth line.
 SLES-53144:
   name: "4 Fantastiques, Les"
   region: "PAL-F"
+  gsHWFixes:
+    halfPixelOffset: 5 # Fixes large depth line.
 SLES-53145:
   name: "Fantastic 4"
   region: "PAL-G"
+  gsHWFixes:
+    halfPixelOffset: 5 # Fixes large depth line.
 SLES-53146:
   name: "I Fantastici Quattro"
   region: "PAL-I"
+  gsHWFixes:
+    halfPixelOffset: 5 # Fixes large depth line.
 SLES-53147:
   name: "4 Fantásticos, Los"
   region: "PAL-S"
+  gsHWFixes:
+    halfPixelOffset: 5 # Fixes large depth line.
 SLES-53148:
   name: "Fruitfall"
   region: "PAL-E"
@@ -22461,6 +22471,8 @@ SLES-53280:
 SLES-53281:
   name: "Fantastic 4"
   region: "PAL-NL"
+  gsHWFixes:
+    halfPixelOffset: 5 # Fixes large depth line.
 SLES-53282:
   name: "Harvest Fishing"
   region: "PAL-E"
@@ -35029,6 +35041,9 @@ SLPM-60279:
   name-en: "Kamen Rider Kabuto [Trial]"
   region: "NTSC-J"
   gsHWFixes:
+    halfPixelOffset: 5 # Fixes post-processing alignment.
+    nativeScaling: 1 # Fixes post-processing alignment.
+    textureInsideRT: 1 # Fixes garbage and missing effects.
     autoFlush: 1 # Fixes garbage corruptions on the bottom of the screen.
 SLPM-60280:
   name: "電撃PS2 PlayStation 2 SAVE DATA COLLECTION 2007"
@@ -55672,6 +55687,9 @@ SLPS-20483:
   name-en: "Kamen Rider Kabuto"
   region: "NTSC-J"
   gsHWFixes:
+    halfPixelOffset: 5 # Fixes post-processing alignment.
+    nativeScaling: 1 # Fixes post-processing alignment.
+    textureInsideRT: 1 # Fixes garbage and missing effects.
     autoFlush: 1 # Fixes garbage corruptions on the bottom of the screen.
 SLPS-20484:
   name: "SIMPLE2000シリーズ Ultimate Vol.34 魁！！男塾"
@@ -65659,6 +65677,8 @@ SLUS-20615:
   name: "Fantastic 4"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 5 # Fixes large depth line.
 SLUS-20616:
   name: "Virtua Fighter 4 - Evolution"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Fixes graphical corruption and overall alignment issues. Fixes #13044 

Before:
![Kamen Rider Kabuto_SLPS-20483_20250719151544](https://github.com/user-attachments/assets/278639a1-7239-41f7-85ce-78b7a0470a26)

After:
![Kamen Rider Kabuto_SLPS-20483_20250719151558](https://github.com/user-attachments/assets/a6a890ea-877d-4e21-97d1-1f9772537cf7)

### Rationale behind Changes
Broken game bad.

### Suggested Testing Steps
N/A

### Did you use AI to help find, test, or implement this issue or feature?
No
