### PR TITLE
GS/HW: Optimize higher blend levels a bit more.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5743,6 +5743,11 @@ void GSRendererHW::EmulateBlending(int rt_alpha_min, int rt_alpha_max, const boo
 	// Primitives don't overlap.
 	const bool no_prim_overlap = (m_prim_overlap == PRIM_OVERLAP_NO);
 
+	// HW blend can handle it, we change the blend formulas and partially do the blend in shader.
+	const bool blend_hw1 = (blend_flag & BLEND_HW1) && !blend_ad && (alpha_eq_less_one || m_conf.ps.dst_fmt != GSLocalMemory::PSM_FMT_16);
+	const bool blend_hw2 = (blend_flag & BLEND_HW2) && (alpha_eq_less_one || m_conf.ps.dst_fmt != GSLocalMemory::PSM_FMT_16);
+	const bool can_blend_hw = blend_hw1 || blend_hw2;
+
 	// HW blend can be done in multiple passes when there's no overlap.
 	// Blend multi pass is only useful when texture barriers aren't supported.
 	// Speed wise Texture barriers > blend multi pass > texture copies.
@@ -5784,16 +5789,16 @@ void GSRendererHW::EmulateBlending(int rt_alpha_min, int rt_alpha_max, const boo
 				sw_blending |= true;
 				[[fallthrough]];
 			case AccBlendLevel::Full:
-				sw_blending |= m_conf.ps.blend_a != m_conf.ps.blend_b && alpha_c0_high_max_one;
+				sw_blending |= m_conf.ps.blend_a != m_conf.ps.blend_b && alpha_c0_high_max_one && !can_blend_hw;
 				[[fallthrough]];
 			case AccBlendLevel::High:
-				sw_blending |= (alpha_c1_high_max_one || alpha_c1_high_no_rta_correct) || (m_conf.ps.blend_a != m_conf.ps.blend_b && alpha_c2_high_one);
+				sw_blending |= (alpha_c1_high_max_one || alpha_c1_high_no_rta_correct) || (m_conf.ps.blend_a != m_conf.ps.blend_b && alpha_c2_high_one && !can_blend_hw);
 				[[fallthrough]];
 			case AccBlendLevel::Medium:
 				// Initial idea was to enable accurate blending for sprite rendering to handle
 				// correctly post-processing effect. Some games (ZoE) use tons of sprites as particles.
 				// In order to keep it fast, let's limit it to smaller draw call.
-				sw_blending |= m_vt.m_primclass == GS_SPRITE_CLASS && m_drawlist.size() < 100;
+				sw_blending |= m_vt.m_primclass == GS_SPRITE_CLASS && m_drawlist.size() < 100 && alpha_c1_high_no_rta_correct && !can_blend_hw;
 				[[fallthrough]];
 			case AccBlendLevel::Basic:
 				// Prefer sw blend if possible.
@@ -5826,15 +5831,15 @@ void GSRendererHW::EmulateBlending(int rt_alpha_min, int rt_alpha_max, const boo
 				[[fallthrough]];
 			case AccBlendLevel::Full:
 				// Enable sw blend on cases where Alpha > 128 when prims don't overlap.
-				sw_blending |= (alpha_c0_high_max_one || alpha_c1_high_max_one || alpha_c2_high_one) && no_prim_overlap;
+				sw_blending |= (alpha_c0_high_max_one || alpha_c1_high_max_one || alpha_c2_high_one) && !can_blend_hw && no_prim_overlap;
 				[[fallthrough]];
 			case AccBlendLevel::High:
 				// Enable sw blend on Cd*(Alpha + 1) cases where prims don't overlap.
-				sw_blending |= (m_conf.ps.blend_a == m_conf.ps.blend_d == 1) && no_prim_overlap;
+				sw_blending |= (m_conf.ps.blend_a == m_conf.ps.blend_d == 1) && !can_blend_hw && no_prim_overlap;
 				[[fallthrough]];
 			case AccBlendLevel::Medium:
 				// Enable sw blend on Ad cases where prims don't overlap, blend_ad_alpha_masked, rta correction or ad_second_pass isn't possible.
-				sw_blending |= !(blend_ad_alpha_masked || ad_second_pass) && (alpha_c1_high_max_one || alpha_c1_high_no_rta_correct) && no_prim_overlap;
+				sw_blending |= !(blend_ad_alpha_masked || ad_second_pass || can_blend_hw) && (alpha_c1_high_max_one || alpha_c1_high_no_rta_correct) && no_prim_overlap;
 				[[fallthrough]];
 			case AccBlendLevel::Basic:
 				// Prefer sw blend if possible.


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/HW: Optimize higher blend levels a bit more.
Prefer some hw blends that can be done properly instead of sw if possible.
The current blends can be done on hw blending so we can skip sw blend on them if possible.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Speed, more speed!

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test Battlefield and other games that needed Medium or higher blending.
Benchmarks will be nice on gl/vk mostly.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.
