### PR TITLE
Qt: Increase the height of the about dialog

### DIFF
--- a/pcsx2-qt/AboutDialog.ui
+++ b/pcsx2-qt/AboutDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>580</width>
-    <height>300</height>
+    <height>320</height>
    </rect>
   </property>
   <property name="windowTitle">


### PR DESCRIPTION
### Description of Changes
Increase the size of the about dialog from 300px to 320px.

Before:
<img width="614" height="354" alt="Screenshot_20250804_234121" src="https://github.com/user-attachments/assets/1dbbe4f2-3691-4378-81a0-f6e332106745" />

After:
<img width="614" height="374" alt="Screenshot_20250804_234237" src="https://github.com/user-attachments/assets/cc12af35-0d9a-4331-9826-f4f5683bc32f" />

### Rationale behind Changes
Previously on my system, the logo would appear squished.

### Suggested Testing Steps
Open the about dialog on an effected system.

### Did you use AI to help find, test, or implement this issue or feature?
No.
