### PR TITLE
GS/SW: Improve accuracy of line drawing and edge antialiasing.

### DIFF
--- a/pcsx2/GS/Renderers/SW/GSRasterizer.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRasterizer.cpp
@@ -296,6 +296,338 @@ void GSRasterizer::DrawPoint(const GSVertexSW* vertex, int vertex_count, const u
 	}
 }
 
+template <bool step_x, bool pos_x, bool pos_y, bool tl, bool side>
+void GSRasterizer::DrawEdgeTriangle(const GSVertexSW& v0, const GSVertexSW& v1, const GSVertexSW& dv,
+	const GSVector4i& efun1, const GSVector4i& efun2)
+{
+	constexpr int dxi = pos_x ? 1 : -1;
+	constexpr int dyi = pos_y ? 1 : -1;
+
+	const float delta_x = dv.p.x;
+	const float delta_y = dv.p.y;
+
+	if (delta_x == 0.0f && delta_y == 0.0f)
+		return;
+
+	const float x0 = v0.p.x;
+	const float y0 = v0.p.y;
+	const float x1 = v1.p.x;
+	const float y1 = v1.p.y;
+
+	const float rx0 = pos_x ? std::ceil(x0 - 1.0f) : std::floor(x0 + 1.0f);
+	const float ry0 = pos_y ? std::ceil(y0 - 1.0f) : std::floor(y0 + 1.0f);
+	const float rx1 = pos_x ? std::floor(x1 + 1.0f) : std::ceil(x1 - 1.0f);
+	const float ry1 = pos_y ? std::floor(y1 + 1.0f) : std::ceil(y1 - 1.0f);
+
+	const int rxi0 = static_cast<int>(rx0);
+	const int ryi0 = static_cast<int>(ry0);
+	const int rxi1 = static_cast<int>(rx1);
+	const int ryi1 = static_cast<int>(ry1);
+
+	// Note: appears to be asymmetry in how x bound and y bound is handled. Y bounds checking
+	// seems to be accurate here but not x. PS2 sometimes allows antialiased pixel to be +/-1 away
+	// from min/max x values and sometimes not. Not sure the reason so just arbitrarily pick the following for x.
+	int bxi0 = static_cast<int>(std::floor(std::min(x0, x1)));
+	int byi0 = static_cast<int>(std::ceil(std::min(y0, y1) - 1.0f));
+	int bxi1 = static_cast<int>(std::ceil(std::max(x0, x1)));
+	int byi1 = static_cast<int>(std::floor(std::max(y0, y1) + 1.0f));
+
+	// Combine with scissor region.
+	bxi0 = std::max(bxi0, m_scissor.x);
+	byi0 = std::max(byi0, m_scissor.y);
+	bxi1 = std::min(bxi1, m_scissor.z - 1); // b has inclusive coordinates.
+	byi1 = std::min(byi1, m_scissor.w - 1); // b has inclusive coordinates.
+
+	const GSVertexSW dedge = dv / GSVector4(std::abs(step_x ? delta_x : delta_y));
+
+	GSVertexSW edge(v0);
+
+	GSVertexSW* RESTRICT e = &m_edge.buff[m_edge.count];
+
+	// Decision value for stepping the dependent direction.
+	// D is the fractional part of dependent coordinate scaled by scaleD.
+	constexpr bool pos_D = step_x ? pos_y : pos_x;
+	const int scaleD = static_cast<int>(2 * 16 * 16 * std::abs(step_x ? delta_x : delta_y));
+	const float scaleDf = static_cast<float>(scaleD);
+	const int dD = static_cast<int>(2 * 16 * 16 * (step_x ? delta_y : delta_x));
+	int D = static_cast<int>(scaleD * (step_x ? (y0 - ry0) : (x0 - rx0)));
+
+	// Stepping variables
+	int xi = rxi0;
+	int yi = ryi0;
+	int e1 = efun1.x * xi + efun1.y * yi + efun1.z;
+	int e2 = efun2.x * xi + efun2.y * yi + efun2.z;
+
+	const auto StepDependent = [&]<int sign>() {
+		D -= scaleD * sign;
+		xi += (step_x ? 0 : 1) * sign;
+		yi += (step_x ? 1 : 0) * sign;
+		e1 += (step_x ? efun1.y : efun1.x) * sign;
+		e2 += (step_x ? efun2.y : efun2.x) * sign;
+	};
+
+	// Pre-steps
+	const float prestep = step_x ? dxi * (rx0 - x0) : dyi * (ry0 - y0);
+	edge += dedge * GSVector4(prestep);
+	D += static_cast<int>(dD * prestep);
+	
+	while (D >= scaleD / 2)
+		StepDependent.template operator()<1>();
+
+	while (D < -scaleD / 2)
+		StepDependent.template operator()<-1>();
+
+	pxAssert(-scaleD / 2 <= D && D < scaleD / 2);
+
+	while (true)
+	{
+		const float d = static_cast<float>(D) / scaleDf;
+
+		// Coverage and coordinates for anti-aliased point.
+		int cov, xi2, yi2, e12, e22;
+
+		const auto GetOffsetVars = [&]<int offset>() {
+			xi2 = xi + (step_x ? 0 : offset);
+			yi2 = yi + (step_x ? offset : 0);
+			e12 = e1 + (step_x ? efun1.y : efun1.x) * offset;
+			e22 = e2 + (step_x ? efun2.y : efun2.x) * offset;
+		};
+
+		if (d > 0.0f)
+		{
+			cov = static_cast<int>(0xffff * (side ? 1.0 - d : d));
+			constexpr int offset = (side ? 0 : 1);
+			GetOffsetVars.template operator()<offset>();
+		}
+		else if (d < 0.0f)
+		{
+			cov = static_cast<int>(0xffff * (side ? -d : 1.0 + d));
+			constexpr int offset = (side ? -1 : 0);
+			GetOffsetVars.template operator()<offset>();
+		}
+		else // d == 0.0f
+		{
+			// When exactly on the pixel center, top-left edges can create 0 coverage points and
+			// bottom-right edges can create full coverage points (with some rounding error).
+			cov = tl ? 0 : 0xffff;
+			constexpr int offset = tl ? (side ? -1 : 1) : 0;
+			GetOffsetVars.template operator()<offset>();
+		}
+
+		if (e12 > 0 && e22 > 0 &&
+			bxi0 <= xi2 && xi2 <= bxi1 &&
+			byi0 <= yi2 && yi2 <= byi1 &&
+			IsOneOfMyScanlines(yi2))
+		{
+			AddScanline(e, 1, xi2, yi2, edge);
+
+			e->p.U32[0] = std::clamp(cov, 0, 0xffff);
+
+			e++;
+		}
+
+		if (step_x ? (xi == rxi1) : (yi == ryi1))
+			break;
+
+		// Step driving axis.
+		edge += dedge;
+		D += dD;
+		xi += step_x ? dxi : 0;
+		yi += step_x ? 0 : dyi;
+		e1 += step_x ? (dxi * efun1.x) : (dyi * efun1.y);
+		e2 += step_x ? (dxi * efun2.x) : (dyi * efun2.y);
+
+		// Step dependent axis.
+		if constexpr (pos_D)
+		{
+			if (D >= scaleD / 2)
+				StepDependent.template operator()<1>();
+		}
+		else
+		{
+			if (D < -scaleD / 2)
+				StepDependent.template operator()<-1>();
+		}
+	}
+
+	m_edge.count += e - &m_edge.buff[m_edge.count];
+}
+
+template <bool step_x, bool pos_x, bool pos_y, bool aa>
+void GSRasterizer::DrawEdgeLine(const GSVertexSW& v0, const GSVertexSW& v1, const GSVertexSW& dv)
+{
+	constexpr int dxi = pos_x ? 1 : -1;
+	constexpr int dyi = pos_y ? 1 : -1;
+
+	const float delta_x = dv.p.x;
+	const float delta_y = dv.p.y;
+
+	const float x0 = v0.p.x;
+	const float y0 = v0.p.y;
+	const float x1 = v1.p.x;
+	const float y1 = v1.p.y;
+
+	float rx0 = std::floor(x0 + 0.5f);
+	float ry0 = std::floor(y0 + 0.5f);
+	float rx1 = std::floor(x1 + 0.5f);
+	float ry1 = std::floor(y1 + 0.5f);
+
+	// Diamond exit rule for determining coverage of first/last pixel.
+	const auto TestEndpoint = [](float dx, float dy) -> bool {
+		float dist = std::abs(dx) + std::abs(dy);
+		if (dist < 0.5f)
+			return false;
+		if constexpr (step_x)
+		{
+			const bool x_good = pos_x ? (dx > 0.0f) : (dx < 0.0f);
+			return x_good && (dist > 0.5f || dy >= 0.0f);
+		}
+		else
+		{
+			const bool y_good = pos_y ? (dy > 0.0f) : (dy < 0.0f);
+			return y_good && (dist > 0.5f || dx >= 0.0f);
+		}
+	};
+
+	const bool draw_first = !TestEndpoint(x0 - rx0, y0 - ry0);
+	const bool draw_last = TestEndpoint(x1 - rx1, y1 - ry1);
+
+	if (!draw_first)
+	{
+		rx0 += step_x ? dxi : 0.0f;
+		ry0 += step_x ? 0.0f : dyi;
+	}
+
+	if (!draw_last)
+	{
+		rx1 -= step_x ? dxi : 0.0f;
+		ry1 -= step_x ? 0.0f : dyi;
+	}
+
+	if ((step_x ? (dxi * (rx1 - rx0)) : (dyi * (ry1 - ry0))) < 0.0f)
+		return;
+
+	const int rxi0 = static_cast<int>(rx0);
+	const int ryi0 = static_cast<int>(ry0);
+	const int rxi1 = static_cast<int>(rx1);
+	const int ryi1 = static_cast<int>(ry1);
+
+	const GSVertexSW dedge = dv / GSVector4(std::abs(step_x ? delta_x : delta_y));
+	
+	GSVertexSW edge(v0);
+
+	GSVertexSW* RESTRICT e = &m_edge.buff[m_edge.count];
+
+	// Decision value for stepping the dependent direction.
+	// D is the fractional part of dependent coordinate scaled by scaleD.
+	constexpr bool pos_D = step_x ? pos_y : pos_x;
+	const int scaleD = static_cast<int>(2 * 16 * 16 * std::abs(step_x ? delta_x : delta_y));
+	const float scaleDf = static_cast<float>(scaleD);
+	const int dD = static_cast<int>(2 * 16 * 16 * (step_x ? delta_y : delta_x));
+	int D = static_cast<int>(scaleD * (step_x ? (y0 - ry0) : (x0 - rx0)));
+
+	// Stepping variables
+	int xi = rxi0;
+	int yi = ryi0;
+
+	const auto StepDependent = [&]<int sign>() {
+		D -= scaleD * sign;
+		xi += (step_x ? 0 : 1) * sign;
+		yi += (step_x ? 1 : 0) * sign;
+	};
+
+	// Pre-steps
+	const float prestep = step_x ? dxi * (rx0 - x0) : dyi * (ry0 - y0);
+	edge += dedge * GSVector4(prestep);
+	D += static_cast<int>(dD * prestep);
+
+	while (D >= scaleD / 2)
+		StepDependent.template operator()<1>();
+	
+	while (D < -scaleD / 2)
+		StepDependent.template operator()<-1>();
+
+	pxAssert(-scaleD / 2 <= D && D < scaleD / 2);
+
+	const auto AddScanlineStepEdge = [&](int x, int y, int cov = 0) {
+		if (m_scissor.left <= x && x < m_scissor.right &&
+			m_scissor.top <= y && y < m_scissor.bottom &&
+			IsOneOfMyScanlines(y))
+		{
+			AddScanline(e, 1, x, y, edge);
+
+			if constexpr (aa)
+				e->p.U32[0] = cov;
+
+			e++;
+		}
+	};
+
+	while (true)
+	{
+		if constexpr (aa)
+		{
+			const float cov = 0xffff * std::abs(static_cast<float>(D) / scaleDf);
+			const int covi = std::clamp(static_cast<int>(cov), 0, 0xffff);
+			const int offset = D >= 0 ? 1 : -1;
+
+			AddScanlineStepEdge(xi, yi, 0xffff - covi);
+			AddScanlineStepEdge(xi + (step_x ? 0 : offset), yi + (step_x ? offset : 0), covi);
+		}
+		else
+		{
+			AddScanlineStepEdge(xi, yi);
+		}
+
+		if (step_x ? (xi == rxi1) : (yi == ryi1))
+			break;
+
+		// Step driving axis.
+		edge += dedge;
+		D += dD;
+		xi += step_x ? dxi : 0;
+		yi += step_x ? 0 : dyi;
+
+		// Step dependent axis.
+		if constexpr (pos_D)
+		{
+			if (D >= scaleD / 2)
+				StepDependent.template operator()<1>();
+		}
+		else
+		{
+			if (D < -scaleD / 2)
+				StepDependent.template operator()<-1>();
+		}
+	}
+
+	m_edge.count += e - &m_edge.buff[m_edge.count];
+}
+
+void GSRasterizer::DrawEdgeTriangle(const GSVertexSW& v0, const GSVertexSW& v1, const GSVertexSW& dv, const GSVector4i& efun1, const GSVector4i& efun2, bool tl)
+{
+	const bool step_x = std::abs(dv.p.x) >= std::abs(dv.p.y);
+	const bool pos_x = dv.p.x >= 0.0f;
+	const bool pos_y = dv.p.y >= 0.0f;
+	
+	// side == true => outside of triangle is towards top or left.
+	// side == false => outside of triangle is towards bottom or right.
+	const bool side = tl ^ (step_x && (dv.p.y != 0.0f) && (pos_x == pos_y));
+
+	(this->*m_draw_edge_triangle[step_x][pos_x][pos_y][tl][side])(v0, v1, dv, efun1, efun2);
+}
+
+void GSRasterizer::DrawEdgeLine(const GSVertexSW& v0, const GSVertexSW& v1, const GSVertexSW& dv, bool has_edge)
+{
+	const bool step_x = std::abs(dv.p.x) >= std::abs(dv.p.y);
+	const bool pos_x = dv.p.x >= 0.0f;
+	const bool pos_y = dv.p.y >= 0.0f;
+
+	(this->*m_draw_edge_line[step_x][pos_x][pos_y][has_edge])(v0, v1, dv);
+
+	return;
+}
+
 void GSRasterizer::DrawLine(const GSVertexSW* vertex, const u16* index)
 {
 	m_primcount++;
@@ -305,99 +637,11 @@ void GSRasterizer::DrawLine(const GSVertexSW* vertex, const u16* index)
 
 	GSVertexSW dv = v1 - v0;
 
-	GSVector4 dp = dv.p.abs();
+	DrawEdgeLine(v0, v1, dv, HasEdge());
 
-	int i = (dp < dp.yxwz()).mask() & 1; // |dx| <= |dy|
+	Flush(vertex, index, GSVertexSW::zero(), HasEdge());
 
-	if (HasEdge())
-	{
-		DrawEdge(v0, v1, dv, i, 0);
-		DrawEdge(v0, v1, dv, i, 1);
-
-		Flush(vertex, index, GSVertexSW::zero(), true);
-
-		return;
-	}
-
-	GSVector4i dpi(dp);
-
-	if (dpi.y == 0)
-	{
-		if (dpi.x > 0)
-		{
-			// shortcut for horizontal lines
-
-			GSVector4 mask = (v0.p > v1.p).xxxx();
-
-			GSVertexSW scan;
-
-			scan.p = v0.p.blend32(v1.p, mask);
-			scan.t = v0.t.blend32(v1.t, mask);
-			scan.c = v0.c.blend32(v1.c, mask);
-
-			GSVector4i p(scan.p);
-
-			if (m_scissor.top <= p.y && p.y < m_scissor.bottom && IsOneOfMyScanlines(p.y))
-			{
-				GSVector4 lrf = scan.p.upl(v1.p.blend32(v0.p, mask)).ceil();
-				GSVector4 l = lrf.max(m_fscissor_x);
-				GSVector4 r = lrf.min(m_fscissor_x);
-				GSVector4i lr = GSVector4i(l.xxyy(r));
-
-				int left = lr.extract32<0>();
-				int right = lr.extract32<2>();
-
-				int pixels = right - left;
-
-				if (pixels > 0)
-				{
-					GSVertexSW dscan = dv / dv.p.xxxx();
-
-					scan += dscan * (l - scan.p).xxxx();
-
-					m_setup_prim(vertex, index, dscan, m_local);
-
-					DrawScanline(pixels, left, p.y, scan);
-				}
-			}
-		}
-
-		return;
-	}
-
-	int steps = dpi.v[i];
-
-	if (steps > 0)
-	{
-		GSVertexSW edge = v0;
-		GSVertexSW dedge = dv / GSVector4(dp.v[i]);
-
-		GSVertexSW* RESTRICT e = m_edge.buff;
-
-		while (1)
-		{
-			GSVector4i p(edge.p);
-
-			if (m_scissor.left <= p.x && p.x < m_scissor.right && m_scissor.top <= p.y && p.y < m_scissor.bottom)
-			{
-				if (IsOneOfMyScanlines(p.y))
-				{
-					AddScanline(e, 1, p.x, p.y, edge);
-
-					e++;
-				}
-			}
-
-			if (--steps == 0)
-				break;
-
-			edge += dedge;
-		}
-
-		m_edge.count = e - m_edge.buff;
-
-		Flush(vertex, index, GSVertexSW::zero());
-	}
+	return;
 }
 
 static const u8 s_ysort[8][4] =
@@ -528,16 +772,39 @@ void GSRasterizer::DrawTriangle(const GSVertexSW* vertex, const u16* index)
 
 	if (HasEdge())
 	{
-		GSVector4 a = dx.abs() < dy.abs();       // |dx| <= |dy|
-		GSVector4 b = dx < GSVector4::zero();    // dx < 0
-		GSVector4 c = cross < GSVector4::zero(); // longest.p.x < 0
+		const bool clockwise = (cross < GSVector4::zero()).mask();
 
-		int orientation = a.mask();
-		int side = ((a | b) ^ c).mask() ^ 2; // evil
+		const bool tl0 = (v0.p.y == v1.p.y) || !clockwise;
+		const bool tl1 = clockwise;
+		const bool tl2 = (v1.p.y != v2.p.y) && !clockwise;
 
-		DrawEdge((GSVertexSW&)v0, (GSVertexSW&)v1, (GSVertexSW&)dv0, orientation & 1, side & 1);
-		DrawEdge((GSVertexSW&)v0, (GSVertexSW&)v2, (GSVertexSW&)dv1, orientation & 2, side & 2);
-		DrawEdge((GSVertexSW&)v1, (GSVertexSW&)v2, (GSVertexSW&)dv2, orientation & 4, side & 4);
+		const GSVector4i xy0 = GSVector4i(v0.p * GSVector4::cxpr(16.0f));
+		const GSVector4i xy1 = GSVector4i(v1.p * GSVector4::cxpr(16.0f));
+		const GSVector4i xy2 = GSVector4i(v2.p * GSVector4::cxpr(16.0f));
+
+		GSVector4i f0 = (xy1 - xy0).yxyx().upl32(xy0 - xy1).sll32<4>();
+		GSVector4i f1 = (xy0 - xy2).yxyx().upl32(xy2 - xy0).sll32<4>();
+		GSVector4i f2 = (xy2 - xy1).yxyx().upl32(xy1 - xy2).sll32<4>();
+
+		f0 = f0.insert32<2>(xy1.x * xy0.y - xy0.x * xy1.y);
+		f1 = f1.insert32<2>(xy0.x * xy2.y - xy2.x * xy0.y);
+		f2 = f2.insert32<2>(xy2.x * xy1.y - xy1.x * xy2.y);
+
+		if (clockwise)
+		{
+			f0 = GSVector4i::cxpr(0) - f0;
+			f1 = GSVector4i::cxpr(0) - f1;
+			f2 = GSVector4i::cxpr(0) - f2;
+		}
+
+		// Bias for top-left edges.
+		f0 += GSVector4i(0, 0, tl0, 0);
+		f1 += GSVector4i(0, 0, tl1, 0);
+		f2 += GSVector4i(0, 0, tl2, 0);
+
+		DrawEdgeTriangle((GSVertexSW&)v0, (GSVertexSW&)v1, (GSVertexSW&)dv0, f1, f2, tl0);
+		DrawEdgeTriangle((GSVertexSW&)v0, (GSVertexSW&)v2, (GSVertexSW&)dv1, f2, f0, tl1);
+		DrawEdgeTriangle((GSVertexSW&)v1, (GSVertexSW&)v2, (GSVertexSW&)dv2, f0, f1, tl2);
 
 		Flush(vertex, index, GSVertexSW::zero(), true);
 	}
@@ -707,16 +974,39 @@ void GSRasterizer::DrawTriangle(const GSVertexSW* vertex, const u16* index)
 
 	if (HasEdge())
 	{
-		GSVector4 a = dx.abs() < dy.abs();       // |dx| <= |dy|
-		GSVector4 b = dx < GSVector4::zero();    // dx < 0
-		GSVector4 c = cross < GSVector4::zero(); // longest.p.x < 0
+		const bool clockwise = (cross < GSVector4::zero()).mask();
 
-		int orientation = a.mask();
-		int side = ((a | b) ^ c).mask() ^ 2; // evil
+		const bool tl0 = (v0.p.y == v1.p.y) || !clockwise;
+		const bool tl1 = clockwise;
+		const bool tl2 = (v1.p.y != v2.p.y) && !clockwise;
 
-		DrawEdge(v0, v1, dv0, orientation & 1, side & 1);
-		DrawEdge(v0, v2, dv1, orientation & 2, side & 2);
-		DrawEdge(v1, v2, dv2, orientation & 4, side & 4);
+		const GSVector4i xy0 = GSVector4i(v0.p * GSVector4::cxpr(16.0f));
+		const GSVector4i xy1 = GSVector4i(v1.p * GSVector4::cxpr(16.0f));
+		const GSVector4i xy2 = GSVector4i(v2.p * GSVector4::cxpr(16.0f));
+
+		GSVector4i f0 = (xy1 - xy0).yxyx().upl32(xy0 - xy1).sll32<4>();
+		GSVector4i f1 = (xy0 - xy2).yxyx().upl32(xy2 - xy0).sll32<4>();
+		GSVector4i f2 = (xy2 - xy1).yxyx().upl32(xy1 - xy2).sll32<4>();
+
+		f0 = f0.insert32<2>(xy1.x * xy0.y - xy0.x * xy1.y);
+		f1 = f1.insert32<2>(xy0.x * xy2.y - xy2.x * xy0.y);
+		f2 = f2.insert32<2>(xy2.x * xy1.y - xy1.x * xy2.y);
+
+		if (clockwise)
+		{
+			f0 = GSVector4i::cxpr(0) - f0;
+			f1 = GSVector4i::cxpr(0) - f1;
+			f2 = GSVector4i::cxpr(0) - f2;
+		}
+
+		// Bias for top-left edges.
+		f0 += GSVector4i(0, 0, tl0, 0);
+		f1 += GSVector4i(0, 0, tl1, 0);
+		f2 += GSVector4i(0, 0, tl2, 0);
+
+		DrawEdgeTriangle(v0, v1, dv0, f1, f2, tl0);
+		DrawEdgeTriangle(v0, v2, dv1, f2, f0, tl1);
+		DrawEdgeTriangle(v1, v2, dv2, f0, f1, tl2);
 
 		Flush(vertex, index, GSVertexSW::zero(), true);
 	}
@@ -1320,3 +1610,35 @@ std::unique_ptr<IRasterizer> GSRasterizerList::Create(int threads)
 void GSRasterizerList::PrintStats()
 {
 }
+
+#define INIT4(x0, x1, x2, x3, x4) static_cast<DrawEdgeTrianglePtr>(&GSRasterizer::DrawEdgeTriangle<x0, x1, x2, x3, x4>)
+#define INIT3(x0, x1, x2, x3) { INIT4(x0, x1, x2, x3, false)    , INIT4(x0, x1, x2, x3, true) } 
+#define INIT2(x0, x1, x2)     { INIT3(x0, x1, x2, false)        , INIT3(x0, x1, x2, true)     } 
+#define INIT1(x0, x1)         { INIT2(x0, x1, false)            , INIT2(x0, x1, true)         }
+#define INIT0(x0)             { INIT1(x0, false)                , INIT1(x0, true)             }
+
+const GSRasterizer::DrawEdgeTrianglePtr GSRasterizer::m_draw_edge_triangle[2][2][2][2][2] = {
+	INIT0(false),
+	INIT0(true)
+};
+
+#undef INIT0
+#undef INIT1
+#undef INIT2
+#undef INIT3
+#undef INIT4
+
+#define INIT3(x0, x1, x2, x3) static_cast<DrawEdgeLinePtr>(&GSRasterizer::DrawEdgeLine<x0, x1, x2, x3>)
+#define INIT2(x0, x1, x2)     { INIT3(x0, x1, x2, false)        , INIT3(x0, x1, x2, true)     } 
+#define INIT1(x0, x1)         { INIT2(x0, x1, false)            , INIT2(x0, x1, true)         }
+#define INIT0(x0)             { INIT1(x0, false)                , INIT1(x0, true)             }
+
+const GSRasterizer::DrawEdgeLinePtr GSRasterizer::m_draw_edge_line[2][2][2][2] = {
+	INIT0(false),
+	INIT0(true)
+};
+
+#undef INIT0
+#undef INIT1
+#undef INIT2
+#undef INIT3

--- a/pcsx2/GS/Renderers/SW/GSRasterizer.h
+++ b/pcsx2/GS/Renderers/SW/GSRasterizer.h
@@ -88,11 +88,27 @@ protected:
 
 	__forceinline bool HasEdge() const { return (m_draw_edge != nullptr); }
 
+	template <bool step_x, bool pos_x, bool pos_y, bool tl, bool side>
+	void DrawEdgeTriangle(const GSVertexSW& v0, const GSVertexSW& v1, const GSVertexSW& dv,
+		const GSVector4i& efun1, const GSVector4i& efun2);
+	template <bool step_x, bool pos_x, bool pos_y, bool aa>
+	void DrawEdgeLine(const GSVertexSW& v0, const GSVertexSW& v1, const GSVertexSW& dv);
+	void DrawEdgeTriangle(const GSVertexSW& v0, const GSVertexSW& v1, const GSVertexSW& dv,
+		const GSVector4i& efun1, const GSVector4i& efun2, bool topleft);
+	void DrawEdgeLine(const GSVertexSW& v0, const GSVertexSW& v1, const GSVertexSW& dv, bool has_edge);
+	
 	template <bool scissor_test>
 	void DrawPoint(const GSVertexSW* vertex, int vertex_count, const u16* index, int index_count);
 	void DrawLine(const GSVertexSW* vertex, const u16* index);
 	void DrawTriangle(const GSVertexSW* vertex, const u16* index);
 	void DrawSprite(const GSVertexSW* vertex, const u16* index);
+
+	using DrawEdgeTrianglePtr = void (GSRasterizer::*)(const GSVertexSW& , const GSVertexSW&, const GSVertexSW&,
+		const GSVector4i&, const GSVector4i&);
+	static const DrawEdgeTrianglePtr m_draw_edge_triangle[2][2][2][2][2];
+
+	using DrawEdgeLinePtr = void (GSRasterizer::*)(const GSVertexSW&, const GSVertexSW&, const GSVertexSW&);
+	static const DrawEdgeLinePtr m_draw_edge_line[2][2][2][2];
 
 #if _M_SSE >= 0x501
 	__forceinline void DrawTriangleSection(int top, int bottom, GSVertexSW2& RESTRICT edge, const GSVertexSW2& RESTRICT dedge, const GSVertexSW2& RESTRICT dscan, const GSVector4& RESTRICT p0);


### PR DESCRIPTION
### Description of Changes
1. Implement accurate rounding and pixel inclusion for lines and antialiased lines.
2. Implement improved pixel inclusion for antialiased triangle edges.

### Rationale behind Changes

Based on hardware tests this appears to give accurate pixel inclusion for lines, both aliased and antialiased. The actual value of coverage (aka alpha) is still not totally accurate; PS2 is doing some rounding/trunation to alpha that requires more research.

Similarly, pixel inclusion for antialiased edges of triangles is improved based on hardware tests. The inclusion is still not 100% accurate because there are some edge cases where the pixel can sometimes be +/-1 outside the bbox of the triangle that I haven't totally figured out.

As fars as games, the main fix is for Largo Winch (uses lines to draw the border color of shadow maps) and a FFXII FMV (appears to be similar). There are some small fixes to UI elements and such.

Note there are also some false positives for regressions. I have checked some of these and they either appear to occur on real hardware or are different issues (more details below).

### Suggested Testing Steps

So far I have done dump runs in SW for regression testing and several homebrew tests to compare accuracy with the actual hardware (can share the tests if there is an interest). For some dumps that seems to have regressions, I have checked them on a PS2 and confirmed that they look similar or differences are due to different issue (exampled provided below).

Testing on games know to use antialiasing or that require accurate lines would be helpful. Testing the performance vs. master would be good to make sure the performance impact is not too much.

### Did you use AI to help find, test, or implement this issue or feature?
I use Copilot for autocompletion.

### Improvements

**Largo Winch - Empire Under Threat_SLES-50841_20230120221136.gs.xz**

Master
<img width="512" height="512" alt="S004569_07689_f00004_fr1_00000_C_32_Largo Winch - Empire Under Threat_SLES-50841_20230120221136 gs xz_master" src="https://github.com/user-attachments/assets/db0e920e-0513-499d-b089-7cf81e94f684" />

PR
<img width="512" height="512" alt="S004569_07689_f00004_fr1_00000_C_32_Largo Winch - Empire Under Threat_SLES-50841_20230120221136 gs xz_accline" src="https://github.com/user-attachments/assets/552c97fa-ee02-45c0-aaf4-b66d71f301f4" />

**Final Fantasy XII preload frame data texture isses.gs.xz**

Master
<img width="448" height="512" alt="S003707_00145_f00005_fr-1_00e00_C_32_Final Fantasy XII preload frame data texture isses gs xz_master" src="https://github.com/user-attachments/assets/bf1fb0d7-37ac-4af9-aa69-6e284d90251f" />

PR
<img width="448" height="512" alt="S003707_00145_f00005_fr-1_00e00_C_32_Final Fantasy XII preload frame data texture isses gs xz_accline" src="https://github.com/user-attachments/assets/967ce844-d4d7-4899-ab12-1248104beec1" />

### False positive regression/other issues

**Booting PS2 BIOS... _20220901235528.gs.xz**

Some corners of cubes stand out more in PR and PS2

Master
<img width="640" height="256" alt="S003455_00476_f00001_fr1_00a00_C_32_Booting PS2 BIOS  _20220901235528 gs xz_master" src="https://github.com/user-attachments/assets/d7e28364-5789-4f4a-a4fa-29a91148349b" />

PR
<img width="640" height="256" alt="S003455_00476_f00001_fr1_00a00_C_32_Booting PS2 BIOS  _20220901235528 gs xz_accline" src="https://github.com/user-attachments/assets/3b68a897-0a17-4480-bf06-bf2c16d22574" />

PS2
<img width="640" height="256" alt="ps2-bios-frame-1-noalpha.bmp" src="https://github.com/user-attachments/files/22453918/ps2-bios-frame-1-noalpha.bmp" />

**Monopoly Party_SLES-51145_In_Game.gs.xz**

Some of the corners of the UI boxes look cleaners but others have more gaps.

Master
<img width="640" height="256" alt="S003834_00272_f00001_fr1_00000_C_32_Monopoly Party_SLES-51145_In_Game gs xz_master" src="https://github.com/user-attachments/assets/bf943006-05ee-48ca-a353-6946620d0fcc" />

PR
<img width="640" height="256" alt="S003834_00272_f00001_fr1_00000_C_32_Monopoly Party_SLES-51145_In_Game gs xz_accline" src="https://github.com/user-attachments/assets/bd307fbf-a31e-4884-b6b4-66db526c1895" />

PS2
<img width="640" height="256" alt="monopoly-frame-1-noalpha" src="https://github.com/user-attachments/files/22453844/monopoly-frame-1-noalpha.bmp" />

**Ridge Racer V_SLUS-20002_20240613085131.gs.xz**

Master has striped pattern shifted up by 1 compared to PS2/PR due to rounding for lines. PR is missing the first line due to the scissoring optimization in the vertex kick not accounting for line rounding (will do in a separate PR).

Master
<img width="640" height="224" alt="S095319_00088_f00002_fr1_00000_C_32_Ridge Racer V_SLUS-20002_20240613085131 gs xz_master" src="https://github.com/user-attachments/assets/ea9e272e-d6e0-4daa-9921-e8149c575fa0" />

PR
<img width="640" height="224" alt="S095319_00088_f00002_fr1_00000_C_32_Ridge Racer V_SLUS-20002_20240613085131 gs xz_accline" src="https://github.com/user-attachments/assets/f88b0810-0ef9-43ad-9bcc-ab33ff1aee0d" />

PS2
<img width="640" height="224" alt="ps2-ridge-racer-frame-2-noalpha" src="https://github.com/user-attachments/files/22453850/ps2-ridge-racer-frame-2-noalpha.bmp" />

**VP2Bloom.gs.xz**

PR/Master HW/PS2 seems to miss one line in the minimap due to different line rounding. Not sure what is causing this because the RTs appears to be fine when the line is actually drawn. Might have something to with the postprocessing bilinear filter used for antialiasing.

Master SW
<img width="640" height="224" alt="S001375_00231_f00001_fr1_01000_C_24_VP2Bloom gs xz_master" src="https://github.com/user-attachments/assets/a5fc76cd-2988-42f7-8a40-3267ce6e6c3e" />

Master HW
<img width="640" height="224" alt="00231_f00001_fr1_01000_C_24_master_gl" src="https://github.com/user-attachments/assets/a6f3d6dc-d0bd-42c8-b3c4-4188d6cfb67a" />

PR SW
<img width="640" height="224" alt="S001375_00231_f00001_fr1_01000_C_24_VP2Bloom gs xz_accline" src="https://github.com/user-attachments/assets/3cc01e09-c256-4297-8966-d4b614acc692" />

PS2
<img width="640" height="224" alt="[ps2-VP2Bloom2-frame-1-noalpha.bmp" src="https://github.com/user-attachments/files/22453864/ps2-VP2Bloom2-frame-1-noalpha.bmp" />

**golf.gs.xz**

PR is missing one of the lines in power-up bar. This is a different issue related to https://github.com/PCSX2/pcsx2/pull/12975. The bbox will need to be adjusted again to be slightly larger to account for line rounding (will do in a separate PR).

Master
<img width="640" height="256" alt="S000557_04496_f00002_fr1_00a00_C_32_golf gs xz_master" src="https://github.com/user-attachments/assets/4178540f-6c4d-475b-88d8-02c7e778a1bc" />

PR
<img width="640" height="256" alt="S000557_04496_f00002_fr1_00a00_C_32_golf gs xz_accline" src="https://github.com/user-attachments/assets/25c68f9c-7564-4c26-b620-4e7e43e73c8c" />

### Details of the pixel inclusion

**Lines**

For aliased lines, the inclusion is the standard method of rounding to nearest pixel in y direction for shallow lines and x direction for steep lines. This was mostly correct in master other than coordinates half way between two pixels should be rounded up instead of floored as currently done.

The criteria for determining whether first/last pixel in the line is drawn is a diamond exit condition (sort of mentioned in the manual; see [here](https://learn.microsoft.com/en-us/windows/win32/direct3d11/d3d10-graphics-programming-guide-rasterizer-stage-rules#line-rasterization-rules-aliased-without-multisampling) also). The diamond region depends on the whether the line is shallow (right-to-left or left-to-right) or steep (up-to-down or down-to-up). For shallow left-to-right line, the diamond contains the top-right border, excludes the right corner, excludes the bottom-right border, and includes the bottom and top corners (see diagram below). The last pixel is drawn only if the diamond is entered and exited; the first pixels is drawn in the opposite cases (makes sense to prevent overlap in a line strip).

<img width="572" height="567" alt="diamond_edit" src="https://github.com/user-attachments/assets/6fa240c0-63fc-4ada-a494-fd77d698cdc8" />

(Above) The diamond region for left-to-right shallow lines. For right-to-left, the region will be flipped horizontally. For steep lines the region will be rotated/flipped accordingly.

For antialiased, it's pretty much what the manual says: instead of rounding to the nearest pixel, consider the two nearest pixels and give then coverage proportational to distance to the line. If the line is exactly on a pixel center, there are still two pixels included: one with full coverage and another with no coverage. In this case the pixel with no coverage is the one in the bottom or right direction. Combined with accurate rounding and first/last pixel inclusion from above, this appears to given accurate antialiased lines (up to errors with calculating the alpha as mentioned earlier).

### Triangles

Aliased triangles already seems to be totally accurate. Possibly there are rounding error somewhere since we use floating point slope, though I did not test it fully.

For antialiased triangles, the procedure is basically what the manual says: treat each edge of the triangle as a line antialias it. However, instead of the including pixels on both sides of the line, just include the one outside the triangles. The antialised pixel must also be on the inside of the other two edges. So if we have a triangle with edges A, B, C, and we are antialiasing edge A, all the antialiased pixels should be on the *outside* of A and the *inside* of B and C (see figure below).

<img width="655" height="702" alt="triangle_edit" src="https://github.com/user-attachments/assets/36f17624-586e-4631-ac45-5d3ea5d92509" />

(Above) The red dots indicate the pixels that will be considered part of the antialias region for edge A. The green dots would be candidated but they are not on the correct side of C and B.

The bounds of the antialiased line seem to be determined by flooring/ceiling the two vertices of the edge and sometimes adding +/-1 to extend the bound. For example, a shallow edge with vertices (x0,y0) -- (x1,y1) might allow the antialiased pixels to range from floor(x0) to ceil(x0). However, in other cases it seems to behave like ceil(x0) - 1 to floor(x1) + 1. I could not determine the exact rule; may require more research.

Some quirks:
1. A top or left edge of a triangle that passes through pixel center can give rise to 0 coverage pixel outside the triangle.
2. A bottom or right edge of a triangle that that passes through pixel center will only give rise to full coverage pixels on the edge (since pixels on bottom or right edges are omitted from the interior of the triangle by the GS).

A different but related issue is that Currently GSState::VertexKick() culls triangles that cover 0 pixel. This is correct for aliased triangles but not for antialiased triangles so may require a separate PR to resolve.

## Other notes

* As mentioned above, alpha calculation based on coverage seems a bit quirky. Sometimes pixels that should have full coverage get alpha 127 (instead of 128). More research may be required.
* Interpolation of vertex attributes is still not done totally accurately for triangles. Right now we treat antialiased edges as a line and simply interpolate the attributes one-dimensionally in the axis being stepped. However, to be more accurate I believe we would need to do full two-dimensional interpolation. Since the gradients for both x and y are already computed in triangle setup it might not add too much overhead to do this.
* Expect a (hopefully small) performance drop in line drawing and antialiased triangle for the extra overhead needed to accuracy. Hopefully, line drawing and antialiased triangle edge drawing is minor enough that it doesn't affect overall performance too much. With that said, the code it probably not as optimized as it could be so I would appreciate any suggestions on this front.
