### PR TITLE
Qt: Use the correct case for the name of the custom.qss file

### DIFF
--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -44,8 +44,8 @@ const char* InterfaceSettingsWidget::THEME_NAMES[] = {
 	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Sapphire (Black/Blue) [Dark]"),
 	//: Ignore what Crowdin says in this string about "[Light]/[Dark]" being untouchable here, these are not variables in this case and must be translated.
 	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Emerald (Black/Green) [Dark]"),
-	//: "Custom.qss" must be kept as-is.
-	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Custom.qss [Drop in PCSX2 Folder]"),
+	//: "custom.qss" must be kept as-is.
+	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "custom.qss [Drop in PCSX2 Folder]"),
 	nullptr};
 
 const char* InterfaceSettingsWidget::THEME_VALUES[] = {


### PR DESCRIPTION
### Description of Changes
Update the UI so it displays the custom theme option as "custom.qss" rather than "Custom.qss".

### Rationale behind Changes
This was confusing for users with case sensitive filesystems.

I reason it's better to change the option in the UI rather than the file that's loaded so we don't break anyone's existing setups.

### Suggested Testing Steps
This doesn't fix all the quirks with custom themes, but maybe try creating a custom.qss file vs a Custom.qss file on Linux.

### Did you use AI to help find, test, or implement this issue or feature?
No.
