### PR TITLE
GS/SW: Make right-to-left horizontal lines draw the correct pixels.

### DIFF
--- a/pcsx2/GS/Renderers/SW/GSRasterizer.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRasterizer.cpp
@@ -340,6 +340,8 @@ void GSRasterizer::DrawLine(const GSVertexSW* vertex, const u16* index)
 			if (m_scissor.top <= p.y && p.y < m_scissor.bottom && IsOneOfMyScanlines(p.y))
 			{
 				GSVector4 lrf = scan.p.upl(v1.p.blend32(v0.p, mask)).ceil();
+				if (mask.mask())
+					lrf += GSVector4(1.0f, 1.0f, 0.0f, 0.0f); // Add bias so that right pixel is included and left pixel is omitted.
 				GSVector4 l = lrf.max(m_fscissor_x);
 				GSVector4 r = lrf.min(m_fscissor_x);
 				GSVector4i lr = GSVector4i(l.xxyy(r));


### PR DESCRIPTION
(Draft PR until I am able to test fully).

### Description of Changes
Shift right-to-left horizontal lines by 1 pixels to have more accurate coverage in SW rasterizer. (Note: still not ps2 accurate, just intended to fix the issue.)

### Rationale behind Changes
Fixes: https://github.com/PCSX2/pcsx2/issues/12764. Seems to also help a FF12 FMV.

Largo Winch - Empire Under Threat_SLES-50841_20230120221136.gs.xz
Master:
<img width="512" height="512" alt="S004570_05126_f00003_fr1_00000_C_32_Largo Winch - Empire Under Threat_SLES-50841_20230120221136 gs xz_master" src="https://github.com/user-attachments/assets/ab3473b8-c337-4016-a747-a3ece8fadec6" />
PR:
<img width="512" height="512" alt="S004570_05126_f00003_fr1_00000_C_32_Largo Winch - Empire Under Threat_SLES-50841_20230120221136 gs xz_hline" src="https://github.com/user-attachments/assets/4dd79706-9b28-4517-ad9c-09c919d70007" />

Final Fantasy XII preload frame data texture isses.gs.xz
Master
<img width="448" height="512" alt="S003707_00145_f00005_fr-1_00e00_C_32_Final Fantasy XII preload frame data texture isses gs xz_master" src="https://github.com/user-attachments/assets/ad796333-1331-4907-a9f1-85a50e05e543" />
PR
<img width="448" height="512" alt="S003707_00145_f00005_fr-1_00e00_C_32_Final Fantasy XII preload frame data texture isses gs xz_hline" src="https://github.com/user-attachments/assets/82e1ea04-20b8-4a8c-a4df-be8510eaa87a" />

### Suggested Testing Steps
Testing any games with SW rendering, expecially those that rely on accurate line drawing.

### Did you use AI to help find, test, or implement this issue or feature?
Yes, GitHub copilot autocompletion.
