### PR TITLE
GS: Properly check for a VU1 recompiler.

### DIFF
--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1435,10 +1435,12 @@ namespace EmuFolders
 
 // ------------ CPU / Recompiler Options ---------------
 
-#ifdef _M_X86 // TODO(Stenzek): Remove me once EE/VU/IOP recs are added.
-#define THREAD_VU1 (EmuConfig.Cpu.Recompiler.EnableVU1 && EmuConfig.Speedhacks.vuThread)
+#ifdef _M_X86 // TODO: Remove me once EE/VU/IOP recs are added.
+#define REC_VU1 (EmuConfig.Cpu.Recompiler.EnableVU1)
+#define THREAD_VU1 (REC_VU1 && EmuConfig.Speedhacks.vuThread)
 #else
 #define THREAD_VU1 false
+#define REC_VU1 false
 #endif
 #define INSTANT_VU1 (EmuConfig.Speedhacks.vu1Instant)
 #define CHECK_EEREC (EmuConfig.Cpu.Recompiler.EnableEE)

--- a/pcsx2/Gif_Unit.h
+++ b/pcsx2/Gif_Unit.h
@@ -603,7 +603,7 @@ struct Gif_Unit
 			}
 			if (curSize >= size)
 				return size;
-			if(((flush && gifTag.tag.EOP) || !flush) && (CHECK_XGKICKHACK || !EmuConfig.Cpu.Recompiler.EnableVU1))
+			if(((flush && gifTag.tag.EOP) || !flush) && (CHECK_XGKICKHACK || !REC_VU1))
 			{
 				return curSize | ((u32)gifTag.tag.EOP << 31);
 			}


### PR DESCRIPTION


### Description of Changes
Adds a compile-time define that is forced to `false` on non-x86 builds or is equal to the vu1 rec toggle on x86 builds.
Uses that define where the GIF was previously using `Recompiler.EnableVU1` (which can be true on ARM, despite there being no VU1 recompiler)

### Rationale behind Changes
This caused chaos when you would try an ARM PCSX2 with games / non-trivial homebrew

### Suggested Testing Steps
Try a game on an ARM PCSX2 build with the VU1 recompiler turned on in the settings.

### Did you use AI to help find, test, or implement this issue or feature?
No
