### PR TITLE
GS: Backup texture to upper 8 bits of Z during format conversion (WIP)

### DIFF
--- a/bin/resources/shaders/opengl/convert.glsl
+++ b/bin/resources/shaders/opengl/convert.glsl
@@ -40,6 +40,10 @@ in vec4 PSin_c;
 
 layout(binding = 0) uniform sampler2D TextureSampler;
 
+#if defined(ps_convert_float32_rgba8_2) || defined(ps_depth_copy_2)
+layout(binding = 1) uniform sampler2D TextureSampler2;
+#endif
+
 // Give a different name so I remember there is a special case!
 #if defined(ps_convert_rgba8_16bits) || defined(ps_convert_float32_32bits)
 layout(location = 0) out uint SV_Target1;
@@ -52,6 +56,13 @@ vec4 sample_c()
 	return texture(TextureSampler, PSin_t);
 }
 
+#if defined(ps_convert_float32_rgba8_2) || defined(ps_depth_copy_2)
+vec4 sample_c2()
+{
+	return texture(TextureSampler2, PSin_t);
+}
+#endif
+
 #ifdef ps_copy
 void ps_copy()
 {
@@ -63,6 +74,15 @@ void ps_copy()
 void ps_depth_copy()
 {
   gl_FragDepth = sample_c().r;
+}
+#endif
+
+#ifdef ps_depth_copy_2
+void ps_depth_copy_2()
+{
+  uint d = clamp(uint(sample_c().r * exp2(32.0f)), 0u, 0xFFFFFFu);
+  uint d2 = clamp(uint(sample_c2().r * exp2(8.0f)), 0u, 0xFFu) << 24;
+  gl_FragDepth = float(d | d2) * exp2(-32.0f);
 }
 #endif
 
@@ -108,6 +128,16 @@ void ps_convert_float32_rgba8()
 	// Convert a GL_FLOAT32 depth texture into a RGBA color texture
 	uint d = uint(sample_c().r * exp2(32.0f));
 	SV_Target0 = vec4(uvec4((d & 0xFFu), ((d >> 8) & 0xFFu), ((d >> 16) & 0xFFu), (d >> 24))) / vec4(255.0);
+}
+#endif
+
+#ifdef ps_convert_float32_rgba8_2
+void ps_convert_float32_rgba8_2()
+{
+	// Convert a GL_FLOAT32 depth texture into a RGBA color texture
+	uint d = uint(sample_c().r * exp2(32.0f));
+	uint d2 = uint(sample_c2().r * exp2(8.0f));
+	SV_Target0 = vec4(uvec4((d & 0xFFu), ((d >> 8) & 0xFFu), ((d >> 16) & 0xFFu), clamp(d2, 0u, 0xFFu))) / vec4(255.0);
 }
 #endif
 

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -54,6 +54,7 @@ const char* shaderName(ShaderConvert value)
 		case ShaderConvert::FLOAT32_TO_16_BITS:     return "ps_convert_float32_32bits";
 		case ShaderConvert::FLOAT32_TO_32_BITS:     return "ps_convert_float32_32bits";
 		case ShaderConvert::FLOAT32_TO_RGBA8:       return "ps_convert_float32_rgba8";
+		case ShaderConvert::FLOAT32_TO_RGBA8_2:     return "ps_convert_float32_rgba8_2";
 		case ShaderConvert::FLOAT32_TO_RGB8:        return "ps_convert_float32_rgba8";
 		case ShaderConvert::FLOAT16_TO_RGB5A1:      return "ps_convert_float16_rgb5a1";
 		case ShaderConvert::RGBA8_TO_FLOAT32:       return "ps_convert_rgba8_float32";
@@ -66,6 +67,7 @@ const char* shaderName(ShaderConvert value)
 		case ShaderConvert::RGB5A1_TO_FLOAT16_BILN: return "ps_convert_rgb5a1_float16_biln";
 		case ShaderConvert::FLOAT32_TO_FLOAT24:     return "ps_convert_float32_float24";
 		case ShaderConvert::DEPTH_COPY:             return "ps_depth_copy";
+		case ShaderConvert::DEPTH_COPY_2:           return "ps_depth_copy_2";
 		case ShaderConvert::DOWNSAMPLE_COPY:        return "ps_downsample_copy";
 		case ShaderConvert::RGBA_TO_8I:             return "ps_convert_rgba_8i";
 		case ShaderConvert::RGB5A1_TO_8I:           return "ps_convert_rgb5a1_8i";
@@ -609,6 +611,9 @@ void GSDevice::Recycle(GSTexture* t)
 		return;
 
 	t->SetLastFrameUsed(m_frame);
+
+	if (t->HasBackup32BitDepth())
+		t->RemoveBackup32BitDepth();
 
 	FastList<GSTexture*>& pool = m_pool[!t->IsTexture()];
 	pool.push_front(t);

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -30,6 +30,7 @@ enum class ShaderConvert
 	FLOAT32_TO_16_BITS,
 	FLOAT32_TO_32_BITS,
 	FLOAT32_TO_RGBA8,
+	FLOAT32_TO_RGBA8_2,
 	FLOAT32_TO_RGB8,
 	FLOAT16_TO_RGB5A1,
 	RGBA8_TO_FLOAT32,
@@ -42,6 +43,7 @@ enum class ShaderConvert
 	RGB5A1_TO_FLOAT16_BILN,
 	FLOAT32_TO_FLOAT24,
 	DEPTH_COPY,
+	DEPTH_COPY_2,
 	DOWNSAMPLE_COPY,
 	RGBA_TO_8I,
 	RGB5A1_TO_8I,
@@ -69,6 +71,33 @@ enum class ShaderInterlace
 	Count
 };
 
+// Indicates that the shader takes two sources: the normal depth texture and the backup texture to access the saved upper 8 bits.
+static inline bool NeedsBackup32BitDepth(ShaderConvert shader)
+{
+	switch (shader)
+	{
+		case ShaderConvert::DEPTH_COPY_2:
+		case ShaderConvert::FLOAT32_TO_RGBA8_2:
+			return true;
+		default:
+			return false;
+	}
+}
+
+// Get the equivalent shader that allows restoring the upper 8 bits of depth with the backup texture.
+static inline ShaderConvert GetShaderWithBackup32BitDepth(ShaderConvert shader)
+{
+	switch (shader)
+	{
+		case ShaderConvert::DEPTH_COPY:
+			return ShaderConvert::DEPTH_COPY_2;
+		case ShaderConvert::FLOAT32_TO_RGBA8:
+			return ShaderConvert::FLOAT32_TO_RGBA8_2;
+		default:
+			return shader;
+	}
+}
+
 static inline bool HasDepthOutput(ShaderConvert shader)
 {
 	switch (shader)
@@ -83,6 +112,7 @@ static inline bool HasDepthOutput(ShaderConvert shader)
 		case ShaderConvert::RGB5A1_TO_FLOAT16_BILN:
 		case ShaderConvert::FLOAT32_TO_FLOAT24:
 		case ShaderConvert::DEPTH_COPY:
+		case ShaderConvert::DEPTH_COPY_2:
 			return true;
 		default:
 			return false;

--- a/pcsx2/GS/Renderers/Common/GSTexture.cpp
+++ b/pcsx2/GS/Renderers/Common/GSTexture.cpp
@@ -14,8 +14,6 @@
 
 GSTexture::GSTexture() = default;
 
-GSTexture::~GSTexture() = default;
-
 bool GSTexture::Save(const std::string& fn)
 {
 	// Depth textures need special treatment - we have a stencil component.

--- a/pcsx2/GS/Renderers/Common/GSTexture.h
+++ b/pcsx2/GS/Renderers/Common/GSTexture.h
@@ -72,9 +72,16 @@ protected:
 	bool m_needs_mipmaps_generated = true;
 	ClearValue m_clear_value = {};
 
+	// Used to store full 32 bit range depth for depth textures in case the upper 8 bits
+	// needs to be used later.
+	GSTexture* m_backup_32_bit_depth = nullptr; 
 public:
 	GSTexture();
-	virtual ~GSTexture();
+	virtual ~GSTexture()
+	{
+		if (m_backup_32_bit_depth)
+			delete m_backup_32_bit_depth;
+	}
 
 	// Returns the native handle of a texture.
 	virtual void* GetNativeHandle() const = 0;
@@ -161,6 +168,29 @@ public:
 
 	// Helper routines for formats/types
 	static bool IsCompressedFormat(Format format) { return (format >= Format::BC1 && format <= Format::BC7); }
+
+	bool HasBackup32BitDepth()
+	{
+		return m_backup_32_bit_depth != nullptr;
+	}
+
+	void SetBackup32BitDepth(GSTexture* tex)
+	{
+		pxAssert(m_backup_32_bit_depth == nullptr);
+		m_backup_32_bit_depth = tex;
+	}
+
+	void RemoveBackup32BitDepth()
+	{
+		if (m_backup_32_bit_depth)
+			delete m_backup_32_bit_depth;
+		m_backup_32_bit_depth = nullptr;
+	}
+
+	GSTexture* GetBackup32BitDepth()
+	{
+		return m_backup_32_bit_depth;
+	}
 };
 
 class GSDownloadTexture

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -7485,8 +7485,9 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 	// Not gonna spend too much time with this, it's not likely to be used much, can't be less accurate than it was.
 	if (ds)
 	{
-		ds->m_alpha_max = std::max(static_cast<u32>(ds->m_alpha_max), static_cast<u32>(m_vt.m_max.p.z) >> 24);
-		ds->m_alpha_min = std::min(static_cast<u32>(ds->m_alpha_min), static_cast<u32>(m_vt.m_min.p.z) >> 24);
+		// Clamp to prevent overflow with float -> int conversion.
+		ds->m_alpha_max = std::max(static_cast<u32>(ds->m_alpha_max), std::clamp(static_cast<u32>(m_vt.m_max.p.z * 0x1.0fp-24), 0u, 255u));
+		ds->m_alpha_min = std::min(static_cast<u32>(ds->m_alpha_min), std::clamp(static_cast<u32>(m_vt.m_min.p.z * 0x1.0fp-24), 0u, 255u));
 		GL_INS("HW: New DS Alpha Range: %d-%d", ds->m_alpha_min, ds->m_alpha_max);
 
 		if (GSLocalMemory::m_psm[ds->m_TEX0.PSM].bpp == 16)

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2657,20 +2657,29 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVe
 		else if (dst->m_scale != scale)
 			scale = dst->m_scale;
 
-		// Game is changing from 32bit deptth to 24bit, meaning any top values in the depth will no longer be valid, I hope no games rely on these values being maintained, else we're screwed.
 		if (type == DepthStencil && dst->m_type == DepthStencil && GSLocalMemory::m_psm[dst->m_TEX0.PSM].trbpp == 32 && GSLocalMemory::m_psm[TEX0.PSM].trbpp == 24 && dst->m_alpha_max > 0)
 		{
+			// Game is changing from 32bit depth to 24bit, so backup the original 32 bit texture to preserve the upper 8 bits of Z.
 			calcRescale(dst);
 			GSTexture* tex = g_gs_device->CreateDepthStencil(new_scaled_size.x, new_scaled_size.y, GSTexture::Format::DepthStencil, false);
 			if (!tex)
 				return nullptr;
 			g_gs_device->StretchRect(dst->m_texture, sRect, tex, dRect, ShaderConvert::FLOAT32_TO_FLOAT24, false);
 			g_perfmon.Put(GSPerfMon::TextureCopies, 1);
-			g_gs_device->Recycle(dst->m_texture);
-
+			tex->SetBackup32BitDepth(dst->m_texture);
 			dst->m_texture = tex;
-			dst->m_alpha_min = 0;
-			dst->m_alpha_max = 0;
+		}
+		else if (type == DepthStencil && dst->m_type == DepthStencil && GSLocalMemory::m_psm[dst->m_TEX0.PSM].trbpp == 24 && GSLocalMemory::m_psm[TEX0.PSM].trbpp == 32 && dst->m_texture->HasBackup32BitDepth())
+		{
+			// Game is changing from 24bit depth to 32bit, so restore the backed up upper 8 bits (if it exists).
+			calcRescale(dst);
+			GSTexture* tex = g_gs_device->CreateDepthStencil(new_scaled_size.x, new_scaled_size.y, GSTexture::Format::DepthStencil, false);
+			if (!tex)
+				return nullptr;
+			g_gs_device->StretchRect(dst->m_texture, sRect, tex, dRect, ShaderConvert::DEPTH_COPY, false); // Depth copy will automatically use the backed up data.
+			g_perfmon.Put(GSPerfMon::TextureCopies, 1);
+			g_gs_device->Recycle(dst->m_texture);
+			dst->m_texture = tex;
 		}
 		else if ((used || type == GSTextureCache::DepthStencil) && (std::abs(static_cast<s16>(GSLocalMemory::m_psm[dst->m_TEX0.PSM].bpp - GSLocalMemory::m_psm[TEX0.PSM].bpp)) == 16))
 		{
@@ -3125,6 +3134,15 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVe
 						dst_match->UnscaleRTAlpha();
 						g_gs_device->StretchRect(dst_match->m_texture, sRect, dst->m_texture, dRect, shader, false);
 						g_perfmon.Put(GSPerfMon::TextureCopies, 1);
+
+						if (shader == ShaderConvert::RGBA8_TO_FLOAT24)
+						{
+							// Copy all 32 bits of color into the back up texture in case the game converts to 32bit depth later.
+							GSTexture* tex = g_gs_device->CreateDepthStencil(new_scaled_size.x, new_scaled_size.y, GSTexture::Format::DepthStencil, false);
+							g_gs_device->StretchRect(dst_match->m_texture, sRect, tex, dRect, ShaderConvert::RGBA8_TO_FLOAT32, false);
+							g_perfmon.Put(GSPerfMon::TextureCopies, 1);
+							dst->m_texture->SetBackup32BitDepth(tex);
+						}
 					}
 				}
 

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -320,7 +320,7 @@ public:
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, ShaderConvert shader = ShaderConvert::COPY, bool linear = true) override;
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, const GLProgram& ps, bool linear = true);
 	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, bool red, bool green, bool blue, bool alpha, ShaderConvert shader = ShaderConvert::COPY) override;
-	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, const GLProgram& ps, bool alpha_blend, OMColorMaskSelector cms, bool linear = true);
+	void StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, const GLProgram& ps, bool alpha_blend, OMColorMaskSelector cms, bool linear = true, bool useBackup32BitDepth = false);
 	void PresentRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, PresentShader shader, float shaderTime, bool linear) override;
 	void UpdateCLUTTexture(GSTexture* sTex, float sScale, u32 offsetX, u32 offsetY, GSTexture* dTex, u32 dOffset, u32 dSize) override;
 	void ConvertToIndexedTexture(GSTexture* sTex, float sScale, u32 offsetX, u32 offsetY, u32 SBW, u32 SPSM, GSTexture* dTex, u32 DBW, u32 DPSM) override;


### PR DESCRIPTION
Status: Waiting on this PR https://github.com/PCSX2/pcsx2/pull/13159 (refactors to make implmentations cleaner)

Draft PR to address issue noted here: https://github.com/PCSX2/pcsx2/issues/13037. Only OpenGL has been implemented and some other things are also unfinished (see below). Any feedback/criticism on whether this is a feasible approach is much appreciated.

All renderers except OpenGL are currently broken in the PR (including software since its uses Vulkan shaders).

### Description of Changes
Add a new member to GSTexture to keep track of 32 bit Z when Z32 is converted to Z24, and the code needed to make sure that the upper 8 bits of Z are preserved when converting from Z24 back to Z32 or to C32/24.

Unfinished things:
1. Conversions from Z24 -> Z32 to a 16 (rather than 32) bit format.
2. Not sure yet how to handle clears, whether the upper 8 bits should be preserved or cleared also when Z buf is in Z24.
3. Handling other conversions like Z32 -> Z24 then using upper 8 bits as P8H, etc. (not sure if games actually do this).

### Rationale behind Changes
Allows preserving the upper 8 bits of Z that might help the issue above.

### Suggested Testing Steps
Might affects a lot of code so testing any game for bugs (there are probably a few) would help. Haven't yet done a fully dump run.

[Army Men - Major Malfunction_SLES-53996_20250806151204.zip](https://github.com/user-attachments/files/21822990/Army.Men.-.Major.Malfunction_SLES-53996_20250806151204.zip)

Master (OpenGL):
<img width="640" height="512" alt="00102_f00001_fr-1_02800_C_16S" src="https://github.com/user-attachments/assets/7936b0be-4d35-4a76-8aa2-5697e1a7835a" />

PR (OpenGL):
<img width="640" height="512" alt="00102_f00001_fr-1_02800_C_16S" src="https://github.com/user-attachments/assets/3baca4a3-a827-4a48-a723-381808586936" />

### Did you use AI to help find, test, or implement this issue or feature?
GitHub copilot.
