### PR TITLE
Settings: Remove obsolete transitionary function

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -71,15 +71,6 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 	setupTab(m_capture, tr("Media Capture"));
 	m_advanced_tab = setupTab(m_advanced, tr("Advanced"));
 
-#ifndef PCSX2_DEVBUILD
-	if (!dialog()->isPerGameSettings())
-	{
-		// We removed hardware fixes from global settings, but people in the past did set this stuff globally.
-		// So, just reset it all. We can remove this code at some point in the future.
-		resetManualHardwareFixes();
-	}
-#endif
-
 	//////////////////////////////////////////////////////////////////////////
 	// Display Settings
 	//////////////////////////////////////////////////////////////////////////
@@ -1316,59 +1307,4 @@ void GraphicsSettingsWidget::onUpscaleMultiplierChanged()
 	const QVariant data = m_hw.upscaleMultiplier->currentData();
 	dialog()->setFloatSettingValue("EmuCore/GS", "upscale_multiplier",
 		data.isValid() ? std::optional<float>(data.toFloat()) : std::optional<float>());
-}
-
-void GraphicsSettingsWidget::resetManualHardwareFixes()
-{
-	bool changed = false;
-	{
-		auto lock = Host::GetSettingsLock();
-		SettingsInterface* const si = Host::Internal::GetBaseSettingsLayer();
-
-		auto check_bool = [&](const char* section, const char* key, bool expected) {
-			if (si->GetBoolValue(section, key, expected) != expected)
-			{
-				si->SetBoolValue(section, key, expected);
-				changed = true;
-			}
-		};
-		auto check_int = [&](const char* section, const char* key, s32 expected) {
-			if (si->GetIntValue(section, key, expected) != expected)
-			{
-				si->SetIntValue(section, key, expected);
-				changed = true;
-			}
-		};
-
-		check_bool("EmuCore/GS", "UserHacks", false);
-
-		check_int("EmuCore/GS", "UserHacks_CPUSpriteRenderBW", 0);
-		check_int("EmuCore/GS", "UserHacks_CPUCLUTRender", 0);
-		check_int("EmuCore/GS", "UserHacks_GPUTargetCLUTMode", 0);
-		check_int("EmuCore/GS", "UserHacks_SkipDraw_Start", 0);
-		check_int("EmuCore/GS", "UserHacks_SkipDraw_End", 0);
-		check_bool("EmuCore/GS", "UserHacks_AutoFlush", false);
-		check_bool("EmuCore/GS", "UserHacks_CPU_FB_Conversion", false);
-		check_bool("EmuCore/GS", "UserHacks_DisableDepthSupport", false);
-		check_bool("EmuCore/GS", "UserHacks_Disable_Safe_Features", false);
-		check_bool("EmuCore/GS", "UserHacks_DisableRenderFixes", false);
-		check_bool("EmuCore/GS", "preload_frame_with_gs_data", false);
-		check_bool("EmuCore/GS", "UserHacks_DisablePartialInvalidation", false);
-		check_int("EmuCore/GS", "UserHacks_TextureInsideRt", static_cast<int>(GSTextureInRtMode::Disabled));
-		check_bool("EmuCore/GS", "UserHacks_ReadTCOnClose", false);
-		check_bool("EmuCore/GS", "UserHacks_EstimateTextureRegion", false);
-		check_bool("EmuCore/GS", "paltex", false);
-		check_int("EmuCore/GS", "UserHacks_HalfPixelOffset", 0);
-		check_int("EmuCore/GS", "UserHacks_native_scaling", static_cast<int>(GSNativeScaling::Off));
-		check_int("EmuCore/GS", "UserHacks_round_sprite_offset", 0);
-		check_int("EmuCore/GS", "UserHacks_TCOffsetX", 0);
-		check_int("EmuCore/GS", "UserHacks_TCOffsetY", 0);
-		check_bool("EmuCore/GS", "UserHacks_align_sprite_X", false);
-		check_bool("EmuCore/GS", "UserHacks_merge_pp_sprite", false);
-		check_bool("EmuCore/GS", "UserHacks_ForceEvenSpritePosition", false);
-		check_bool("EmuCore/GS", "UserHacks_BilinearHack", false);
-	}
-
-	if (changed)
-		Host::CommitBaseSettingChanges();
 }

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.h
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.h
@@ -60,7 +60,6 @@ private:
 	GSRendererType getEffectiveRenderer() const;
 	void updateRendererDependentOptions();
 	void populateUpscaleMultipliers(u32 max_upscale_multiplier);
-	void resetManualHardwareFixes();
 
 	Ui::GraphicsSettingsHeader m_header;
 	Ui::GraphicsDisplaySettingsTab m_display;


### PR DESCRIPTION
### Description of Changes
Removes a function added three years ago which was 1) designed to be removed in the future and 2) written to transition us away from having global manual hardware fixes. Each time the graphics settings window is created, it nukes any global manual hardware fixes.

### Rationale behind Changes
This was implemented in the v1.7 dev cycle before(?) we even had an auto-updater. This function has done its job to the point where anybody who would actually be impacted by this removal:

* Is on a version prior to when this was added in the middle of v1.7.X.
* Has global manual hardware fixes.
* Will update to the latest PCSX2 v2.5.X or later.
* Will manually take their `.ini` config file with them – which probably isn't even compatible at this point.
* Actually experiences problems with said global manual hardware fixes.

It's functionally a nonexistent problem now. This removal was originally part of a WiP PR that touches most of the Qt settings, but @Mrlinkwii et al. suggested that I make this a separate PR.

### Suggested Testing Steps
Make sure that the settings widget is still fine, including if you manually insert global hardware fix settings into the `.ini` file.

### Did you use AI to help find, test, or implement this issue or feature?
No.
