### PR TITLE
GameList: Prioritize file title over serial for covers

### DIFF
--- a/pcsx2/GameList.cpp
+++ b/pcsx2/GameList.cpp
@@ -1215,22 +1215,22 @@ std::string GameList::GetCoverImagePathForEntry(const Entry* entry)
 	for (const char* extension : extensions)
 	{
 
-		// Prioritize lookup by serial (Most specific)
-		if (!entry->serial.empty())
-		{
-			const std::string cover_filename(entry->serial + extension);
-			cover_path = Path::Combine(EmuFolders::Covers, cover_filename);
-			if (FileSystem::FileExists(cover_path.c_str()))
-				return cover_path;
-		}
-
-		// Try file title (for modded games or specific like above)
+		// Prioritize file title since users can change these (e.g. for modded games)
 		const std::string_view file_title(Path::GetFileTitle(entry->path));
 		if (!file_title.empty() && entry->title != file_title)
 		{
 			std::string cover_filename = fmt::format("{}{}", file_title, extension);
 			Path::SanitizeFileName(&cover_filename);
 
+			cover_path = Path::Combine(EmuFolders::Covers, cover_filename);
+			if (FileSystem::FileExists(cover_path.c_str()))
+				return cover_path;
+		}
+
+		// Lookup by serial (most specific)
+		if (!entry->serial.empty())
+		{
+			const std::string cover_filename(entry->serial + extension);
 			cover_path = Path::Combine(EmuFolders::Covers, cover_filename);
 			if (FileSystem::FileExists(cover_path.c_str()))
 				return cover_path;


### PR DESCRIPTION
### Description of Changes
Swaps the priority for finding cover art.

Previously:

* Serial
* File title
* GameDB title
* GameDB English title

Now:

* File title
* Serial
* GameDB title
* GameDB English title

### Rationale behind Changes
Fixes very minor oversight introduced in #6214 with the introduction of serial image names.

For modded games that retain the serial, it was not possible to simultaneously (1) have the base game and the modded game, (2) have separate cover art for the modded version, *while* (3) retaining the base, unmodded cover name as `serial.extension` which is the most common default name with the downloader.

If, for example, you have an existing base game whose cover named `serial.extension` was imported through the cover downloader and then have a separate modded version of the game (same serial), you have to simultaneously name the new mod cover image after the mod filename *and* rename the old base game cover name to its filename or GameDB name. Else the modded game will get "snagged" on `serial.extension` and use the base game's cover, because serials are prioritized.

This PR makes it so that the modded cover image filename will function independently from that old cover name.

Theoretically this PR could negatively behaviorally impact somebody one time who meets these extremely convoluted criteria:

1. Uses the game grid.
2. For at least one game, has both a cover image named after a serial and one named after the game.
3. The contents of these images are different.
4. They expect the serial name one to take priority.

On the performance side rather than the behavioral, because the cover downloader creates serial names by default (by far the most sensible default; GameDB names change all the time, and this should not change), this means that the most likely code execution path for 99.99% of cover names is negatively impacted with no benefit to them. With this PR, if there's a serial cover name, you have to first check if the filename and the game name are identical, and if they aren't (which is the case for many game files), check to see if the filename cover exists for them. *Then* move to check for a serial image name.

Thus this is technically marginally more expressive and intuitive for a somewhat niche use case but comes at a small performance penalty for the overwhelming majority of use cases.

### Suggested Testing Steps
Make sure your existing covers still work correctly and that modded games with different file titles are prioritized correctly.

### Did you use AI to help find, test, or implement this issue or feature?
It took me nine yearials to deprioritize the serials. (No)