### PR TITLE
Settings: Transfer regional frame rate to advanced Graphics settings

### DIFF
--- a/pcsx2-qt/Settings/AdvancedSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AdvancedSettingsWidget.cpp
@@ -53,9 +53,6 @@ AdvancedSettingsWidget::AdvancedSettingsWidget(SettingsWindow* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.gameFixes, "EmuCore", "EnableGameFixes", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.patches, "EmuCore", "EnablePatches", true);
 
-	SettingWidgetBinder::BindWidgetToFloatSetting(sif, m_ui.ntscFrameRate, "EmuCore/GS", "FramerateNTSC", 59.94f);
-	SettingWidgetBinder::BindWidgetToFloatSetting(sif, m_ui.palFrameRate, "EmuCore/GS", "FrameratePAL", 50.00f);
-
 	dialog->registerWidgetHelp(m_ui.savestateSelector, tr("Use Save State Selector"), tr("Checked"), 
 			tr("Show a save state selector UI when switching slots instead of showing a notification bubble."));
 

--- a/pcsx2-qt/Settings/AdvancedSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AdvancedSettingsWidget.ui
@@ -509,61 +509,6 @@
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="framerateControlSettings">
-         <property name="title">
-          <string>Frame Rate Control</string>
-         </property>
-         <layout class="QGridLayout" name="framerateControlLayout">
-          <item row="1" column="1">
-           <widget class="QDoubleSpinBox" name="palFrameRate">
-            <property name="suffix">
-             <string extracomment="hz=Hertz, as in the measuring unit. Shown after the corresponding number. Those languages who'd need to remove the space or do something in between should do so."> hz</string>
-            </property>
-            <property name="minimum">
-             <double>10.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>300.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.010000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QDoubleSpinBox" name="ntscFrameRate">
-            <property name="suffix">
-             <string> hz</string>
-            </property>
-            <property name="minimum">
-             <double>10.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>300.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.010000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="palLabel">
-            <property name="text">
-             <string>PAL Frame Rate:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="ntscLabel">
-            <property name="text">
-             <string>NTSC Frame Rate:</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
         <widget class="QGroupBox" name="pineSettings">
          <property name="title">
           <string>PINE Settings</string>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -130,7 +130,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdShowHardwareInfo, "EmuCore/GS", "OsdShowHardwareInfo", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdShowVideoCapture, "EmuCore/GS", "OsdShowVideoCapture", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdShowInputRec, "EmuCore/GS", "OsdShowInputRec", true);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdWarnAboutUnsafeSettings, "EmuCore", "osdWarnAboutUnsafeSettings", true);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.osdWarnAboutUnsafeSettings, "EmuCore", "OsdWarnAboutUnsafeSettings", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.fxaa, "EmuCore/GS", "fxaa", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.shadeBoost, "EmuCore/GS", "ShadeBoost", false);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.shadeBoostBrightness, "EmuCore/GS", "ShadeBoost_Brightness", false);
@@ -254,6 +254,8 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.disableVertexShaderExpand, "EmuCore/GS", "DisableVertexShaderExpand", false);
 	SettingWidgetBinder::BindWidgetToIntSetting(
 		sif, m_ui.gsDownloadMode, "EmuCore/GS", "HWDownloadMode", static_cast<int>(GSHardwareDownloadMode::Enabled));
+	SettingWidgetBinder::BindWidgetToFloatSetting(sif, m_ui.ntscFrameRate, "EmuCore/GS", "FrameRateNTSC", 59.94f);
+	SettingWidgetBinder::BindWidgetToFloatSetting(sif, m_ui.palFrameRate, "EmuCore/GS", "FrameRatePAL", 50.00f);
 
 	//////////////////////////////////////////////////////////////////////////
 	// SW Settings
@@ -392,6 +394,8 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 		m_ui.useBlitSwapChain = nullptr;
 		m_ui.disableMailboxPresentation = nullptr;
 		m_ui.extendedUpscales = nullptr;
+		m_ui.ntscFrameRate = nullptr;
+		m_ui.palFrameRate = nullptr;
 		m_ui.spinCPUDuringReadbacks = nullptr;
 		m_ui.spinGPUDuringReadbacks = nullptr;
 		m_ui.overrideTextureBarriers = nullptr;
@@ -857,6 +861,12 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 			tr("Skips synchronizing with the GS thread and host GPU for GS downloads. "
 			   "Can result in a large speed boost on slower systems, at the cost of many broken graphical effects. "
 			   "If games are broken and you have this option enabled, please disable it first."));
+
+		dialog->registerWidgetHelp(m_ui.ntscFrameRate, tr("NTSC Frame Rate"), tr("59.94 Hz"),
+			tr("Determines what frame rate NTSC games run at."));
+
+		dialog->registerWidgetHelp(m_ui.palFrameRate, tr("PAL Frame Rate"), tr("50.00 Hz"),
+			tr("Determines what frame rate PAL games run at."));
 	}
 }
 

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>720</width>
-    <height>588</height>
+    <width>722</width>
+    <height>626</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -55,12 +55,12 @@
    <item>
     <widget class="QTabWidget" name="tabs">
      <property name="currentIndex">
-      <number>0</number>
+      <number>9</number>
      </property>
      <property name="documentMode">
       <bool>true</bool>
      </property>
-     <widget class="QGroupBox" name="gameDisplayTab">
+     <widget class="QWidget" name="gameDisplayTab">
       <attribute name="title">
        <string>Display</string>
       </attribute>
@@ -391,7 +391,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QGroupBox" name="hardwareRenderingTab">
+     <widget class="QWidget" name="hardwareRenderingTab">
       <attribute name="title">
        <string>Rendering</string>
       </attribute>
@@ -652,7 +652,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QGroupBox" name="hardwareFixesTab">
+     <widget class="QWidget" name="hardwareFixesTab">
       <attribute name="title">
        <string>Hardware Fixes</string>
       </attribute>
@@ -950,7 +950,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QGroupBox" name="upscalingFixesTab">
+     <widget class="QWidget" name="upscalingFixesTab">
       <attribute name="title">
        <string>Upscaling Fixes</string>
       </attribute>
@@ -1470,7 +1470,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QGroupBox" name="osdTab">
+     <widget class="QWidget" name="osdTab">
       <attribute name="title">
        <string>OSD</string>
       </attribute>
@@ -1837,7 +1837,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QGroupBox" name="recordingTab">
+     <widget class="QWidget" name="recordingTab">
       <attribute name="title">
        <string>Media Capture</string>
       </attribute>
@@ -2158,7 +2158,7 @@
        <item>
         <spacer name="verticalSpacer_6">
          <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
+          <enum>Qt::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -2170,247 +2170,393 @@
        </item>
       </layout>
      </widget>
-     <widget class="QGroupBox" name="advancedTab">
+     <widget class="QWidget" name="advancedTab">
       <attribute name="title">
        <string extracomment="Advanced here refers to the advanced graphics options.">Advanced</string>
       </attribute>
       <layout class="QVBoxLayout" name="advancedTabLayout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
        <item>
-        <widget class="QGroupBox" name="advancedOptions">
-         <property name="title">
-          <string>Advanced Options</string>
+        <widget class="QScrollArea" name="advancedScrollArea">
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
          </property>
-         <layout class="QFormLayout" name="advancedOptionsFormLayout">
-          <item row="0" column="0">
-           <widget class="QLabel" name="hwDownloadModeLabel">
-            <property name="text">
-             <string>Hardware Download Mode:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="gsDownloadMode">
-            <item>
-             <property name="text">
-              <string>Accurate (Recommended)</string>
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="advancedScrollAreaWidgetContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>722</width>
+            <height>499</height>
+           </rect>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>499</height>
+           </size>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_2">
+           <item>
+            <widget class="QGroupBox" name="advancedOptions">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
              </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Disable Readbacks (Synchronize GS Thread)</string>
+             <property name="title">
+              <string>Advanced Options</string>
              </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Unsynchronized (Non-Deterministic)</string>
+             <layout class="QFormLayout" name="advancedOptionsFormLayout">
+              <item row="0" column="0">
+               <widget class="QLabel" name="hwDownloadModeLabel">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Hardware Download Mode:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QComboBox" name="gsDownloadMode">
+                <item>
+                 <property name="text">
+                  <string>Accurate (Recommended)</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Disable Readbacks (Synchronize GS Thread)</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Unsynchronized (Non-Deterministic)</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Disabled (Ignore Transfers)</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="gsDumpCompressionLabel">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>GS Dump Compression:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QComboBox" name="gsDumpCompression">
+                <item>
+                 <property name="text">
+                  <string>Uncompressed</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>LZMA (xz)</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Zstandard (zst)</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+              <item row="10" column="0" colspan="2">
+               <layout class="QGridLayout" name="advancedLayout">
+                <item row="1" column="1">
+                 <widget class="QCheckBox" name="extendedUpscales">
+                  <property name="text">
+                   <string>Extended Upscaling Multipliers</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="0">
+                 <widget class="QCheckBox" name="disableMailboxPresentation">
+                  <property name="text">
+                   <string extracomment="Mailbox Presentation: a type of graphics-rendering technique that has not been exposed to the public that often, so chances are you will need to keep the word mailbox in English. It does not have anything to do with postal mailboxes or email inboxes/outboxes.">Disable Mailbox Presentation</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="0">
+                 <widget class="QCheckBox" name="useBlitSwapChain">
+                  <property name="text">
+                   <string extracomment="Blit = a data operation. You might want to write it as-is, but fully uppercased. More information: https://en.wikipedia.org/wiki/Bit_blit \nSwap chain: see Microsoft's Terminology Portal.">Use Blit Swap Chain</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="1">
+                 <widget class="QCheckBox" name="spinCPUDuringReadbacks">
+                  <property name="text">
+                   <string>Spin CPU During Readbacks</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="3" column="0">
+                 <widget class="QCheckBox" name="spinGPUDuringReadbacks">
+                  <property name="text">
+                   <string>Spin GPU During Readbacks</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item row="6" column="0">
+               <widget class="QLabel" name="exclussiveFSLabel">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Allow Exclusive Fullscreen:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="6" column="1">
+               <widget class="QComboBox" name="exclusiveFullscreenControl">
+                <item>
+                 <property name="text">
+                  <string>Automatic (Default)</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Disallowed</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Allowed</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+              <item row="5" column="1">
+               <widget class="QComboBox" name="texturePreloading">
+                <item>
+                 <property name="text">
+                  <string>None</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Partial</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Full (Hash Cache)</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+              <item row="5" column="0">
+               <widget class="QLabel" name="label">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Texture Preloading:</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QGroupBox" name="frameRateOptions">
+             <property name="title">
+              <string>Frame Rate Options</string>
              </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Disabled (Ignore Transfers)</string>
+             <layout class="QGridLayout" name="frameRateOptionsFormLayout">
+              <item row="0" column="0">
+               <widget class="QLabel" name="ntscLabel">
+                <property name="text">
+                 <string>NTSC Frame Rate:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QDoubleSpinBox" name="ntscFrameRate">
+                <property name="suffix">
+                 <string extracomment="Hz=Hertz, as in the measuring unit. Shown after the corresponding number. Those languages who'd need to remove the space or do something in between should do so."> Hz</string>
+                </property>
+                <property name="minimum">
+                 <double>10.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>300.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.010000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="palLabel">
+                <property name="text">
+                 <string>PAL Frame Rate:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QDoubleSpinBox" name="palFrameRate">
+                <property name="suffix">
+                 <string> Hz</string>
+                </property>
+                <property name="minimum">
+                 <double>10.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>300.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.010000000000000</double>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QGroupBox" name="debuggingOptions">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
              </property>
-            </item>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="gsDumpCompressionLabel">
-            <property name="text">
-             <string>GS Dump Compression:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QComboBox" name="gsDumpCompression">
-            <item>
-             <property name="text">
-              <string>Uncompressed</string>
+             <property name="title">
+              <string>Debugging Options</string>
              </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>LZMA (xz)</string>
+             <layout class="QFormLayout" name="debuggingOptionsFormLayout">
+              <item row="0" column="0">
+               <widget class="QLabel" name="barriersLabel">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Override Texture Barriers:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QComboBox" name="overrideTextureBarriers">
+                <item>
+                 <property name="text">
+                  <string>Automatic (Default)</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Force Disabled</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Force Enabled</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+              <item row="2" column="0" colspan="2">
+               <layout class="QGridLayout" name="debuggingOptionsLayout">
+                <item row="0" column="1">
+                 <widget class="QCheckBox" name="disableFramebufferFetch">
+                  <property name="text">
+                   <string>Disable Framebuffer Fetch</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="0">
+                 <widget class="QCheckBox" name="disableShaderCache">
+                  <property name="text">
+                   <string>Disable Shader Cache</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="1">
+                 <widget class="QCheckBox" name="disableVertexShaderExpand">
+                  <property name="text">
+                   <string>Disable Vertex Shader Expand</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="0">
+                 <widget class="QCheckBox" name="useDebugDevice">
+                  <property name="text">
+                   <string>Use Debug Device</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <spacer name="verticalSpacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
              </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Zstandard (zst)</string>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
              </property>
-            </item>
-           </widget>
-          </item>
-          <item row="10" column="0" colspan="2">
-           <layout class="QGridLayout" name="advancedLayout">
-            <item row="1" column="1">
-             <widget class="QCheckBox" name="extendedUpscales">
-              <property name="text">
-               <string>Extended Upscaling Multipliers</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QCheckBox" name="disableMailboxPresentation">
-              <property name="text">
-               <string extracomment="Mailbox Presentation: a type of graphics-rendering technique that has not been exposed to the public that often, so chances are you will need to keep the word mailbox in English. It does not have anything to do with postal mailboxes or email inboxes/outboxes.">Disable Mailbox Presentation</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QCheckBox" name="useBlitSwapChain">
-              <property name="text">
-               <string extracomment="Blit = a data operation. You might want to write it as-is, but fully uppercased. More information: https://en.wikipedia.org/wiki/Bit_blit \nSwap chain: see Microsoft's Terminology Portal.">Use Blit Swap Chain</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QCheckBox" name="spinCPUDuringReadbacks">
-              <property name="text">
-               <string>Spin CPU During Readbacks</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="0">
-             <widget class="QCheckBox" name="spinGPUDuringReadbacks">
-              <property name="text">
-               <string>Spin GPU During Readbacks</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item row="6" column="0">
-           <widget class="QLabel" name="exclussiveFSLabel">
-            <property name="text">
-             <string>Allow Exclusive Fullscreen:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="1">
-           <widget class="QComboBox" name="exclusiveFullscreenControl">
-            <item>
-             <property name="text">
-              <string>Automatic (Default)</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Disallowed</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Allowed</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="5" column="1">
-           <widget class="QComboBox" name="texturePreloading">
-            <item>
-             <property name="text">
-              <string>None</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Partial</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Full (Hash Cache)</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Texture Preloading:</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
         </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="debuggingOptions">
-         <property name="title">
-          <string>Debugging Options</string>
-         </property>
-         <layout class="QFormLayout" name="debuggingOptionsFormLayout">
-          <item row="0" column="0">
-           <widget class="QLabel" name="barriersLabel">
-            <property name="text">
-             <string>Override Texture Barriers:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="overrideTextureBarriers">
-            <item>
-             <property name="text">
-              <string>Automatic (Default)</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Force Disabled</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Force Enabled</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="2" column="0" colspan="2">
-           <layout class="QGridLayout" name="debuggingOptionsLayout">
-            <item row="0" column="1">
-             <widget class="QCheckBox" name="disableFramebufferFetch">
-              <property name="text">
-               <string>Disable Framebuffer Fetch</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QCheckBox" name="disableShaderCache">
-              <property name="text">
-               <string>Disable Shader Cache</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QCheckBox" name="disableVertexShaderExpand">
-              <property name="text">
-               <string>Disable Vertex Shader Expand</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QCheckBox" name="useDebugDevice">
-              <property name="text">
-               <string>Use Debug Device</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
        </item>
       </layout>
      </widget>

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -367,12 +367,9 @@ namespace FullscreenUI
 	static void DrawIntSpinBoxSetting(SettingsInterface* bsi, const char* title, const char* summary, const char* section, const char* key,
 		int default_value, int min_value, int max_value, int step_value, const char* format = "%d", bool enabled = true,
 		float height = ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT, std::pair<ImFont*, float> font = g_large_font, std::pair<ImFont*, float> summary_font = g_medium_font);
-#if 0
-	// Unused as of now
 	static void DrawFloatRangeSetting(SettingsInterface* bsi, const char* title, const char* summary, const char* section, const char* key,
 		float default_value, float min_value, float max_value, const char* format = "%f", float multiplier = 1.0f, bool enabled = true,
 		float height = ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT, std::pair<ImFont*, float> font = g_large_font, std::pair<ImFont*, float> summary_font = g_medium_font);
-#endif
 	static void DrawFloatSpinBoxSetting(SettingsInterface* bsi, const char* title, const char* summary, const char* section,
 		const char* key, float default_value, float min_value, float max_value, float step_value, float multiplier,
 		const char* format = "%f", bool enabled = true, float height = ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT,
@@ -2217,8 +2214,6 @@ void FullscreenUI::DrawIntSpinBoxSetting(SettingsInterface* bsi, const char* tit
 	ImGui::PopFont();
 }
 
-#if 0
-// Unused as of now
 void FullscreenUI::DrawFloatRangeSetting(SettingsInterface* bsi, const char* title, const char* summary, const char* section,
 	const char* key, float default_value, float min_value, float max_value, const char* format, float multiplier, bool enabled,
 	float height, std::pair<ImFont*, float> font, std::pair<ImFont*, float> summary_font)
@@ -2275,7 +2270,6 @@ void FullscreenUI::DrawFloatRangeSetting(SettingsInterface* bsi, const char* tit
 	ImGui::PopStyleVar(4);
 	ImGui::PopFont();
 }
-#endif
 
 void FullscreenUI::DrawFloatSpinBoxSetting(SettingsInterface* bsi, const char* title, const char* summary, const char* section,
 	const char* key, float default_value, float min_value, float max_value, float step_value, float multiplier, const char* format,
@@ -4479,6 +4473,10 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 				"Uploads full textures to the GPU on use, rather than only the utilized regions. Can improve performance in some games."),
 			"EmuCore/GS", "texture_preloading", static_cast<int>(TexturePreloadingLevel::Off), s_preloading_options,
 			std::size(s_preloading_options), true);
+		DrawFloatRangeSetting(bsi, FSUI_CSTR("NTSC Frame Rate"), FSUI_CSTR("Determines what frame rate NTSC games run at."),
+							  "EmuCore/GS", "FrameRateNTSC", 59.94f, 10.0f, 300.0f, "%.2f Hz");
+		DrawFloatRangeSetting(bsi, FSUI_CSTR("PAL Frame Rate"), FSUI_CSTR("Determines what frame rate PAL games run at."),
+							  "EmuCore/GS", "FrameRatePAL", 50.0f, 10.0f, 300.0f, "%.2f Hz");
 	}
 
 	EndMenuButtons();


### PR DESCRIPTION
### Description of Changes
* Transfers the NTSC and PAL Frame Rate options from `Advanced` to the center of `Graphics` > `Advanced`.
* Corrects `hz` to `Hz`, the correct SI symbol.
* Adds mouseover text for these two options not present in current version.
* Adds this option to the FSUI under advanced graphics settings, as it did not have this before. The slider is currently a bit janky due to a non-unit (>0.01) step. This appears to be [a problem on ImGUI's part](https://github.com/ocornut/imgui/issues/180).
* Per feedback and thanks to @chaoticgd, adds a scrollbar to the `Advanced` tab of `Graphics` as not to bloat the minimum window size.

### Rationale behind Changes
As advanced graphics settings (in `Advanced` and obviously a graphics setting), having these under `Advanced` is highly unintuitive and arbitrary based on being 'grandfathered in'. As an additional benefit (which this rationale would be just fine without), this reduces some of the clutter in `Advanced` and places it into the not-yet-full `Graphics` > `Advanced`.

### Suggested Testing Steps
Make sure these options still work, and double-check I haven't left any remnants of the frame rate code or UI in the `Advanced` tab.

### Did you use AI to help find, test, or implement this issue or feature?
No LLM could match my level of careless slop; an LLM could probably have told me the prescribed way to fix my dumpster fire of a Git history instead of opening a second PR.

### Screenshots
![Screenshot of the advanced graphics settings window with the regional frame rate options](https://github.com/user-attachments/assets/98faedd3-f911-4f13-83a7-0917e8628456)

![Screenshot of the FSUI frame rate settings](https://github.com/user-attachments/assets/74e316d7-5d8d-4961-b76c-91f113caa84c)