### PR TITLE
GS/shaders: Fix shader compile errors and warnings.

### DIFF
--- a/bin/resources/shaders/dx11/convert.fx
+++ b/bin/resources/shaders/dx11/convert.fx
@@ -305,64 +305,64 @@ PS_OUTPUT ps_convert_rgb5a1_8i(PS_INPUT input)
 	uint2 pos = uint2(input.p.xy);
 
 	// Collapse separate R G B A areas into their base pixel
-	uint2 column = (pos & ~uint2(0u, 3u)) / uint2(1,2);
+	uint2 column = (pos & ~uint2(0u, 3u)) / uint2(1u, 2u);
 	uint2 subcolumn = (pos & uint2(0u, 1u));
-	column.x -= (column.x / 128) * 64;
-	column.y += (column.y / 32) * 32;
+	column.x -= (column.x / 128u) * 64u;
+	column.y += (column.y / 32u) * 32u;
 	
 	uint PSM = uint(DOFFSET);
 	
 	// Deal with swizzling differences
-	if ((PSM & 0x8) != 0) // PSMCT16S
+	if ((PSM & 0x8u) != 0u) // PSMCT16S
 	{
-		if ((pos.x & 32) != 0)
+		if ((pos.x & 32u) != 0u)
 		{
-			column.y += 32; // 4 columns high times 4 to get bottom 4 blocks
-			column.x &= ~32;
+			column.y += 32u; // 4 columns high times 4 to get bottom 4 blocks
+			column.x &= ~32u;
 		}
 		
-		if ((pos.x & 64) != 0)
+		if ((pos.x & 64u) != 0u)
 		{
-			column.x -= 32;
+			column.x -= 32u;
 		}
 		
-		if (((pos.x & 16) != 0) != ((pos.y & 16) != 0))
+		if (((pos.x & 16u) != 0u) != ((pos.y & 16u) != 0u))
 		{
-			column.x ^= 16; 
-			column.y ^= 8;
+			column.x ^= 16u; 
+			column.y ^= 8u;
 		}
 		
-		if ((PSM & 0x30) != 0) // PSMZ16S - Untested but hopefully ok if anything uses it.
+		if ((PSM & 0x30u) != 0u) // PSMZ16S - Untested but hopefully ok if anything uses it.
 		{
-			column.x ^= 32;
-			column.y ^= 16;
+			column.x ^= 32u;
+			column.y ^= 16u;
 		}
 	}
 	else // PSMCT16
 	{
-		if ((pos.y & 32) != 0)
+		if ((pos.y & 32u) != 0u)
 		{
-			column.y -= 16;
-			column.x += 32;
+			column.y -= 16u;
+			column.x += 32u;
 		}
 		
-		if ((pos.x & 96) != 0)
+		if ((pos.x & 96u) != 0u)
 		{
-			uint multi = (pos.x & 96) / 32;
-			column.y += 16 * multi; // 4 columns high times 4 to get bottom 4 blocks
-			column.x -= (pos.x & 96);
+			uint multi = (pos.x & 96u) / 32u;
+			column.y += 16u * multi; // 4 columns high times 4 to get bottom 4 blocks
+			column.x -= (pos.x & 96u);
 		}
 		
-		if (((pos.x & 16) != 0) != ((pos.y & 16) != 0))
+		if (((pos.x & 16u) != 0u) != ((pos.y & 16) != 0))
 		{
-			column.x ^= 16; 
-			column.y ^= 8;
+			column.x ^= 16u; 
+			column.y ^= 8u;
 		}
 		
-		if ((PSM & 0x30) != 0) // PSMZ16 - Untested but hopefully ok if anything uses it.
+		if ((PSM & 0x30u) != 0u) // PSMZ16 - Untested but hopefully ok if anything uses it.
 		{
-			column.x ^= 32;
-			column.y ^= 32;
+			column.x ^= 32u;
+			column.y ^= 32u;
 		}
 	}
 	
@@ -371,10 +371,10 @@ PS_OUTPUT ps_convert_rgb5a1_8i(PS_INPUT input)
 	// Compensate for potentially differing page pitch.
 	uint SBW = uint(EMODA);
 	uint DBW = uint(EMODC);
-	uint2 block_xy = coord / uint2(64,64);
-	uint block_num = (block_xy.y * (DBW / 128)) + block_xy.x;
-	uint2 block_offset = uint2((block_num % (SBW / 64)) * 64, (block_num / (SBW / 64)) * 64);
-	coord = (coord % uint2(64, 64)) + block_offset;
+	uint2 block_xy = coord / uint2(64u, 64u);
+	uint block_num = (block_xy.y * (DBW / 128u)) + block_xy.x;
+	uint2 block_offset = uint2((block_num % (SBW / 64u)) * 64u, (block_num / (SBW / 64u)) * 64u);
+	coord = (coord % uint2(64u, 64u)) + block_offset;
 
 	// Apply offset to cols 1 and 2
 	uint is_col23 = pos.y & 4u;
@@ -394,18 +394,16 @@ PS_OUTPUT ps_convert_rgb5a1_8i(PS_INPUT input)
 	{
 		uint red = (denorm_c.r >> 3) & 0x1Fu;
 		uint green = (denorm_c.g >> 3) & 0x1Fu;
-		float sel0 = (float)(((green << 5) | red) & 0xFF) / 255.0f;
 		
-		output.c = (float4)(sel0);
+		output.c = (float4)(((float)(((green << 5) | red) & 0xFFu)) / 255.0f);
 	}
 	else
 	{
 		uint green = (denorm_c.g >> 3) & 0x1Fu;
 		uint blue = (denorm_c.b >> 3) & 0x1Fu;
 		uint alpha = denorm_c.a & 0x80u;
-		float sel0 = (float)((alpha | (blue << 2) | (green >> 3)) & 0xFF) / 255.0f;
 
-		output.c = (float4)(sel0);
+		output.c = (float4)(((float)((alpha | (blue << 2) | (green >> 3)) & 0xFFu)) / 255.0f);
 	}
 	return output;
 }

--- a/bin/resources/shaders/dx11/shadeboost.fx
+++ b/bin/resources/shaders/dx11/shadeboost.fx
@@ -37,7 +37,7 @@ float4 ContrastSaturationBrightness(float4 color) // Ported to HLSL
 	float3 conColor = lerp(AvgLumin, satColor, con);
 	
 	float3 csb = conColor;
-	csb = pow(csb, 1.0 / gam);
+	csb = exp2(log2(csb) * (1.0 / gam));
 	color.rgb = csb;
 	return color;
 }

--- a/bin/resources/shaders/opengl/convert.glsl
+++ b/bin/resources/shaders/opengl/convert.glsl
@@ -258,62 +258,62 @@ void ps_convert_rgb5a1_8i()
 	uvec2 pos = uvec2(gl_FragCoord.xy);
 
 	// Collapse separate R G B A areas into their base pixel
-	uvec2 column = (pos & ~uvec2(0u, 3u)) / uvec2(1,2);
+	uvec2 column = (pos & ~uvec2(0u, 3u)) / uvec2(1u, 2u);
 	uvec2 subcolumn = (pos & uvec2(0u, 1u));
-	column.x -= (column.x / 128) * 64;
-	column.y += (column.y / 32) * 32;
+	column.x -= (column.x / 128u) * 64u;
+	column.y += (column.y / 32u) * 32u;
 	
 	// Deal with swizzling differences
-	if ((PSM & 0x8) != 0) // PSMCT16S
+	if ((PSM & 0x8u) != 0u) // PSMCT16S
 	{
-		if ((pos.x & 32) != 0)
+		if ((pos.x & 32u) != 0u)
 		{
-			column.y += 32; // 4 columns high times 4 to get bottom 4 blocks
-			column.x &= ~32;
+			column.y += 32u; // 4 columns high times 4 to get bottom 4 blocks
+			column.x &= ~32u;
 		}
 		
-		if ((pos.x & 64) != 0)
+		if ((pos.x & 64u) != 0u)
 		{
-			column.x -= 32;
+			column.x -= 32u;
 		}
 		
-		if (((pos.x & 16) != 0) != ((pos.y & 16) != 0))
+		if (((pos.x & 16u) != 0u) != ((pos.y & 16u) != 0u))
 		{
-			column.x ^= 16; 
-			column.y ^= 8;
+			column.x ^= 16u; 
+			column.y ^= 8u;
 		}
 		
-		if ((PSM & 0x30) != 0) // PSMZ16S - Untested but hopefully ok if anything uses it.
+		if ((PSM & 0x30u) != 0u) // PSMZ16S - Untested but hopefully ok if anything uses it.
 		{
-			column.x ^= 32;
-			column.y ^= 16;
+			column.x ^= 32u;
+			column.y ^= 16u;
 		}
 	}
 	else // PSMCT16
 	{
-		if ((pos.y & 32) != 0)
+		if ((pos.y & 32u) != 0u)
 		{
-			column.y -= 16;
-			column.x += 32;
+			column.y -= 16u;
+			column.x += 32u;
 		}
 		
-		if ((pos.x & 96) != 0)
+		if ((pos.x & 96u) != 0u)
 		{
-			uint multi = (pos.x & 96) / 32;
-			column.y += 16 * multi; // 4 columns high times 4 to get bottom 4 blocks
-			column.x -= (pos.x & 96);
+			uint multi = (pos.x & 96u) / 32u;
+			column.y += 16u * multi; // 4 columns high times 4 to get bottom 4 blocks
+			column.x -= (pos.x & 96u);
 		}
 		
-		if (((pos.x & 16) != 0) != ((pos.y & 16) != 0))
+		if (((pos.x & 16u) != 0u) != ((pos.y & 16u) != 0u))
 		{
-			column.x ^= 16; 
-			column.y ^= 8;
+			column.x ^= 16u; 
+			column.y ^= 8u;
 		}
 		
-		if ((PSM & 0x30) != 0) // PSMZ16 - Untested but hopefully ok if anything uses it.
+		if ((PSM & 0x30u) != 0u) // PSMZ16 - Untested but hopefully ok if anything uses it.
 		{
-			column.x ^= 32;
-			column.y ^= 32;
+			column.x ^= 32u;
+			column.y ^= 32u;
 		}
 	}
 	uvec2 coord = column | subcolumn;
@@ -342,18 +342,16 @@ void ps_convert_rgb5a1_8i()
 	{
 		uint red = (denorm_c.r >> 3) & 0x1Fu;
 		uint green = (denorm_c.g >> 3) & 0x1Fu;
-		float sel0 = float(((green << 5) | red) & 0xFF) / 255.0f;
 		
-		SV_Target0 = vec4(sel0);
+		SV_Target0 = vec4(float(((green << 5) | red) & 0xFFu) / 255.0f);
 	}
 	else
 	{
 		uint green = (denorm_c.g >> 3) & 0x1Fu;
 		uint blue = (denorm_c.b >> 3) & 0x1Fu;
 		uint alpha = denorm_c.a & 0x80u;
-		float sel0 = float((alpha | (blue << 2) | (green >> 3)) & 0xFF) / 255.0f;
 
-		SV_Target0 = vec4(sel0);
+		SV_Target0 = vec4(float((alpha | (blue << 2) | (green >> 3)) & 0xFFu) / 255.0f);
 	}
 }
 #endif

--- a/bin/resources/shaders/vulkan/convert.glsl
+++ b/bin/resources/shaders/vulkan/convert.glsl
@@ -332,62 +332,62 @@ void ps_convert_rgb5a1_8i()
 	uvec2 pos = uvec2(gl_FragCoord.xy);
 
 	// Collapse separate R G B A areas into their base pixel
-	uvec2 column = (pos & ~uvec2(0u, 3u)) / uvec2(1,2);
+	uvec2 column = (pos & ~uvec2(0u, 3u)) / uvec2(1u, 2u);
 	uvec2 subcolumn = (pos & uvec2(0u, 1u));
-	column.x -= (column.x / 128) * 64;
-	column.y += (column.y / 32) * 32;
+	column.x -= (column.x / 128u) * 64u;
+	column.y += (column.y / 32u) * 32u;
 	
 	// Deal with swizzling differences
-	if ((PSM & 0x8) != 0) // PSMCT16S
+	if ((PSM & 0x8u) != 0u) // PSMCT16S
 	{
-		if ((pos.x & 32) != 0)
+		if ((pos.x & 32u) != 0u)
 		{
-			column.y += 32; // 4 columns high times 4 to get bottom 4 blocks
-			column.x &= ~32;
+			column.y += 32u; // 4 columns high times 4 to get bottom 4 blocks
+			column.x &= ~32u;
 		}
 		
-		if ((pos.x & 64) != 0)
+		if ((pos.x & 64u) != 0u)
 		{
-			column.x -= 32;
+			column.x -= 32u;
 		}
 		
-		if (((pos.x & 16) != 0) != ((pos.y & 16) != 0))
+		if (((pos.x & 16u) != 0u) != ((pos.y & 16u) != 0u))
 		{
-			column.x ^= 16; 
-			column.y ^= 8;
+			column.x ^= 16u; 
+			column.y ^= 8u;
 		}
 		
-		if ((PSM & 0x30) != 0) // PSMZ16S - Untested but hopefully ok if anything uses it.
+		if ((PSM & 0x30u) != 0u) // PSMZ16S - Untested but hopefully ok if anything uses it.
 		{
-			column.x ^= 32;
-			column.y ^= 16;
+			column.x ^= 32u;
+			column.y ^= 16u;
 		}
 	}
 	else // PSMCT16
 	{
-		if ((pos.y & 32) != 0)
+		if ((pos.y & 32u) != 0u)
 		{
-			column.y -= 16;
-			column.x += 32;
+			column.y -= 16u;
+			column.x += 32u;
 		}
 		
-		if ((pos.x & 96) != 0)
+		if ((pos.x & 96u) != 0u)
 		{
-			uint multi = (pos.x & 96) / 32;
-			column.y += 16 * multi; // 4 columns high times 4 to get bottom 4 blocks
-			column.x -= (pos.x & 96);
+			uint multi = (pos.x & 96u) / 32u;
+			column.y += 16u * multi; // 4 columns high times 4 to get bottom 4 blocks
+			column.x -= (pos.x & 96u);
 		}
 		
-		if (((pos.x & 16) != 0) != ((pos.y & 16) != 0))
+		if (((pos.x & 16u) != 0u) != ((pos.y & 16u) != 0u))
 		{
-			column.x ^= 16; 
-			column.y ^= 8;
+			column.x ^= 16u; 
+			column.y ^= 8u;
 		}
 		
-		if ((PSM & 0x30) != 0) // PSMZ16 - Untested but hopefully ok if anything uses it.
+		if ((PSM & 0x30u) != 0u) // PSMZ16 - Untested but hopefully ok if anything uses it.
 		{
-			column.x ^= 32;
-			column.y ^= 32;
+			column.x ^= 32u;
+			column.y ^= 32u;
 		}
 	}
 	uvec2 coord = column | subcolumn;
@@ -410,23 +410,22 @@ void ps_convert_rgb5a1_8i()
 		coord *= uvec2(ScaleFactor);
 
 	vec4 pixel = texelFetch(samp0, ivec2(coord), 0);
+	
 	uvec4 denorm_c = uvec4(pixel * 255.5f);
 	if ((pos.y & 2u) == 0u)
 	{
 		uint red = (denorm_c.r >> 3) & 0x1Fu;
 		uint green = (denorm_c.g >> 3) & 0x1Fu;
-		float sel0 = float(((green << 5) | red) & 0xFF) / 255.0f;
 		
-		o_col0 = vec4(sel0);
+		o_col0 = vec4(float(((green << 5) | red) & 0xFFu) / 255.0f);
 	}
 	else
 	{
 		uint green = (denorm_c.g >> 3) & 0x1Fu;
 		uint blue = (denorm_c.b >> 3) & 0x1Fu;
 		uint alpha = denorm_c.a & 0x80u;
-		float sel0 = float((alpha | (blue << 2) | (green >> 3)) & 0xFF) / 255.0f;
 
-		o_col0 = vec4(sel0);
+		o_col0 = vec4(float((alpha | (blue << 2) | (green >> 3)) & 0xFFu) / 255.0f);
 	}
 }
 #endif


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/shaders: Fix false positive warning for pow being negative. 
Replaced pow with exp2 log2.
Fixes warning:
warning X3571: pow(f, e) will not work for negative f, use abs(f) or conditionally handle negative values if you expect them

GS/shaders: Fix types mismatch for ps_convert_rgb5a1_8i shader.
Fixes shader compile errors and warnings on mesa, also synch vk and dx shaders for consistency.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Fixes https://github.com/PCSX2/pcsx2/issues/13230 , fixes shader compile errors and warnings on gl and dx.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test harry potter games on GL on mesa linux or mesa3d software renderer for windows and run a dump using gl.
Test Post processing brightness, contrast, gamma, saturation if it still works on all renderers.
Test dx11, dx12, gl, vk and make sure they still work.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.
