### PR TITLE
GS: Detect triangles-are-quads in primitive overlap

### DIFF
--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -238,7 +238,9 @@ public:
 	std::unique_ptr<GSDumpBase> m_dump;
 	bool m_scissor_invalid = false;
 	bool m_quad_check_valid = false;
+	bool m_quad_check_valid_shuffle = false;
 	bool m_are_quads = false;
+	bool m_are_quads_shuffle = false;
 	bool m_nativeres = false;
 	bool m_mipmap = false;
 	bool m_texflush_flag = false;
@@ -447,7 +449,9 @@ public:
 	void DumpVertices(const std::string& filename);
 	void DumpTransferList(const std::string& filename);
 	void DumpTransferImages();
-
+	
+	template<bool shuffle_check>
+	bool TrianglesAreQuadsImpl();
 	bool TrianglesAreQuads(bool shuffle_check = false);
 	template <u32 primclass>
 	PRIM_OVERLAP GetPrimitiveOverlapDrawlistImpl(bool save_drawlist = false, bool save_bbox = false, float bbox_scale = 1.0f);


### PR DESCRIPTION
### Description of Changes
1. Added utility functions for detecting when vertices form axis-aligned right triangles or quads (original code by TellowKrinkle, modified by me).
2. Updated primitive overlap detection to account for pairs of triangles that together form axis-aligned quads.

### Rationale behind Changes
Currently, pairs of axis-aligned right triangles that form a quad are treated as overlapping. This PR adds logical to detect such triangles as non-overlapping. This should reduce barriers (OpenGL/Vulkan) and copies (DX11) when doing SW blending with multidraw (requires higher than basic blending).

In a dump with DX11/max blending, there were significant reductions in the number of copies. Many of these are menus but some are also in-game.

Examples:
```
Gradius V_SLUS-20712_20220830220750.gs.xz
Dark Cloud_SCUS-97111_20231026205150.gs.xz
kaan.gs.xz
Valkyrie_Profile_2_-_Silmeria_SLUS-21452_20230105135006.gs.xz
Jak_X_-_Combat_Racing_SCUS-97429_20240317114104.gs.xz
Legacy of Kain - Blood Omen 2_SLUS-20024_20221019151207.gs.xz
Magical Sports - Go Go Golf_SLPS-20037_20230731171544.gs.xz
Call_of_Duty_-_Finest_Hour_SLUS-20725_20230514111828.gs.xz
Grand_Theft_Auto_-_San_Andreas_SLUS-20946_20230725171446.gs.xz
Bloody Roar 3_SLUS-20212_20230307054849.gs.xz
```

In some dumps the number of copes in basic blend changed slightly (up or down). I have checked several by hand and they appear to be a result of increased accuracy with single-quad detection in this PR (single quads are special cases that are handled differently in both PR and master).

I also profiled the modified function `TrianglesAreQuads()` in both the PR and master and CPU overhead appears to be negligible (though I only checked one dump). Hopefully, there be no difference in games that do not require quad detection.

### Suggested Testing Steps
- Benchmarking games to make sure the performance did not drop and accuracy was not affected.
- So far I have done only dumps runs in DX11. However, all renderers should be run eventually.

### Did you use AI to help find, test, or implement this issue or feature?
I used AI to brainstorm deas and review my code. Nothing was copy/pasted directly in the final PR.