### PR TITLE
FSUI: Fix Navigation of leaderboards

### DIFF
--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -2848,8 +2848,14 @@ void Achievements::DrawLeaderboardsWindow()
 				const float tab_width = (ImGui::GetWindowWidth() / ImGuiFullscreen::g_layout_scale) * 0.5f;
 				ImGui::SetCursorPos(ImVec2(0.0f, top + spacing_small));
 
-				if (ImGui::IsKeyPressed(ImGuiKey_NavGamepadTweakSlow, false) || ImGui::IsKeyPressed(ImGuiKey_NavGamepadTweakFast, false))
+				if (ImGui::IsKeyPressed(ImGuiKey_NavGamepadTweakSlow, false) || ImGui::IsKeyPressed(ImGuiKey_NavGamepadTweakFast, false) ||
+					ImGui::IsKeyPressed(ImGuiKey_GamepadDpadLeft, false) || ImGui::IsKeyPressed(ImGuiKey_GamepadDpadRight, false) ||
+					ImGui::IsKeyPressed(ImGuiKey_LeftArrow, false) || ImGui::IsKeyPressed(ImGuiKey_RightArrow, false))
+				{
 					s_is_showing_all_leaderboard_entries = !s_is_showing_all_leaderboard_entries;
+				}
+
+				ImGuiFullscreen::BeginNavBar();
 
 				for (const bool show_all : {false, true})
 				{
@@ -2860,6 +2866,8 @@ void Achievements::DrawLeaderboardsWindow()
 						s_is_showing_all_leaderboard_entries = show_all;
 					}
 				}
+
+				ImGuiFullscreen::EndNavBar();
 
 				const ImVec2 bg_pos = ImVec2(0.0f, ImGui::GetCurrentWindow()->DC.CursorPos.y + LayoutScale(tab_height_unscaled));
 				const ImVec2 bg_size =
@@ -2914,7 +2922,6 @@ void Achievements::DrawLeaderboardsWindow()
 		}
 	}
 	ImGuiFullscreen::EndFullscreenWindow();
-	FullscreenUI::SetStandardSelectionFooterText(true);
 
 	if (!is_leaderboard_open)
 	{
@@ -2935,6 +2942,8 @@ void Achievements::DrawLeaderboardsWindow()
 			ImGuiFullscreen::EndMenuButtons();
 		}
 		ImGuiFullscreen::EndFullscreenWindow();
+
+		FullscreenUI::SetStandardSelectionFooterText(true);
 	}
 	else
 	{
@@ -3001,6 +3010,24 @@ void Achievements::DrawLeaderboardsWindow()
 			ImGuiFullscreen::EndMenuButtons();
 		}
 		ImGuiFullscreen::EndFullscreenWindow();
+
+		if (ImGuiFullscreen::IsGamepadInputSource())
+		{
+			const bool circleOK = ImGui::GetIO().ConfigNavSwapGamepadButtons;
+			ImGuiFullscreen::SetFullscreenFooterText(std::array{
+				std::make_pair(ICON_PF_DPAD_LEFT_RIGHT, TRANSLATE_SV("Achievements", "Switch Rankings")),
+				std::make_pair(ICON_PF_DPAD_UP_DOWN, TRANSLATE_SV("Achievements", "Change Selection")),
+				std::make_pair(circleOK ? ICON_PF_BUTTON_CROSS : ICON_PF_BUTTON_CIRCLE, TRANSLATE_SV("Achievements", "Back")),
+			});
+		}
+		else
+		{
+			ImGuiFullscreen::SetFullscreenFooterText(std::array{
+				std::make_pair(ICON_PF_ARROW_LEFT ICON_PF_ARROW_RIGHT, TRANSLATE_SV("Achievements", "Switch Rankings")),
+				std::make_pair(ICON_PF_ARROW_UP ICON_PF_ARROW_DOWN, TRANSLATE_SV("Achievements", "Change Selection")),
+				std::make_pair(ICON_PF_ESC, TRANSLATE_SV("Achievements", "Back")),
+			});
+		}
 	}
 
 	if (close_leaderboard_on_exit)

--- a/pcsx2/ImGui/ImGuiFullscreen.cpp
+++ b/pcsx2/ImGui/ImGuiFullscreen.cpp
@@ -1939,6 +1939,11 @@ bool ImGuiFullscreen::NavTab(const char* title, bool is_active, bool enabled /* 
 	if (enabled)
 	{
 		pressed = ImGui::ButtonBehavior(bb, id, &hovered, &held, ImGuiButtonFlags_NoNavFocus);
+		if (hovered)
+		{
+			const ImU32 col = ImGui::GetColorU32(held ? ImGuiCol_ButtonActive : ImGuiCol_ButtonHovered, 1.0f);
+			DrawMenuButtonFrame(bb.Min, bb.Max, col, true, 0.0f);
+		}
 	}
 	else
 	{
@@ -1947,11 +1952,11 @@ bool ImGuiFullscreen::NavTab(const char* title, bool is_active, bool enabled /* 
 		hovered = false;
 	}
 
-	const ImU32 col =
-		hovered ? ImGui::GetColorU32(held ? ImGuiCol_ButtonActive : ImGuiCol_ButtonHovered, 1.0f) :
-				  ImGui::GetColorU32(is_active ? background : ImVec4(background.x, background.y, background.z, 0.5f));
-
-	DrawMenuButtonFrame(bb.Min, bb.Max, col, true, 0.0f);
+	if (!hovered)
+	{
+		const ImU32 col = ImGui::GetColorU32(is_active ? background : ImVec4(background.x, background.y, background.z, 0.5f));
+		ImGui::RenderFrame(bb.Min, bb.Max, col, false, 0.0f);
+	}
 
 #if 0
 	// This looks a bit rubbish... but left it here if someone thinks they can improve it.


### PR DESCRIPTION
### Description of Changes
Fixes rendering of the "Show Best" Button
Fixes the selected cursor glitching out (Fixes https://github.com/PCSX2/pcsx2/issues/12932)

### Rationale behind Changes
`ImGuiFullscreen::NavTab()` is intended to draw the Nav buttons with a background.
It attempts to use `DrawMenuButtonFrame()` for this, however, this function is intended the selected outline, which ends up breaking the time navigation.
Instead, only use `DrawMenuButtonFrame()` for hovered (matching `ImGuiFullscreen::NavButton()` and directly use ImGui functions for drawing the background 

### Suggested Testing Steps
Navigate to Achievements > Leaderboards > [any leaderboard] and try navigating

### Did you use AI to help find, test, or implement this issue or feature?
No
