### PR TITLE
GS: Small additions to vertex dumping

### DIFF
--- a/pcsx2/GS/GSDrawingEnvironment.cpp
+++ b/pcsx2/GS/GSDrawingEnvironment.cpp
@@ -49,18 +49,6 @@ void GSDrawingEnvironment::Dump(const std::string& filename) const
 	            "    FIX: %u\n\n",
 		PRIM.PRIM, GSUtil::GetPrimName(PRIM.PRIM), PRIM.IIP, PRIM.TME, PRIM.FGE, PRIM.ABE, PRIM.AA1, PRIM.FST, PRIM.CTXT, PRIM.FIX);
 
-	fprintf(fp, "PRMODE: # when AC=0\n"
-	            "    _PRIM: %u # %s\n"
-	            "    IIP: %u\n"
-	            "    TME: %u\n"
-	            "    FGE: %u\n"
-	            "    ABE: %u\n"
-	            "    AA1: %u\n"
-	            "    FST: %u\n"
-	            "    CTXT: %u\n"
-	            "    FIX: %u\n\n",
-		PRMODE._PRIM, GSUtil::GetPrimName(PRMODE._PRIM), PRMODE.IIP, PRMODE.TME, PRMODE.FGE, PRMODE.ABE, PRMODE.AA1, PRMODE.FST, PRMODE.CTXT, PRMODE.FIX);
-
 	fprintf(fp, "PRMODECONT:\n"
 	            "    AC: %u # %s\n\n",
 		PRMODECONT.AC, GSUtil::GetACName(PRMODECONT.AC));

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -478,11 +478,13 @@ void GSState::DumpVertices(const std::string& filename)
 	constexpr const char* CLOSE_MAP = "}";
 	
 	constexpr int TRACE_INDEX_WIDTH = 10;
-	constexpr int XYUV_WIDTH = 9;
+	constexpr int XYUV_WIDTH = 10;
 	constexpr int Z_WIDTH = 10;
 	constexpr int RGBA_WIDTH = 3;
 	constexpr int SCI_FLOAT_WIDTH = 15;
 	constexpr int STQ_BITS_WIDTH = 10;
+
+	const int n = GSUtil::GetClassVertexCount(m_vt.m_primclass);
 
 	auto WriteVertexIndex = [&file](int index) {
 		file << std::left << std::dec << " # " << index;
@@ -599,6 +601,9 @@ void GSState::DumpVertices(const std::string& filename)
 	for (u32 i = 0; i < count; ++i)
 	{
 		GSVertex v = buffer[m_index.buff[i]];
+
+		if ((n > 1) && (i > 0) && ((i % n) == 0))
+			file << std::endl;
 		
 		file << INDENT << LIST_ITEM << OPEN_MAP;
 		WriteXYZ_vert(v);
@@ -629,6 +634,9 @@ void GSState::DumpVertices(const std::string& filename)
 		file << "vertex_stq:" << std::endl;
 		for (u32 i = 0; i < count; ++i)
 		{
+			if ((n > 1) && (i > 0) && ((i % n) == 0))
+				file << std::endl;
+
 			file << INDENT << LIST_ITEM << OPEN_MAP;
 			WriteSTQ_vert(buffer[m_index.buff[i]]);
 			file << CLOSE_MAP;
@@ -637,9 +645,9 @@ void GSState::DumpVertices(const std::string& filename)
 
 			file << std::endl;
 		}
+		
+		file << std::endl;
 	}
-
-	file << std::endl;
 
 	// Dump vertex trace
 	file << "vertex_trace:" << std::endl;

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -550,6 +550,10 @@ void GSState::DumpVertices(const std::string& filename)
 		WriteRGBA_vec(vec);
 	};
 
+	auto WriteF = [&file](const int f) {
+		file << "F: " << std::setw(RGBA_WIDTH) << std::setfill(' ') << f;
+	};
+
 	auto WriteSTQ_vec = [&file](const GSVector4& v) {
 		file << std::defaultfloat << std::right;
 		file << "S: " << std::setw(SCI_FLOAT_WIDTH) << std::setfill(' ') << v.x << DEL;
@@ -605,6 +609,11 @@ void GSState::DumpVertices(const std::string& filename)
 		}
 		file << DEL;
 		WriteRGBA_vert(v);
+		if (PRIM->FGE)
+		{
+			file << DEL;
+			WriteF(v.FOG);
+		}
 		file << CLOSE_MAP;
 
 		WriteVertexIndex(i);
@@ -693,6 +702,21 @@ void GSState::DumpVertices(const std::string& filename)
 	WriteRGBA_vec(m_vt.m_max.c);
 	file << CLOSE_MAP << std::endl;
 
+	if (PRIM->FGE)
+	{
+		file << INDENT;
+		WriteTraceIndex("min_f: ");
+		file << OPEN_MAP;
+		WriteF(m_vt.m_min.p.w);
+		file << CLOSE_MAP << std::endl;
+
+		file << INDENT;
+		WriteTraceIndex("max_f: ");
+		file << OPEN_MAP;
+		WriteF(m_vt.m_max.p.w);
+		file << CLOSE_MAP << std::endl;
+	}
+
 	file << std::endl;
 
 	file << INDENT;
@@ -728,6 +752,15 @@ void GSState::DumpVertices(const std::string& filename)
 	file << OPEN_MAP;
 	WriteBools({"R", "G", "B", "A"}, {m_vt.m_eq.r, m_vt.m_eq.g, m_vt.m_eq.b, m_vt.m_eq.a});
 	file << CLOSE_MAP << std::endl;
+
+	if (PRIM->FGE)
+	{
+		file << INDENT;
+		WriteTraceIndex("eq_f: ");
+		file << OPEN_MAP;
+		WriteBools({"F"}, {m_vt.m_eq.f});
+		file << CLOSE_MAP << std::endl;
+	}
 }
 
 void GSState::DumpTransferList(const std::string& filename)

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -595,7 +595,7 @@ void GSState::DumpVertices(const std::string& filename)
 	file << std::endl;
 
 	// Dump vertices
-	file << "vertex:" << std::endl;
+	file << "vertex: # " << GSUtil::GetPrimClassName(m_vt.m_primclass) << std::endl;
 	const u32 count = m_index.tail;
 	GSVertex* buffer = &m_vertex.buff[0];
 	for (u32 i = 0; i < count; ++i)
@@ -631,7 +631,7 @@ void GSState::DumpVertices(const std::string& filename)
 	// Dump extra info for STQ
 	if (PRIM->TME && !PRIM->FST)
 	{
-		file << "vertex_stq:" << std::endl;
+		file << "vertex_stq: # " << GSUtil::GetPrimClassName(m_vt.m_primclass) << std::endl;
 		for (u32 i = 0; i < count; ++i)
 		{
 			if ((n > 1) && (i > 0) && ((i % n) == 0))

--- a/pcsx2/GS/GSUtil.cpp
+++ b/pcsx2/GS/GSUtil.cpp
@@ -114,6 +114,13 @@ const char* GSUtil::GetPrimName(u32 prim)
 	return (prim < std::size(names)) ? names[prim] : "";
 }
 
+const char* GSUtil::GetPrimClassName(u32 primclass)
+{
+	static constexpr const char* names[] = {
+		"POINT", "LINE", "TRIANGLE", "SPRITE", "INVALID"};
+	return (primclass < std::size(names)) ? names[primclass] : "";
+}
+
 const char* GSUtil::GetMMAGName(u32 mmag)
 {
 	static constexpr const char* names[] = {"NEAREST", "LINEAR"};

--- a/pcsx2/GS/GSUtil.h
+++ b/pcsx2/GS/GSUtil.h
@@ -15,6 +15,7 @@ public:
 	static const char* GetWMName(u32 wm);
 	static const char* GetZTSTName(u32 ztst);
 	static const char* GetPrimName(u32 prim);
+	static const char* GetPrimClassName(u32 primclass);
 	static const char* GetMMAGName(u32 mmag);
 	static const char* GetMMINName(u32 mmin);
 	static const char* GetMTBAName(u32 mtba);


### PR DESCRIPTION
### Description of Changes
Forgot to add the fog coefficient in https://github.com/PCSX2/pcsx2/pull/13088 so added it here.

Made the vertex list a bit more readable by adding spacing between every 2, 3 line depending on the primitive.

Some small formatting improvements.

### Rationale behind Changes

Make debugging a better experience. Make the fog pipeline better : P

### Suggested Testing Steps
Dumping info in Settings>Debug>GS (after enabling Dump GS Draws). "00003_vertex.txt" and such should look like this:

```
flush_reason: "CLUT CHANGE (RELOAD REQ)"

vertex: # TRIANGLE
  - {X:   128.9375, Y:   -90.8750, Z:     375437, U:             128, V:           133.5, R:  49, G:  49, B:  49, A: 128, F: 255} # 0
  - {X:   143.6875, Y:  -123.3750, Z:     387402, U:             128, V:           121.5, R:  51, G:  51, B:  51, A: 128, F: 255} # 1
  - {X:   252.0000, Y:     8.8125, Z:     252185, U:           243.5, V:           121.5, R:  42, G:  42, B:  42, A: 128, F: 255} # 2

  - {X:   252.0000, Y:     8.8125, Z:     252185, U:           243.5, V:           121.5, R:  44, G:  44, B:  44, A: 128, F: 255} # 3
  - {X:   399.5000, Y:   -24.0000, Z:     302960, U:           255.5, V:              17, R:  62, G:  62, B:  62, A: 128, F: 255} # 4
  - {X:   397.3750, Y:   -52.4375, Z:     314871, U:           243.5, V:              17, R:  66, G:  66, B:  66, A: 128, F: 255} # 5

vertex_stq: # TRIANGLE
  - {S:         0.05604, T:         0.05845, Q:          0.2242, Si: 0x3d658d3d, Ti: 0x3d6f6a4e, Qi: 0x3e658d3d} # 0
  - {S:         0.05783, T:         0.05489, Q:          0.2313, Si: 0x3d6cdae2, Ti: 0x3d60d3c4, Qi: 0x3e6cdae2} # 1
  - {S:         0.07167, T:         0.03576, Q:          0.1507, Si: 0x3d92c9b6, Ti: 0x3d127c8d, Qi: 0x3e1a52c1} # 2

  - {S:         0.07167, T:         0.03576, Q:          0.1507, Si: 0x3d92c9b6, Ti: 0x3d127c8d, Qi: 0x3e1a52c1} # 3
  - {S:         0.09031, T:        0.006009, Q:           0.181, Si: 0x3db8f3bc, Ti: 0x3bc4e56b, Qi: 0x3e395065} # 4
  - {S:         0.08944, T:        0.006245, Q:          0.1881, Si: 0x3db72e43, Ti: 0x3bcc9eea, Qi: 0x3e409591} # 5

vertex_trace:
  min_xyz:  {X:  -191.1875, Y:  -198.0000, Z:     224793}
  max_xyz:  {X:   592.8125, Y:   632.7500, Z:    1207398}
  min_uvq:  {S:             0.5, T:             0.5, Q:          0.1344}
  max_uvq:  {S:           511.5, T:           511.5, Q:          0.7201}
  min_rgba: {R:  21, G:  21, B:  21, A: 128}
  max_rgba: {R: 255, G: 255, B: 255, A: 128}
  min_f:    {F: 255}
  max_f:    {F: 255}

  eq_xyz:   {X: 0, Y: 0, Z: 0}
  eq_uvq:   {U: 0, V: 0, Q: 0}
  eq_rgba:  {R: 0, G: 0, B: 0, A: 1}
  eq_f:     {F: 1}
```

### Did you use AI to help find, test, or implement this issue or feature?
No.
