### PR TITLE
GS/SW: Misc code cleanup.

### DIFF
--- a/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
@@ -1293,15 +1293,6 @@ __ri void GSDrawScanline::CDrawScanline(int pixels, int left, int top, const GSV
 
 				rb = frb.lerp16<0>(rb, fog);
 				ga = fga.lerp16<0>(ga, fog).mix16(ga);
-
-				/*
-				fog = fog.srl16<7>();
-
-				VectorI ifog = VectorI::x00ff().sub16(fog);
-
-				rb = rb.mul16l(fog).add16(frb.mul16l(ifog)).srl16<8>();
-				ga = ga.mul16l(fog).add16(fga.mul16l(ifog)).srl16<8>().mix16(ga);
-				*/
 			}
 
 			// ReadFrame

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -1091,8 +1091,6 @@ bool GSRendererSW::GetScanlineGlobalData(SharedData* data)
 				if (gd.sel.fst)
 				{
 					pxAssert(gd.sel.lcm == 1);
-					pxAssert(((m_vt.m_min.t.uph(m_vt.m_max.t) == GSVector4::zero()).mask() & 3) == 3); // ratchet and clank (menu)
-
 					gd.sel.lcm = 1;
 				}
 


### PR DESCRIPTION
### Description of Changes
1. Remove an unecessary assertion related to mipmapping in SW renderer (this assertion triggers randomly in games that use mipmapping and seem not useful).
2. Remove and old comment related to fogging (the commented code is not accurate; see https://github.com/PCSX2/pcsx2/issues/11477).

### Rationale behind Changes
1. Make debugging games with mipmapping in SW renderer easier.
2. Avoid confusion with the fog equation, especially since it has been fixed here: https://github.com/PCSX2/pcsx2/pull/13171.

### Suggested Testing Steps
Running games with mipmapping in SW mode with a debug build shouldn't throw the assertion anymore.

Example: [Conspiracy - Weapons of Mass Destruction_SLES-53098_20250214222606.gs.zip](https://github.com/user-attachments/files/22322620/Conspiracy.-.Weapons.of.Mass.Destruction_SLES-53098_20250214222606.gs.zip)

### Did you use AI to help find, test, or implement this issue or feature?
No.
