### PR TITLE
GameDB: Fix #13070 wrong title for SLES-54435

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -26209,7 +26209,7 @@ SLES-54434:
   name: "Babe"
   region: "PAL-A"
 SLES-54435:
-  name: "Babe"
+  name: "Casper and the Ghostly Trio"
   region: "PAL-A"
 SLES-54436:
   name: "Jumanji"


### PR DESCRIPTION
### Description of Changes
Changed title for SLES-54435 to "Casper and the Ghostly Trio" in GameIndex.yaml.

### Rationale behind Changes
Wrong title bad.
Fixes https://github.com/PCSX2/pcsx2/issues/13070

### Suggested Testing Steps
Re-scan game library for title to update.

### Did you use AI to help find, test, or implement this issue or feature?
No.
