### PR TITLE
Debugger: Improve logic for applying custom font sizes

### DIFF
--- a/pcsx2-qt/Debugger/DebuggerView.cpp
+++ b/pcsx2-qt/Debugger/DebuggerView.cpp
@@ -203,11 +203,6 @@ void DebuggerView::updateStyleSheet()
 #endif
 	}
 
-	// HACK: Make the font size smaller without applying a stylesheet to the
-	// whole window (which would impact performance).
-	if (g_debugger_window)
-		stylesheet += QString("font-size: %1pt;").arg(g_debugger_window->fontSize());
-
 	setStyleSheet(stylesheet);
 }
 

--- a/pcsx2-qt/Debugger/DebuggerWindow.cpp
+++ b/pcsx2-qt/Debugger/DebuggerWindow.cpp
@@ -179,9 +179,9 @@ void DebuggerWindow::clearToolBarState()
 
 void DebuggerWindow::setupFonts()
 {
-	m_font_size = Host::GetBaseIntSettingValue("Debugger/UserInterface", "FontSize", DEFAULT_FONT_SIZE);
+	m_font_size = Host::GetBaseIntSettingValue("Debugger/UserInterface", "FontSize", QApplication::font().pointSize());
 	if (m_font_size < MINIMUM_FONT_SIZE || m_font_size > MAXIMUM_FONT_SIZE)
-		m_font_size = DEFAULT_FONT_SIZE;
+		m_font_size = QApplication::font().pointSize();
 
 	m_ui.actionIncreaseFontSize->setShortcuts(QKeySequence::ZoomIn);
 	connect(m_ui.actionIncreaseFontSize, &QAction::triggered, this, [this]() {
@@ -208,7 +208,7 @@ void DebuggerWindow::setupFonts()
 	});
 
 	connect(m_ui.actionResetFontSize, &QAction::triggered, this, [this]() {
-		m_font_size = DEFAULT_FONT_SIZE;
+		m_font_size = QApplication::font().pointSize();
 
 		updateFontActions();
 		updateTheme();
@@ -222,7 +222,7 @@ void DebuggerWindow::updateFontActions()
 {
 	m_ui.actionIncreaseFontSize->setEnabled(m_font_size < MAXIMUM_FONT_SIZE);
 	m_ui.actionDecreaseFontSize->setEnabled(m_font_size > MINIMUM_FONT_SIZE);
-	m_ui.actionResetFontSize->setEnabled(m_font_size != DEFAULT_FONT_SIZE);
+	m_ui.actionResetFontSize->setEnabled(m_font_size != QApplication::font().pointSize());
 }
 
 void DebuggerWindow::saveFontSize()
@@ -239,15 +239,13 @@ int DebuggerWindow::fontSize()
 void DebuggerWindow::updateTheme()
 {
 	// TODO: Migrate away from stylesheets to improve performance.
-	if (m_font_size != DEFAULT_FONT_SIZE)
-	{
-		int size = m_font_size + QApplication::font().pointSize() - DEFAULT_FONT_SIZE;
-		setStyleSheet(QString("* { font-size: %1pt; } QTabBar { font-size: %2pt; }").arg(size).arg(size + 1));
-	}
-	else
-	{
+	setStyleSheet(QString("font-size: %1pt;").arg(m_font_size));
+
+	// HACK: Improve performance for the default font size setting. It seems we
+	// need to call setStyleSheet twice here otherwise some widgets do not
+	// update properly.
+	if (m_font_size == QApplication::font().pointSize())
 		setStyleSheet(QString());
-	}
 
 	dockManager().updateTheme();
 }

--- a/pcsx2-qt/Debugger/DebuggerWindow.h
+++ b/pcsx2-qt/Debugger/DebuggerWindow.h
@@ -73,7 +73,6 @@ private:
 	QTimer* m_refresh_timer = nullptr;
 
 	int m_font_size;
-	static const constexpr int DEFAULT_FONT_SIZE = 10;
 	static const constexpr int MINIMUM_FONT_SIZE = 5;
 	static const constexpr int MAXIMUM_FONT_SIZE = 30;
 };


### PR DESCRIPTION
### Description of Changes
Fix the logic for setting font sizes so that the font size stored in the config file is no longer relative to the system font size. The default font size will probably also appear a bit smaller now, depending on your system.

### Rationale behind Changes
The logic I had before for this was confused: It was calculating a font size relative to the system font size for the overall window but was using an absolute one for the individual views. 

This meant that if you set a system font size wildly different to the default, the text in the window would scale but not the text in the views.

I think a slightly smaller default font size makes sense anyway to take into account monitors with a lower pixel density.

### Suggested Testing Steps
Try with all sorts of different system font sizes and debugger font sizes (modifiable from the View menu). After settings the system font size, restart PCSX2 and set the debugger font size back to the default (View -> Reset Font Size in the debugger).

### Did you use AI to help find, test, or implement this issue or feature?
No.
