### PR TITLE
GameDB: Remove InstantDMAHack for MGS3

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -4014,7 +4014,7 @@ SCED-52952:
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
-    halfPixelOffset: 4 # Aligns post-processing.
+    halfPixelOffset: 5 # Aligns post-processing; HPO 5 fixes desert tile seams
     nativeScaling: 2 # Fixes lighting effects due to upscaling.
 SCED-52969:
   name: "EyeToy - Play 2"
@@ -5735,7 +5735,7 @@ SCES-52460:
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
-    halfPixelOffset: 4 # Aligns post-processing.
+    halfPixelOffset: 5 # Aligns post-processing; HPO 5 fixes desert tile seams
     nativeScaling: 2 # Fixes lighting effects due to upscaling.
 SCES-52529:
   name: "Sly 2 - Band of Thieves"
@@ -7324,7 +7324,8 @@ SCKA-20039:
     alignSprite: 1 # Fixes FMV lines.
     textureInsideRT: 1 # Fixes post shuffles.
 SCKA-20040:
-  name: "Jak 3"
+  name: "잭 3"
+  name-en: "Jak 3"
   region: "NTSC-K"
   gameFixes:
     - InstantDMAHack # Fixes holes in face geometry.
@@ -7333,7 +7334,7 @@ SCKA-20040:
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
-    halfPixelOffset: 4 # Aligns post-processing.
+    halfPixelOffset: 5 # Aligns post-processing; HPO 5 fixes desert tile seams
     nativeScaling: 2 # Fixes lighting effects due to upscaling.
 SCKA-20041:
   name: "EyeToy - Play 2"
@@ -11578,7 +11579,7 @@ SCUS-97330:
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
-    halfPixelOffset: 4 # Aligns post-processing.
+    halfPixelOffset: 5 # Aligns post-processing; HPO 5 fixes desert tile seams
     nativeScaling: 2 # Fixes lighting effects due to upscaling.
 SCUS-97331:
   name: "Official U.S. PlayStation Magazine Demo Disc 078"
@@ -11862,7 +11863,7 @@ SCUS-97412:
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
-    halfPixelOffset: 4 # Aligns post-processing.
+    halfPixelOffset: 5 # Aligns post-processing; HPO 5 fixes desert tile seams
     nativeScaling: 2 # Fixes lighting effects due to upscaling.
 SCUS-97413:
   name: "Ratchet & Clank - Up Your Arsenal [Public Beta v1.0]"
@@ -12400,7 +12401,7 @@ SCUS-97516:
     cpuSpriteRenderBW: 4 # Fixes character and water textures.
     cpuSpriteRenderLevel: 2 # Needed for above.
     autoFlush: 2 # Fixes lighting.
-    halfPixelOffset: 4 # Aligns post-processing.
+    halfPixelOffset: 5 # Aligns post-processing; HPO 5 fixes desert tile seams
     nativeScaling: 2 # Fixes lighting effects due to upscaling.
 SCUS-97517:
   name: "Killzone [Greatest Hits]"
@@ -30110,7 +30111,6 @@ SLES-82013:
   compat: 5
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 5 # Aligns depth of field effect.
@@ -30138,7 +30138,6 @@ SLES-82024:
   region: "PAL-I"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 5 # Aligns depth of field effect.
@@ -30150,7 +30149,6 @@ SLES-82026:
   region: "PAL-S"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 5 # Aligns depth of field effect.
@@ -30202,7 +30200,6 @@ SLES-82032:
   region: "PAL-G"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 5 # Aligns depth of field effect.
@@ -30248,7 +30245,6 @@ SLES-82042:
   region: "PAL-E-F"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
@@ -30260,7 +30256,6 @@ SLES-82043:
   region: "PAL-E-F"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
@@ -30274,7 +30269,6 @@ SLES-82044:
   region: "PAL-I"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
@@ -30286,7 +30280,6 @@ SLES-82045:
   region: "PAL-I"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
@@ -30300,7 +30293,6 @@ SLES-82046:
   region: "PAL-G"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
@@ -30312,7 +30304,6 @@ SLES-82047:
   region: "PAL-G"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
@@ -30326,7 +30317,6 @@ SLES-82048:
   region: "PAL-S"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
@@ -30338,7 +30328,6 @@ SLES-82049:
   region: "PAL-S"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
@@ -30352,7 +30341,6 @@ SLES-82050:
   region: "PAL-E-F"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
@@ -30366,7 +30354,6 @@ SLES-82051:
   region: "PAL-I"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
@@ -30380,7 +30367,6 @@ SLES-82052:
   region: "PAL-G"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
@@ -30394,7 +30380,6 @@ SLES-82053:
   region: "PAL-S"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
@@ -31594,7 +31579,6 @@ SLKA-25251:
   region: "NTSC-K"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 5 # Aligns depth of field effect.
@@ -32076,7 +32060,6 @@ SLKA-25353:
   compat: 5
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
@@ -32089,7 +32072,6 @@ SLKA-25354:
   compat: 5
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
@@ -32104,7 +32086,6 @@ SLKA-25355:
   compat: 5
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
@@ -33906,7 +33887,6 @@ SLPM-55236:
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 5 # Aligns depth of field effect.
@@ -44540,7 +44520,6 @@ SLPM-65789:
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 5 # Aligns depth of field effect.
@@ -44554,7 +44533,6 @@ SLPM-65790:
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 5 # Aligns depth of field effect.
@@ -46515,7 +46493,6 @@ SLPM-66117:
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
@@ -46529,7 +46506,6 @@ SLPM-66118:
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
@@ -46543,7 +46519,6 @@ SLPM-66119:
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
@@ -47182,7 +47157,6 @@ SLPM-66220:
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
@@ -47198,7 +47172,6 @@ SLPM-66221:
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
@@ -47214,7 +47187,6 @@ SLPM-66222:
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
@@ -47230,7 +47202,6 @@ SLPM-66223:
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
@@ -47246,7 +47217,6 @@ SLPM-66224:
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
@@ -50844,7 +50814,6 @@ SLPM-66794:
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 5 # Aligns depth of field effect.
@@ -52452,7 +52421,6 @@ SLPM-68516:
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 5 # Aligns depth of field effect.
@@ -53001,7 +52969,6 @@ SLPM-74257:
   region: "NTSC-J"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 5 # Aligns depth of field effect.
@@ -67348,7 +67315,6 @@ SLUS-20915:
   compat: 5
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     halfPixelOffset: 5 # Aligns depth of field effect.
@@ -69417,7 +69383,6 @@ SLUS-21243:
   compat: 5
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
@@ -70279,7 +70244,6 @@ SLUS-21359:
   compat: 5
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
@@ -70291,7 +70255,6 @@ SLUS-21360:
   region: "NTSC-U"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.
@@ -75018,7 +74981,6 @@ TLES-82043:
   region: "PAL-E"
   gameFixes:
     - BlitInternalFPSHack # Fixes internal FPS detection.
-    - InstantDMAHack # Fixes missing letters in text such as E.
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes skin colour and banding.
     autoFlush: 2 # Fixes lens flare.


### PR DESCRIPTION
### Description of Changes
* Removes InstantDMAHack for all serials of Metal Gear Solid 3: Snake Eater and Subsistence
* Adds AtN:TO (HPO 5) to Jak 3.
* Adds the Korean name for Jak 3.

### Rationale behind Changes
All MGS3 serials except SLKA-25472 have InstantDMAHack in the GameDB (first added April 2023 by Jordan) with the comment "Fixes missing letters in text such as E." I looked for any evidence that this may be a problem without InstantDMAHack – not just 'E', but 'e' and any other character. None were missing or even broken. I tested:

* The start menu
* The file select/new game menu
* The pause menu (survival viewer)
* The radio
* The cutscene subtitles
* The game over screen
* The HUD (Snake's health bar, camo, and the item select with L2/R2)
* The "item get" text that hovers where Snake collected an item for a few seconds
* The area name text

I tested all of these multiple times on both games with a lot of variation. This is the second time I've done this, and I got the same result as last time; last time just happened to be right before a new stable, so we were very conservative. This experiment to me is thorough enough to eliminate the hack absent affirmative evidence that 1) this issue exists on latest master (separately if we want to include it in both) and 2) it is solved by InstantDMAHack. The only vague circumstantial evidence that this is possibly still beneficial is that we use the hack for MGS2 for "Fixes broken half-bottom artifacts.", but this is something I'd also like to test after this, and there's no evidence of that problem in MGS3 that I saw.

In Jak 2, AtN:TO very slightly screws up the prison lights by a single-pixel misalignment, but in Jak 3, this fixes a misaligned leftmost column (screenshot of garbage below) and fixes the seams between broken desert tiles when they occasionally show up in the Wasteland. I saw no evidence of it breaking anything after playing for about an hour. The seams are very conspicuous when they show up, although this isn't very often; example below. Adding the Korean name is a small bonus while I'm here; ReDump and other sources confirm `잭 3` is the correct name.

<img width="36" height="383" alt="image" src="https://github.com/user-attachments/assets/dda5968f-a0e5-4fdd-bfc7-c77de9175b44" />


<img width="1285" height="964" alt="image" src="https://github.com/user-attachments/assets/7da32a4f-dfa0-4a9d-868a-d9f2e3273513" />

<img width="1285" height="964" alt="image" src="https://github.com/user-attachments/assets/faa23378-16ba-4c3a-8004-1738a6f923a0" />

### Suggested Testing Steps
Test Snake Eater and Subsistence with InstantDMAHack off. Test Jak 3 with HPO 5 on and see if it causes any issues that would be fixed by reverting to HPO 4.

### Did you use AI to help find, test, or implement this issue or feature?
Who are the Patriots?
