### PR TITLE
GS/DX11: Micro optimize SendHWDraw framebuffer copies.

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -343,7 +343,7 @@ public:
 	void SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, u8 afix);
 
 	void RenderHW(GSHWDrawConfig& config) override;
-	void SendHWDraw(const GSHWDrawConfig& config, GSTexture* draw_rt_clone, GSTexture* draw_rt, const bool one_barrier, const bool full_barrier, const bool skip_first_barrier);
+	void SendHWDraw(const GSHWDrawConfig& config, GSTexture* draw_rt, GSTexture* draw_rt_clone, const bool one_barrier, const bool full_barrier, const bool skip_first_barrier);
 
 	void ClearSamplerCache() override;
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/DX11: Micro optimize SendHWDraw framebuffer copies.
Change the fb copy texture type from CreateTexture to CreateRenderTarget which matches the source, and will save resources converting it back to RenderTarget upon copying.
Other micro optimizations.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Speed, optimizations.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test games that uses fb copies for sw blending, see if there's a difference, in gpu, cpu, vram usage, fps.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.
