### PR TITLE
Correct lingual-code

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -30298,7 +30298,7 @@ SLES-55674:
   region: "PAL-F-G"
 SLES-55675:
   name: "Pro Evolution Soccer 2014"
-  region: "PAL-G-I"
+  region: "PAL-Gr-I"
 SLES-55676:
   name: "Pro Evolution Soccer 2014"
   region: "PAL-P-S"

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -30298,7 +30298,7 @@ SLES-55674:
   region: "PAL-F-G"
 SLES-55675:
   name: "Pro Evolution Soccer 2014"
-  region: "PAL-Gr-I"
+  region: "PAL-GR-I"
 SLES-55676:
   name: "Pro Evolution Soccer 2014"
   region: "PAL-P-S"


### PR DESCRIPTION
SLES-55675 has Greek (and Italian) in menu, not German (and Italian).
SLES-55674 has German (and French).

https://github.com/PCSX2/pcsx2_patches/pull/616
http://redump.org/disc/51722/
