### PR TITLE
Qt: Add shortcut for Search Bar

### DIFF
--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -26,6 +26,7 @@
 #include <QtWidgets/QMenu>
 #include <QtWidgets/QScrollBar>
 #include <QtWidgets/QStyledItemDelegate>
+#include <QShortcut>
 
 static const char* SUPPORTED_FORMATS_STRING = QT_TRANSLATE_NOOP(GameListWidget,
 	".bin/.iso (ISO Disc Images)\n"
@@ -215,6 +216,10 @@ void GameListWidget::initialize()
 	});
 	connect(m_ui.searchText, &QLineEdit::textChanged, this, [this](const QString& text) {
 		m_sort_model->setFilterName(text);
+	});
+
+	connect(new QShortcut(QKeySequence::Find, this), &QShortcut::activated, [this]() {
+		m_ui.searchText->setFocus();
 	});
 
 	m_table_view = new QTableView(m_ui.stack);


### PR DESCRIPTION
### Description of Changes

Adds a shortcut to activate the Search Bar on the GameListWidget. This shortcut is bound to [`QKeySequence::Find`](https://doc.qt.io/qt-6/qkeysequence.html), so on Windows and Linux this will correspond to Ctrl+F and on macOS this will correspond to Cmd+F to preserve expected behaviour across platforms.

No corresponding action was added to the menu bar, instead this is implemented using a `QShortcut` and a lambda to set the focus to the search bar.

### Rationale behind Changes

This is a minor quality of life change to implement further keyboard navigation.

### Suggested Testing Steps

1. Open PCSX2.
2. Press Ctrl+F on Windows or Linux, or Cmd+F on macOS.
3. The Search Bar should gain focus.

### Did you use AI to help find, test, or implement this issue or feature?

No, and I am not an expert with Qt or C++, so please don't hesitate to give feedback if there is a preferred way (to this codebase's standards or otherwise) to implement this functionality! :slightly_smiling_face: 
