### PR TITLE
usb-msd: separate message for empty image path

### DIFF
--- a/pcsx2/USB/usb-msd/usb-msd.cpp
+++ b/pcsx2/USB/usb-msd/usb-msd.cpp
@@ -1139,9 +1139,16 @@ namespace usb_msd
 				break;
 		}
 
-		if (path.empty() || !(s->file = FileSystem::OpenCFile(path.c_str(), "r+b")))
+		if (path.empty())
 		{
-			Host::AddOSDMessage(fmt::format(TRANSLATE_FS("USB", "usb-msd: Could not open image file '{}'"), path),
+			Host::AddOSDMessage(fmt::format(TRANSLATE_FS("USB", "USB mass storage: No image path specified")),
+				Host::OSD_ERROR_DURATION);
+			goto fail;
+		}
+
+		if (!(s->file = FileSystem::OpenCFile(path.c_str(), "r+b")))
+		{
+			Host::AddOSDMessage(fmt::format(TRANSLATE_FS("USB", "USB mass storage: Could not open image file '{}'"), path),
 				Host::OSD_ERROR_DURATION);
 			goto fail;
 		}


### PR DESCRIPTION
### Description of Changes
* Changes the current OSD message for a failure to open a USB mass storage device from `usb-msd: Could not open image file '[path]'` to `USB mass storage: Could not open image file '[path]'`
* Adds a separate condition for an empty path: `USB mass storage: No image path specified`

<img width="310" height="83" alt="image" src="https://github.com/user-attachments/assets/f5558717-96c7-4ca1-b5eb-6dc3b3e51bc9" />

### Rationale behind Changes
* `usb-msd` is not legible to most users. I had to ask somebody what it meant because I didn't realize I had the option enabled.
* Previously, the empty path message was `usb-msd: Could not open image file ''`.
  * This looks confusing to the user, especially one who might've selected the MSD by accident.
  * The current message implies it's tried and failed to open a file when, in reality, it has nothing to try.

### Suggested Testing Steps
* Try opening a game with an empty path on both MSD device types.
* Try opening a game with a garbage path on both MSD device types.
* Try opening a game with a valid path to a valid image on both MSD device types.

### Did you use AI to help find, test, or implement this issue or feature?
Yes. Without even being asked, GitHub helpfully hallucinated up a fix to my search term. I could NOT have made this PR without it. God bless you, Thomas Dohmke.

<img width="944" height="378" alt="image" src="https://github.com/user-attachments/assets/0c294c26-a67a-4a86-911a-490cc9b07b86" />