### PR TITLE
Qt: Add null check for gamelist icons

### DIFF
--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -131,6 +131,10 @@ namespace
 			// Fetch icon pixmap
 			const QRect r = option.rect;
 			const QPixmap pix = qvariant_cast<QPixmap>(index.data(Qt::DecorationRole));
+
+			if (pix.isNull())
+				return;
+
 			const int pix_width = static_cast<int>(pix.width() / pix.devicePixelRatio());
 			const int pix_height = static_cast<int>(pix.height() / pix.devicePixelRatio());
 


### PR DESCRIPTION
### Description of Changes
Adds a check for null icons in `GameListIconStyleDelegate`

### Rationale behind Changes
Fixes the following console warnings
```
QPainter::begin: Paint device returned engine == 0, type: 3
QPainter::setCompositionMode: Painter not active
QPainter::fillRect: Painter not active
QPainter::end: Painter not active, aborted
```
When selecting a game with no compatibility ratings

### Suggested Testing Steps
In the gamelist, select a game that has no compatibility rating and check the console output.
Check that other icons render correctly.

### Did you use AI to help find, test, or implement this issue or feature?
No