### PR TITLE
Debugger: Add Integer Base and Show Leading Zeroes options to the symbol trees

### DIFF
--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeDelegates.h
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeDelegates.h
@@ -3,10 +3,12 @@
 
 #pragma once
 
-#include <QtWidgets/QStyledItemDelegate>
-#include <QtWidgets/QLineEdit>
+#include "Debugger/SymbolTree/SymbolTreeNode.h"
 
 #include "DebugTools/DebugInterface.h"
+
+#include <QtWidgets/QStyledItemDelegate>
+#include <QtWidgets/QLineEdit>
 
 class SymbolTreeValueDelegate : public QStyledItemDelegate
 {
@@ -21,8 +23,6 @@ public:
 	void setEditorData(QWidget* editor, const QModelIndex& index) const override;
 	void setModelData(QWidget* editor, QAbstractItemModel* model, const QModelIndex& index) const override;
 
-	void setIntegerBase(int base) { m_integer_base = base; }
-
 private:
 	// These make it so the values inputted are written back to memory
 	// immediately when the widgets are interacted with rather than when they
@@ -31,7 +31,6 @@ private:
 	void onComboBoxIndexChanged(int index);
 
 	DebugInterface& m_cpu;
-	int m_integer_base = 10;
 };
 
 class SymbolTreeLocationDelegate : public QStyledItemDelegate
@@ -75,7 +74,7 @@ class SymbolTreeIntegerLineEdit : public QLineEdit
 	Q_OBJECT
 
 public:
-	SymbolTreeIntegerLineEdit(int base, QWidget* parent);
+	SymbolTreeIntegerLineEdit(SymbolTreeDisplayOptions display_options, s32 size_bits, QWidget* parent);
 
 	std::optional<u64> unsignedValue();
 	void setUnsignedValue(u64 value);
@@ -84,5 +83,6 @@ public:
 	void setSignedValue(s64 value);
 
 private:
-	int m_base;
+	SymbolTreeDisplayOptions m_display_options;
+	s32 m_size_bits;
 };

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeDelegates.h
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeDelegates.h
@@ -4,9 +4,9 @@
 #pragma once
 
 #include <QtWidgets/QStyledItemDelegate>
+#include <QtWidgets/QLineEdit>
 
 #include "DebugTools/DebugInterface.h"
-#include "DebugTools/SymbolGuardian.h"
 
 class SymbolTreeValueDelegate : public QStyledItemDelegate
 {
@@ -21,7 +21,9 @@ public:
 	void setEditorData(QWidget* editor, const QModelIndex& index) const override;
 	void setModelData(QWidget* editor, QAbstractItemModel* model, const QModelIndex& index) const override;
 
-protected:
+	void setIntegerBase(int base) { m_integer_base = base; }
+
+private:
 	// These make it so the values inputted are written back to memory
 	// immediately when the widgets are interacted with rather than when they
 	// are deselected.
@@ -29,6 +31,7 @@ protected:
 	void onComboBoxIndexChanged(int index);
 
 	DebugInterface& m_cpu;
+	int m_integer_base = 10;
 };
 
 class SymbolTreeLocationDelegate : public QStyledItemDelegate
@@ -45,7 +48,7 @@ public:
 	void setEditorData(QWidget* editor, const QModelIndex& index) const override;
 	void setModelData(QWidget* editor, QAbstractItemModel* model, const QModelIndex& index) const override;
 
-protected:
+private:
 	DebugInterface& m_cpu;
 	u32 m_alignment;
 };
@@ -63,6 +66,23 @@ public:
 	void setEditorData(QWidget* editor, const QModelIndex& index) const override;
 	void setModelData(QWidget* editor, QAbstractItemModel* model, const QModelIndex& index) const override;
 
-protected:
+private:
 	DebugInterface& m_cpu;
+};
+
+class SymbolTreeIntegerLineEdit : public QLineEdit
+{
+	Q_OBJECT
+
+public:
+	SymbolTreeIntegerLineEdit(int base, QWidget* parent);
+
+	std::optional<u64> unsignedValue();
+	void setUnsignedValue(u64 value);
+
+	std::optional<s64> signedValue();
+	void setSignedValue(s64 value);
+
+private:
+	int m_base;
 };

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeModel.cpp
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeModel.cpp
@@ -183,10 +183,10 @@ bool SymbolTreeModel::setData(const QModelIndex& index, const QVariant& value, i
 		switch (role)
 		{
 			case EDIT_ROLE:
-				data_changed = node->writeToVM(value, m_cpu, database);
+				data_changed = node->writeToVM(value, m_cpu, database, m_display_options);
 				break;
 			case UPDATE_FROM_MEMORY_ROLE:
-				data_changed = node->readFromVM(m_cpu, database);
+				data_changed = node->readFromVM(m_cpu, database, m_display_options);
 				break;
 		}
 	});
@@ -216,7 +216,13 @@ void SymbolTreeModel::fetchMore(const QModelIndex& parent)
 			return;
 
 		children = populateChildren(
-			parent_node->name, parent_node->location, *logical_parent_type, parent_node->type, m_cpu, database);
+			parent_node->name,
+			parent_node->location,
+			*logical_parent_type,
+			parent_node->type,
+			m_cpu,
+			database,
+			m_display_options);
 	});
 
 	bool insert_children = !children.empty();
@@ -403,7 +409,8 @@ std::vector<std::unique_ptr<SymbolTreeNode>> SymbolTreeModel::populateChildren(
 	const ccc::ast::Node& logical_type,
 	ccc::NodeHandle parent_handle,
 	DebugInterface& cpu,
-	const ccc::SymbolDatabase& database)
+	const ccc::SymbolDatabase& database,
+	const SymbolTreeNode::DisplayOptions& display_options)
 {
 	auto [physical_type, symbol] = logical_type.physical_type(database);
 
@@ -485,7 +492,7 @@ std::vector<std::unique_ptr<SymbolTreeNode>> SymbolTreeModel::populateChildren(
 	}
 
 	for (std::unique_ptr<SymbolTreeNode>& child : children)
-		child->readFromVM(cpu, database);
+		child->readFromVM(cpu, database, display_options);
 
 	return children;
 }

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeModel.cpp
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeModel.cpp
@@ -410,7 +410,7 @@ std::vector<std::unique_ptr<SymbolTreeNode>> SymbolTreeModel::populateChildren(
 	ccc::NodeHandle parent_handle,
 	DebugInterface& cpu,
 	const ccc::SymbolDatabase& database,
-	const SymbolTreeNode::DisplayOptions& display_options)
+	const SymbolTreeDisplayOptions& display_options)
 {
 	auto [physical_type, symbol] = logical_type.physical_type(database);
 

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeModel.h
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeModel.h
@@ -65,7 +65,8 @@ public:
 	std::optional<QString> changeTypeTemporarily(QModelIndex index, std::string_view type_string);
 	std::optional<QString> typeFromModelIndexToString(QModelIndex index);
 
-	void setDisplayOptions(const SymbolTreeNode::DisplayOptions& options) { m_display_options = options; }
+	const SymbolTreeDisplayOptions& displayOptions() const { return m_display_options; }
+	void setDisplayOptions(const SymbolTreeDisplayOptions& options) { m_display_options = options; }
 
 protected:
 	static std::vector<std::unique_ptr<SymbolTreeNode>> populateChildren(
@@ -75,12 +76,12 @@ protected:
 		ccc::NodeHandle parent_handle,
 		DebugInterface& cpu,
 		const ccc::SymbolDatabase& database,
-		const SymbolTreeNode::DisplayOptions& display_options);
+		const SymbolTreeDisplayOptions& display_options);
 
 	static bool nodeHasChildren(const ccc::ast::Node& logical_type, const ccc::SymbolDatabase& database);
 
 	std::unique_ptr<SymbolTreeNode> m_root;
 	QString m_filter;
 	DebugInterface& m_cpu;
-	SymbolTreeNode::DisplayOptions m_display_options;
+	SymbolTreeDisplayOptions m_display_options;
 };

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeModel.h
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeModel.h
@@ -65,6 +65,8 @@ public:
 	std::optional<QString> changeTypeTemporarily(QModelIndex index, std::string_view type_string);
 	std::optional<QString> typeFromModelIndexToString(QModelIndex index);
 
+	void setDisplayOptions(const SymbolTreeNode::DisplayOptions& options) { m_display_options = options; }
+
 protected:
 	static std::vector<std::unique_ptr<SymbolTreeNode>> populateChildren(
 		const QString& name,
@@ -72,11 +74,13 @@ protected:
 		const ccc::ast::Node& logical_type,
 		ccc::NodeHandle parent_handle,
 		DebugInterface& cpu,
-		const ccc::SymbolDatabase& database);
+		const ccc::SymbolDatabase& database,
+		const SymbolTreeNode::DisplayOptions& display_options);
 
 	static bool nodeHasChildren(const ccc::ast::Node& logical_type, const ccc::SymbolDatabase& database);
 
 	std::unique_ptr<SymbolTreeNode> m_root;
 	QString m_filter;
 	DebugInterface& m_cpu;
+	SymbolTreeNode::DisplayOptions m_display_options;
 };

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeNode.cpp
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeNode.cpp
@@ -724,15 +724,43 @@ void SymbolTreeNode::sortChildrenRecursively(bool sort_by_if_type_is_known)
 
 // *****************************************************************************
 
+int SymbolTreeDisplayOptions::integerBase() const
+{
+	return m_integer_base;
+}
+
+bool SymbolTreeDisplayOptions::setIntegerBase(int base)
+{
+	if (base == m_integer_base || (base != 2 && base != 8 && base != 10 && base != 16))
+		return false;
+
+	m_integer_base = base;
+	return true;
+}
+
+bool SymbolTreeDisplayOptions::showLeadingZeroes() const
+{
+	return m_show_leading_zeroes;
+}
+
+bool SymbolTreeDisplayOptions::setShowLeadingZeroes(bool show)
+{
+	if (show == m_show_leading_zeroes)
+		return false;
+
+	m_show_leading_zeroes = show;
+	return true;
+}
+
 std::optional<u64> SymbolTreeDisplayOptions::stringToUnsignedInteger(QString string) const
 {
 	bool ok;
-	u64 value = string.toULongLong(&ok, integer_base);
+	u64 value = string.toULongLong(&ok, m_integer_base);
 	if (!ok)
 	{
 		// Try parsing it as a signed integer too, just in case the user tried
 		// to use a minus sign.
-		value = static_cast<u64>(string.toLongLong(&ok, integer_base));
+		value = static_cast<u64>(string.toLongLong(&ok, m_integer_base));
 		if (!ok)
 			return std::nullopt;
 	}
@@ -743,22 +771,22 @@ std::optional<u64> SymbolTreeDisplayOptions::stringToUnsignedInteger(QString str
 QString SymbolTreeDisplayOptions::unsignedIntegerToString(u64 value, s32 size_bits) const
 {
 	int field_width = 0;
-	if (show_leading_zeroes && integer_base > 0)
-		field_width = static_cast<int>(ceilf(size_bits / log2f(integer_base)));
+	if (m_show_leading_zeroes)
+		field_width = static_cast<int>(ceilf(size_bits / log2f(m_integer_base)));
 
-	return QStringLiteral("%1").arg(value, field_width, integer_base, QLatin1Char('0'));
+	return QStringLiteral("%1").arg(value, field_width, m_integer_base, QLatin1Char('0'));
 }
 
 std::optional<s64> SymbolTreeDisplayOptions::stringToSignedInteger(QString string) const
 {
 	bool ok;
-	s64 value = string.toLongLong(&ok, integer_base);
+	s64 value = string.toLongLong(&ok, m_integer_base);
 	if (!ok)
 	{
 		// Try to parse it as an unsigned integer too to handle bases other than
 		// decimal (see below), and to handle the case that the user entered a
 		// value that was too big for a signed integer.
-		value = static_cast<s64>(string.toULongLong(&ok, integer_base));
+		value = static_cast<s64>(string.toULongLong(&ok, m_integer_base));
 		if (!ok)
 			return std::nullopt;
 	}
@@ -769,8 +797,8 @@ std::optional<s64> SymbolTreeDisplayOptions::stringToSignedInteger(QString strin
 QString SymbolTreeDisplayOptions::signedIntegerToString(s64 value, s32 size_bits) const
 {
 	// For bases other than decimal, the user most likely just wants to view the
-	// underlying representation, so we want to print it as unsigned.
-	if (integer_base != 10)
+	// underlying representation, so we want to display it as unsigned.
+	if (m_integer_base != 10)
 	{
 		// Truncate sign extended bits.
 		u64 mask = (static_cast<u64>(1) << size_bits) - 1;
@@ -778,14 +806,14 @@ QString SymbolTreeDisplayOptions::signedIntegerToString(s64 value, s32 size_bits
 	}
 
 	int field_width = 0;
-	if (show_leading_zeroes && integer_base > 0)
+	if (m_show_leading_zeroes)
 	{
-		field_width = static_cast<int>(ceilf(size_bits / log2f(integer_base)));
+		field_width = static_cast<int>(ceilf(size_bits / log2f(m_integer_base)));
 
 		// An extra character is needed for the minus sign.
 		if (value < 0)
 			field_width++;
 	}
 
-	return QStringLiteral("%1").arg(value, field_width, integer_base, QLatin1Char('0'));
+	return QStringLiteral("%1").arg(value, field_width, m_integer_base, QLatin1Char('0'));
 }

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeNode.h
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeNode.h
@@ -9,7 +9,7 @@
 #include "SymbolTreeLocation.h"
 
 class DebugInterface;
-struct SymbolTreeDisplayOptions;
+class SymbolTreeDisplayOptions;
 
 // A node in a symbol tree model.
 class SymbolTreeNode
@@ -105,15 +105,24 @@ private:
 	bool m_children_fetched = false;
 };
 
-// Settings that control how text in the edit column is displayed, including for
-// the editor widgets.
-struct SymbolTreeDisplayOptions
+// Settings that control how text in the value column is displayed, including
+// for the editor widgets.
+class SymbolTreeDisplayOptions
 {
-	int integer_base = 10;
-	bool show_leading_zeroes = false;
+public:
+	int integerBase() const;
+	bool setIntegerBase(int base);
+
+	bool showLeadingZeroes() const;
+	bool setShowLeadingZeroes(bool show);
 
 	std::optional<u64> stringToUnsignedInteger(QString string) const;
 	QString unsignedIntegerToString(u64 value, s32 size_bits) const;
+
 	std::optional<s64> stringToSignedInteger(QString string) const;
 	QString signedIntegerToString(s64 value, s32 size_bits) const;
+
+private:
+	int m_integer_base = 10;
+	bool m_show_leading_zeroes = false;
 };

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeNode.h
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeNode.h
@@ -9,9 +9,10 @@
 #include "SymbolTreeLocation.h"
 
 class DebugInterface;
+struct SymbolTreeDisplayOptions;
 
 // A node in a symbol tree model.
-struct SymbolTreeNode
+class SymbolTreeNode
 {
 public:
 	enum Tag
@@ -47,28 +48,30 @@ public:
 	const QString& display_value() const;
 	std::optional<bool> liveness();
 
-	struct DisplayOptions
-	{
-		int integer_base = 10;
-	};
-
 	// Read the value from the VM memory, update liveness information, and
 	// generate a display string. Returns true if the data changed.
-	bool readFromVM(DebugInterface& cpu, const ccc::SymbolDatabase& database, const DisplayOptions& display_options);
+	bool readFromVM(
+		DebugInterface& cpu,
+		const ccc::SymbolDatabase& database,
+		const SymbolTreeDisplayOptions& display_options);
 
 	// Write the value back to the VM memory. Returns true on success.
 	bool writeToVM(
-		QVariant value, DebugInterface& cpu, const ccc::SymbolDatabase& database, const DisplayOptions& display_options);
+		QVariant value,
+		DebugInterface& cpu,
+		const ccc::SymbolDatabase& database,
+		const SymbolTreeDisplayOptions& display_options);
 
 	QVariant readValueAsVariant(const ccc::ast::Node& physical_type, DebugInterface& cpu, const ccc::SymbolDatabase& database) const;
 	bool writeValueFromVariant(QVariant value, const ccc::ast::Node& physical_type, DebugInterface& cpu) const;
 
-	bool updateDisplayString(DebugInterface& cpu, const ccc::SymbolDatabase& database, const DisplayOptions& display);
+	bool updateDisplayString(
+		DebugInterface& cpu, const ccc::SymbolDatabase& database, const SymbolTreeDisplayOptions& display);
 	QString generateDisplayString(
 		const ccc::ast::Node& physical_type,
 		DebugInterface& cpu,
 		const ccc::SymbolDatabase& database,
-		const DisplayOptions& display_options,
+		const SymbolTreeDisplayOptions& display_options,
 		s32 depth) const;
 
 	bool updateLiveness(DebugInterface& cpu);
@@ -91,7 +94,7 @@ public:
 
 	void sortChildrenRecursively(bool sort_by_if_type_is_known);
 
-protected:
+private:
 	QVariant m_value;
 	QString m_display_value;
 	std::optional<bool> m_liveness;
@@ -100,4 +103,17 @@ protected:
 	SymbolTreeNode* m_parent = nullptr;
 	std::vector<std::unique_ptr<SymbolTreeNode>> m_children;
 	bool m_children_fetched = false;
+};
+
+// Settings that control how text in the edit column is displayed, including for
+// the editor widgets.
+struct SymbolTreeDisplayOptions
+{
+	int integer_base = 10;
+	bool show_leading_zeroes = false;
+
+	std::optional<u64> stringToUnsignedInteger(QString string) const;
+	QString unsignedIntegerToString(u64 value, s32 size_bits) const;
+	std::optional<s64> stringToSignedInteger(QString string) const;
+	QString signedIntegerToString(s64 value, s32 size_bits) const;
 };

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeNode.h
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeNode.h
@@ -47,18 +47,29 @@ public:
 	const QString& display_value() const;
 	std::optional<bool> liveness();
 
+	struct DisplayOptions
+	{
+		int integer_base = 10;
+	};
+
 	// Read the value from the VM memory, update liveness information, and
 	// generate a display string. Returns true if the data changed.
-	bool readFromVM(DebugInterface& cpu, const ccc::SymbolDatabase& database);
+	bool readFromVM(DebugInterface& cpu, const ccc::SymbolDatabase& database, const DisplayOptions& display_options);
 
 	// Write the value back to the VM memory. Returns true on success.
-	bool writeToVM(QVariant value, DebugInterface& cpu, const ccc::SymbolDatabase& database);
+	bool writeToVM(
+		QVariant value, DebugInterface& cpu, const ccc::SymbolDatabase& database, const DisplayOptions& display_options);
 
 	QVariant readValueAsVariant(const ccc::ast::Node& physical_type, DebugInterface& cpu, const ccc::SymbolDatabase& database) const;
 	bool writeValueFromVariant(QVariant value, const ccc::ast::Node& physical_type, DebugInterface& cpu) const;
 
-	bool updateDisplayString(DebugInterface& cpu, const ccc::SymbolDatabase& database);
-	QString generateDisplayString(const ccc::ast::Node& physical_type, DebugInterface& cpu, const ccc::SymbolDatabase& database, s32 depth) const;
+	bool updateDisplayString(DebugInterface& cpu, const ccc::SymbolDatabase& database, const DisplayOptions& display);
+	QString generateDisplayString(
+		const ccc::ast::Node& physical_type,
+		DebugInterface& cpu,
+		const ccc::SymbolDatabase& database,
+		const DisplayOptions& display_options,
+		s32 depth) const;
 
 	bool updateLiveness(DebugInterface& cpu);
 

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeViews.h
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeViews.h
@@ -96,8 +96,6 @@ protected:
 
 	SymbolTreeModel* m_model = nullptr;
 
-	SymbolTreeValueDelegate* m_value_delegate = nullptr;
-
 	enum Flags
 	{
 		NO_SYMBOL_TREE_FLAGS = 0,
@@ -117,7 +115,7 @@ protected:
 	bool m_group_by_source_file = false;
 	bool m_sort_by_if_type_is_known = false;
 
-	int m_integer_base = 10;
+	SymbolTreeDisplayOptions m_display_options;
 };
 
 class FunctionTreeView : public SymbolTreeView

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeViews.h
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeViews.h
@@ -8,6 +8,8 @@
 #include "Debugger/DebuggerView.h"
 #include "Debugger/SymbolTree/SymbolTreeModel.h"
 
+class SymbolTreeValueDelegate;
+
 // A symbol tree view with its associated refresh button, filter box and
 // right-click menu. Supports grouping, sorting and various other settings.
 class SymbolTreeView : public DebuggerView
@@ -94,6 +96,8 @@ protected:
 
 	SymbolTreeModel* m_model = nullptr;
 
+	SymbolTreeValueDelegate* m_value_delegate = nullptr;
+
 	enum Flags
 	{
 		NO_SYMBOL_TREE_FLAGS = 0,
@@ -112,6 +116,8 @@ protected:
 	bool m_group_by_section = false;
 	bool m_group_by_source_file = false;
 	bool m_sort_by_if_type_is_known = false;
+
+	int m_integer_base = 10;
 };
 
 class FunctionTreeView : public SymbolTreeView


### PR DESCRIPTION
### Description of Changes
Adds context menu options to the relevant symbol trees the change the base of integers displayed, and to show leading zeroes.

### Rationale behind Changes
Closes #13059.

### Suggested Testing Steps
Open the debugger, create some global variables with integer types (char, unsigned char, etc) and verify the options all work correctly.

### Did you use AI to help find, test, or implement this issue or feature?
No.
