### PR TITLE
GS/HW: Swap Stencil/PrimID date with Barrier date when framebuffer is already sampled.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -97,7 +97,7 @@ private:
 	void SetupIA(float target_scale, float sx, float sy, bool req_vert_backup);
 	void EmulateTextureShuffleAndFbmask(GSTextureCache::Target* rt, GSTextureCache::Source* tex);
 	bool EmulateChannelShuffle(GSTextureCache::Target* src, bool test_only, GSTextureCache::Target* rt = nullptr);
-	void EmulateBlending(int rt_alpha_min, int rt_alpha_max, const bool DATE, bool& DATE_PRIMID, bool& DATE_BARRIER, GSTextureCache::Target* rt,
+	void EmulateBlending(int rt_alpha_min, int rt_alpha_max, const bool DATE, bool& DATE_one, bool& DATE_PRIMID, bool& DATE_BARRIER, GSTextureCache::Target* rt,
 		bool can_scale_rt_alpha, bool& new_rt_alpha_scale);
 	void CleanupDraw(bool invalidate_temp_src);
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/HW: Swap Stencil/PrimID date with barrier date when fb is already sampled.
If a draw will be sw blended we can swap Stencil/PrimID date with Barrier date to cut down on draws/render passes that stencil/primid date would introduce.

This will be more prevalent as blending level is increased.

DX11 will benefit the most, even on basic blending, and when increasing blending level.
VK/GL will benefit only when blend level increases as we already do barrier date when prims don't overlap on basic level.
DX12: similar to dx11 but less cases since sw blending is limited.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Speed, optimizations.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test the games listed in the compare file with reduced draw calls/render passes, ignore the ones with difference as they are false positives. Testing for vk/gl is only useful above basic blending.
Some highlights on dx11 basic blend:
```
bge ['Draw Calls: -14 [915=>901]', 'Render Passes: -29 [881=>852]']
Need_for_Speed_-_Underground_SLES-51967_20240617051110 ['Draw Calls: -17 [2465=>2448]', 'Render Passes: -34 [271=>237]']
Enthusia Professional Racing_SLUS-20967_SW ['Draw Calls: -13 [816=>803]', 'Render Passes: -25 [417=>392]']
Sims_2_The_-_Pets_SLES-54347_20230317012045 ['Draw Calls: -16 [717=>701]', 'Render Passes: -32 [377=>345]']
Wild Arms 3 Depth Clamp (21) ['Draw Calls: -49 [1055=>1006]', 'Render Passes: -99 [399=>300]']
```
Others are in single digits so no need to bench those, some other games will show up as you increase blend level such as persona 3 and 4, Amagami and so on, testers will have to find out.

Some benchmarks will be nice

[changes-dx11.html](https://github.com/user-attachments/files/22031428/changes-dx11.html)

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.