### PR TITLE
GS:SW: Use accurate fog equation

### DIFF
--- a/pcsx2/GS/GSVector4i.h
+++ b/pcsx2/GS/GSVector4i.h
@@ -985,10 +985,6 @@ public:
 	__forceinline GSVector4i modulate16(const GSVector4i& f) const
 	{
 		// a * f << shift
-		if (shift == 0)
-		{
-			return mul16hrs(f);
-		}
 
 		return sll16<shift + 1>().mul16hs(f);
 	}

--- a/pcsx2/GS/GSVector4i_arm64.h
+++ b/pcsx2/GS/GSVector4i_arm64.h
@@ -958,10 +958,6 @@ public:
 	__forceinline GSVector4i modulate16(const GSVector4i& f) const
 	{
 		// a * f << shift
-		if (shift == 0)
-		{
-			return mul16hrs(f);
-		}
 
 		return sll16<shift + 1>().mul16hs(f);
 	}

--- a/pcsx2/GS/GSVector8i.h
+++ b/pcsx2/GS/GSVector8i.h
@@ -798,11 +798,6 @@ public:
 	{
 		// a * f << shift
 
-		if (shift == 0)
-		{
-			return mul16hrs(f);
-		}
-
 		return sll16<shift + 1>().mul16hs(f);
 	}
 

--- a/pcsx2/GS/Renderers/SW/GSDrawScanlineCodeGenerator.all.cpp
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanlineCodeGenerator.all.cpp
@@ -174,15 +174,8 @@ void GSDrawScanlineCodeGenerator::broadcastGPRToVec(const XYm& vec, const Xbyak:
 
 void GSDrawScanlineCodeGenerator::modulate16(const XYm& a, const Operand& f, u8 shift)
 {
-	if (shift == 0)
-	{
-		pmulhrsw(a, f);
-	}
-	else
-	{
-		psllw(a, shift + 1);
-		pmulhw(a, f);
-	}
+	psllw(a, shift + 1);
+	pmulhw(a, f);
 }
 
 void GSDrawScanlineCodeGenerator::lerp16(const XYm& a, const XYm& b, const XYm& f, u8 shift)

--- a/pcsx2/GS/Renderers/SW/GSDrawScanlineCodeGenerator.arm64.cpp
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanlineCodeGenerator.arm64.cpp
@@ -2352,14 +2352,15 @@ void GSDrawScanlineCodeGenerator::modulate16(const VRegister& a, const VRegister
 
 void GSDrawScanlineCodeGenerator::modulate16(const VRegister& d, const VRegister& a, const VRegister& f, u8 shift)
 {
-	// potentially going to cause issues due to saturation
-	armAsm->Shl(d.V8H(), a.V8H(), shift + 1);
-	if (shift != 0)
-		armAsm->Sqdmulh(a.V8H(), a.V8H(), f.V8H());
+	if (shift)
+	{
+		armAsm->Shl(d.V8H(), a.V8H(), shift);
+		armAsm->Sqdmulh(d.V8H(), d.V8H(), f.V8H());
+	}
 	else
-		armAsm->Sqrdmulh(a.V8H(), a.V8H(), f.V8H());
-
-	armAsm->Sshr(a.V8H(), a.V8H(), 1);
+	{
+		armAsm->Sqdmulh(a.V8H(), d.V8H(), f.V8H());
+	}
 }
 
 void GSDrawScanlineCodeGenerator::lerp16(const VRegister& a, const VRegister& b, const VRegister& f, u8 shift)


### PR DESCRIPTION
### Description of Changes
Avoids using the mulhrsw instruction, since it rounds instead of truncating
Fixes #5898
Helps #11477

### Rationale behind Changes
Accurate fog

### Suggested Testing Steps
Test the things in the referenced issues

### Did you use AI to help find, test, or implement this issue or feature?
Running copilot helped remind me that we had an ARM implementation that needed fixing as well
