### PR TITLE
Revert "GitHub: Add types to issue templates"

### DIFF
--- a/.github/ISSUE_TEMPLATE/app_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/app_bug_report.yaml
@@ -3,7 +3,6 @@ name: Application Bug Report
 description: Found a problem with the application itself (ie. bad file path handling, UX issue)? Help us improve it.
 title: "[BUG]: "
 labels: [Bug]
-type: [Bug]
 # assignees:
 #   - octocat
 body:

--- a/.github/ISSUE_TEMPLATE/emu_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/emu_bug_report.yaml
@@ -3,7 +3,6 @@ name: Emulation Bug Report
 description: Problem in a game (ie. graphical artifacts, crashes)? Help us improve it.
 title: "[BUG]: "
 labels: [Bug]
-type: [Bug]
 # assignees:
 #   - octocat
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -3,7 +3,6 @@ name: Feature request
 description: Suggest a new feature or improve an existing one
 title: "[Feature Request]: "
 labels: ["Enhancement / Feature Request", "FR: Awaiting Consideration"]
-type: [Enhancement]
 # assignees:
 #   - octocat
 body:


### PR DESCRIPTION
Reverts PCSX2/pcsx2#13042

Cannot create issues anymore, so reverting

<img width="806" height="248" alt="Capture d’écran 2025-07-20 à 12 46 10" src="https://github.com/user-attachments/assets/1702015f-0cb0-476a-98a9-39c9230a8ab5" />
