### PR TITLE
Video Capture: Split on resolution change and allow recording on 0x0 resolution.

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -386,10 +386,10 @@ float GSState::GetTvRefreshRate()
 			return 50;
 		case GSVideoMode::HDTV_720P:
 		case GSVideoMode::HDTV_1080I:
-			return 60;
 		default:
-			Console.Error("GS: Unknown video mode. Please report: https://github.com/PCSX2/pcsx2/issues");
-			return 0;
+			return 60;
+			//Console.Error("GS: Unknown video mode. Please report: https://github.com/PCSX2/pcsx2/issues");
+			//return 0;
 	}
 
 	ASSUME(0); // unreachable


### PR DESCRIPTION
### Description of Changes
Add video splitting for every resolution change. Allow recording from frame 0 (if using "Pause on Start") or when resolution is 0x0 / No Image, this will create blank video with 640x480 resolution. Before on blank frames it used last visible frame that was visible but now it's blank.

### Rationale behind Changes
Instead of stretching video we can keep the resolution as is and just create a new file for each resolution, and later stretch or do something else with raw footage. Fixes not being able to start video capture when starting emulation. Fixes blanks using last visible frame.

### Suggested Testing Steps
Test recording from frame 0, when resolution changes, during 0x0 resolution (should result in a 640x480 video).

### Did you use AI to help find, test, or implement this issue or feature?
Yes, asked copilot to explain why blank frame used last visible frame in video capture.

---

This works but in my opinion code needs refactoring.