### PR TITLE
MemoryCardFolder: Prevent rapidyaml from including trailing \0's in the index file names

### DIFF
--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -33,7 +33,7 @@ namespace GameDatabaseSchema
 
 namespace GameDatabase
 {
-	static void parseAndInsert(const std::string_view serial, const c4::yml::NodeRef& node);
+	static void parseAndInsert(const std::string_view serial, const ryml::NodeRef& node);
 	static void initDatabase();
 } // namespace GameDatabase
 
@@ -84,7 +84,7 @@ const char* GameDatabaseSchema::GameEntry::compatAsString() const
 	}
 }
 
-void GameDatabase::parseAndInsert(const std::string_view serial, const c4::yml::NodeRef& node)
+void GameDatabase::parseAndInsert(const std::string_view serial, const ryml::NodeRef& node)
 {
 	GameDatabaseSchema::GameEntry gameEntry;
 	if (node.has_child("name"))
@@ -947,7 +947,7 @@ void GameDatabase::initDatabase()
 			loc.line, loc.col, loc.offset, std::string_view(msg, msg_len)));
 	};
 	ryml::set_callbacks(rymlCallbacks);
-	c4::set_error_callback([](const char* msg, size_t msg_size) {
+	ryml::set_error_callback([](const char* msg, size_t msg_size) {
 		Console.Error(fmt::format("[GameDB YAML] Internal Parsing error: {}", std::string_view(msg, msg_size)));
 	});
 
@@ -958,7 +958,7 @@ void GameDatabase::initDatabase()
 		return;
 	}
 
-	ryml::Tree tree = ryml::parse_in_arena(c4::to_csubstr(buf.value()));
+	ryml::Tree tree = ryml::parse_in_arena(ryml::to_csubstr(buf.value()));
 	ryml::NodeRef root = tree.rootref();
 
 	for (const ryml::NodeRef& n : root.children())
@@ -1049,7 +1049,7 @@ static constexpr char HASHDB_YAML_FILE_NAME[] = "RedumpDatabase.yaml";
 std::unordered_map<GameDatabase::TrackHash, u32, TrackHashHasher> s_track_hash_to_entry_map;
 std::vector<GameDatabase::HashDatabaseEntry> s_hash_database;
 
-static bool parseHashDatabaseEntry(const c4::yml::NodeRef& node)
+static bool parseHashDatabaseEntry(const ryml::NodeRef& node)
 {
 	if (!node.has_child("name") || !node.has_child("hashes"))
 	{
@@ -1106,7 +1106,7 @@ bool GameDatabase::loadHashDatabase()
 			"[HashDatabase YAML] Parsing error at {}:{} (bufpos={}): {}", loc.line, loc.col, loc.offset, msg));
 	};
 	ryml::set_callbacks(rymlCallbacks);
-	c4::set_error_callback([](const char* msg, size_t msg_size) {
+	ryml::set_error_callback([](const char* msg, size_t msg_size) {
 		Console.Error(fmt::format("[HashDatabase YAML] Internal Parsing error: {}", std::string_view(msg, msg_size)));
 	});
 
@@ -1119,7 +1119,7 @@ bool GameDatabase::loadHashDatabase()
 		return false;
 	}
 
-	ryml::Tree tree = ryml::parse_in_arena(c4::to_csubstr(buf.value()));
+	ryml::Tree tree = ryml::parse_in_arena(ryml::to_csubstr(buf.value()));
 	ryml::NodeRef root = tree.rootref();
 
 	bool okay = true;

--- a/pcsx2/SIO/Memcard/MemoryCardFolder.cpp
+++ b/pcsx2/SIO/Memcard/MemoryCardFolder.cpp
@@ -43,12 +43,12 @@ static std::optional<ryml::Tree> loadYamlFile(const char* filePath)
 		errorCount++;
 	};
 	ryml::set_callbacks(rymlCallbacks);
-	c4::set_error_callback([](const char* msg, size_t msg_size) {
+	ryml::set_error_callback([](const char* msg, size_t msg_size) {
 		Console.Error(fmt::format("[YAML] Internal Parsing error: {}", std::string_view(msg, msg_size)));
 		errorCount++;
 	});
 
-	ryml::Tree tree = ryml::parse_in_arena(c4::to_csubstr(buffer.value()));
+	ryml::Tree tree = ryml::parse_in_arena(ryml::to_csubstr(buffer.value()));
 	ryml::reset_callbacks();
 	if (errorCount > 0)
 	{
@@ -1286,8 +1286,8 @@ void FolderMemoryCard::FlushFileEntries(const u32 dirCluster, const u32 remainin
 						// if _pcsx2_index hasn't been made yet, start a new file
 						if (!yaml.has_value())
 						{
-							char initialData[] = "{$ROOT: {timeCreated: 0, timeModified: 0}}";
-							ryml::Tree newYaml = ryml::parse_in_arena(c4::to_csubstr(initialData));
+							const char initialData[] = "{$ROOT: {timeCreated: 0, timeModified: 0}}";
+							ryml::Tree newYaml = ryml::parse_in_arena(ryml::to_csubstr(initialData));
 							ryml::NodeRef newNode = newYaml.rootref()["$ROOT"];
 							newNode["timeCreated"] << entry->entry.data.timeCreated.ToTime();
 							newNode["timeModified"] << entry->entry.data.timeModified.ToTime();
@@ -1751,7 +1751,7 @@ void FolderMemoryCard::AttemptToRecreateIndexFile(const std::string& directory) 
 		}
 
 		root.append_child() << ryml::key(fd.FileName) |= ryml::MAP;
-		ryml::NodeRef newNode = root[c4::to_csubstr(fd.FileName)];
+		ryml::NodeRef newNode = root[ryml::to_csubstr(fd.FileName)];
 		newNode["order"] << currOrder++;
 		newNode["timeCreated"] << currTime++;
 		newNode["timeModified"] << currTime++;
@@ -1812,9 +1812,9 @@ std::vector<FolderMemoryCard::EnumeratedFileEntry> FolderMemoryCard::GetOrderedF
 					{
 						auto key = std::string(n.key().str, n.key().len);
 					}
-					if (index.has_child(c4::to_csubstr(fd.FileName)))
+					if (index.has_child(ryml::to_csubstr(fd.FileName)))
 					{
-						const auto& node = index[c4::to_csubstr(fd.FileName)];
+						const auto& node = index[ryml::to_csubstr(fd.FileName)];
 						if (node.has_child("timeCreated"))
 						{
 							node["timeCreated"] >> entry.m_timeCreated;
@@ -1910,9 +1910,9 @@ void FolderMemoryCard::DeleteFromIndex(const std::string& filePath, const std::s
 	{
 		ryml::NodeRef index = yaml.value().rootref();
 
-		if (index.has_child(c4::csubstr(entry.data(), entry.length())))
+		if (index.has_child(ryml::csubstr(entry.data(), entry.length())))
 		{
-			index.remove_child(c4::csubstr(entry.data(), entry.length()));
+			index.remove_child(ryml::csubstr(entry.data(), entry.length()));
 			// Write out the changes
 			SaveYAMLToFile(indexName.c_str(), index);
 		}


### PR DESCRIPTION
### Description of Changes

Rapid YAML has a stupid `csubstr` constructor that spans the entire char array if one is given. After #11373 folder memcards started using that overly large span for the file name keys, and even serialized those trailing `\0`'s to disk.

In this PR, I:
1. Fix the index writing not to include the trailing NULs.
2. Add "repair" code to YAML loading to trim the NULs from the existing broken index files.

Relevant rapidyaml bug report for this defect:
https://github.com/biojppm/rapidyaml/issues/531

### Rationale behind Changes

Fixes #12659, even retroactively - existing "broken" folder memcards will work again once this PR is in.

### Suggested Testing Steps

Test if folder memcards load and save, and if the timestamps of files are correct across sessions.

### Did you use AI to help find, test, or implement this issue or feature?

No.