### PR TITLE
GameDB: Onimusha Dawn of Dreams fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -7691,14 +7691,18 @@ SCKA-20086:
   name: "Shin Onimusha - Dawn of Dreams [Disc 1 of 2]"
   region: "NTSC-K"
   gsHWFixes:
-    halfPixelOffset: 4 # Mostly aligns post-processing.
+    recommendedBlendingLevel: 2 # Improves brightness.
+    halfPixelOffset: 5 # Mostly aligns post-processing.
     nativeScaling: 2 # Fixes post-processing smoothness and position.
+    bilinearUpscale: 2 # Attempts to sharpen blurry text in menus.
 SCKA-20087:
   name: "Shin Onimusha - Dawn of Dreams [Disc 2 of 2]"
   region: "NTSC-K"
   gsHWFixes:
-    halfPixelOffset: 4 # Mostly aligns post-processing.
+    recommendedBlendingLevel: 2 # Improves brightness.
+    halfPixelOffset: 5 # Mostly aligns post-processing.
     nativeScaling: 2 # Fixes post-processing smoothness and position.
+    bilinearUpscale: 2 # Attempts to sharpen blurry text in menus.
   memcardFilters:
     - "SCKA-20086"
 SCKA-20088:
@@ -30253,15 +30257,19 @@ SLES-82038:
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 4 # Mostly aligns post-processing.
+    recommendedBlendingLevel: 2 # Improves brightness.
+    halfPixelOffset: 5 # Mostly aligns post-processing.
     nativeScaling: 2 # Fixes post-processing smoothness and position.
+    bilinearUpscale: 2 # Attempts to sharpen blurry text in menus.
 SLES-82039:
   name: "Onimusha - Dawn of Dreams [Disc 2 of 2]"
   region: "PAL-M5"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 4 # Mostly aligns post-processing.
+    recommendedBlendingLevel: 2 # Improves brightness.
+    halfPixelOffset: 5 # Mostly aligns post-processing.
     nativeScaling: 2 # Fixes post-processing smoothness and position.
+    bilinearUpscale: 2 # Attempts to sharpen blurry text in menus.
   memcardFilters:
     - "SLES-82038"
 SLES-82042:
@@ -47593,8 +47601,10 @@ SLPM-66275:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 4 # Mostly aligns post-processing.
+    recommendedBlendingLevel: 2 # Improves brightness.
+    halfPixelOffset: 5 # Mostly aligns post-processing.
     nativeScaling: 2 # Fixes post-processing smoothness and position.
+    bilinearUpscale: 2 # Attempts to sharpen blurry text in menus.
 SLPM-66276:
   name: "新 鬼武者 DAWN OF DREAMS [ディスク2/2]"
   name-sort: "しん おにむしゃ DAWN OF DREAMS [でぃすく2/2]"
@@ -47602,8 +47612,10 @@ SLPM-66276:
   region: "NTSC-J"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 4 # Mostly aligns post-processing.
+    recommendedBlendingLevel: 2 # Improves brightness.
+    halfPixelOffset: 5 # Mostly aligns post-processing.
     nativeScaling: 2 # Fixes post-processing smoothness and position.
+    bilinearUpscale: 2 # Attempts to sharpen blurry text in menus.
   memcardFilters:
     - "SLPM-66275"
 SLPM-66277:
@@ -52816,8 +52828,10 @@ SLPM-74232:
   gameFixes:
     - SoftwareRendererFMVHack # Wrong white textures in FMV.
   gsHWFixes:
-    halfPixelOffset: 4 # Mostly aligns post-processing.
+    recommendedBlendingLevel: 2 # Improves brightness.
+    halfPixelOffset: 5 # Mostly aligns post-processing.
     nativeScaling: 2 # Fixes post-processing smoothness and position.
+    bilinearUpscale: 2 # Attempts to sharpen blurry text in menus.
   memcardFilters:
     - "SLPM-66275"
 SLPM-74233:
@@ -52826,8 +52840,10 @@ SLPM-74233:
   name-en: "Shin Onimusha - Dawn of Dreams [PlayStation2 the Best] [Disc 2 of 2]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 4 # Mostly aligns post-processing.
+    recommendedBlendingLevel: 2 # Improves brightness.
+    halfPixelOffset: 5 # Mostly aligns post-processing.
     nativeScaling: 2 # Fixes post-processing smoothness and position.
+    bilinearUpscale: 2 # Attempts to sharpen blurry text in menus.
   memcardFilters:
     - "SLPM-74232"
 SLPM-74234:
@@ -52975,8 +52991,10 @@ SLPM-74251:
   name-en: "Shin Onimusha - Dawn of Dreams [PlayStation 2 the Best - Reprint Disc 1]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 4 # Mostly aligns post-processing.
+    recommendedBlendingLevel: 2 # Improves brightness.
+    halfPixelOffset: 5 # Mostly aligns post-processing.
     nativeScaling: 2 # Fixes post-processing smoothness and position.
+    bilinearUpscale: 2 # Attempts to sharpen blurry text in menus.
   memcardFilters:
     - "SLPM-66275"
 SLPM-74252:
@@ -52985,8 +53003,10 @@ SLPM-74252:
   name-en: "Shin Onimusha - Dawn of Dreams [PlayStation 2 the Best - Reprint Disc 2]"
   region: "NTSC-J"
   gsHWFixes:
-    halfPixelOffset: 4 # Mostly aligns post-processing.
+    recommendedBlendingLevel: 2 # Improves brightness.
+    halfPixelOffset: 5 # Mostly aligns post-processing.
     nativeScaling: 2 # Fixes post-processing smoothness and position.
+    bilinearUpscale: 2 # Attempts to sharpen blurry text in menus.
   memcardFilters:
     - "SLPM-74251"
 SLPM-74253:
@@ -69009,8 +69029,10 @@ SLUS-21180:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 4 # Mostly aligns post-processing.
+    recommendedBlendingLevel: 2 # Improves brightness.
+    halfPixelOffset: 5 # Mostly aligns post-processing.
     nativeScaling: 2 # Fixes post-processing smoothness and position.
+    bilinearUpscale: 2 # Attempts to sharpen blurry text in menus.
 SLUS-21181:
   name: "D.I.C.E. - DNA Integrated Cybernetic Enterprises"
   region: "NTSC-U"
@@ -70357,8 +70379,10 @@ SLUS-21362:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 4 # Mostly aligns post-processing.
+    recommendedBlendingLevel: 2 # Improves brightness.
+    halfPixelOffset: 5 # Mostly aligns post-processing.
     nativeScaling: 2 # Fixes post-processing smoothness and position.
+    bilinearUpscale: 2 # Attempts to sharpen blurry text in menus.
   memcardFilters:
     - "SLUS-21180"
 SLUS-21363:


### PR DESCRIPTION
### Description of Changes
Fixes black garbage and improves brightness by swapping ATN for ATNWTO and recommending the use of Medium blending.

Before:
<img width="1158" height="812" alt="image" src="https://github.com/user-attachments/assets/d34f0ea1-d5b2-4cac-b44d-73b98140c9f5" />

After:
<img width="1158" height="812" alt="image" src="https://github.com/user-attachments/assets/ad8a4e0f-283c-42b5-90f0-fc352bdaaa2d" />

### Rationale behind Changes
Broken game bad.

### Suggested Testing Steps
CI needs watching it's suspicious,

### Did you use AI to help find, test, or implement this issue or feature?
No
