### PR TITLE
GameDB: Deadly Strike fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -21758,6 +21758,8 @@ SLES-52954:
 SLES-52955:
   name: "Deadly Strike"
   region: "PAL-E"
+  roundModes:
+    eeDivRoundMode: 3 # Fixes grid like pattern.
 SLES-52956:
   name: "Action Girlz Racing"
   region: "PAL-E"
@@ -38928,6 +38930,8 @@ SLPM-62459:
   name-en: "Simple 2000 Series Vol. 16 - Sengoku vs. Gendai"
   region: "NTSC-J"
   compat: 5
+  roundModes:
+    eeDivRoundMode: 3 # Fixes grid like pattern.
 SLPM-62460:
   name: "SuperLite2000 シミュレーション 箱庭鉄道 ～ブルートレイン・特急編～"
   name-sort: "すーぱーらいと 2000 しみゅれーしょん はこにわてつどう ぶるーとれいんとっきゅうへん"


### PR DESCRIPTION
### Description of Changes
Fixes the grid like pattern over the screen.

Fixes #13031 

Before:
<img width="1158" height="812" alt="image" src="https://github.com/user-attachments/assets/22a6609a-65aa-42de-b88f-d6c719e83a77" />

After:
<img width="1158" height="812" alt="image" src="https://github.com/user-attachments/assets/a6ae1414-8c73-4f5b-a7ce-d26b5e1d9d6a" />

### Rationale behind Changes
Broken game bad.

### Suggested Testing Steps
Make sure CI passes.

### Did you use AI to help find, test, or implement this issue or feature?
No
