### PR TITLE
Toolbar: Add 'Hotkeys' action

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -339,6 +339,8 @@ void MainWindow::connectSignals()
 	connect(m_ui.actionToolbarSettings, &QAction::triggered, this, &MainWindow::onSettingsTriggeredFromToolbar);
 	connect(m_ui.actionToolbarControllerSettings, &QAction::triggered,
 		[this]() { doControllerSettings(ControllerSettingsWindow::Category::GlobalSettings); });
+	connect(m_ui.actionToolbarHotkeySettings, &QAction::triggered,
+		[this]() { doControllerSettings(ControllerSettingsWindow::Category::HotkeySettings); });
 	connect(m_ui.actionToolbarScreenshot, &QAction::triggered, this, &MainWindow::onScreenshotActionTriggered);
 	connect(m_ui.actionExit, &QAction::triggered, this, &MainWindow::close);
 	connect(m_ui.actionScreenshot, &QAction::triggered, this, &MainWindow::onScreenshotActionTriggered);

--- a/pcsx2-qt/MainWindow.ui
+++ b/pcsx2-qt/MainWindow.ui
@@ -266,6 +266,7 @@
    <addaction name="separator"/>
    <addaction name="actionToolbarSettings"/>
    <addaction name="actionToolbarControllerSettings"/>
+   <addaction name="actionToolbarHotkeySettings"/>
   </widget>
   <widget class="QStatusBar" name="statusBar"/>
   <action name="actionStartFile">
@@ -456,6 +457,14 @@
    </property>
    <property name="text">
     <string>&amp;Hotkeys</string>
+   </property>
+  </action>
+  <action name="actionToolbarHotkeySettings">
+   <property name="icon">
+    <iconset theme="keyboard-line"/>
+   </property>
+   <property name="text">
+    <string comment="In Toolbar">Hotkeys</string>
    </property>
   </action>
   <action name="actionGraphicsSettings">


### PR DESCRIPTION
### Description of Changes
Adds a 'Hotkeys' action to the Qt toolbar to the right of the 'Controllers' action.

### Rationale behind Changes
#13243 prompted a discussion where we realized that, although this is 100% clear when using the menu bar, a user primarily using the toolbar would have no reasonable idea how to find hotkeys:

* Scan the toolbar for `Hotkeys`. Nothing.
* See a `Settings` button; check that; nothing.
* From there, while there are very good reasons (both technical for us and logistical for the end user) to keep `Hotkeys` within the controllers settings, almost no end user would think to click the `Controllers` button in the toolbar to get to the hotkeys.

With this button, said user can readily find hotkeys, and the toolbar still has abundant empty space for this on a 16:9 display.

### Suggested Testing Steps
Make sure the button appears and works, and consider if you agree with this position within the toolbar.

### Did you use AI to help find, test, or implement this issue or feature?
Would have, but I couldn't find the ChatGPT button in the toolbar.
