### PR TITLE
GS: Allow full dirty rect on zero age targets.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -137,10 +137,6 @@ bool GSTextureCache::FullRectDirty(Target* target, u32 rgba_mask)
 
 bool GSTextureCache::FullRectDirty(Target* target)
 {
-	// Why?
-	if (target->m_age == 0)
-		return false;
-
 	return FullRectDirty(target, GSUtil::GetChannelMask(target->m_TEX0.PSM));
 }
 


### PR DESCRIPTION
### Description of Changes
Remove the check that prevented zero-age targets from being invalidated/destroyed.

### Rationale behind Changes
Allows EE->GS transfers to invalidate zero-age targets (i.e. targets updated in the current draw) if they are fully overwritten by the transfer. Fixes https://github.com/PCSX2/pcsx2/issues/13058

### Suggested Testing Steps
GS dumps runs and general game testing.

### Did you use AI to help find, test, or implement this issue or feature?
Yes. Github copilot.
