### PR TITLE
[ci skip] CI: Use GITHUB_TOKEN to dispatch actions onto windows deps

### DIFF
--- a/.github/workflows/windows_deps_dispatch.yml
+++ b/.github/workflows/windows_deps_dispatch.yml
@@ -12,6 +12,5 @@ jobs:
       - name: Dispatch to windows-dependencies repo
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.DEPS_REPO_DISPATCH_ACCESS_TOKEN }}
           repository: pcsx2/pcsx2-windows-dependencies
           event-type: deps-update


### PR DESCRIPTION
testing in prod