### PR TITLE
Qt/FSUI: Various changes

### DIFF
--- a/pcsx2-qt/MainWindow.ui
+++ b/pcsx2-qt/MainWindow.ui
@@ -132,7 +132,7 @@
     </property>
     <widget class="QMenu" name="menuDebugSwitchRenderer">
      <property name="title">
-      <string>&amp;Switch Renderer</string>
+      <string>&amp;Switch Graphics API</string>
      </property>
      <property name="icon">
       <iconset theme="brush-line"/>

--- a/pcsx2-qt/Settings/GraphicsSettingsHeader.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsHeader.ui
@@ -23,7 +23,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="rendererText">
         <property name="text">
-         <string>Renderer:</string>
+         <string>Graphics API:</string>
         </property>
        </widget>
       </item>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -40,7 +40,7 @@ static constexpr RendererInfo s_renderer_info[] = {
 	{QT_TRANSLATE_NOOP("GraphicsSettingsWidget", "Metal"), GSRendererType::Metal},
 #endif
 	//: Graphics backend/engine type (refers to emulating the GS in software, on the CPU). Translate accordingly.
-	{QT_TRANSLATE_NOOP("GraphicsSettingsWidget", "Software"), GSRendererType::SW},
+	{QT_TRANSLATE_NOOP("GraphicsSettingsWidget", "Software Renderer"), GSRendererType::SW},
 	//: Null here means that this is a graphics backend that will show nothing.
 	{QT_TRANSLATE_NOOP("GraphicsSettingsWidget", "Null"), GSRendererType::Null},
 };
@@ -635,7 +635,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 
 		dialog()->registerWidgetHelp(m_fixes.readTCOnClose, tr("Read Targets When Closing"), tr("Unchecked"),
 			tr("Flushes all targets in the texture cache back to local memory when shutting down. Can prevent lost visuals when saving "
-			   "state or switching renderers, but can also cause graphical corruption."));
+			   "state or switching graphics APIs, but can also cause graphical corruption."));
 
 		dialog()->registerWidgetHelp(m_fixes.estimateTextureRegion, tr("Estimate Texture Region"), tr("Unchecked"),
 			tr("Attempts to reduce the texture size when games do not set it themselves (e.g. Snowblind games)."));
@@ -828,7 +828,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 		dialog()->registerWidgetHelp(m_advanced.useBlitSwapChain, tr("Use Blit Swap Chain"), tr("Unchecked"),
 			//: Blit = a data operation. You might want to write it as-is, but fully uppercased. More information: https://en.wikipedia.org/wiki/Bit_blit
 			tr("Uses a blit presentation model instead of flipping when using the Direct3D 11 "
-			   "renderer. This usually results in slower performance, but may be required for some "
+			   "graphics API. This usually results in slower performance, but may be required for some "
 			   "streaming applications, or to uncap framerates on some systems."));
 
 		dialog()->registerWidgetHelp(m_advanced.exclusiveFullscreenControl, tr("Allow Exclusive Fullscreen"), tr("Automatic (Default)"),

--- a/pcsx2/GS/Renderers/DX11/D3D.cpp
+++ b/pcsx2/GS/Renderers/DX11/D3D.cpp
@@ -409,7 +409,7 @@ GSRendererType D3D::GetPreferredRenderer()
 			return true;
 
 		Host::AddIconOSDMessage("VKDriverUnsupported", ICON_FA_TV, TRANSLATE_STR("GS",
-			"The Vulkan renderer was automatically selected, but no compatible devices were found.\n"
+			"The Vulkan graphics API was automatically selected, but no compatible devices were found.\n"
 			"       You should update all graphics drivers in your system, including any integrated GPUs\n"
 			"       to use the Vulkan renderer."), Host::OSD_WARNING_DURATION);
 		return false;

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3981,7 +3981,7 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 #ifdef __APPLE__
 		FSUI_NSTR("Metal"),
 #endif
-		FSUI_NSTR("Software"),
+		FSUI_NSTR("Software Renderer"),
 		FSUI_NSTR("Null"),
 	};
 	static constexpr const char* s_renderer_values[] = {
@@ -4128,8 +4128,8 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 
 	BeginMenuButtons();
 
-	MenuHeading(FSUI_CSTR("Renderer"));
-	DrawStringListSetting(bsi, FSUI_ICONSTR(ICON_FA_PAINTBRUSH, "Renderer"), FSUI_CSTR("Selects the API used to render the emulated GS."), "EmuCore/GS",
+	MenuHeading(FSUI_CSTR("Graphics API"));
+	DrawStringListSetting(bsi, FSUI_ICONSTR(ICON_FA_PAINTBRUSH, "Graphics API"), FSUI_CSTR("Selects the API used to render the emulated GS."), "EmuCore/GS",
 		"Renderer", "-1", s_renderer_names, s_renderer_values, std::size(s_renderer_names), true);
 
 	MenuHeading(FSUI_CSTR("Display"));

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -3211,7 +3211,7 @@ void VMManager::WarnAboutUnsafeSettings()
 			render_change_warn = true;
 
 			append(ICON_FA_CIRCLE_EXCLAMATION,
-				TRANSLATE_SV("VMManager", "Renderer is not set to Automatic. This may cause performance problems and graphical issues."));
+				TRANSLATE_SV("VMManager", "Graphics API is not set to Automatic. This may cause performance problems and graphical issues."));
 		}
 	}
 	if (EmuConfig.GS.TextureFiltering != BiFiltering::PS2)

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -3204,6 +3204,11 @@ void VMManager::WarnAboutUnsafeSettings()
 			append(ICON_FA_TV,
 				TRANSLATE_SV("VMManager", "Dithering is set to Force 32 bit. This will break rendering in some games."));
 		}
+		if (EmuConfig.GS.Dithering == 0)
+		{
+			append(ICON_FA_TV,
+				TRANSLATE_SV("VMManager", "Dithering is disabled. This will cause color banding in some games."));
+		}
 		static bool render_change_warn = false;
 		if (EmuConfig.GS.Renderer != GSRendererType::Auto && EmuConfig.GS.Renderer != GSRendererType::SW && !render_change_warn)
 		{

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -3199,6 +3199,11 @@ void VMManager::WarnAboutUnsafeSettings()
 			append(ICON_FA_BUG,
 				TRANSLATE_SV("VMManager", "Debug device is enabled. This will massively reduce performance."));
 		}
+		if (EmuConfig.GS.Dithering == 3)
+		{
+			append(ICON_FA_TV,
+				TRANSLATE_SV("VMManager", "Dithering is set to Force 32 bit. This will break rendering in some games."));
+		}
 		static bool render_change_warn = false;
 		if (EmuConfig.GS.Renderer != GSRendererType::Auto && EmuConfig.GS.Renderer != GSRendererType::SW && !render_change_warn)
 		{

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -3209,6 +3209,11 @@ void VMManager::WarnAboutUnsafeSettings()
 			append(ICON_FA_TV,
 				TRANSLATE_SV("VMManager", "Dithering is disabled. This will cause color banding in some games."));
 		}
+		if (EmuConfig.GS.IntegerScaling)
+		{
+			append(ICON_FA_TV,
+				TRANSLATE_SV("VMManager", "Integer scaling is enabled. This may shrink the image."));
+		}
 		static bool render_change_warn = false;
 		if (EmuConfig.GS.Renderer != GSRendererType::Auto && EmuConfig.GS.Renderer != GSRendererType::SW && !render_change_warn)
 		{


### PR DESCRIPTION
### Description of Changes
Changes Renderer to Graphics API and Software to Software Renderer. Also adds warnings for Force 32 bit Dithering dithering being disabled and Integer Scaling being enabled.

### Rationale behind Changes
We already call Renderer API in description text so this makes far more sense to more people what it actually does and is more consistent with existing texts. Warnings are just nice for users who don't under force 32 bit dithering can blow up games.

### Suggested Testing Steps
Test new warnings and names to make sure they are correct.

### Did you use AI to help find, test, or implement this issue or feature?
No
