### PR TITLE
UI: Enhance warning for memory card corruption

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1158,8 +1158,8 @@ bool MainWindow::shouldAbortForMemcardBusy(const VMLock& lock)
 	{
 		const QMessageBox::StandardButton res = QMessageBox::critical(
 			lock.getDialogParent(),
-			tr("WARNING: Memory Card Busy"),
-			tr("WARNING: Your memory card is still writing data. Shutting down now <b>WILL IRREVERSIBLY DESTROY YOUR MEMORY CARD.</b> It is strongly recommended to resume your game and let it finish writing to your memory card.<br><br>Do you wish to shutdown anyways and <b>IRREVERSIBLY DESTROY YOUR MEMORY CARD?</b>"), QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+			tr("⚠️ DANGER: Memory Card Busy! ⚠️"),
+			tr("Your memory card is still saving data. Shutting down now will <b>IRREVERSIBLY CORRUPT YOUR MEMORY CARD.</b> You are strongly advised to select 'No' and let the game finish saving.<br><br>Do you want to shut down anyway and <b>IRREVERSIBLY CORRUPT YOUR MEMORY CARD?</b>"), QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
 
 		if (res != QMessageBox::Yes)
 		{

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -1389,9 +1389,9 @@ void FullscreenUI::ConfirmShutdownIfMemcardBusy(std::function<void(bool)> callba
 		return;
 	}
 
-	OpenConfirmMessageDialog(FSUI_ICONSTR(ICON_PF_MEMORY_CARD, "WARNING: Memory Card Busy"),
-		FSUI_STR("WARNING: Your memory card is still writing data. Shutting down now will IRREVERSIBLY DESTROY YOUR MEMORY CARD. It is strongly recommended to resume your game and let it finish writing to your memory card.\n\nDo you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?"),
-		std::move(callback));
+	OpenConfirmMessageDialog(FSUI_ICONSTR(ICON_PF_MEMORY_CARD, "⚠️ DANGER: Memory Card Busy! ⚠️"),
+		FSUI_STR("Your memory card is still saving data. Shutting down now will IRREVERSIBLY CORRUPT YOUR MEMORY CARD. You are strongly advised to select 'No' and let the game finish saving.\n\nDo you want to shut down anyway and IRREVERSIBLY CORRUPT YOUR MEMORY CARD?"),
+		std::move(callback), FSUI_STR("🔥 Yes, corrupt my memory card."), FSUI_STR("💾 No, let the save finish."));
 }
 
 bool FullscreenUI::ShouldDefaultToGameList()
@@ -7960,7 +7960,9 @@ void FullscreenUI::DrawAchievementsSettingsPage(std::unique_lock<std::mutex>& se
 // TRANSLATION-STRING-AREA-BEGIN
 TRANSLATE_NOOP("FullscreenUI", "Error");
 TRANSLATE_NOOP("FullscreenUI", "Could not find any CD/DVD-ROM devices. Please ensure you have a drive connected and sufficient permissions to access it.");
-TRANSLATE_NOOP("FullscreenUI", "WARNING: Your memory card is still writing data. Shutting down now will IRREVERSIBLY DESTROY YOUR MEMORY CARD. It is strongly recommended to resume your game and let it finish writing to your memory card.\n\nDo you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?");
+TRANSLATE_NOOP("FullscreenUI", "Your memory card is still saving data. Shutting down now will IRREVERSIBLY CORRUPT YOUR MEMORY CARD. You are strongly advised to select 'No' and let the game finish saving.\n\nDo you want to shut down anyway and IRREVERSIBLY CORRUPT YOUR MEMORY CARD?");
+TRANSLATE_NOOP("FullscreenUI", "🔥 Yes, corrupt my memory card.");
+TRANSLATE_NOOP("FullscreenUI", "💾 No, let the save finish.");
 TRANSLATE_NOOP("FullscreenUI", "Use Global Setting");
 TRANSLATE_NOOP("FullscreenUI", "Automatic binding failed, no devices are available.");
 TRANSLATE_NOOP("FullscreenUI", "Game title copied to clipboard.");
@@ -8679,7 +8681,7 @@ TRANSLATE_NOOP("FullscreenUI", "Change View");
 TRANSLATE_NOOP("FullscreenUI", "Launch Options");
 TRANSLATE_NOOP("FullscreenUI", "Select Disc Image");
 TRANSLATE_NOOP("FullscreenUI", "Select Disc Drive");
-TRANSLATE_NOOP("FullscreenUI", "WARNING: Memory Card Busy");
+TRANSLATE_NOOP("FullscreenUI", "⚠️ DANGER: Memory Card Busy! ⚠️");
 TRANSLATE_NOOP("FullscreenUI", "Set Input Binding");
 TRANSLATE_NOOP("FullscreenUI", "Region");
 TRANSLATE_NOOP("FullscreenUI", "Compatibility Rating");


### PR DESCRIPTION
### Description of Changes
Changes the Desktop UI and Fullscreen UI warning presented when the user attempts to close while the game is still saving data. It's more obvious and direct.

<img width="949" height="523" alt="image" src="https://github.com/user-attachments/assets/bcd44ee3-62e7-418b-bc8d-0c2117763273" />

<img width="670" height="350" alt="image" src="https://github.com/user-attachments/assets/7ff2c84b-f429-44d5-b94e-2b5609013f0c" />

### Rationale behind Changes
* Change "WARNING" to "DANGER" because we assert this "will" happen if the user proceeds.
* Removing the second "WARNING" right beneath the first one makes the message more legible and draws the user's eyes toward "IRREVERSIBLY DESTROY YOUR MEMORY CARD". All-caps needs to be used sparingly to direct the user's eyes and not have them glaze over. The user has already been generically warned; now we want them to know specifically *why* as soon as possible.
* "save" instead of "write", because that's just as accurate but also more concrete to the large portion of non-technical users. I'm going to cite [a relevant xkcd](https://xkcd.com/2501/) for anyone who doesn't believe most people don't know what read–write is.
* Added warning symbols and an exclamation point to the banner so the user is immediately aware something is wrong (more beneficial to the Fullscreen UI where there's no large 'stop' cross).
* Changed "DESTROY" to "CORRUPT", as even though "destroy" is more severe than "corrupt", "corrupt" more immediately grabs people's attention and simultaneously gives them concrete consequences.
* Changed "It is strongly recommended to" to "You are strongly advised to". First is too indirect for an urgent request like this.
* Changed the recommendation from "resume the game and let it finish writing to your memory card" to "select 'No' and let the game finish saving". This directly connects to the recommended option, which is important for a user who might be panicked seeing this message.
* "shutdown" to "shut down", as "shutdown" is strictly a noun, and "anyways" to "anyway" because that's not the correct usage.
* In the Fullscreen UI, added symbols to the options and spelled out what the user is asking to do. This prevents any confusion from a user who might think 'Yes' is the recommended option (especially given it had a checkmark before).

### Suggested Testing Steps
Make sure the message still displays correctly with emojis and that there are no typos.

### Did you use AI to help find, test, or implement this issue or feature?
WARNING: ChatGPT is still writing code. Shutting down now will IRREVERSIBLY DESTROY YOUR PULL REQUEST. It is strongly recommended to resume and let it finish writing your code.

Do you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR PULL REQUEST?
