### PR TITLE
FSUI: Don't attempt to translate savestate load error

### DIFF
--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -6457,7 +6457,7 @@ void FullscreenUI::DoLoadState(std::string path)
 					{
 						ImGuiFullscreen::OpenInfoMessageDialog(
 							FSUI_ICONSTR(ICON_FA_TRIANGLE_EXCLAMATION, "Incompatible Save State"),
-							FSUI_STR(error_desc));
+							error_desc);
 					});
 				}
 				else


### PR DESCRIPTION
### Description of Changes
Don't attempt to translate `error.GetDescription()` when displaying an error dialog.

### Rationale behind Changes
This is not translated anywhere else, and would not be translatable anyway.

This was breaking the translation script since the emoji update
The define parser was made smarter to handle emojis,
The old translation script looked beyond the bounds of the define and grabbed the next literal string, which was `"VMManager"`
The updated script now limits the bounds for searching for strings, and thus correctly finds no literal string.

### Suggested Testing Steps
Checkout locally and run `generate_fullscreen_ui_translation_strings.py`

### Did you use AI to help find, test, or implement this issue or feature?
No