### PR TITLE
CI/Flatpak: Upgrade runtime to 6.9

### DIFF
--- a/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
+++ b/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
@@ -1,7 +1,7 @@
 {
   "app-id": "net.pcsx2.PCSX2",
   "runtime": "org.kde.Platform",
-  "runtime-version": "6.8",
+  "runtime-version": "6.9",
   "sdk": "org.kde.Sdk",
   "sdk-extensions": [
     "org.freedesktop.Sdk.Extension.llvm18"


### PR DESCRIPTION
### Description of Changes
Upgrade the KDE runtime to 6.9, which bumps Qt to version 6.9.
PCSX2 supports 6.9 since https://github.com/PCSX2/pcsx2/pull/12476.

### Rationale behind Changes
being up-to-date is good.

### Suggested Testing Steps
Run the flatpak.

### Did you use AI to help find, test, or implement this issue or feature?
No
