### PR TITLE
GS/DX11: Post dx11 multidraw fb copy cleanup.

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -2741,12 +2741,6 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 
 	OMSetRenderTargets(draw_rt, draw_ds, &config.scissor, read_only_dsv);
 	SetupOM(config.depth, OMBlendSelector(config.colormask, config.blend), config.blend.constant);
-
-	// Clear stencil as close as possible to the RT bind, to avoid framebuffer swaps.
-	if (draw_ds && config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::StencilOne &&
-		m_features.multidraw_fb_copy && (config.require_one_barrier || config.require_full_barrier))
-		m_ctx->ClearDepthStencilView(*static_cast<GSTexture11*>(draw_ds), D3D11_CLEAR_STENCIL, 0.0f, 1);
-
 	SendHWDraw(config, draw_rt_clone, draw_rt, config.require_one_barrier, config.require_full_barrier, false);
 
 	if (config.blend_multi_pass.enable)


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/DX11: Post dx11 multidraw fb copy cleanup.
Don't clear stencil for stencil date.
We don't want to do this unless we always sample with stencil date like vk/gl.
Only swap primid date with barrier date if there is overlap, stencil date might send the wrong alpha on a previous draw which could be wrong when we use the alpha to sample from.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Bugfixes, cleanup.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test games that had issues with primid + sw blending like GT4 car reflections on higher blends, test other stuff.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
