### PR TITLE
GS/HW: Point m_from_target to new target if it's also a source in CombineAlignedInsideTargets, update manual deswizzle.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2310,6 +2310,7 @@ void GSTextureCache::CombineAlignedInsideTargets(Target* target, GSTextureCache:
 					if (src && src->m_from_target == t)
 					{
 						src->m_texture = t->m_texture;
+						src->m_from_target = target;
 						src->m_shared_texture = false;
 						src->m_target_direct = false;
 						t->m_texture = nullptr;


### PR DESCRIPTION
### Description of Changes
GS/TC: Point m_from_target to new target if it's also a source in CombineAlignedInsideTargets.
<!-- Brief description or overview on what was changed in the PR -->
Issue is it was erasing the source which doesn't get passed back to the main draw function, so we should be setting m_from_target to null because it is linked.

GS/HW: Update manual deswizzle detection.
Check if a draw is either a palette or 32bit depth format, also check for swizzle format is 16 or 32bit.
Expand/update quadrant detection, use the quadrant size of what it should be from the page size and compare it to the actual quadrant size from the vertex positions.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Crash fixes.
Fixes Stolen crashing and swizzle issues.
Fixes https://github.com/PCSX2/pcsx2/issues/13348

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test mentioned games/issues with the dumps provided, test some other random stuff, dump run no issues.
Dump to crash test: 
[Stolen_SLUS-21099_20250916221711.gs.zip](https://github.com/user-attachments/files/22704793/Stolen_SLUS-21099_20250916221711.gs.zip)
[Enthusia Professional Racing_SLES-53125_20251005045009.gs.zip](https://github.com/user-attachments/files/22705360/Enthusia.Professional.Racing_SLES-53125_20251005045009.gs.zip)

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.

Stolen comparison:
<img width="1396" height="546" alt="image" src="https://github.com/user-attachments/assets/8ac48e56-1732-48be-be6d-96edc5f09cb2" />
