### PR TITLE
Config: Increase space in GS config struct

### DIFF
--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -711,7 +711,7 @@ struct Pcsx2Config
 
 		union
 		{
-			u64 bitset;
+			u64 bitset[2];
 
 			struct
 			{

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -708,7 +708,8 @@ std::optional<bool> Pcsx2Config::GSOptions::TriStateToOptionalBoolean(int value)
 
 Pcsx2Config::GSOptions::GSOptions()
 {
-	bitset = 0;
+	bitset[0] = 0;
+	bitset[1] = 0;
 
 	PCRTCAntiBlur = true;
 	DisableInterlaceOffset = false;


### PR DESCRIPTION
### Description of Changes
The GS config union had 73 members for a u64 which broke settings outside of this range, this PR doubles the space allowing these settings to function again.

Fixes #13278 

### Rationale behind Changes
Broken settings are bad.

### Suggested Testing Steps
Test all GS options to make sure they still work or now work after they broke.

### Did you use AI to help find, test, or implement this issue or feature?
No
