### PR TITLE
GameDB: Add memcard filters for Gundam series (Limited Edition)

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -56300,11 +56300,15 @@ SLPS-25060:
   name-sort: "きどうせんしがんだむ めぐりあいそら [げんていばん]"
   name-en: "Mobile Suit Gundam - Meguriai Sora [Limited Edition]"
   region: "NTSC-J"
+  memcardFilters:
+    - "SLPS-25062"
 SLPS-25061:
   name: "機動戦士ガンダムVer.1.5 [限定版]"
   name-sort: "きどうせんしがんだむVer.1.5 [げんていばん]"
   name-en: "Mobile Suit Gundam Ver.1.5 [Limited Edition]"
   region: "NTSC-J"
+  memcardFilters:
+    - "SLPS-25063"
 SLPS-25062:
   name: "機動戦士ガンダム めぐりあい宇宙 [DVD同梱版]"
   name-sort: "きどうせんしがんだむ めぐりあいそら [DVDどうこんばん]"


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Add a memcard filter to the following games.
- Mobile Suit Gundam - Meguriai Sora [Limited Edition]
- Mobile Suit Gundam Ver.1.5 [Limited Edition]

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Couldn't load savedata due to a different game ID.
Absorbs the difference between the title and save data game IDs, which is common in limited editions.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
The following tests were performed on v2.5.121.
1. Save.
2. Restart PCSX2 and launch the game.
3. Load.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No
