### PR TITLE
GS: Improve degenerate primitive testing in vertex kick and SW bounding box calculation. Other minor fixes.

### DIFF
--- a/pcsx2/GS/GSDrawingContext.cpp
+++ b/pcsx2/GS/GSDrawingContext.cpp
@@ -91,11 +91,11 @@ void GSDrawingContext::UpdateScissor()
 	scissor.in = rscissor + GSVector4i::cxpr(0, 0, 1, 1);
 
 	// Fixed-point scissor min/max, used for rejecting primitives which are entirely outside.
-	scissor.cull = rscissor.sll32<4>();
+	// Bottom-right end point should be exclusive for rectangle intersection test to work correctly.
+	scissor.cull = rscissor.sll32<4>() + GSVector4i::cxpr(0, 0, 1, 1);
 
-	// Offset applied to vertices for culling, zw is for native resolution culling
-	// We want to round subpixels down, because at least one pixel gets filled per scanline.
-	scissor.xyof = GSVector4i::loadl(&XYOFFSET.U64).xyxy().sub32(GSVector4i::cxpr(0, 0, 15, 15));
+	// Offset applied to vertices for culling.
+	scissor.xyof = GSVector4i::loadl(&XYOFFSET.U64).xyxy();
 }
 
 GIFRegTEX0 GSDrawingContext::GetSizeFixedTEX0(const GSVector4& st, bool linear, bool mipmap) const

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2666,7 +2666,6 @@ void GSState::FlushPrim()
 					GSVector4i* RESTRICT vert_ptr = (GSVector4i*)&m_vertex->buff[i];
 					GSVector4i v = vert_ptr[1];
 					v = v.xxxx().u16to32().sub32(m_xyof);
-					v = v.blend32<12>(v.sra32<4>());
 					m_vertex->xy[i & 3] = v;
 					m_vertex->xy_tail = unused;
 				}
@@ -3790,10 +3789,8 @@ void GSState::UpdateContext()
 
 void GSState::UpdateScissor()
 {
-	m_scissor_cull_min = m_context->scissor.cull.xyxy();
-	m_scissor_cull_max = m_context->scissor.cull.zwzw();
 	m_xyof = m_context->scissor.xyof;
-	m_scissor_invalid = !m_context->scissor.in.gt32(m_context->scissor.in.zwzw()).allfalse();
+	m_scissor_invalid = m_context->scissor.in.rempty();
 }
 
 void GSState::UpdateVertexKick()
@@ -5841,6 +5838,7 @@ template <u32 prim, bool auto_flush>
 __forceinline void GSState::VertexKick(u32 skip)
 {
 	constexpr u32 n = NumIndicesForPrim(prim);
+	constexpr int primclass = GSUtil::GetPrimClass(prim);
 	static_assert(n > 0);
 
 	pxAssert(m_vertex->tail < m_vertex->maxcount + 3);
@@ -5884,11 +5882,7 @@ __forceinline void GSState::VertexKick(u32 skip)
 
 	// We maintain the X/Y coordinates for the last 4 vertices, as well as the head for triangle fans, so we can compute
 	// the min/max, and cull degenerate triangles, which saves draws in some cases. Why 4? Mod 4 is cheaper than Mod 3.
-	// These vertices are a full vector containing <X_Fixed_Point, Y_Fixed_Point, X_Integer, Y_Integer>. We use the
-	// integer coordinates for culling at native resolution, and the fixed point for all others. The XY offset has to be
-	// applied, then we split it into the fixed/integer portions.
-	const GSVector4i xy_ofs = new_v1.xxxx().u16to32().sub32(m_xyof);
-	const GSVector4i xy = xy_ofs.blend32<12>(xy_ofs.sra32<4>());
+	const GSVector4i xy = new_v1.xxxx().u16to32().sub32(m_xyof);
 	m_vertex->xy[xy_tail & 3] = xy;
 
 	// Backup head for triangle fans so we can read it later, otherwise it'll get lost after the 4th vertex.
@@ -5918,69 +5912,55 @@ __forceinline void GSState::VertexKick(u32 skip)
 	// Skip draws when scissor is out of range (i.e. bottom-right is less than top-left), since everything will get clipped.
 	skip |= static_cast<u32>(m_scissor_invalid);
 
-	GSVector4i pmin, pmax;
+	GSVector4i bbox;
 	if (skip == 0)
 	{
 		const GSVector4i v0 = m_vertex->xy[(xy_tail - 1) & 3];
 		const GSVector4i v1 = m_vertex->xy[(xy_tail - 2) & 3];
 		const GSVector4i v2 = (prim == GS_TRIANGLEFAN) ? m_vertex->xyhead : m_vertex->xy[(xy_tail - 3) & 3];
 
-		switch (prim)
+		if constexpr (n == 1)
 		{
-			case GS_POINTLIST:
-				pmin = v0;
-				pmax = v0;
-				break;
-			case GS_LINELIST:
-			case GS_LINESTRIP:
-			case GS_SPRITE:
-				pmin = v0.min_i32(v1);
-				pmax = v0.max_i32(v1);
-				break;
-			case GS_TRIANGLELIST:
-			case GS_TRIANGLESTRIP:
-			case GS_TRIANGLEFAN:
-				pmin = v0.min_i32(v1.min_i32(v2));
-				pmax = v0.max_i32(v1.max_i32(v2));
-				break;
-			default:
-				break;
+			bbox = v0;
+		}
+		else if constexpr (n == 2)
+		{
+			bbox = v0.runion(v1);
+		}
+		else if constexpr (n == 3)
+		{
+			bbox = v0.runion(v1).runion(v2);
 		}
 
-		GSVector4i test = pmax.lt32(m_scissor_cull_min) | pmin.gt32(m_scissor_cull_max);
-
-		switch (prim)
+		if (m_nativeres && (primclass == GS_TRIANGLE_CLASS || primclass == GS_SPRITE_CLASS))
 		{
-			case GS_TRIANGLELIST:
-			case GS_TRIANGLESTRIP:
-			case GS_TRIANGLEFAN:
-			case GS_SPRITE:
-			{
-				// Discard degenerate triangles which don't cover at least one pixel. Since the vertices are in native
-				// resolution space, we can use the integer locations. When upscaling, we can't, because a primitive which
-				// does not span a single pixel at 1x may span multiple pixels at higher resolutions.
-				const GSVector4i degen_test = pmin.eq32(pmax);
-				test |= m_nativeres ? degen_test.zwzw() : degen_test;
-			}
-			break;
-			default:
-				break;
+			// For triangles and sprites at native res take the region strictly within the bounds
+			// omitting the bottom/right.
+			bbox = (bbox + GSVector4i(0xF, 0xF, -1, -1)) & GSVector4i(~0xF);
 		}
 
-		switch (prim)
+		// For AA1 triangles and lines, expand the bounds by 1 pixel on all sides.
+		// Note: redundant check for the AA1 flag to avoid calling a function if not needed.
+		if ((primclass == GS_TRIANGLE_CLASS || primclass == GS_LINE_CLASS) && PRIM->AA1 && IsCoverageAlphaSupported())
 		{
-			case GS_TRIANGLELIST:
-			case GS_TRIANGLESTRIP:
-			case GS_TRIANGLEFAN:
-				test = (test | v0.eq64(v1)) | (v1.eq64(v2) | v0.eq64(v2));
-				break;
-			default:
-				break;
+			bbox += GSVector4i(-0x10, -0x10, 0x10, 0x10);
+		}
+
+		// Make the bottom-right endpoints exclusive for rectangle intersection to work correctly.
+		bbox += GSVector4i::cxpr(0, 0, 1, 1);
+
+		// Do scissor test and empty bbox test.
+		GSVector4i test = GSVector4i(bbox.rintersects(m_context->scissor.cull)) == GSVector4i::cxpr(0);
+
+		// Test for degenerate triangle.
+		if (primclass == GS_TRIANGLE_CLASS)
+		{
+			test |= v0.eq64(v1) | v1.eq64(v2) | v0.eq64(v2);
 		}
 
 #ifndef ARCH_ARM64
-		// We only care about the xy passing the skip test. zw is the offset coordinates for native culling.
-		skip |= test.mask() & 0xff;
+		// We only care about the xy passing the skip test.
+		skip |= test.mask();
 #else
 		// mask() is slow on ARM, so just pull the bits out instead, thankfully we only care about the first 4 bytes.
 		skip |= (static_cast<u64>(test.extract64<0>()) & UINT64_C(0x8080808080808080)) != 0;
@@ -6094,13 +6074,12 @@ __forceinline void GSState::VertexKick(u32 skip)
 			ASSUME(0);
 	}
 
-	// Update rectangle for the current draw. We can use the re-integer coordinates from min/max here.
-	const GSVector4i draw_min = pmin.zwzw();
-	const GSVector4i draw_max = pmax;
-	if (m_index->tail != n)
-		temp_draw_rect = temp_draw_rect.min_i32(draw_min).blend32<12>(temp_draw_rect.max_i32(draw_max));
+	// Update rectangle for the current draw. Needs exclusive endpoints.
+	const GSVector4i draw_rect = bbox.sra32<4>() + GSVector4i(0, 0, 1, 1);
+	if (m_vertex->tail != n)
+		temp_draw_rect = temp_draw_rect.runion(draw_rect);
 	else
-		temp_draw_rect = draw_min.blend32<12>(draw_max);
+		temp_draw_rect = draw_rect;
 	temp_draw_rect = temp_draw_rect.rintersect(m_context->scissor.in);
 
 	constexpr u32 max_vertices = MaxVerticesForPrim(prim);

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -131,8 +131,6 @@ protected:
 
 	GSVertex m_v = {};
 	float m_q = 1.0f;
-	GSVector4i m_scissor_cull_min = {};
-	GSVector4i m_scissor_cull_max = {};
 	GSVector4i m_xyof = {};
 	int  m_used_buffers_idx = 0;
 	int m_current_buffer_idx = 0;

--- a/pcsx2/GS/Renderers/SW/GSRasterizer.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRasterizer.cpp
@@ -1550,7 +1550,7 @@ void GSRasterizerList::Queue(const GSRingHeap::SharedPtr<GSRasterizerData>& data
 		m_ds.SetupDraw(*data.get());
 	}
 
-	pxAssert(r.top >= 0 && r.top < 2048 && r.bottom >= 0 && r.bottom < 2048);
+	pxAssert(r.top >= 0 && r.top <= 2048 && r.bottom >= 0 && r.bottom <= 2048);
 
 	int top = r.top >> m_thread_height;
 	int bottom = std::min<int>((r.bottom + (1 << m_thread_height) - 1) >> m_thread_height, top + (int)m_workers.size());

--- a/pcsx2/GS/Renderers/SW/GSRasterizer.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRasterizer.cpp
@@ -527,6 +527,10 @@ void GSRasterizer::DrawEdgeLine(const GSVertexSW& v0, const GSVertexSW& v1, cons
 	const int rxi1 = static_cast<int>(rx1);
 	const int ryi1 = static_cast<int>(ry1);
 
+	// Early exit for horizontal lines.
+	if (delta_y == 0.0f && !IsOneOfMyScanlines(ryi0) && !aa)
+		return;
+
 	const GSVertexSW dedge = dv / GSVector4(std::abs(step_x ? delta_x : delta_y));
 	
 	GSVertexSW edge(v0);

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -468,7 +468,25 @@ void GSRendererSW::Draw()
 	std::memcpy(sd->index, m_index->buff, sizeof(u16) * m_index->tail);
 
 	GSVector4i scissor = context->scissor.in;
-	GSVector4i bbox = GSVector4i(m_vt.m_min.p.floor().upld(m_vt.m_max.p.floor())) + GSVector4i(0, 0, 1, 1); // right/bottom should be exclusive so +1
+	GSVector4i bbox;
+	
+	if (m_vt.m_primclass == GS_LINE_CLASS || m_vt.m_primclass == GS_POINT_CLASS)
+	{
+		// min: round, max: round
+		bbox = GSVector4i((m_vt.m_min.p + GSVector4(0.5f)).floor().upld((m_vt.m_max.p + GSVector4(0.5f)).floor()));
+	}
+	else
+	{
+		// min: ceil, max: floor
+		bbox = GSVector4i(m_vt.m_min.p.ceil().upld(m_vt.m_max.p.floor()));
+	}
+
+	if (PRIM->AA1 && (m_vt.m_primclass == GS_LINE_CLASS || m_vt.m_primclass == GS_TRIANGLE_CLASS))
+	{
+		bbox += GSVector4i(-1, -1, 1, 1); // Expand bbox by 1 on all sides when using antialiasing.
+	}
+
+	bbox += GSVector4i(0, 0, 1, 1); // right/bottom should be exclusive so +1
 
 	GSVector4i r = bbox.rintersect(scissor);
 


### PR DESCRIPTION
### Description of Changes
1. Vertex kick: Ensure line/point rounding and AA are accounted for in the degenerate primitive test.
2. SW: Apply the same degenerate primitive test fix as vertex kick.
3. Simplify primitive bounding box and scissor calculations in vertex kick.
4. SW: Minor optimization for horizontal lines in the rasterizer.
5. SW: Adjust an assertion to prevent false positives.

### Rationale behind Changes
Some edge cases cause the degenerate primitive test to incorrectly pass or fail primitives, especially when antialiasing is enabled. This can result in issues such as and fixes [#8677](https://github.com/PCSX2/pcsx2/issues/8677). These changes should fix that issue and address additional minor problems discussed in [#13297](https://github.com/PCSX2/pcsx2/pull/13297).

### Suggested Testing Steps
This update will affect any GS drawing, so testing games with both HW/SW under different options will be helpful. This should not affect performance much, so only accuracy needs to be checked.

### Did you use AI to help find, test, or implement this issue or feature?
Copilot occasionaly for code completion.
