### PR TITLE
Qt: Use default scrollbar policy

### DIFF
--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -230,7 +230,6 @@ void GameListWidget::initialize()
 	m_table_view->horizontalHeader()->setHighlightSections(false);
 	m_table_view->horizontalHeader()->setContextMenuPolicy(Qt::CustomContextMenu);
 	m_table_view->verticalHeader()->hide();
-	m_table_view->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
 	m_table_view->setVerticalScrollMode(QAbstractItemView::ScrollMode::ScrollPerPixel);
 	m_table_view->setItemDelegateForColumn(0, new GameListIconStyleDelegate(this));
 	m_table_view->setItemDelegateForColumn(8, new GameListIconStyleDelegate(this));


### PR DESCRIPTION
### Description of Changes

Adjusts the display policy of the vertical scrollbar on the Table View from `ScrollBarAlwaysOn` to the Qt default, which is [`ScrollBarAsNeeded`](https://doc.qt.io/qt-6/qabstractscrollarea.html#verticalScrollBarPolicy-prop).

#### Before (PCSX2 Flatpak)

| Before (PCSX2 Flatpak v2.4.0) | After (This PR) |
|-----|-----|
| <img width="1031" height="841" alt="image" src="https://github.com/user-attachments/assets/fbd919ec-ecc5-459b-9d9a-7769e866d8c8" /> | <img width="1029" height="841" alt="image" src="https://github.com/user-attachments/assets/e0daee4e-9bd0-4499-97f8-ffa92395b5e9" /> |


### Rationale behind Changes

I recognise that in the code, it is deliberate that the scrollbar policy is set to `ScrollBarAlwaysOn`. However, I will attempt to make a case as to why it should not be. I also recognise this may be a pedantic change, it bothered me while using PCSX2 and I thought I would change it. :slightly_smiling_face:

- It adds consistency with the Grid View, which does not display a scrollbar if there is no content to scroll to.
- The Grid View only displays the scrollbar as needed, and other Qt GUI applications that I have interacted with (at least on the Linux side) display the scrollbar as needed.
- This adds extra real estate, which could be at a premium on smaller displays.
- There is no reason to show the scrollbar if it is not required (i.e. if there is nothing to scroll to).

### Suggested Testing Steps

1. Open PCSX2.
2. If not selected, select the "Table View" option.
3. Adjust the height of the window until all items are visible within the height of the window.
4. The scrollbar will not display.
5. Shrink the window down so that items are cut off by the height of the window.
6. The scrollbar will display again.

### Did you use AI to help find, test, or implement this issue or feature?

No.
