### PR TITLE
Debugger: Disable filter search button while filter search is active

### DIFF
--- a/pcsx2-qt/Debugger/Memory/MemorySearchView.cpp
+++ b/pcsx2-qt/Debugger/Memory/MemorySearchView.cpp
@@ -610,6 +610,7 @@ void MemorySearchView::onSearchButtonClicked()
 	m_searchResults.clear();
 	m_ui.resultsCountLabel->setText(tr("Searching..."));
 	m_ui.resultsCountLabel->setVisible(true);
+	m_ui.btnFilterSearch->setDisabled(true);
 }
 
 void MemorySearchView::onSearchResultsListScroll(u32 value)

--- a/pcsx2-qt/Debugger/Memory/MemorySearchView.cpp
+++ b/pcsx2-qt/Debugger/Memory/MemorySearchView.cpp
@@ -599,6 +599,7 @@ void MemorySearchView::onSearchButtonClicked()
 	connect(workerWatcher, &QFutureWatcher<std::vector<u32>>::finished, onSearchFinished);
 
 	m_ui.btnSearch->setDisabled(true);
+	m_ui.btnFilterSearch->setDisabled(true);
 	if (!isFilterSearch)
 	{
 		m_searchResults.clear();
@@ -610,7 +611,6 @@ void MemorySearchView::onSearchButtonClicked()
 	m_searchResults.clear();
 	m_ui.resultsCountLabel->setText(tr("Searching..."));
 	m_ui.resultsCountLabel->setVisible(true);
-	m_ui.btnFilterSearch->setDisabled(true);
 }
 
 void MemorySearchView::onSearchResultsListScroll(u32 value)


### PR DESCRIPTION
### Rationale behind Changes
To prevent crashes.
I like to accelerate my debugger searches by spamming the filter button. However, doing so while PCSX2 was actively searching crashed PCSX2. This PR fixes said issue, by preventing filter searches while filter-searching is active.

### Suggested Testing Steps
Filter search/search and ensure the button is activated, disabled, and re-activated correctly.

### Did you use AI to help find, test, or implement this issue or feature?
No.
