### PR TITLE
Fix vumem export and offsets used in SysMemory::DumpMemoryMap

### DIFF
--- a/pcsx2/Memory.cpp
+++ b/pcsx2/Memory.cpp
@@ -198,8 +198,8 @@ void SysMemory::DumpMemoryMap()
 	DUMP_REGION("EE Main Memory", s_data_memory, HostMemoryMap::EEmemOffset, HostMemoryMap::EEmemSize);
 	DUMP_REGION("IOP Main Memory", s_data_memory, HostMemoryMap::IOPmemOffset, HostMemoryMap::IOPmemSize);
 	DUMP_REGION("VU0/1 On-Chip Memory", s_data_memory, HostMemoryMap::VUmemOffset, HostMemoryMap::VUmemSize);
-	DUMP_REGION("VTLB Virtual Map", s_data_memory, HostMemoryMap::VTLBAddressMapOffset, HostMemoryMap::VTLBVirtualMapSize);
-	DUMP_REGION("VTLB Address Map", s_data_memory, HostMemoryMap::VTLBAddressMapSize, HostMemoryMap::VTLBAddressMapSize);
+	DUMP_REGION("VTLB Virtual Map", s_data_memory, HostMemoryMap::VTLBVirtualMapOffset, HostMemoryMap::VTLBVirtualMapSize);
+	DUMP_REGION("VTLB Address Map", s_data_memory, HostMemoryMap::VTLBAddressMapOffset, HostMemoryMap::VTLBAddressMapSize);
 
 	DUMP_REGION("R5900 Recompiler Cache", s_code_memory, HostMemoryMap::EErecOffset, HostMemoryMap::EErecSize);
 	DUMP_REGION("R3000A Recompiler Cache", s_code_memory, HostMemoryMap::IOPrecOffset, HostMemoryMap::IOPrecSize);

--- a/pcsx2/Memory.cpp
+++ b/pcsx2/Memory.cpp
@@ -183,7 +183,7 @@ bool SysMemory::AllocateMemoryMap()
 
 	HostMemoryMap::EEmem = (uptr)(s_data_memory + HostMemoryMap::EEmemOffset);
 	HostMemoryMap::IOPmem = (uptr)(s_data_memory + HostMemoryMap::IOPmemOffset);
-	HostMemoryMap::VUmem = (uptr)(s_data_memory + HostMemoryMap::VUmemSize);
+	HostMemoryMap::VUmem = (uptr)(s_data_memory + HostMemoryMap::VUmemOffset);
 
 	DumpMemoryMap();
 	return true;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
- Sets `HostMemoryMap::VUmem` to use `VUmemOffset` instead of `VUmemSize`
- Corrected the offsets used for dumping the VTLB Virtual Map and VTLB Address Map in `SysMemory::DumpMemoryMap`

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Accurate data is dumped and a valid address will be exported for access to VU Memory

### Suggested Testing Steps
If built without the change to the VUMem offset the export is effectively useless as its pointing to the wrong region of memory

The image below shows myself trying to access VUMemory unsucessfully as the pointer is the wrong location. If you look in the PCSX2 debug log however the correct address is dumped
<img width="334" height="243" alt="image" src="https://github.com/user-attachments/assets/e44f919c-976e-4629-a682-ee5abc768bab" />

<img width="695" height="123" alt="image" src="https://github.com/user-attachments/assets/aef9ed6c-ae14-4a71-9c74-9b0ccf7b4ec8" />


### Did you use AI to help find, test, or implement this issue or feature?
no.
