### PR TITLE
OSD: Add ability to show the amount of activated patches

### DIFF
--- a/pcsx2-qt/Settings/GraphicsOnScreenDisplaySettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsOnScreenDisplaySettingsTab.ui
@@ -103,7 +103,7 @@
       <item row="4" column="0" colspan="2">
        <layout class="QGridLayout" name="optionLayout" rowstretch="0,0,0,0,0,0,0,0,0,0,0">
         <property name="sizeConstraint">
-         <enum>QLayout::SetDefaultConstraint</enum>
+         <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
         </property>
         <property name="topMargin">
          <number>10</number>
@@ -251,6 +251,13 @@
           </property>
          </widget>
         </item>
+        <item row="3" column="2">
+         <widget class="QCheckBox" name="showPatches">
+          <property name="text">
+           <string>Show Patches</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
       <item row="0" column="0">
@@ -317,10 +324,10 @@
       <item row="3" column="0" colspan="2">
        <spacer name="checkboxSpacer">
         <property name="orientation">
-         <enum>Qt::Vertical</enum>
+         <enum>Qt::Orientation::Vertical</enum>
         </property>
         <property name="sizeType">
-         <enum>QSizePolicy::Fixed</enum>
+         <enum>QSizePolicy::Policy::Fixed</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -343,7 +350,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -243,6 +243,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_osd.showGSStats, "EmuCore/GS", "OsdShowGSStats", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_osd.showIndicators, "EmuCore/GS", "OsdShowIndicators", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_osd.showSettings, "EmuCore/GS", "OsdShowSettings", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_osd.showPatches, "EmuCore/GS", "OsdshowPatches", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_osd.showInputs, "EmuCore/GS", "OsdShowInputs", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_osd.showFrameTimes, "EmuCore/GS", "OsdShowFrameTimes", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_osd.showVersion, "EmuCore/GS", "OsdShowVersion", false);
@@ -756,6 +757,9 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 		dialog()->registerWidgetHelp(m_osd.showSettings, tr("Show Settings"), tr("Unchecked"),
 			tr("Displays various settings and the current values of those settings, useful for debugging."));
 
+		dialog()->registerWidgetHelp(m_osd.showPatches, tr("Show Patches"), tr("Unchecked"),
+			tr("Shows the amount of currently active patches/cheats on the bottom-right corner of the display."));
+
 		dialog()->registerWidgetHelp(m_osd.showInputs, tr("Show Inputs"), tr("Unchecked"),
 			tr("Shows the current controller state of the system in the bottom-left corner of the display."));
 
@@ -776,6 +780,9 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 
 		dialog()->registerWidgetHelp(m_osd.warnAboutUnsafeSettings, tr("Warn About Unsafe Settings"), tr("Checked"),
 			tr("Displays warnings when settings are enabled which may break games."));
+
+		connect(m_osd.showSettings, &QCheckBox::checkStateChanged, this,
+			&GraphicsSettingsWidget::onOsdShowSettingsToggled);
 	}
 
 	// Recording tab
@@ -1037,6 +1044,12 @@ void GraphicsSettingsWidget::onEnableVideoCaptureChanged()
 {
 	const bool enabled = dialog()->getEffectiveBoolValue("EmuCore/GS", "EnableVideoCapture", true);
 	m_capture.videoCaptureOptions->setEnabled(enabled);
+}
+
+void GraphicsSettingsWidget::onOsdShowSettingsToggled()
+{
+	const bool enabled = dialog()->getEffectiveBoolValue("EmuCore/GS", "OsdShowSettings", false);
+	m_osd.showPatches->setEnabled(enabled);
 }
 
 void GraphicsSettingsWidget::onEnableVideoCaptureArgumentsChanged()

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.h
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.h
@@ -54,6 +54,7 @@ private Q_SLOTS:
 	void onVideoCaptureAutoResolutionChanged();
 	void onEnableAudioCaptureChanged();
 	void onEnableAudioCaptureArgumentsChanged();
+	void onOsdShowSettingsToggled();
 
 private:
 	GSRendererType getEffectiveRenderer() const;

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -740,6 +740,7 @@ struct Pcsx2Config
 					OsdShowGSStats : 1,
 					OsdShowIndicators : 1,
 					OsdShowSettings : 1,
+					OsdshowPatches : 1,
 					OsdShowInputs : 1,
 					OsdShowFrameTimes : 1,
 					OsdShowVersion : 1,

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1082,6 +1082,7 @@ static void HotkeyAdjustUpscaleMultiplier(s32 delta)
 static void HotkeyToggleOSD()
 {
 	GSConfig.OsdShowSettings ^= EmuConfig.GS.OsdShowSettings;
+	GSConfig.OsdshowPatches ^= EmuConfig.GS.OsdshowPatches;
 	GSConfig.OsdShowInputs ^= EmuConfig.GS.OsdShowInputs;
 	GSConfig.OsdShowInputRec ^= EmuConfig.GS.OsdShowInputRec;
 	GSConfig.OsdShowVideoCapture ^= EmuConfig.GS.OsdShowVideoCapture;

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3653,6 +3653,11 @@ void FullscreenUI::DrawInterfaceSettingsPage()
 		"OsdShowVideoCapture", true);
 	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_SLIDERS, "Show Settings"),
 		FSUI_CSTR("Shows the current configuration in the bottom-right corner of the display."), "EmuCore/GS", "OsdShowSettings", false);
+
+	bool show_settings = (bsi->GetBoolValue("EmuCore/GS", "OsdShowSettings", false) == false);
+	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_HAMMER, "Show Patches"),
+		FSUI_CSTR("Shows the amount of currently active patches/cheats on the bottom-right corner of the display."), "EmuCore/GS",
+		"OsdshowPatches", false, !show_settings);
 	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_PF_GAMEPAD_ALT, "Show Inputs"),
 		FSUI_CSTR("Shows the current controller state of the system in the bottom-left corner of the display."), "EmuCore/GS",
 		"OsdShowInputs", false);

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -19,6 +19,7 @@
 #include "ImGui/ImGuiOverlays.h"
 #include "Input/InputManager.h"
 #include "MTGS.h"
+#include "Patch.h"
 #include "PerformanceMetrics.h"
 #include "Recording/InputRecording.h"
 #include "SIO/Pad/Pad.h"
@@ -520,6 +521,12 @@ __ri void ImGuiManager::DrawSettingsOverlay(float scale, float margin, float spa
 		fmt::format_to(std::back_inserter(text), __VA_ARGS__); \
 	} while (0)
 
+	if (Patch::GetAllActivePatchesCount() > 0 && EmuConfig.GS.OsdshowPatches)
+	APPEND("DB={} P={} C={} | ",
+		Patch::GetActiveGameDBPatchesCount(),
+		Patch::GetActivePatchesCount(),
+		Patch::GetActiveCheatsCount());
+
 	if (EmuConfig.Speedhacks.EECycleRate != 0)
 		APPEND("CR={} ", EmuConfig.Speedhacks.EECycleRate);
 	if (EmuConfig.Speedhacks.EECycleSkip != 0)
@@ -536,12 +543,6 @@ __ri void ImGuiManager::DrawSettingsOverlay(float scale, float margin, float spa
 	APPEND("EER={} EEC={} VUR={} VUC={} VQS={} ", static_cast<unsigned>(EmuConfig.Cpu.FPUFPCR.GetRoundMode()),
 		EmuConfig.Cpu.Recompiler.GetEEClampMode(), static_cast<unsigned>(EmuConfig.Cpu.VU0FPCR.GetRoundMode()),
 		EmuConfig.Cpu.Recompiler.GetVUClampMode(), EmuConfig.GS.VsyncQueueSize);
-
-	if (EmuConfig.EnableCheats || EmuConfig.EnableWideScreenPatches || EmuConfig.EnableNoInterlacingPatches)
-	{
-		APPEND("C={}{}{} ", EmuConfig.EnableCheats ? "C" : "", EmuConfig.EnableWideScreenPatches ? "W" : "",
-			EmuConfig.EnableNoInterlacingPatches ? "N" : "");
-	}
 
 	if (GSIsHardwareRenderer())
 	{

--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -179,6 +179,10 @@ namespace Patch
 	static PatchList s_game_patches;
 	static PatchList s_cheat_patches;
 
+	static u32 s_gamedb_counts = 0;
+	static u32 s_patches_counts = 0;
+	static u32 s_cheats_counts = 0;
+
 	static ActivePatchList s_active_patches;
 	static std::vector<DynamicPatch> s_active_gamedb_dynamic_patches;
 	static std::vector<DynamicPatch> s_active_pnach_dynamic_patches;
@@ -759,23 +763,22 @@ void Patch::UpdateActivePatches(bool reload_enabled_list, bool verbose, bool ver
 	if (EmuConfig.EnablePatches)
 	{
 		gp_count = EnablePatches(s_gamedb_patches, EnablePatchList(), EnablePatchList());
+		s_gamedb_counts = gp_count;
 		if (gp_count > 0)
 			message.append(TRANSLATE_PLURAL_STR("Patch", "%n GameDB patches are active.", "OSD Message", gp_count));
 	}
 
 	const u32 p_count = EnablePatches(s_game_patches, s_enabled_patches, apply_new_patches ? s_just_enabled_patches : EnablePatchList());
+	s_patches_counts = p_count;
 	if (p_count > 0)
-	{
 		message.append_format("{}{}", message.empty() ? "" : "\n",
 			TRANSLATE_PLURAL_STR("Patch", "%n game patches are active.", "OSD Message", p_count));
-	}
 
 	const u32 c_count = EmuConfig.EnableCheats ? EnablePatches(s_cheat_patches, s_enabled_cheats, apply_new_patches ? s_just_enabled_cheats : EnablePatchList()) : 0;
+	s_cheats_counts = c_count;
 	if (c_count > 0)
-	{
 		message.append_format("{}{}", message.empty() ? "" : "\n",
 			TRANSLATE_PLURAL_STR("Patch", "%n cheat patches are active.", "OSD Message", c_count));
-	}
 
 	// Display message on first boot when we load patches.
 	// Except when it's just GameDB.
@@ -1088,6 +1091,26 @@ void Patch::ApplyLoadedPatches(patch_place_type place)
 		if (i->placetopatch == place)
 			ApplyPatch(i);
 	}
+}
+
+u32 Patch::GetActiveGameDBPatchesCount()
+{
+	return s_gamedb_counts;
+}
+
+u32 Patch::GetActivePatchesCount()
+{
+	return s_patches_counts;
+}
+
+u32 Patch::GetActiveCheatsCount()
+{
+	return s_cheats_counts;
+}
+
+u32 Patch::GetAllActivePatchesCount()
+{
+	return s_gamedb_counts + s_patches_counts + s_cheats_counts;
 }
 
 bool Patch::IsGloballyToggleablePatch(const PatchInfo& patch_info)

--- a/pcsx2/Patch.h
+++ b/pcsx2/Patch.h
@@ -105,5 +105,11 @@ namespace Patch
 	// (this happens at AppCoreThread::ApplySettings(...) )
 	extern void ApplyLoadedPatches(patch_place_type place);
 
+	// Get the total counts of the active game patches.
+	extern u32 GetActiveGameDBPatchesCount();
+	extern u32 GetActivePatchesCount();
+	extern u32 GetActiveCheatsCount();
+	extern u32 GetAllActivePatchesCount();
+
 	extern bool IsGloballyToggleablePatch(const PatchInfo& patch_info);
 } // namespace Patch

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -734,6 +734,7 @@ Pcsx2Config::GSOptions::GSOptions()
 	OsdShowGSStats = false;
 	OsdShowIndicators = true;
 	OsdShowSettings = false;
+	OsdshowPatches = false;
 	OsdShowInputs = false;
 	OsdShowFrameTimes = false;
 	OsdShowVersion = false;
@@ -951,6 +952,7 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitBool(OsdShowGSStats);
 	SettingsWrapBitBool(OsdShowIndicators);
 	SettingsWrapBitBool(OsdShowSettings);
+	SettingsWrapBitBool(OsdshowPatches);
 	SettingsWrapBitBool(OsdShowInputs);
 	SettingsWrapBitBool(OsdShowFrameTimes);
 	SettingsWrapBitBool(OsdShowVersion);


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

This PR adds the indicator for currently activated game patches.

Preview:
<img width="185" height="54" alt="Screenshot_20250928_214153" src="https://github.com/user-attachments/assets/9236e4fe-1544-49d5-b03f-66d92bcc4f1a" />

DB = GameDB patches
P  = Patches (Widescreen, No-Interlacing, etc)
C  = Cheats

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Useful during user supports to check if a user has enabled patches for their games.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

Test if the amount counter is correct, try combinations of patches/cheats, etc.

To enable: `Settings -> Graphics -> OSD -> Show Patches`
NB: `Show Settings` must also be enabled in conjunction.

<img width="272" height="234" alt="image" src="https://github.com/user-attachments/assets/ffe8f4ee-e5ec-4ed4-92e7-95645cb2c5fc" />


### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
Ora