### PR TITLE
Achievements: Harden RetroAchievements Hardcore Compliance

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -568,7 +568,7 @@ void MainWindow::recreate()
 	if (was_display_created)
 	{
 		g_emu_thread->setSurfaceless(false);
-		g_main_window->updateEmulationActions(false, s_vm_valid, Achievements::IsHardcoreModeActive());
+		g_main_window->updateEmulationActions(false, s_vm_valid, false);
 		g_main_window->onFullscreenUIStateChange(g_emu_thread->isRunningFullscreenUI());
 	}
 }
@@ -852,6 +852,10 @@ void MainWindow::onAchievementsHardcoreModeChanged(bool enabled)
 {
 	// disable debugger while hardcore mode is active
 	m_ui.actionDebugger->setDisabled(enabled);
+
+	// refresh emulation actions to show/hide load state buttons based on hardcore mode
+	updateEmulationActions(s_vm_valid, s_vm_valid, false);
+
 	if (enabled)
 	{
 		// If PauseOnEntry is enabled, we prompt the user to disable Hardcore Mode
@@ -947,7 +951,7 @@ void MainWindow::updateEmulationActions(bool starting, bool running, bool stoppi
 	m_ui.actionPause->setEnabled(running);
 	m_ui.actionScreenshot->setEnabled(running);
 	m_ui.menuChangeDisc->setEnabled(running);
-	m_ui.menuLoadState->setEnabled(running);
+	m_ui.menuLoadState->setEnabled(running && !Achievements::IsHardcoreModeActive());
 	m_ui.menuSaveState->setEnabled(running);
 	m_ui.actionSaveGSDump->setEnabled(running);
 
@@ -956,7 +960,7 @@ void MainWindow::updateEmulationActions(bool starting, bool running, bool stoppi
 	m_ui.actionToolbarPause->setEnabled(running);
 	m_ui.actionToolbarScreenshot->setEnabled(running);
 	m_ui.actionToolbarChangeDisc->setEnabled(running);
-	m_ui.actionToolbarLoadState->setEnabled(running);
+	m_ui.actionToolbarLoadState->setEnabled(running && !Achievements::IsHardcoreModeActive());
 	m_ui.actionToolbarSaveState->setEnabled(running);
 
 	m_ui.actionViewGameProperties->setEnabled(running);

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -5753,7 +5753,8 @@ void FullscreenUI::DrawPauseMenu(MainWindowType type)
 			case PauseSubMenu::None:
 			{
 				// NOTE: Menu close must come first, because otherwise VM destruction options will race.
-				const bool can_load_or_save_state = s_current_disc_crc != 0;
+				const bool can_load_state = s_current_disc_crc != 0 && !Achievements::IsHardcoreModeActive();
+				const bool can_save_state = s_current_disc_crc != 0;
 
 				if (just_focused)
 					ImGui::SetFocusID(ImGui::GetID(FSUI_ICONSTR(ICON_FA_PLAY, "Resume Game")), ImGui::GetCurrentWindow());
@@ -5767,19 +5768,19 @@ void FullscreenUI::DrawPauseMenu(MainWindowType type)
 					DoToggleFrameLimit();
 				}
 
-				if (ActiveButton(FSUI_ICONSTR(ICON_FA_ARROW_ROTATE_LEFT, "Load State"), false, can_load_or_save_state))
+				if (ActiveButton(FSUI_ICONSTR(ICON_FA_ARROW_ROTATE_LEFT, "Load State"), false, can_load_state))
 				{
 					if (OpenSaveStateSelector(true))
 						s_current_main_window = MainWindowType::None;
 				}
 
-				if (ActiveButton(FSUI_ICONSTR(ICON_FA_DOWNLOAD, "Save State"), false, can_load_or_save_state))
+				if (ActiveButton(FSUI_ICONSTR(ICON_FA_DOWNLOAD, "Save State"), false, can_save_state))
 				{
 					if (OpenSaveStateSelector(false))
 						s_current_main_window = MainWindowType::None;
 				}
 
-				if (ActiveButton(FSUI_ICONSTR(ICON_FA_WRENCH, "Game Properties"), false, can_load_or_save_state))
+				if (ActiveButton(FSUI_ICONSTR(ICON_FA_WRENCH, "Game Properties"), false, can_save_state))
 				{
 					SwitchToGameSettings();
 				}
@@ -5819,7 +5820,7 @@ void FullscreenUI::DrawPauseMenu(MainWindowType type)
 				if (ActiveButton(FSUI_ICONSTR(ICON_FA_POWER_OFF, "Close Game"), false))
 				{
 					// skip submenu when we can't save anyway
-					if (!can_load_or_save_state)
+					if (!can_save_state)
 						RequestShutdown(false);
 					else
 						OpenPauseSubMenu(PauseSubMenu::Exit);
@@ -6144,7 +6145,7 @@ void FullscreenUI::DrawSaveStateSelector(bool is_loading)
 
 					if (ActiveButton(
 							is_loading ? FSUI_ICONSTR(ICON_FA_FOLDER_OPEN, "Load State") : FSUI_ICONSTR(ICON_FA_FOLDER_OPEN, "Save State"),
-							false, true, LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY))
+							false, is_loading ? !Achievements::IsHardcoreModeActive() : true, LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY))
 					{
 						if (is_loading)
 							DoLoadState(std::move(entry.path));

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1970,11 +1970,9 @@ bool VMManager::LoadState(const char* filename)
 {
 	if (Achievements::IsHardcoreModeActive())
 	{
-		Achievements::ConfirmHardcoreModeDisableAsync(TRANSLATE("VMManager", "Loading state"),
-			[filename = std::string(filename)](bool approved) {
-				if (approved)
-					LoadState(filename.c_str());
-			});
+		Host::AddIconOSDMessage("LoadStateHardcoreBlocked", ICON_FA_TRIANGLE_EXCLAMATION,
+			TRANSLATE_SV("VMManager", "Cannot load save state while RetroAchievements Hardcore Mode is active."),
+			Host::OSD_WARNING_DURATION);
 		return false;
 	}
 
@@ -2007,11 +2005,9 @@ bool VMManager::LoadStateFromSlot(s32 slot, bool backup)
 
 	if (Achievements::IsHardcoreModeActive())
 	{
-		Achievements::ConfirmHardcoreModeDisableAsync(TRANSLATE("VMManager", "Loading state"),
-			[slot](bool approved) {
-				if (approved)
-					LoadStateFromSlot(slot);
-			});
+		Host::AddIconOSDMessage("LoadStateHardcoreBlocked", ICON_FA_TRIANGLE_EXCLAMATION,
+			fmt::format(TRANSLATE_FS("VMManager", "Cannot load save {} from slot {} while RetroAchievements Hardcore Mode is active."), backup ? TRANSLATE("VMManager", "backup state") : TRANSLATE("VMManager", "state"), slot),
+			Host::OSD_WARNING_DURATION);
 		return false;
 	}
 
@@ -2223,12 +2219,9 @@ void VMManager::FrameAdvance(u32 num_frames /*= 1*/)
 
 	if (Achievements::IsHardcoreModeActive())
 	{
-		Achievements::ConfirmHardcoreModeDisableAsync(TRANSLATE("VMManager", "Frame advancing"),
-			[num_frames](bool approved) {
-				if (approved)
-					FrameAdvance(num_frames);
-			});
-
+		Host::AddIconOSDMessage("FrameAdvanceHardcoreBlocked", ICON_FA_TRIANGLE_EXCLAMATION,
+			TRANSLATE_SV("VMManager", "Cannot frame advance while RetroAchievements Hardcore Mode is active."),
+			Host::OSD_WARNING_DURATION);
 		return;
 	}
 
@@ -3067,7 +3060,6 @@ void VMManager::EnforceAchievementsChallengeModeSettings()
 {
 	if (!Achievements::IsHardcoreModeActive())
 	{
-		Host::RemoveKeyedOSDMessage("ChallengeDisableCheats");
 		return;
 	}
 
@@ -3084,8 +3076,8 @@ void VMManager::EnforceAchievementsChallengeModeSettings()
 	// Can't use cheats.
 	if (EmuConfig.EnableCheats)
 	{
-		Host::AddKeyedOSDMessage("ChallengeDisableCheats",
-			TRANSLATE_STR("VMManager", "Cheats have been disabled due to achievements hardcore mode."),
+		Host::AddIconOSDMessage("ChallengeDisableCheats", ICON_FA_TRIANGLE_EXCLAMATION,
+			TRANSLATE_SV("VMManager", "Cheats have been disabled due to RetroAchievements Hardcore Mode."),
 			Host::OSD_WARNING_DURATION);
 		EmuConfig.EnableCheats = false;
 	}


### PR DESCRIPTION
Fixes #13273  
- Fully block save state loading, frame advance, and cheats when Hardcore Mode is active  
- Disable Load State UI buttons while in Hardcore Mode (with an OSD message if bypassed)  
- Standardize OSD warnings for most Hardcore restrictions I could see in VMManager.

Totally up to suggestions with all of this just wanted to try to prevent any issues from happening again. And if you would like me not to remove asking the user if they want to turn off Hardcore let me know (Did this just in case somehow they were able to cheat the UI)

### Description of Changes
This PR enforces stricter RetroAchievements Hardcore compliance by preventing restricted actions both in the UI and at the core level. It also improves consistency in how users are notified through OSD messages.

### Rationale Behind Changes
Previously, users were prompted to disable Hardcore Mode if they attempted a restricted action. This approach possibly allowed people to bypass it. With this change, actions such as loading states, frame advancing, or using cheats are now hard-blocked.

### Suggested Testing Steps
- Enable Hardcore Mode and attempt to:
  - Load a save state (should be blocked with an OSD warning).  
  - Save a state (should still be allowed).  
  - Use frame advance (should be blocked with an OSD warning).  
  - Enable cheats (should be disabled automatically with an OSD warning).  
- Verify that UI elements for restricted actions are disabled while Hardcore Mode is active.  
- Confirm that normal behavior is unaffected when Hardcore Mode is off.  

### Did you use AI to help find, test, or implement this issue or feature?
No