### PR TITLE
OSD: Display correct CPU info in Rosetta

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -174,9 +174,6 @@ else()
 		target_compile_definitions(common PRIVATE "HAS_LIBBACKTRACE=1")
 		target_link_libraries(common PRIVATE libbacktrace::libbacktrace)
 	endif()
-	if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
-		target_link_libraries(common PRIVATE cpuinfo)
-	endif()
 endif()
 
 set_source_files_properties(PrecompiledHeader.cpp PROPERTIES HEADER_FILE_ONLY TRUE)
@@ -206,6 +203,7 @@ target_link_libraries(common PRIVATE
 	JPEG::JPEG
 	PNG::PNG
 	WebP::libwebp
+	cpuinfo
 )
 
 target_link_libraries(common PUBLIC

--- a/common/Darwin/DarwinMisc.cpp
+++ b/common/Darwin/DarwinMisc.cpp
@@ -271,7 +271,7 @@ std::vector<DarwinMisc::CPUClass> DarwinMisc::GetCPUClasses()
 	}
 	else if (std::optional<u32> physcpu = sysctlbyname_T<u32>("hw.physicalcpu"))
 	{
-		out.push_back({"Default", *physcpu, sysctlbyname_T<u32>("hw.logicalcpu").value_or(0)});
+		out.push_back({"Default", *physcpu, sysctlbyname_T<u32>("hw.logicalcpu").value_or(*physcpu)});
 	}
 	else
 	{
@@ -279,6 +279,35 @@ std::vector<DarwinMisc::CPUClass> DarwinMisc::GetCPUClasses()
 	}
 
 	return out;
+}
+
+static CPUInfo CalcCPUInfo()
+{
+	CPUInfo out;
+	char name[256];
+	size_t name_size = sizeof(name);
+	if (0 != sysctlbyname("machdep.cpu.brand_string", name, &name_size, nullptr, 0))
+		strcpy(name, "Unknown");
+	out.name = name;
+	if (sysctlbyname_T<u32>("sysctl.proc_translated").value_or(0))
+		out.name += " (Rosetta)";
+	std::vector<DarwinMisc::CPUClass> classes = DarwinMisc::GetCPUClasses();
+	out.num_clusters = static_cast<u32>(classes.size());
+	out.num_big_cores = classes.empty() ? 0 : classes[0].num_physical;
+	out.num_threads   = classes.empty() ? 0 : classes[0].num_logical;
+	out.num_small_cores = 0;
+	for (std::size_t i = 1; i < classes.size(); i++)
+	{
+		out.num_small_cores += classes[i].num_physical;
+		out.num_threads += classes[i].num_logical;
+	}
+	return out;
+}
+
+const CPUInfo& GetCPUInfo()
+{
+	static const CPUInfo info = CalcCPUInfo();
+	return info;
 }
 
 size_t HostSys::GetRuntimePageSize()

--- a/common/HostSys.h
+++ b/common/HostSys.h
@@ -192,6 +192,16 @@ extern const u32 SPIN_TIME_NS;
 
 extern std::string GetOSVersionString();
 
+struct CPUInfo {
+	std::string name;
+	u32 num_big_cores;
+	u32 num_small_cores;
+	u32 num_threads;
+	u32 num_clusters;
+};
+
+const CPUInfo& GetCPUInfo();
+
 namespace Common
 {
 	/// Enables or disables the screen saver from starting.

--- a/common/common.vcxproj
+++ b/common/common.vcxproj
@@ -32,6 +32,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SolutionDir)3rdparty\cpuinfo\include</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SolutionDir)3rdparty\fast_float\include</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SolutionDir)3rdparty\fmt\include</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SolutionDir)3rdparty\jpgd</AdditionalIncludeDirectories>

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -25,7 +25,6 @@
 #include "SIO/Pad/PadBase.h"
 #include "USB/USB.h"
 #include "VMManager.h"
-#include "cpuinfo.h"
 
 #include "common/BitUtils.h"
 #include "common/FileSystem.h"
@@ -307,10 +306,16 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 		{
 			// CPU
 			text.clear();
-			text.append_format("CPU: {} ({}C/{}T)",
-				cpuinfo_get_package(0)->name,
-				cpuinfo_get_cores_count(),
-				cpuinfo_get_processors_count());
+			const CPUInfo& info = GetCPUInfo();
+			bool has_small = info.num_small_cores > 0;
+			bool has_ht = info.num_threads != info.num_big_cores + info.num_small_cores;
+			text.append_format("CPU: {}", info.name);
+			if (has_ht & has_small)
+				text.append_format(" ({}P/{}E/{}T)", info.num_big_cores, info.num_small_cores, info.num_threads);
+			else if (has_small)
+				text.append_format(" ({}P/{}E)", info.num_big_cores, info.num_small_cores);
+			else
+				text.append_format(" ({}C/{}T)", info.num_big_cores, info.num_threads);
 			DRAW_LINE(fixed_font, font_size, text.c_str(), IM_COL32(255, 255, 255, 255));
 
 			// GPU

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -2516,10 +2516,11 @@ void VMManager::LogCPUCapabilities()
 		GetPhysicalMemory() / _1mb,
 		static_cast<double>(GetPhysicalMemory()) / static_cast<double>(_1gb));
 
-	Console.WriteLnFmt("  Processor        = {}", cpuinfo_get_package(0)->name);
-	Console.WriteLnFmt("  Core Count       = {} cores", cpuinfo_get_cores_count());
-	Console.WriteLnFmt("  Thread Count     = {} threads", cpuinfo_get_processors_count());
-	Console.WriteLnFmt("  Cluster Count    = {} clusters", cpuinfo_get_clusters_count());
+	const CPUInfo& cpuinfo = GetCPUInfo();
+	Console.WriteLnFmt("  Processor        = {}", cpuinfo.name);
+	Console.WriteLnFmt("  Core Count       = {} cores", cpuinfo.num_big_cores + cpuinfo.num_small_cores);
+	Console.WriteLnFmt("  Thread Count     = {} threads", cpuinfo.num_threads);
+	Console.WriteLnFmt("  Cluster Count    = {} clusters", cpuinfo.num_clusters);
 #ifdef _WIN32
 	LogUserPowerPlan();
 #endif


### PR DESCRIPTION
### Description of Changes
Uses macOS sysctl to get the CPU name instead of cpuinfo, so that even in rosetta, it picks up the correct CPU name, rather than VirtualApple.

Also marks P/E cores in the OSD.

### Rationale behind Changes
Better OSD info

### Suggested Testing Steps
Run PCSX2 with hardware info enabled on the OSD

### Did you use AI to help find, test, or implement this issue or feature?
No