### PR TITLE
GameDB: Final Fantasy X FMV Fix

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -2976,8 +2976,6 @@ SCED-50633:
 SCED-50642:
   name: "Final Fantasy X [Demo] [Final Fantasy VI PS1 - Bonus Disc]"
   region: "PAL-E"
-  gameFixes:
-    - SoftwareRendererFMVHack # Fixes interlacing.
   roundModes:
     eeRoundMode: 2 # Fixes cutscene animations while slightly dislocating a few select meshes. Setting round mode to Chop/Zero or Nearest fixes the issues with meshes at the cost of breaking important cutscenes.
   clampModes:
@@ -2987,6 +2985,7 @@ SCED-50642:
     recommendedBlendingLevel: 4 # Fixes missing effect on the magus sisters.
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes blur effect on attacks.
+    preloadFrameData: 1 # Fixes an issue that causes FMVs to flicker black when subtitles appear on screen.
 SCED-50660:
   name: "Dropship - United Peace Force"
   region: "PAL-A"
@@ -4848,8 +4847,6 @@ SCES-50490:
   name: "Final Fantasy X"
   region: "PAL-E"
   compat: 5
-  gameFixes:
-    - SoftwareRendererFMVHack # Fixes interlacing.
   roundModes:
     eeRoundMode: 2 # Fixes cutscene animations while slightly dislocating a few select meshes. Setting round mode to Chop/Zero or Nearest fixes the issues with meshes at the cost of breaking important cutscenes.
   clampModes:
@@ -4859,11 +4856,10 @@ SCES-50490:
     recommendedBlendingLevel: 4 # Fixes missing effect on the magus sisters.
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes blur effect on attacks.
+    preloadFrameData: 1 # Fixes an issue that causes FMVs to flicker black when subtitles appear on screen.
 SCES-50491:
   name: "Final Fantasy X"
   region: "PAL-F"
-  gameFixes:
-    - SoftwareRendererFMVHack # Fixes interlacing.
   roundModes:
     eeRoundMode: 2 # Fixes cutscene animations while slightly dislocating a few select meshes. Setting round mode to Chop/Zero or Nearest fixes the issues with meshes at the cost of breaking important cutscenes.
   clampModes:
@@ -4873,12 +4869,11 @@ SCES-50491:
     recommendedBlendingLevel: 4 # Fixes missing effect on the magus sisters.
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes blur effect on attacks.
+    preloadFrameData: 1 # Fixes an issue that causes FMVs to flicker black when subtitles appear on screen.
 SCES-50492:
   name: "Final Fantasy X"
   region: "PAL-G"
   compat: 5
-  gameFixes:
-    - SoftwareRendererFMVHack # Fixes interlacing.
   roundModes:
     eeRoundMode: 2 # Fixes cutscene animations while slightly dislocating a few select meshes. Setting round mode to Chop/Zero or Nearest fixes the issues with meshes at the cost of breaking important cutscenes.
   clampModes:
@@ -4888,11 +4883,10 @@ SCES-50492:
     recommendedBlendingLevel: 4 # Fixes missing effect on the magus sisters.
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes blur effect on attacks.
+    preloadFrameData: 1 # Fixes an issue that causes FMVs to flicker black when subtitles appear on screen.
 SCES-50493:
   name: "Final Fantasy X"
   region: "PAL-I"
-  gameFixes:
-    - SoftwareRendererFMVHack # Fixes interlacing.
   roundModes:
     eeRoundMode: 2 # Fixes cutscene animations while slightly dislocating a few select meshes. Setting round mode to Chop/Zero or Nearest fixes the issues with meshes at the cost of breaking important cutscenes.
   clampModes:
@@ -4902,11 +4896,10 @@ SCES-50493:
     recommendedBlendingLevel: 4 # Fixes missing effect on the magus sisters.
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes blur effect on attacks.
+    preloadFrameData: 1 # Fixes an issue that causes FMVs to flicker black when subtitles appear on screen.
 SCES-50494:
   name: "Final Fantasy X"
   region: "PAL-S"
-  gameFixes:
-    - SoftwareRendererFMVHack # Fixes interlacing.
   roundModes:
     eeRoundMode: 2 # Fixes cutscene animations while slightly dislocating a few select meshes. Setting round mode to Chop/Zero or Nearest fixes the issues with meshes at the cost of breaking important cutscenes.
   clampModes:
@@ -4916,6 +4909,7 @@ SCES-50494:
     recommendedBlendingLevel: 4 # Fixes missing effect on the magus sisters.
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes blur effect on attacks.
+    preloadFrameData: 1 # Fixes an issue that causes FMVs to flicker black when subtitles appear on screen.
 SCES-50499:
   name: "Ecco the Dolphin - Defender of the Future"
   region: "PAL-M5"
@@ -31429,6 +31423,7 @@ SLKA-25214:
     recommendedBlendingLevel: 4 # Fixes missing effect on the magus sisters.
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes blur effect on attacks.
+    preloadFrameData: 1 # Fixes an issue that causes FMVs to flicker black when subtitles appear on screen.
 SLKA-25215:
   name: "Shining Wind"
   region: "NTSC-K"
@@ -40700,6 +40695,7 @@ SLPM-65115:
     recommendedBlendingLevel: 4 # Fixes missing effect on the magus sisters.
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes blur effect on attacks.
+    preloadFrameData: 1 # Fixes an issue that causes FMVs to flicker black when subtitles appear on screen.
 SLPM-65116:
   name: "リリーのアトリエ プラス ～ザールブルグの錬金術士3～"
   name-sort: "りりーのあとりえ ぷらす ～ざーるぶるぐのれんきんじゅつし3～"
@@ -46586,8 +46582,6 @@ SLPM-66124:
   name-sort: "ふぁいなるふぁんたじー10 [Ultimate Hits]"
   name-en: "Final Fantasy X [Ultimate Hits]"
   region: "NTSC-J"
-  gameFixes:
-    - SoftwareRendererFMVHack # Fixes interlacing.
   roundModes:
     eeRoundMode: 2 # Fixes cutscene animations while slightly dislocating a few select meshes. Setting round mode to Chop/Zero or Nearest fixes the issues with meshes at the cost of breaking important cutscenes.
   clampModes:
@@ -46597,6 +46591,7 @@ SLPM-66124:
     recommendedBlendingLevel: 4 # Fixes missing effect on the magus sisters.
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes blur effect on attacks.
+    preloadFrameData: 1 # Fixes an issue that causes FMVs to flicker black when subtitles appear on screen.
 SLPM-66125:
   name: "ファイナルファンタジーⅩ-2 [Ultimate Hits]"
   name-sort: "ふぁいなるふぁんたじー10-2 [Ultimate Hits]"
@@ -50118,6 +50113,7 @@ SLPM-66677:
     recommendedBlendingLevel: 4 # Fixes missing effect on the magus sisters.
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes blur effect on attacks.
+    preloadFrameData: 1 # Fixes an issue that causes FMVs to flicker black when subtitles appear on screen.
 SLPM-66678:
   name: "ファイナルファンタジーⅩ-2 インターナショナル+ラストミッション [Ultimate Hits]"
   name-sort: "ふぁいなるふぁんたじー10-2 いんたーなしょなる+らすとみっしょん [Ultimate Hits]"
@@ -52180,6 +52176,7 @@ SLPM-67513:
     recommendedBlendingLevel: 4 # Fixes missing effect on the magus sisters.
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes blur effect on attacks.
+    preloadFrameData: 1 # Fixes an issue that causes FMVs to flicker black when subtitles appear on screen.
 SLPM-67514:
   name: "Kessen"
   region: "NTSC-K"
@@ -56207,8 +56204,6 @@ SLPS-25050:
   name-en: "Final Fantasy X"
   region: "NTSC-J"
   compat: 5
-  gameFixes:
-    - SoftwareRendererFMVHack # Fixes interlacing.
   roundModes:
     eeRoundMode: 2 # Fixes cutscene animations while slightly dislocating a few select meshes. Setting round mode to Chop/Zero or Nearest fixes the issues with meshes at the cost of breaking important cutscenes.
   clampModes:
@@ -56218,6 +56213,7 @@ SLPS-25050:
     recommendedBlendingLevel: 4 # Fixes missing effect on the magus sisters.
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes blur effect on attacks.
+    preloadFrameData: 1 # Fixes an issue that causes FMVs to flicker black when subtitles appear on screen.
 SLPS-25051:
   name: "Missing Blue [通常版]"
   name-sort: "みっしんぐ ぶるー [つうじょうばん]"
@@ -56446,6 +56442,7 @@ SLPS-25088:
     recommendedBlendingLevel: 4 # Fixes missing effect on the magus sisters.
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes blur effect on attacks.
+    preloadFrameData: 1 # Fixes an issue that causes FMVs to flicker black when subtitles appear on screen.
 SLPS-25089:
   name: "SALT LAKE 2002"
   name-sort: "そるとれいく 2002"
@@ -61860,8 +61857,6 @@ SLPS-72501:
   name-sort: "ふぁいなるふぁんたじー10 [MEGA HITS!]"
   name-en: "Final Fantasy X [MEGA HITS!]"
   region: "NTSC-J"
-  gameFixes:
-    - SoftwareRendererFMVHack # Fixes interlacing.
   roundModes:
     eeRoundMode: 2 # Fixes cutscene animations while slightly dislocating a few select meshes. Setting round mode to Chop/Zero or Nearest fixes the issues with meshes at the cost of breaking important cutscenes.
   clampModes:
@@ -61871,6 +61866,7 @@ SLPS-72501:
     recommendedBlendingLevel: 4 # Fixes missing effect on the magus sisters.
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes blur effect on attacks.
+    preloadFrameData: 1 # Fixes an issue that causes FMVs to flicker black when subtitles appear on screen.
 SLPS-72502:
   name: "テイルズ オブ デスティニー2 [MEGA HITS!]"
   name-sort: "ているず おぶ ですてぃにー2 [MEGA HITS!]"
@@ -64087,8 +64083,6 @@ SLUS-20312:
   name: "Final Fantasy X"
   region: "NTSC-U"
   compat: 5
-  gameFixes:
-    - SoftwareRendererFMVHack # Fixes interlacing.
   roundModes:
     eeRoundMode: 2 # Fixes cutscene animations while slightly dislocating a few select meshes. Setting round mode to Chop/Zero or Nearest fixes the issues with meshes at the cost of breaking important cutscenes.
   clampModes:
@@ -64098,6 +64092,7 @@ SLUS-20312:
     recommendedBlendingLevel: 4 # Fixes missing effect on the magus sisters.
     roundSprite: 2 # Fixes font artifacts.
     autoFlush: 1 # Fixes blur effect on attacks.
+    preloadFrameData: 1 # Fixes an issue that causes FMVs to flicker black when subtitles appear on screen.
 SLUS-20313:
   name: "Wave Rally"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Added preloadFrameData to the gamedb for every version of Final Fantasy X as well as removing the obsolete SoftwareRendererFMVHack setting.

### Rationale behind Changes
Fixes an issue where FMVs flicker black whenever subtitles appear on screen.
Fixes https://github.com/PCSX2/pcsx2/issues/10887

### Did you use AI to help find, test, or implement this issue or feature?
no
