### PR TITLE
GS: Make GSUtil constexpr functions header only.

### DIFF
--- a/pcsx2/GS/GSUtil.cpp
+++ b/pcsx2/GS/GSUtil.cpp
@@ -25,38 +25,12 @@
 namespace {
 struct GSUtilMaps
 {
-	u8 PrimClassField[8] = {};
-	u8 VertexCountField[8] = {};
-	u8 ClassVertexCountField[4] = {};
 	u32 CompatibleBitsField[64][2] = {};
 	u32 SharedBitsField[64][2] = {};
 	u32 SwizzleField[64][2] = {};
 
 	constexpr GSUtilMaps()
 	{
-		PrimClassField[GS_POINTLIST] = GS_POINT_CLASS;
-		PrimClassField[GS_LINELIST] = GS_LINE_CLASS;
-		PrimClassField[GS_LINESTRIP] = GS_LINE_CLASS;
-		PrimClassField[GS_TRIANGLELIST] = GS_TRIANGLE_CLASS;
-		PrimClassField[GS_TRIANGLESTRIP] = GS_TRIANGLE_CLASS;
-		PrimClassField[GS_TRIANGLEFAN] = GS_TRIANGLE_CLASS;
-		PrimClassField[GS_SPRITE] = GS_SPRITE_CLASS;
-		PrimClassField[GS_INVALID] = GS_INVALID_CLASS;
-
-		VertexCountField[GS_POINTLIST] = 1;
-		VertexCountField[GS_LINELIST] = 2;
-		VertexCountField[GS_LINESTRIP] = 2;
-		VertexCountField[GS_TRIANGLELIST] = 3;
-		VertexCountField[GS_TRIANGLESTRIP] = 3;
-		VertexCountField[GS_TRIANGLEFAN] = 3;
-		VertexCountField[GS_SPRITE] = 2;
-		VertexCountField[GS_INVALID] = 1;
-
-		ClassVertexCountField[GS_POINT_CLASS] = 1;
-		ClassVertexCountField[GS_LINE_CLASS] = 2;
-		ClassVertexCountField[GS_TRIANGLE_CLASS] = 3;
-		ClassVertexCountField[GS_SPRITE_CLASS] = 2;
-
 		for (int i = 0; i < 64; i++)
 		{
 			CompatibleBitsField[i][i >> 5] |= 1U << (i & 0x1f);
@@ -118,21 +92,6 @@ const char* GSUtil::GetAFAILName(u32 afail)
 {
 	static constexpr const char* names[] = {"KEEP", "FB_ONLY", "ZB_ONLY", "RGB_ONLY"};
 	return (afail < std::size(names)) ? names[afail] : "";
-}
-
-GS_PRIM_CLASS GSUtil::GetPrimClass(u32 prim)
-{
-	return (GS_PRIM_CLASS)s_maps.PrimClassField[prim];
-}
-
-int GSUtil::GetVertexCount(u32 prim)
-{
-	return s_maps.VertexCountField[prim];
-}
-
-int GSUtil::GetClassVertexCount(u32 primclass)
-{
-	return s_maps.ClassVertexCountField[primclass];
 }
 
 const u32* GSUtil::HasSharedBitsPtr(u32 dpsm)

--- a/pcsx2/GS/GSUtil.h
+++ b/pcsx2/GS/GSUtil.h
@@ -13,10 +13,6 @@ public:
 	static const char* GetAFAILName(u32 afail);
 	static const char* GetPSMName(int psm);
 
-	static GS_PRIM_CLASS GetPrimClass(u32 prim);
-	static int GetVertexCount(u32 prim);
-	static int GetClassVertexCount(u32 primclass);
-
 	static const u32* HasSharedBitsPtr(u32 dpsm);
 	static bool HasSharedBits(u32 spsm, const u32* ptr);
 	static bool HasSharedBits(u32 spsm, u32 dpsm);
@@ -27,4 +23,41 @@ public:
 	static u32 GetChannelMask(u32 spsm, u32 fbmsk);
 
 	static GSRendererType GetPreferredRenderer();
+
+	static constexpr GS_PRIM_CLASS GetPrimClass(u32 prim)
+	{
+		switch (prim)
+		{
+			case GS_POINTLIST:
+				return GS_POINT_CLASS;
+			case GS_LINELIST:
+			case GS_LINESTRIP:
+				return GS_LINE_CLASS;
+			case GS_TRIANGLELIST:
+			case GS_TRIANGLESTRIP:
+			case GS_TRIANGLEFAN:
+				return GS_TRIANGLE_CLASS;
+			case GS_SPRITE:
+				return GS_SPRITE_CLASS;
+			default:
+				return GS_INVALID_CLASS;
+		}
+	}
+
+	static constexpr int GetClassVertexCount(u32 primclass)
+	{
+		switch (primclass)
+		{
+			case GS_POINT_CLASS:    return 1;
+			case GS_LINE_CLASS:     return 2;
+			case GS_TRIANGLE_CLASS: return 3;
+			case GS_SPRITE_CLASS:   return 2;
+			default:                return -1;
+		}
+	}
+
+	static constexpr int GetVertexCount(u32 prim)
+	{
+		return GetClassVertexCount(GetPrimClass(prim));
+	}
 };


### PR DESCRIPTION
### Description of Changes
Make some of the utility functions in GSUtil header-only.

### Rationale behind Changes
The functions couldn't be used as constexpr in other files because they were defined in the cpp file instead of header. Some of these functions could be used in e.g. templated functions in GSVertexTrace as compile-time constants.

### Suggested Testing Steps
Changes should be transparently equivalent so no testing required.

### Did you use AI to help find, test, or implement this issue or feature?
Yes, code autocompletion w/ Github copilot.
