### PR TITLE
GS/HW: Backport depth test and sampling from dx11 to dx12, crash/bug fixes and some cleanup.

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -49,6 +49,7 @@
 #define PS_PROCESS_RG 0
 #define PS_SHUFFLE_ACROSS 0
 #define PS_READ16_SRC 0
+#define PS_WRITE_RG 0
 #define PS_DST_FMT 0
 #define PS_DEPTH_FMT 0
 #define PS_PAL_FMT 0

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -2606,7 +2606,7 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 		{
 			config.colclip_update_area = config.drawarea;
 
-			colclip_rt = CreateRenderTarget(rtsize.x, rtsize.y, GSTexture::Format::ColorClip);
+			colclip_rt = CreateRenderTarget(rtsize.x, rtsize.y, GSTexture::Format::ColorClip, false);
 			if (!colclip_rt)
 			{
 				Console.Warning("D3D11: Failed to allocate ColorClip render target, aborting draw.");
@@ -2762,10 +2762,6 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 			Console.Warning("D3D11: Failed to allocate temp texture for RT copy.");
 	}
 
-	// Update again as it may have changed.
-	if (config.tex && config.tex == config.ds)
-		read_only_dsv = static_cast<GSTexture11*>(draw_ds)->ReadOnlyDepthStencilView();
-
 	OMSetRenderTargets(draw_rt, draw_ds, &config.scissor, read_only_dsv);
 	SetupOM(config.depth, OMBlendSelector(config.colormask, config.blend), config.blend.constant);
 	SendHWDraw(config, draw_rt_clone, draw_rt, config.require_one_barrier, config.require_full_barrier, false);
@@ -2829,8 +2825,6 @@ void GSDevice11::SendHWDraw(const GSHWDrawConfig& config, GSTexture* draw_rt_clo
 			Console.Warning("D3D11: Possible unnecessary copy detected.");
 #endif
 
-		const u32 indices_per_prim = config.indices_per_prim;
-
 		auto CopyAndBind = [&](GSVector4i drawarea) {
 			CopyRect(draw_rt, draw_rt_clone, drawarea, drawarea.left, drawarea.top);
 			if (one_barrier || full_barrier)
@@ -2838,10 +2832,11 @@ void GSDevice11::SendHWDraw(const GSHWDrawConfig& config, GSTexture* draw_rt_clo
 			if (config.tex && config.tex == config.rt)
 				PSSetShaderResource(0, draw_rt_clone);
 		};
-		
+
 		if (m_features.multidraw_fb_copy && full_barrier)
 		{
 			const u32 draw_list_size = static_cast<u32>(config.drawlist->size());
+			const u32 indices_per_prim = config.indices_per_prim;
 
 			pxAssert(config.drawlist && !config.drawlist->empty());
 			pxAssert(config.drawlist_bbox && static_cast<u32>(config.drawlist_bbox->size()) == draw_list_size);

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -1747,6 +1747,7 @@ void GSDevice11::SetupPS(const PSSelector& sel, const GSHWDrawConfig::PSConstant
 		sm.AddMacro("PS_PROCESS_RG", sel.process_rg);
 		sm.AddMacro("PS_SHUFFLE_ACROSS", sel.shuffle_across);
 		sm.AddMacro("PS_READ16_SRC", sel.real16src);
+		sm.AddMacro("PS_WRITE_RG", sel.write_rg);
 		sm.AddMacro("PS_CHANNEL_FETCH", sel.channel);
 		sm.AddMacro("PS_TALES_OF_ABYSS_HLE", sel.tales_of_abyss_hle);
 		sm.AddMacro("PS_URBAN_CHAOS_HLE", sel.urban_chaos_hle);

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -1235,7 +1235,7 @@ bool GSDevice12::CheckFeatures(const u32& vendor_id)
 	m_features.framebuffer_fetch = false;
 	m_features.stencil_buffer = true;
 	m_features.cas_sharpening = true;
-	m_features.test_and_sample_depth = false;
+	m_features.test_and_sample_depth = true;
 	m_features.vs_expand = !GSConfig.DisableVertexShaderExpand;
 
 	m_features.dxt_textures = SupportsTextureFormat(DXGI_FORMAT_BC1_UNORM) &&
@@ -3825,7 +3825,6 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 	GSTexture12* draw_rt = static_cast<GSTexture12*>(config.rt);
 	GSTexture12* draw_ds = static_cast<GSTexture12*>(config.ds);
 	GSTexture12* draw_rt_clone = nullptr;
-	GSTexture12* draw_ds_clone = nullptr;
 
 	// Align the render area to 128x128, hopefully avoiding render pass restarts for small render area changes (e.g. Ratchet and Clank).
 	const GSVector2i rtsize(config.rt ? config.rt->GetSize() : config.ds->GetSize());
@@ -3890,6 +3889,15 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 	if (config.blend.constant_enable)
 		SetBlendConstants(config.blend.constant);
 
+	// Depth testing and sampling, bind resource as dsv read only and srv at the same time without the need of a copy.
+	if (config.tex && config.tex == config.ds)
+	{
+		EndRenderPass();
+
+		// Transition dsv as read only.
+		draw_ds->TransitionToState(D3D12_RESOURCE_STATE_DEPTH_READ);
+	}
+
 	// Primitive ID tracking DATE setup.
 	GSTexture12* date_image = nullptr;
 	if (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking)
@@ -3905,7 +3913,7 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 		}
 	}
 
-	if (config.require_one_barrier || (config.tex && config.tex == config.rt))
+	if (draw_rt && (config.require_one_barrier || (config.tex && config.tex == config.rt)))
 	{
 		// Requires a copy of the RT.
 		// Used as "bind rt" flag when texture barrier is unsupported for tex is fb.
@@ -3926,25 +3934,6 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 		}
 		else
 			Console.Warning("D3D12: Failed to allocate temp texture for RT copy.");
-	}
-
-	if (config.tex && config.tex == config.ds)
-	{
-		// DX requires a copy when sampling the depth buffer.
-		draw_ds_clone = static_cast<GSTexture12*>(CreateDepthStencil(rtsize.x, rtsize.y, config.ds->GetFormat(), false));
-		if (draw_ds_clone)
-		{
-			EndRenderPass();
-
-			GL_PUSH("D3D12: Copy DS to temp texture {%d,%d %dx%d}", config.drawarea.left, config.drawarea.top,
-				config.drawarea.width(), config.drawarea.height());
-
-			draw_ds_clone->SetState(GSTexture::State::Invalidated);
-			CopyRect(config.ds, draw_ds_clone, config.drawarea, config.drawarea.left, config.drawarea.top);
-			PSSetShaderResource(0, draw_ds_clone, true);
-		}
-		else
-			Console.Warning("D3D12: Failed to allocate temp texture for DS copy.");
 	}
 
 	// Switch to colclip target for colclip hw rendering
@@ -3989,12 +3978,9 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 		draw_rt = colclip_rt;
 	}
 
-	// clear texture binding when it's bound to RT or DS
-	if (((draw_rt && static_cast<GSTexture12*>(draw_rt)->GetSRVDescriptor() == m_tfx_textures[0]) ||
-			(config.ds && static_cast<GSTexture12*>(config.ds)->GetSRVDescriptor() == m_tfx_textures[0])))
-	{
+	// Clear texture binding when it's bound to RT, DSV will be read only.
+	if (draw_rt && static_cast<GSTexture12*>(draw_rt)->GetSRVDescriptor() == m_tfx_textures[0])
 		PSSetShaderResource(0, nullptr, false);
-	}
 
 	if (m_in_render_pass && (m_current_render_target == draw_rt || m_current_depth_target == draw_ds))
 	{
@@ -4095,9 +4081,6 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 
 	if (draw_rt_clone)
 		Recycle(draw_rt_clone);
-
-	if (draw_ds_clone)
-		Recycle(draw_ds_clone);
 
 	if (date_image)
 		Recycle(date_image);

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -3950,6 +3950,9 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 			{
 				Console.Warning("D3D12: Failed to allocate ColorClip render target, aborting draw.");
 
+				if (draw_rt_clone)
+					Recycle(draw_rt_clone);
+
 				if (date_image)
 					Recycle(date_image);
 

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -2767,10 +2767,10 @@ void GSDeviceOGL::SendHWDraw(const GSHWDrawConfig& config, bool one_barrier, boo
 		        config.nindices / config.indices_per_prim, config.drawlist->size(), message.c_str());
 #endif
 
-		g_perfmon.Put(GSPerfMon::Barriers, static_cast<u32>(config.drawlist->size()));
-
 		const u32 indices_per_prim = config.indices_per_prim;
 		const u32 draw_list_size = static_cast<u32>(config.drawlist->size());
+
+		g_perfmon.Put(GSPerfMon::Barriers, static_cast<u32>(draw_list_size));
 
 		for (u32 n = 0, p = 0; n < draw_list_size; n++)
 		{

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 73;
+static constexpr u32 SHADER_CACHE_VERSION = 74;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/DX12: Backport depth test and sampling from dx11.
Unlike in dx11 where we create a separate dsv as read only we can transition the current dsv as read only which is cleaner.

GS/DX12/VK: Fix CopyRect partial clear regression.
Partial clears texture type should be either render target or depth stencil.
Oversight, I thought I did this but it looks like I only did it for the common process clears.
Fixes games crashing on dx12/vk with texture barriers disabled on some games.

GS/HW: Remove rebinding read only dsv after framebuffer optimizations
 on dx11.
The condition would never be triggered so useless.
Clean up SendHWDraw across renderers.
Recycle tex for rt copy if colclip tex fails.
Set flags for colclip CreateRenderTarget clear to false on dx11, consistent across renderers.

GS/DX11: Add missing write_rg shader bit for date barrier on texture shuffle.
Forgot to include this.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Speed/optimizations, bug/crash fixes.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test games mentioned in: https://github.com/PCSX2/pcsx2/pull/13180 for depth testing/sampling on dx12.
For the crash issue test : 
[Malice_SLES-52413_20240617171243.gs.zip](https://github.com/user-attachments/files/22652076/Malice_SLES-52413_20240617171243.gs.zip)
Test other games on dx11, dx12, vk to make sure I didn't break anything.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.
