### PR TITLE
Patch: Clear R5900 recompiler cache after updating dynamic patches

### DIFF
--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -18,6 +18,7 @@
 #include "IopMem.h"
 #include "Memory.h"
 #include "Patch.h"
+#include "R5900.h"
 
 #include "IconsFontAwesome6.h"
 #include "fmt/format.h"
@@ -793,6 +794,9 @@ void Patch::UpdateActivePatches(bool reload_enabled_list, bool verbose, bool ver
 				Host::OSD_INFO_DURATION);
 		}
 	}
+
+	if ((!s_active_gamedb_dynamic_patches.empty() || !s_active_pnach_dynamic_patches.empty()) && Cpu)
+		Cpu->Reset();
 }
 
 void Patch::ApplyPatchSettingOverrides()


### PR DESCRIPTION
### Description of Changes
If any dynamic patches are enabled, clear the R5900 recompiled code cache after updating patches.

### Rationale behind Changes
This makes it so the dynamic patches are applied immediately instead of when the patched block is next recompiled.

### Suggested Testing Steps
- Disable compatibility patches (Advanced page).
- Load Ratchet & Clank 2 (PAL).
- Throw out a few (upgraded) megaturrets, observe them bugging out.
- Enable compatibility patches.
- After this PR, the change should be immediately visible.

### Did you use AI to help find, test, or implement this issue or feature?
No.
