### PR TITLE
GS/HW: Handle texture shuffle with pixel reversals.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -65,6 +65,7 @@ private:
 	bool IsDiscardingDstRGB();
 	bool IsDiscardingDstAlpha() const;
 	bool TextureCoversWithoutGapsNotEqual();
+	bool Is8PixelReverseSprite(const GSVertex& v0, const GSVertex& v1);
 
 	enum class CLUTDrawTestResult
 	{


### PR DESCRIPTION
### Description of Changes
Detect when a game (maybe just Colin McRae Rally 2005) is doing a texture shuffle and (a) flipping pixels locations horizontally in columns and (b) correcting the pixels locations by flipping pixels horizontally again. Ignore both flips so that they cancel out.

### Rationale behind Changes
The flipping coordinates where throwing off the heuristics to detemine which channels to shuffle. By ignoring them we obtain correct heuristics. Aims to address some of the issues here: https://github.com/PCSX2/pcsx2/issues/1546. In a dump run only Colin McRae Rally 2005 seems to be affected by the PR.

Master:
<img width="512" height="512" alt="S043747_19099_f00002_fr-1_01000_C_16_Colin McRae Rally 2005_SLES-52636_20230403172639 gs xz_master" src="https://github.com/user-attachments/assets/7c2538e5-fdea-458f-9a0b-238afac1d702" />

PR:
<img width="512" height="512" alt="S043747_19099_f00002_fr-1_01000_C_16_Colin McRae Rally 2005_SLES-52636_20230403172639 gs xz_reversal" src="https://github.com/user-attachments/assets/11671bd2-87d9-4b62-8500-54c10faac71c" />

[Colin McRae Rally 2005_SLES-52636_20230403172639.gs.xz.zip](https://github.com/user-attachments/files/21820025/Colin.McRae.Rally.2005_SLES-52636_20230403172639.gs.xz.zip)

### Suggested Testing Steps
So far tested on dumps run with OpenGL and about ~500 dumps know to use texture shuffle. Testing on any games that use texture shuffle would be helpful.

Edit: Tested of full dump run.

### Did you use AI to help find, test, or implement this issue or feature?
Yes. GitHub Copilot.
