### PR TITLE
GS/DX12: Backport dx11 full rt copy optimizations.

### DIFF
--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -1409,9 +1409,18 @@ void GSDevice12::CopyRect(GSTexture* sTex, GSTexture* dTex, const GSVector4i& r,
 	dstloc.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
 	dstloc.SubresourceIndex = 0;
 
-	const D3D12_BOX srcbox{static_cast<UINT>(r.left), static_cast<UINT>(r.top), 0u, static_cast<UINT>(r.right),
-		static_cast<UINT>(r.bottom), 1u};
-	GetCommandList()->CopyTextureRegion(&dstloc, destX, destY, 0, &srcloc, &srcbox);
+	const GSVector4i src_rect(0, 0, sTex->GetWidth(), sTex->GetHeight());
+	const bool full_rt_copy = destX == 0 && destY == 0 && r.eq(src_rect) && src_rect.eq(dst_rect);
+	if (full_rt_copy)
+	{
+		GetCommandList()->CopyResource(dTex12->GetResource(), sTex12->GetResource());
+	}
+	else
+	{
+		const D3D12_BOX srcbox{static_cast<UINT>(r.left), static_cast<UINT>(r.top), 0u, static_cast<UINT>(r.right),
+			static_cast<UINT>(r.bottom), 1u};
+		GetCommandList()->CopyTextureRegion(&dstloc, destX, destY, 0, &srcloc, &srcbox);
+	}
 
 	dTex12->SetState(GSTexture::State::Dirty);
 }

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -1802,7 +1802,7 @@ void GSRendererHW::HandleManualDeswizzle()
 	// we're gonna have to get creative and swap around the quandrants, but that's a TODO.
 	GSVertex* v = &m_vertex.buff[0];
 
-	// Check for page quadrant and compare it to the quadrant from the verts, if it doesn't match then we need to do correction.
+	// Check for page quadrant and compare it to the quadrant from the verts, if it does match then we need to do correction.
 	const GSVector2i page_quadrant = GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].pgs / 2;
 
 	if (PRIM->FST)


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/DX12: Backport dx11 full rt copy optimizations.
We are copying the whole RT so just call CopyResource instead of CopyTextureRegion which will be faster.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Speed.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test /benchmark games, as well as the list in the file, may also benefit the most as it also uses copies for blending.
[full rt copies list.txt](https://github.com/user-attachments/files/22747920/full.rt.copies.list.txt)


### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.
