### PR TITLE
Achievements: Separate token into its own secrets.ini file

### DIFF
--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -86,6 +86,7 @@ namespace QtHost
 //////////////////////////////////////////////////////////////////////////
 static QTimer* s_settings_save_timer = nullptr;
 static std::unique_ptr<INISettingsInterface> s_base_settings_interface;
+static std::unique_ptr<INISettingsInterface> s_secrets_settings_interface;
 static bool s_batch_mode = false;
 static bool s_nogui_mode = false;
 static bool s_start_fullscreen_ui = false;
@@ -1329,6 +1330,7 @@ bool QtHost::InitializeConfig()
 	// Write crash dumps to the data directory, since that'll be accessible for certain.
 	CrashHandler::SetWriteDirectory(EmuFolders::DataRoot);
 
+	// Load main settings ini
 	const std::string path = Path::Combine(EmuFolders::Settings, "PCSX2.ini");
 	const bool settings_exists = FileSystem::FileExists(path.c_str());
 	Console.WriteLnFmt("Loading config from {}.", path);
@@ -1367,6 +1369,29 @@ bool QtHost::InitializeConfig()
 		// Don't save if we're running the setup wizard. We want to run it next time if they don't finish it.
 		if (!s_run_setup_wizard)
 			SaveSettings();
+	}
+
+	// Layer secrets ini on top
+	const std::string secrets_path = Path::Combine(EmuFolders::Settings, "secrets.ini");
+	const bool secrets_settings_exists = FileSystem::FileExists(secrets_path.c_str());
+	Console.WriteLnFmt("Loading secrets from {}.", secrets_path);
+
+	s_secrets_settings_interface = std::make_unique<INISettingsInterface>(std::move(secrets_path));
+	Host::Internal::SetSecretsSettingsLayer(s_secrets_settings_interface.get());
+	if (!secrets_settings_exists || !s_secrets_settings_interface->Load())
+	{
+		if (!s_base_settings_interface->Save(&error))
+		{
+			QMessageBox::critical(
+				nullptr, QStringLiteral("PCSX2"),
+				QStringLiteral(
+					"Failed to save secrets to\n\n%1\n\nThe error was: %2\n\nPlease ensure this directory is writable. You "
+					"can also try portable mode by creating portable.txt in the same directory you installed PCSX2 into.")
+					.arg(QString::fromStdString(s_secrets_settings_interface->GetFileName()))
+					.arg(QString::fromStdString(error.GetDescription())));
+			return false;
+		}
+		
 	}
 
 	// Setup wizard was incomplete last time?

--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -26,6 +26,7 @@
 #include "common/MD5Digest.h"
 #include "common/Path.h"
 #include "common/ScopedGuard.h"
+#include "common/SettingsInterface.h"
 #include "common/SmallString.h"
 #include "common/StringUtil.h"
 #include "common/Timer.h"
@@ -433,7 +434,7 @@ bool Achievements::Initialize()
 		IdentifyGame(VMManager::GetDiscCRC(), VMManager::GetCurrentCRC());
 
 	const std::string username = Host::GetBaseStringSettingValue("Achievements", "Username");
-	const std::string api_token = Host::GetBaseStringSettingValue("Achievements", "Token");
+	const std::string api_token = Host::GetStringSettingValue("Achievements", "Token");
 	if (!username.empty() && !api_token.empty())
 	{
 		Console.WriteLn("Achievements: Attempting login with user '%s'...", username.c_str());
@@ -1772,8 +1773,8 @@ void Achievements::ClientLoginWithPasswordCallback(int result, const char* error
 
 	// Store configuration.
 	Host::SetBaseStringSettingValue("Achievements", "Username", params->username);
-	Host::SetBaseStringSettingValue("Achievements", "Token", user->token);
 	Host::SetBaseStringSettingValue("Achievements", "LoginTimestamp", fmt::format("{}", std::time(nullptr)).c_str());
+	Host::Internal::GetSecretsSettingsLayer()->SetStringValue("Achievements", "Token", user->token);
 	Host::CommitBaseSettingChanges();
 
 	ShowLoginSuccess(client);

--- a/pcsx2/Host.cpp
+++ b/pcsx2/Host.cpp
@@ -382,7 +382,7 @@ SettingsInterface* Host::Internal::GetInputSettingsLayer()
 void Host::Internal::SetBaseSettingsLayer(SettingsInterface* sif)
 {
 	pxAssertRel(s_layered_settings_interface.GetLayer(LayeredSettingsInterface::LAYER_BASE) == nullptr,
-		"Base layer has not been set");
+		"Base layer has already been set");
 	s_layered_settings_interface.SetLayer(LayeredSettingsInterface::LAYER_BASE, sif);
 }
 

--- a/pcsx2/Host.cpp
+++ b/pcsx2/Host.cpp
@@ -364,6 +364,11 @@ SettingsInterface* Host::Internal::GetBaseSettingsLayer()
 	return s_layered_settings_interface.GetLayer(LayeredSettingsInterface::LAYER_BASE);
 }
 
+SettingsInterface* Host::Internal::GetSecretsSettingsLayer()
+{
+	return s_layered_settings_interface.GetLayer(LayeredSettingsInterface::LAYER_SECRETS);
+}
+
 SettingsInterface* Host::Internal::GetGameSettingsLayer()
 {
 	return s_layered_settings_interface.GetLayer(LayeredSettingsInterface::LAYER_GAME);
@@ -379,6 +384,13 @@ void Host::Internal::SetBaseSettingsLayer(SettingsInterface* sif)
 	pxAssertRel(s_layered_settings_interface.GetLayer(LayeredSettingsInterface::LAYER_BASE) == nullptr,
 		"Base layer has not been set");
 	s_layered_settings_interface.SetLayer(LayeredSettingsInterface::LAYER_BASE, sif);
+}
+
+void Host::Internal::SetSecretsSettingsLayer(SettingsInterface* sif)
+{
+	pxAssertRel(s_layered_settings_interface.GetLayer(LayeredSettingsInterface::LAYER_SECRETS) == nullptr,
+		"Secrets layer has already been set");
+	s_layered_settings_interface.SetLayer(LayeredSettingsInterface::LAYER_SECRETS, sif);
 }
 
 void Host::Internal::SetGameSettingsLayer(SettingsInterface* sif, std::unique_lock<std::mutex>& settings_lock)

--- a/pcsx2/Host.h
+++ b/pcsx2/Host.h
@@ -151,6 +151,9 @@ namespace Host
 		/// Retrieves the base settings layer. Must call with lock held.
 		SettingsInterface* GetBaseSettingsLayer();
 
+		/// Retrieves the base settings layer. Must call with lock held.
+		SettingsInterface* GetSecretsSettingsLayer();
+
 		/// Retrieves the game settings layer, if present. Must call with lock held.
 		SettingsInterface* GetGameSettingsLayer();
 
@@ -159,6 +162,9 @@ namespace Host
 
 		/// Sets the base settings layer. Should be called by the host at initialization time.
 		void SetBaseSettingsLayer(SettingsInterface* sif);
+
+		/// Sets the secrets settings layer. Should follow call to SetBaseSettingsLayer.
+		void SetSecretsSettingsLayer(SettingsInterface* sif);
 
 		/// Sets the game settings layer. Called by VMManager when the game changes.
 		void SetGameSettingsLayer(SettingsInterface* sif, std::unique_lock<std::mutex>& settings_lock);

--- a/pcsx2/LayeredSettingsInterface.h
+++ b/pcsx2/LayeredSettingsInterface.h
@@ -16,6 +16,7 @@ public:
 		LAYER_GAME,
 		LAYER_INPUT,
 		LAYER_BASE,
+		LAYER_SECRETS,
 		NUM_LAYERS
 	};
 


### PR DESCRIPTION
### Description of Changes
Creates a separate secrets.ini file for storing sensitive or privileged information. Adds the RetroAchievements login token to this file, removing it from the base PCSX2.ini.

Please give this one a very thorough grilling on code review, I do not know if I did this right, I probably have some kind of unsafe access somewhere, something something threading and locks and internal vs external core/host stuff.

### Rationale behind Changes
Makes it safer to share actual settings ini files without potentially compromising RetroAchievements sessions tokens.

### Suggested Testing Steps
Try logging in to RetroAchievements, verify your login is respected across restarts, check if your token is still present in your old PCSX2.ini file (this one might need a separate action to remove but I'm not sure how we go about that, tbd).

### Did you use AI to help find, test, or implement this issue or feature?
No, and I'm not angry, just disappointed that we have to ask people.
