### PR TITLE
GraphicsSettingsWidget: Index regression fix

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.ui
@@ -55,7 +55,7 @@
    <item>
     <widget class="QTabWidget" name="tabs">
      <property name="currentIndex">
-      <number>9</number>
+      <number>0</number>
      </property>
      <property name="documentMode">
       <bool>true</bool>


### PR DESCRIPTION
### Description of Changes
Fixes a regression for the current index for graphics settings from #13047 

### Rationale behind Changes
Bugs are bad.

### Suggested Testing Steps
N/A

### Did you use AI to help find, test, or implement this issue or feature?
No
