### PR TITLE
GS/GL: Try to use glBindTextures for binding multiple srv slots.

### DIFF
--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -137,6 +137,7 @@ public:
 	};
 
 private:
+	static constexpr u8 MAX_TEXTURES = 4;
 	static constexpr u8 NUM_TIMESTAMP_QUERIES = 5;
 
 	std::unique_ptr<GLContext> m_gl_context;
@@ -340,6 +341,7 @@ public:
 	void IASetIndexBuffer(const void* index, size_t count);
 
 	void PSSetShaderResource(int i, GSTexture* sr);
+	void PSSetShaderResources(GSTexture* srvs[]);
 	void PSSetSamplerState(GLuint ss);
 	void ClearSamplerCache() override;
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/GL: Try to use glBindTextures for binding multiple srv slots.
Use glBindTextures for 2 slots or more, should be generally faster, otherwise use glBindTextureUnit.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Speed.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Try games such as Sly 2, Star ocean, and other games that could use 2-3 slots (blending, palette tex), see if there's any speed up and if it's worth adding this, benchmark it.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.
