### PR TITLE
ImGui: Add contingent for empty binding in save state select menu

### DIFF
--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -1004,6 +1004,8 @@ void SaveStateSelectorUI::RefreshHotkeyLegend()
 {
 	auto format_legend_entry = [](SmallString binding, std::string_view caption) {
 		InputManager::PrettifyInputBinding(binding);
+		if (binding.empty())
+			binding.append(TRANSLATE_STR("ImGuiOverlays", "Empty"));
 		return fmt::format("{} - {}", binding, caption);
 	};
 


### PR DESCRIPTION
### Description of Changes
In the ImGui save state menu which shows hotkeys at the bottom, adds a condition for an empty hotkey instead of just "".

Before (note the unbound 'Save' hotkey):

<img width="603" height="439" alt="image" src="https://github.com/user-attachments/assets/1580d71c-8b5a-4fd7-878b-285a0b092c01" />

After:

<img width="611" height="440" alt="image" src="https://github.com/user-attachments/assets/842157dd-245d-4270-82a7-0baf005839f3" />

### Rationale behind Changes
Addresses #13290. Unable to use the null sign `∅` to avoid a translatable string because it's a 3-byte Unicode character, and trying to place it into the string results in garbage on the ImGui menu.

Theoretically this could be another word like "Unbound". I just hoped "Empty" is the shortest and easiest to understand across English and other languages.

We can't just use "`if (!InputManager::PrettifyInputBinding(binding))`", because this function doesn't only return `false` if `binding` is empty. Append the translatable string rather than set equal because `binding` is a `SmallString` while the translatable string is a `std::string`.

### Suggested Testing Steps
Make sure the hotkeys still show up correctly and that an empty binding shows up correctly.

### Did you use AI to help find, test, or implement this issue or feature?
No.
