### PR TITLE
Hotkeys: Fix crash when swapping memory cards

### DIFF
--- a/pcsx2/Hotkeys.cpp
+++ b/pcsx2/Hotkeys.cpp
@@ -227,9 +227,10 @@ DEFINE_HOTKEY("InputRecToggleMode", TRANSLATE_NOOP("Hotkeys", "System"),
 DEFINE_HOTKEY("SwapMemCards", TRANSLATE_NOOP("Hotkeys", "System"),
 	TRANSLATE_NOOP("Hotkeys", "Swap Memory Cards"), [](s32 pressed) {
 		if (!pressed && VMManager::HasValidVM())
-			FileMcd_Swap();
+			Host::RunOnCPUThread([]() {
+				FileMcd_Swap();
+			});
 	})
-
 DEFINE_HOTKEY("PreviousSaveStateSlot", TRANSLATE_NOOP("Hotkeys", "Save States"),
 	TRANSLATE_NOOP("Hotkeys", "Select Previous Save Slot"), [](s32 pressed) {
 		if (!pressed && VMManager::HasValidVM())
@@ -250,7 +251,7 @@ DEFINE_HOTKEY("LoadStateFromSlot", TRANSLATE_NOOP("Hotkeys", "Save States"),
 		if (!pressed && VMManager::HasValidVM())
 			SaveStateSelectorUI::LoadCurrentSlot();
 	})
-	DEFINE_HOTKEY("LoadBackupStateFromSlot", TRANSLATE_NOOP("Hotkeys", "Save States"),
+DEFINE_HOTKEY("LoadBackupStateFromSlot", TRANSLATE_NOOP("Hotkeys", "Save States"),
 	TRANSLATE_NOOP("Hotkeys", "Load Backup State From Selected Slot"), [](s32 pressed) {
 		if (!pressed && VMManager::HasValidVM())
 			SaveStateSelectorUI::LoadCurrentBackupSlot();


### PR DESCRIPTION
### Description of Changes
The FileMcd_Swap function is now kicked off to run at a later time instead of while the input manager is inside its event processing loop.

### Rationale behind Changes
FileMcd_Swap triggers the following calls: VMManager::ApplySettings -> VMManager::LoadSettings -> VMManager::LoadInputBindings -> InputManager::ReloadBindings. This causes iterator invalidation for s_binding_map so when FileMcd_Swap returns and InputManager::ProcessEvent tries to start walking through the map again it may crash.

This bug may only be visible on certain platforms due to the implementation of std::unordered_mutlimap being different. I'm testing this on Linux.

I found this a while ago but forgot to open an issue.

### Suggested Testing Steps
Load both memory card slots, bind a key for swapping memory cards, press that key while a game is running. Test on Linux.

### Did you use AI to help find, test, or implement this issue or feature?
No.
