### PR TITLE
Pad/OSD: Add Analog Light/Locked State Indicator

### DIFF
--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -688,7 +688,11 @@ __ri void ImGuiManager::DrawInputsOverlay(float scale, float margin, float spaci
 			continue;
 
 		const Pad::ControllerInfo& cinfo = pad->GetInfo();
-		text.format("{} {} • {} |", ICON_FA_GAMEPAD, slot + 1u, cinfo.icon_name ? cinfo.icon_name : ICON_FA_TRIANGLE_EXCLAMATION);
+
+		const bool analog_light = pad->IsAnalogLightEnabled();
+		const bool analog_lock = pad->IsAnalogLocked();
+
+		text.format("{} {} • {} {}{} | ", ICON_FA_GAMEPAD, slot + 1u, cinfo.icon_name ? cinfo.icon_name : ICON_FA_TRIANGLE_EXCLAMATION, analog_light ? ICON_FA_LIGHTBULB : "", analog_lock ? ICON_FA_LOCK : "");
 
 		for (u32 bind = 0; bind < static_cast<u32>(cinfo.bindings.size()); bind++)
 		{

--- a/pcsx2/SIO/Pad/PadBase.h
+++ b/pcsx2/SIO/Pad/PadBase.h
@@ -26,6 +26,8 @@ protected:
 	Pad::Mode currentMode = Pad::Mode::NOT_SET;
 	Pad::Command currentCommand = Pad::Command::NOT_SET;
 	size_t commandBytesReceived = 0;
+	bool analogLight = false;
+	bool analogLocked = false;
 
 public: // Public members
 	PadBase(u8 unifiedSlot, size_t ejectTicks = 0);
@@ -54,6 +56,8 @@ public: // Public members
 	virtual std::tuple<u8, u8> GetRawRightAnalog() const = 0;
 	virtual u32 GetButtons() const = 0;
 	virtual u8 GetPressure(u32 index) const = 0;
+	virtual bool IsAnalogLightEnabled() const = 0;
+	virtual bool IsAnalogLocked() const = 0;
 
 	virtual bool Freeze(StateWrapper& sw);
 

--- a/pcsx2/SIO/Pad/PadDualshock2.cpp
+++ b/pcsx2/SIO/Pad/PadDualshock2.cpp
@@ -853,6 +853,16 @@ u8 PadDualshock2::GetPressure(u32 index) const
 	}
 }
 
+bool PadDualshock2::IsAnalogLightEnabled() const
+{
+	return this->analogLight;
+}
+
+bool PadDualshock2::IsAnalogLocked() const
+{
+	return this->analogLocked;
+}
+
 bool PadDualshock2::Freeze(StateWrapper& sw)
 {
 	if (!PadBase::Freeze(sw) || !sw.DoMarker("PadDualshock2"))

--- a/pcsx2/SIO/Pad/PadDualshock2.h
+++ b/pcsx2/SIO/Pad/PadDualshock2.h
@@ -63,8 +63,6 @@ private:
 
 	u32 buttons = 0xffffffffu;
 	Analogs analogs;
-	bool analogLight = false;
-	bool analogLocked = false;
 	// Analog button can be held without changing its state.
 	// We track here if it is currently held down, to avoid flipping in
 	// and out of analog mode every frame.
@@ -155,6 +153,8 @@ public:
 	std::tuple<u8, u8> GetRawRightAnalog() const override;
 	u32 GetButtons() const override;
 	u8 GetPressure(u32 index) const override;
+	bool IsAnalogLightEnabled() const override;
+	bool IsAnalogLocked() const override;
 
 	bool Freeze(StateWrapper& sw) override;
 

--- a/pcsx2/SIO/Pad/PadGuitar.cpp
+++ b/pcsx2/SIO/Pad/PadGuitar.cpp
@@ -402,6 +402,16 @@ u8 PadGuitar::GetPressure(u32 index) const
 	return 0;
 }
 
+bool PadGuitar::IsAnalogLightEnabled() const
+{
+	return this->analogLight;
+}
+
+bool PadGuitar::IsAnalogLocked() const
+{
+	return this->analogLocked;
+}
+
 bool PadGuitar::Freeze(StateWrapper& sw)
 {
 	if (!PadBase::Freeze(sw) || !sw.DoMarker("PadGuitar"))

--- a/pcsx2/SIO/Pad/PadGuitar.h
+++ b/pcsx2/SIO/Pad/PadGuitar.h
@@ -27,11 +27,6 @@ public:
 private:
 	u32 buttons = 0xffffffffu;
 	u8 whammy = Pad::ANALOG_NEUTRAL_POSITION;
-	// Technically guitars do not have an analog light, but they still use the same ModeSwitch command
-	// as a DS2, and are told to "turn on their light".
-	bool analogLight = false;
-	// Guitars are also instructed to "lock" their "analog light", despite not having one.
-	bool analogLocked = false;
 	bool commandStage = false;
 	float whammyAxisScale = 1.0f; // Guitars only have 1 axis on the whammy bar.
 	float whammyDeadzone = 0.0f;
@@ -87,6 +82,8 @@ public:
 	std::tuple<u8, u8> GetRawRightAnalog() const override;
 	u32 GetButtons() const override;
 	u8 GetPressure(u32 index) const override;
+	bool IsAnalogLightEnabled() const override;
+	bool IsAnalogLocked() const override;
 
 	bool Freeze(StateWrapper& sw) override;
 

--- a/pcsx2/SIO/Pad/PadJogcon.cpp
+++ b/pcsx2/SIO/Pad/PadJogcon.cpp
@@ -450,6 +450,16 @@ u8 PadJogcon::GetPressure(u32 index) const
 	return 0;
 }
 
+bool PadJogcon::IsAnalogLightEnabled() const
+{
+	return this->analogLight;
+}
+
+bool PadJogcon::IsAnalogLocked() const
+{
+	return this->analogLocked;
+}
+
 bool PadJogcon::Freeze(StateWrapper& sw)
 {
 	if (!PadBase::Freeze(sw) || !sw.DoMarker("PadJogcon"))

--- a/pcsx2/SIO/Pad/PadJogcon.h
+++ b/pcsx2/SIO/Pad/PadJogcon.h
@@ -43,8 +43,6 @@ private:
 	s16 dial = 0x0000;
 	s16 lastdial = 0x0000;
 
-	bool analogLight = false;
-	bool analogLocked = false;
 	bool commandStage = false;
 	std::array<u8, VIBRATION_MOTORS> vibrationMotors = {};
 	std::array<float, 2> vibrationScale = {1.0f, 1.0f};
@@ -114,6 +112,8 @@ public:
 	std::tuple<u8, u8> GetRawRightAnalog() const override;
 	u32 GetButtons() const override;
 	u8 GetPressure(u32 index) const override;
+	bool IsAnalogLightEnabled() const override;
+	bool IsAnalogLocked() const override;
 
 	bool Freeze(StateWrapper& sw) override;
 

--- a/pcsx2/SIO/Pad/PadNegcon.cpp
+++ b/pcsx2/SIO/Pad/PadNegcon.cpp
@@ -458,6 +458,16 @@ u8 PadNegcon::GetPressure(u32 index) const
 	return 0;
 }
 
+bool PadNegcon::IsAnalogLightEnabled() const
+{
+	return this->analogLight;
+}
+
+bool PadNegcon::IsAnalogLocked() const
+{
+	return this->analogLocked;
+}
+
 bool PadNegcon::Freeze(StateWrapper& sw)
 {
 	if (!PadBase::Freeze(sw) || !sw.DoMarker("PadNegcon"))

--- a/pcsx2/SIO/Pad/PadNegcon.h
+++ b/pcsx2/SIO/Pad/PadNegcon.h
@@ -47,8 +47,6 @@ private:
 	u32 buttons = 0xffffffffu;
 	Analogs analogs;
 
-	bool analogLight = false;
-	bool analogLocked = false;
 	bool commandStage = false;
 	std::array<u8, VIBRATION_MOTORS> vibrationMotors = {};
 	std::array<float, 2> vibrationScale = {1.0f, 1.0f};
@@ -126,6 +124,8 @@ public:
 	std::tuple<u8, u8> GetRawRightAnalog() const override;
 	u32 GetButtons() const override;
 	u8 GetPressure(u32 index) const override;
+	bool IsAnalogLightEnabled() const override;
+	bool IsAnalogLocked() const override;
 
 	bool Freeze(StateWrapper& sw) override;
 

--- a/pcsx2/SIO/Pad/PadNotConnected.cpp
+++ b/pcsx2/SIO/Pad/PadNotConnected.cpp
@@ -111,6 +111,16 @@ u8 PadNotConnected::GetPressure(u32 index) const
 	return 0;
 }
 
+bool PadNotConnected::IsAnalogLightEnabled() const
+{
+	return this->analogLight;
+}
+
+bool PadNotConnected::IsAnalogLocked() const
+{
+	return this->analogLocked;
+}
+
 u8 PadNotConnected::SendCommandByte(u8 commandByte)
 {
 	return 0xff;

--- a/pcsx2/SIO/Pad/PadNotConnected.h
+++ b/pcsx2/SIO/Pad/PadNotConnected.h
@@ -30,6 +30,8 @@ public:
 	std::tuple<u8, u8> GetRawRightAnalog() const override;
 	u32 GetButtons() const override;
 	u8 GetPressure(u32 index) const override;
+	bool IsAnalogLightEnabled() const override;
+	bool IsAnalogLocked() const override;
 
 	u8 SendCommandByte(u8 commandByte) override;
 

--- a/pcsx2/SIO/Pad/PadPopn.cpp
+++ b/pcsx2/SIO/Pad/PadPopn.cpp
@@ -475,6 +475,16 @@ u8 PadPopn::GetPressure(u32 index) const
 	return 0;
 }
 
+bool PadPopn::IsAnalogLightEnabled() const
+{
+	return this->analogLight;
+}
+
+bool PadPopn::IsAnalogLocked() const
+{
+	return this->analogLocked;
+}
+
 bool PadPopn::Freeze(StateWrapper& sw)
 {
 	if (!PadBase::Freeze(sw) || !sw.DoMarker("PadPopn"))

--- a/pcsx2/SIO/Pad/PadPopn.h
+++ b/pcsx2/SIO/Pad/PadPopn.h
@@ -50,8 +50,6 @@ private:
 
 	u32 buttons = 0xffffffffu;
 	Analogs analogs;
-	bool analogLight = false;
-	bool analogLocked = false;
 	// Analog button can be held without changing its state.
 	// We track here if it is currently held down, to avoid flipping in
 	// and out of analog mode every frame.
@@ -111,6 +109,8 @@ public:
 	std::tuple<u8, u8> GetRawRightAnalog() const override;
 	u32 GetButtons() const override;
 	u8 GetPressure(u32 index) const override;
+	bool IsAnalogLightEnabled() const override;
+	bool IsAnalogLocked() const override;
 	
 	bool Freeze(StateWrapper& sw) override;
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
This PR is the extension of #13143 (Please merge that first before this PR)

Adds Analog Light/Locked Indicator to the Input OSD.

Preview:
<img width="238" height="120" alt="Screenshot_20250817_134256" src="https://github.com/user-attachments/assets/895e2ac7-7feb-491c-a58a-e493d96cb0c7" />

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
More QoL Improvements.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Check games that uses analog in some way and make sure it still works.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
I use Pan if that count 