### PR TITLE
QtHost: Fix verbose status toggle

### DIFF
--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -991,30 +991,33 @@ void Host::OnGameChanged(const std::string& title, const std::string& elf_overri
 
 void EmuThread::updatePerformanceMetrics(bool force)
 {
-	if (m_verbose_status && VMManager::HasValidVM())
+	if (VMManager::HasValidVM())
 	{
-		std::string gs_stat_str;
-		GSgetTitleStats(gs_stat_str);
-
 		QString gs_stat;
-		if (THREAD_VU1)
+		if (m_verbose_status)
 		{
-			gs_stat = tr("Slot: %1 | Volume: %2% | %3 | EE: %4% | VU: %5% | GS: %6%")
-			              .arg(SaveStateSelectorUI::GetCurrentSlot())
-			              .arg(SPU2::GetOutputVolume())
-			              .arg(gs_stat_str.c_str())
-			              .arg(PerformanceMetrics::GetCPUThreadUsage(), 0, 'f', 0)
-			              .arg(PerformanceMetrics::GetVUThreadUsage(), 0, 'f', 0)
-			              .arg(PerformanceMetrics::GetGSThreadUsage(), 0, 'f', 0);
-		}
-		else
-		{
-			gs_stat = tr("Slot: %1 | Volume: %2% | %3 | EE: %4% | GS: %5%")
-			              .arg(SaveStateSelectorUI::GetCurrentSlot())
-			              .arg(SPU2::GetOutputVolume())
-			              .arg(gs_stat_str.c_str())
-			              .arg(PerformanceMetrics::GetCPUThreadUsage(), 0, 'f', 0)
-			              .arg(PerformanceMetrics::GetGSThreadUsage(), 0, 'f', 0);
+			std::string gs_stat_str;
+			GSgetTitleStats(gs_stat_str);
+
+			if (THREAD_VU1)
+			{
+				gs_stat = tr("Slot: %1 | Volume: %2% | %3 | EE: %4% | VU: %5% | GS: %6%")
+				              .arg(SaveStateSelectorUI::GetCurrentSlot())
+				              .arg(SPU2::GetOutputVolume())
+				              .arg(gs_stat_str.c_str())
+				              .arg(PerformanceMetrics::GetCPUThreadUsage(), 0, 'f', 0)
+				              .arg(PerformanceMetrics::GetVUThreadUsage(), 0, 'f', 0)
+				              .arg(PerformanceMetrics::GetGSThreadUsage(), 0, 'f', 0);
+			}
+			else
+			{
+				gs_stat = tr("Slot: %1 | Volume: %2% | %3 | EE: %4% | GS: %5%")
+				              .arg(SaveStateSelectorUI::GetCurrentSlot())
+				              .arg(SPU2::GetOutputVolume())
+				              .arg(gs_stat_str.c_str())
+				              .arg(PerformanceMetrics::GetCPUThreadUsage(), 0, 'f', 0)
+				              .arg(PerformanceMetrics::GetGSThreadUsage(), 0, 'f', 0);
+			}
 		}
 
 		QMetaObject::invokeMethod(g_main_window->getStatusVerboseWidget(), "setText", Qt::QueuedConnection, Q_ARG(const QString&, gs_stat));
@@ -2333,11 +2336,13 @@ bool QtHost::RunSetupWizard()
 	return true;
 }
 
-class PCSX2MainApplication : public QApplication {
+class PCSX2MainApplication : public QApplication
+{
 public:
 	using QApplication::QApplication;
 
-	bool event(QEvent* event) override {
+	bool event(QEvent* event) override
+	{
 		if (event->type() == QEvent::FileOpen)
 		{
 			QFileOpenEvent* open = static_cast<QFileOpenEvent*>(event);


### PR DESCRIPTION
### Description of Changes
Allows `View` > `Verbose Status` to work as intended while the VM is running.

While a function `onViewStatusBarVerboseActionToggled` in `MainWindow.cpp` which updates the setting and ends with `m_status_verbose_widget->setText("")` does work, that's a bodge. The logic for the verbose status text is in `QtHost.cpp` and has a working accessor for the `Verbose Status` setting. Thus, declare the `QString` like normal and then let it fill up if `Verbose Status` is on – else it remains empty.

### Rationale behind Changes
Fixes #13221. `View` > `Verbose Status` should toggle the verbose status on and off while the VM is running. However, as of current master, it only works as a fixed boot option for the VM rather than as a dynamic toggle.

### Suggested Testing Steps
Make sure the verbose status (bottom left corner) can be toggled on and off during VM operation. Make sure that pausing and unpausing the VM does not interfere with this (it should change the text to "Paused" only while paused). Make sure that booting the VM with the option works (checked and unchecked).

Check the code to make sure I didn't introduce any logical errors by shuffling the conditionals around.

### Did you use AI to help find, test, or implement this issue or feature?
No, that's the *extra* verbose status toggle.
