### PR TITLE
Debugger: Fix Automatically Select Symbols To Clear checkbox

### DIFF
--- a/pcsx2/DebugTools/SymbolImporter.cpp
+++ b/pcsx2/DebugTools/SymbolImporter.cpp
@@ -311,9 +311,10 @@ void SymbolImporter::ClearExistingSymbols(ccc::SymbolDatabase& database, const P
 	{
 		bool should_destroy = ShouldClearSymbolsFromSourceByDefault(source.name());
 
-		for (const DebugSymbolSource& source_config : options.SymbolSources)
-			if (source_config.Name == source.name())
-				should_destroy = source_config.ClearDuringAnalysis;
+		if (!options.AutomaticallySelectSymbolsToClear)
+			for (const DebugSymbolSource& source_config : options.SymbolSources)
+				if (source_config.Name == source.name())
+					should_destroy = source_config.ClearDuringAnalysis;
 
 		if (should_destroy)
 			sources_to_destroy.emplace_back(source.handle());
@@ -326,9 +327,9 @@ void SymbolImporter::ClearExistingSymbols(ccc::SymbolDatabase& database, const P
 bool SymbolImporter::ShouldClearSymbolsFromSourceByDefault(const std::string& source_name)
 {
 	return source_name.find("Symbol Table") != std::string::npos ||
-		   source_name == "ELF Section Headers" ||
-		   source_name == "Function Scanner" ||
-		   source_name == "Nocash Symbols";
+	       source_name == "ELF Section Headers" ||
+	       source_name == "Function Scanner" ||
+	       source_name == "Nocash Symbols";
 }
 
 void SymbolImporter::ImportSymbols(


### PR DESCRIPTION
### Description of Changes
Honour the state of the "Automatically Select Symbols To Clear" checkbox.

### Rationale behind Changes
This is clearly the right solution.

### Suggested Testing Steps
- Launch a game with symbols.
- Open the debugger.
- Click the "Analyze" button in the toolbar.
- Uncheck the "Automatically Select Symbols To Clear" checkbox.
- Uncheck all the symbol source checkboxes below.
- Recheck the "Automatically Select Symbols To Clear" checkbox.
- Click the "Analyze" button at the bottom of the dialog.
- The symbols shown in the Functions view should not all be duplicated twice.

### Did you use AI to help find, test, or implement this issue or feature?
No.
