### PR TITLE
CDVD: Fix block index past EoF error message

### DIFF
--- a/pcsx2/CDVD/InputIsoFile.cpp
+++ b/pcsx2/CDVD/InputIsoFile.cpp
@@ -75,7 +75,7 @@ void InputIsoFile::BeginRead2(uint lsn)
 	{
 		// While this usually indicates that the ISO is corrupted, some games do attempt
 		// to read past the end of the disc, so don't error here.
-		ERROR_LOG("isoFile error: Block index is past the end of file! (%u >= %u).", lsn, m_blocks);
+		ERROR_LOG("isoFile error: Block index is past the end of file! ({} >= {}).", lsn, m_blocks);
 		return;
 	}
 


### PR DESCRIPTION
### Description of Changes
Fixes a failed attempt at string interpolation in an error message in InputIsoFile.cpp.

### Rationale behind Changes
<img width="833" height="676" alt="image" src="https://github.com/user-attachments/assets/cf3ff952-ce12-4fda-af78-b3ce7b4bfe2b" />

Saw this error message Jordan got where what's clearly supposed to be two unsigned ints are printed as the string literal `%u`. InputIsoFile.cpp has two versions directly beside each other using the `ERROR_LOG` function: one uses `{}` for interpolation, while the other ostensibly incorrectly uses `%u`.

### Suggested Testing Steps
If you're somehow able to reproduce this error organically, see how it prints to the log.

### Did you use AI to help find, test, or implement this issue or feature?
I %d%i%d n%ot %u%s%e a%i %f%or t%hi%s %pr.
