### PR TITLE
ImGui: Remove usage of deprecated fmt::localtime

### DIFF
--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -50,6 +50,7 @@
 #include <algorithm>
 #include <array>
 #include <bitset>
+#include <ctime>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -1432,7 +1433,8 @@ void FullscreenUI::DrawLandingTemplate(ImVec2* menu_pos, ImVec2* menu_size)
 		// draw time
 		ImVec2 time_pos;
 		{
-			heading_str.format(FSUI_FSTR("{:%H:%M}"), fmt::localtime(std::time(nullptr)));
+			const std::time_t current_time = std::time(nullptr);
+			heading_str.format(FSUI_FSTR("{:%H:%M}"), *std::localtime(&current_time));
 
 			const ImVec2 time_size = heading_font.first->CalcTextSizeA(heading_font.second, FLT_MAX, 0.0f, "00:00");
 			time_pos = ImVec2(heading_size.x - LayoutScale(LAYOUT_MENU_BUTTON_X_PADDING) - time_size.x,

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -40,6 +40,7 @@
 #include <array>
 #include <chrono>
 #include <cmath>
+#include <ctime>
 #include <deque>
 #include <limits>
 #include <mutex>
@@ -1069,7 +1070,7 @@ void SaveStateSelectorUI::InitializeListEntry(const std::string& serial, u32 crc
 	}
 
 	li->title = fmt::format(TRANSLATE_FS("ImGuiOverlays", "Save Slot {0}"), slot);
-	li->summary = fmt::format(TRANSLATE_FS("ImGuiOverlays", DATE_TIME_FORMAT), fmt::localtime(sd.ModificationTime));
+	li->summary = fmt::format(TRANSLATE_FS("ImGuiOverlays", DATE_TIME_FORMAT), *std::localtime(&sd.ModificationTime));
 	li->filename = Path::GetFileName(path);
 
 	u32 screenshot_width, screenshot_height;
@@ -1269,7 +1270,7 @@ void SaveStateSelectorUI::ShowSlotOSDMessage()
 	FILESYSTEM_STAT_DATA sd;
 	std::string date;
 	if (!filename.empty() && FileSystem::StatFile(filename.c_str(), &sd))
-		date = fmt::format(TRANSLATE_FS("ImGuiOverlays", DATE_TIME_FORMAT), fmt::localtime(sd.ModificationTime));
+		date = fmt::format(TRANSLATE_FS("ImGuiOverlays", DATE_TIME_FORMAT), *std::localtime(&sd.ModificationTime));
 	else
 		date = TRANSLATE_STR("ImGuiOverlays", "no save yet");
 


### PR DESCRIPTION
Replace deprecated fmt::localtime with std::localtime in ImGuiOverlays.cpp and FullscreenUI.cpp. The fmt library deprecated this function in favor of using the standard library version.

Fixes #13017

### Description of Changes
Replaced all occurrences of deprecated `fmt::localtime` with `std::localtime` in the ImGui code.

### Rationale behind Changes
The fmt library has deprecated `fmt::localtime()` in favor of using the standard library's `std::localtime()`. This change removes the deprecation warnings mentioned in issue #13017 and ensures the code remains compatible with future versions of the fmt library.

### Suggested Testing Steps
- Build PCSX2 with the latest fmt library
- Verify that save state timestamps display correctly in the UI
- Check that the time display in FullscreenUI works properly
- Confirm no deprecation warnings appear during compilation

### Did you use AI to help find, test, or implement this issue or feature?
Yes, I used Claude to help identify all occurrences of `fmt::localtime` in the codebase and understand the appropriate replacement approach.
