### PR TITLE
Qt: Use radio buttons for actions under 'Switch Renderer' menu

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -504,10 +504,13 @@ void MainWindow::createRendererSwitchMenu()
 	};
 	const GSRendererType current_renderer = static_cast<GSRendererType>(
 		Host::GetBaseIntSettingValue("EmuCore/GS", "Renderer", static_cast<int>(GSRendererType::Auto)));
+
+	QActionGroup* switch_renderer_group = new QActionGroup(m_ui.menuDebugSwitchRenderer);
+
 	for (const GSRendererType renderer : renderers)
 	{
-		QAction* action = m_ui.menuDebugSwitchRenderer->addAction(
-			QString::fromUtf8(Pcsx2Config::GSOptions::GetRendererName(renderer)));
+		QAction* action = new QAction(
+			QString::fromUtf8(Pcsx2Config::GSOptions::GetRendererName(renderer)), switch_renderer_group);
 		action->setCheckable(true);
 		action->setChecked(current_renderer == renderer);
 		connect(action,
@@ -515,15 +518,10 @@ void MainWindow::createRendererSwitchMenu()
 				Host::SetBaseIntSettingValue("EmuCore/GS", "Renderer", static_cast<int>(renderer));
 				Host::CommitBaseSettingChanges();
 				g_emu_thread->applySettings();
-
-				// clear all others
-				for (QObject* obj : m_ui.menuDebugSwitchRenderer->children())
-				{
-					if (QAction* act = qobject_cast<QAction*>(obj); act && act != action)
-						act->setChecked(false);
-				}
 			});
 	}
+
+	m_ui.menuDebugSwitchRenderer->addActions(switch_renderer_group->actions());
 }
 
 void MainWindow::recreate()


### PR DESCRIPTION
### Description of Changes
Changes the actions under the 'Switch Renderer' menu, inside the 'Debug' menu, to use radio buttons instead of checkboxes.

(I did notice

### Rationale behind Changes
Fixes #13014 - you can no longer unselect your current renderer without selecting a new one. Also makes the UI more intuitive.

### Suggested Testing Steps
Launch a game, and try switching between different renderers using the 'Switch Renderer' menu, as well as trying to unselect your renderer by clicking on it.

### Did you use AI to help find, test, or implement this issue or feature?
No.
