### PR TITLE
CDVD: Add message for attempting to remove a disc when no disc exists

### DIFF
--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -2251,8 +2251,15 @@ bool VMManager::ChangeDisc(CDVD_SourceType source, std::string path)
 	{
 		if (source == CDVD_SourceType::NoDisc)
 		{
-			Host::AddIconOSDMessage("ChangeDisc", ICON_FA_COMPACT_DISC, TRANSLATE_SV("VMManager", "Disc removed."),
-				Host::OSD_INFO_DURATION);
+			if (old_path.empty())
+				Host::AddIconOSDMessage("ChangeDisc", ICON_FA_COMPACT_DISC, TRANSLATE_SV("VMManager", "No disc to remove."),
+					Host::OSD_INFO_DURATION);
+			else
+			{
+				Host::AddIconOSDMessage("ChangeDisc", ICON_FA_COMPACT_DISC, TRANSLATE_SV("VMManager", "Disc removed."),
+					Host::OSD_INFO_DURATION);
+				Console.WriteLnFmt("Removed disc: '{}'", old_path);
+			}
 		}
 		else
 		{


### PR DESCRIPTION
### Description of Changes
Adds an OSD message distinct from "Disc removed." when the user attempts to remove a disc (`Change Disc` > `Remove Disc`) but there is no disc in the tray ("No disc to remove."). Also adds a console message if there was a disc to remove what the file path of that removed disc was.

### Rationale behind Changes
* If you continue clicking `Remove Disc`, the OSD will just tell you forever you're removing a disc – even though that clearly makes no sense. This accurately tells the user the state of the disc tray (also prevents the user wrongly thinking it's failing because they can see "Disc removed." *ad infinitum*).
* Previously, the log didn't actually say what disc was being removed. You could get this information by going back to when the game was loaded, but this is inconvenient. It's also not possible if the logging began after the game was loaded.

### Suggested Testing Steps
Mess around with removing a game disc.

### Did you use AI to help find, test, or implement this issue or feature?
Thankfully this is a fogless PR that I could handle on my own.