### PR TITLE
Debugger: Paste assembly instruction text

### DIFF
--- a/pcsx2-qt/Debugger/DisassemblyView.cpp
+++ b/pcsx2-qt/Debugger/DisassemblyView.cpp
@@ -135,6 +135,31 @@ void DisassemblyView::contextAssembleInstruction()
 	setInstructions(m_selectedAddressStart, m_selectedAddressEnd, encodedInstruction);
 }
 
+void DisassemblyView::contextPasteInstructionText()
+{
+	if (!cpu().isCpuPaused())
+	{
+		QMessageBox::warning(this, tr("Assemble Error"), tr("Unable to change assembly while core is running"));
+		return;
+	}
+
+    std::vector<std::string> newInstructions = StringUtil::splitOnNewLine(QApplication::clipboard()->text());
+    for (int instructionIdx = 0; instructionIdx < newInstructions.size(); instructionIdx++)
+    {
+        u32 replaceAddress = m_selectedAddressStart + instructionIdx * 4;
+        u32 encodedInstruction;
+        std::string errorText;
+        bool valid = MipsAssembleOpcode(newInstructions[instructionIdx].c_str(), &cpu(), replaceAddress, encodedInstruction, errorText);
+        if (!valid)
+        {
+            QMessageBox::warning(this, tr("Assemble Error"), QString::fromStdString(errorText));
+            return;
+        }
+        
+        setInstructions(replaceAddress, replaceAddress + 4, encodedInstruction);
+    }
+}
+
 void DisassemblyView::contextNoopInstruction()
 {
 	setInstructions(m_selectedAddressStart, m_selectedAddressEnd, 0);

--- a/pcsx2-qt/Debugger/DisassemblyView.cpp
+++ b/pcsx2-qt/Debugger/DisassemblyView.cpp
@@ -121,6 +121,7 @@ void DisassemblyView::contextPasteInstructionText()
 	int newInstructionsSize = newInstructions.size();
 
 	// validate new instructions before pasting them
+	std::vector<u32> encodedInstructions;
 	for (int instructionIdx = 0; instructionIdx < newInstructionsSize; instructionIdx++)
 	{
 		u32 replaceAddress = m_selectedAddressStart + instructionIdx * 4;
@@ -132,16 +133,14 @@ void DisassemblyView::contextPasteInstructionText()
 			QMessageBox::warning(this, tr("Assemble Error"), QString("%1 %2").arg(errorText.c_str()).arg(newInstructions[instructionIdx].c_str()));
 			return;
 		}
+		encodedInstructions.push_back(encodedInstruction);
 	}
 
 	// paste validated instructions
 	for (int instructionIdx = 0; instructionIdx < newInstructionsSize; instructionIdx++)
 	{
 		u32 replaceAddress = m_selectedAddressStart + instructionIdx * 4;
-		u32 encodedInstruction;
-		std::string errorText;
-		MipsAssembleOpcode(newInstructions[instructionIdx].c_str(), &cpu(), replaceAddress, encodedInstruction, errorText);
-		setInstructions(replaceAddress, replaceAddress, encodedInstruction);
+		setInstructions(replaceAddress, replaceAddress, encodedInstructions[instructionIdx]);
 	}
 }
 

--- a/pcsx2-qt/Debugger/DisassemblyView.h
+++ b/pcsx2-qt/Debugger/DisassemblyView.h
@@ -43,6 +43,7 @@ public slots:
 	void contextCopyInstructionHex();
 	void contextCopyInstructionText();
 	void contextCopyFunctionName();
+	void contextPasteInstructionText();	
 	void contextAssembleInstruction();
 	void contextNoopInstruction();
 	void contextRestoreInstruction();


### PR DESCRIPTION
### Description of Changes
In the debugger's disassembly view, added a new "Paste Instruction Text" item in the context menu. This allows a user to paste one or more lines of assembly instruction text from their clipboard into the disassembly view. The instructions are pasted starting at the currently selected disassembled instruction. 

<img width="1535" height="681" alt="image" src="https://github.com/user-attachments/assets/584298c0-4d22-41db-8bfd-edd8c9832e0e" />

The assembly instructions must be split by new line characters. When using the existing "Copy Instruction Text" item in the context menu, the instructions are split by new line characters when copied into the clipboard. 

Assembly instructions are validated before they are pasted. This means that if several instructions are attempted to be pasted from the clipboard and one of the instructions is invalid, no instructions will actually be pasted. The error presented to the user in this case includes the instruction that was invalid.

### Rationale behind Changes
#13229 

### Suggested Testing Steps
- Ensure single instructions can be pasted
- Ensure multiple instructions split by new lines can be pasted
- Ensure invalid instructions are caught and prevent pasting

### Did you use AI to help find, test, or implement this issue or feature?
No
