### PR TITLE
GS/HW: Make sure we use date barrier on sw fbmask instead of primid date.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -7545,6 +7545,13 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 				m_conf.require_full_barrier = true;
 				DATE_BARRIER = true;
 			}
+			else if ((features.texture_barrier || features.multidraw_fb_copy) && m_conf.require_full_barrier)
+			{
+				// Full barrier is enabled (likely sw fbmask), we need to use date barrier.
+				GL_PERF("DATE: Accurate with alpha %d-%d", GetAlphaMinMax().min, GetAlphaMinMax().max);
+				m_conf.require_full_barrier = true;
+				DATE_BARRIER = true;
+			}
 			else if (features.primitive_id)
 			{
 				GL_PERF("DATE: Accurate with alpha %d-%d", GetAlphaMinMax().min, GetAlphaMinMax().max);


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/HW: Make sure we use date barrier on sw fbmask instead of primid date.

Edge case when we have sw fbmask but no sw blending.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Bugfix and optimization.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Only RE Outbreak is affected but we already optimize that game with a gamefix patch.
Will save a couple of draw calls/render passes.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.
