### PR TITLE
Qt: Set QStyleHints colorScheme property properly

### DIFF
--- a/common/CocoaTools.h
+++ b/common/CocoaTools.h
@@ -15,10 +15,6 @@ namespace CocoaTools
 	void DestroyMetalLayer(WindowInfo* wi);
 	std::optional<float> GetViewRefreshRate(const WindowInfo& wi);
 
-	/// Add a handler to be run when macOS changes between dark and light themes
-	void AddThemeChangeHandler(void* ctx, void(handler)(void* ctx));
-	/// Remove a handler previously added using AddThemeChangeHandler with the given context
-	void RemoveThemeChangeHandler(void* ctx);
 	/// Mark an NSMenu as the help menu
 	void MarkHelpMenu(void* menu);
 	/// Returns the bundle path.
@@ -44,6 +40,6 @@ namespace CocoaTools
 	void RunCocoaEventLoop(bool wait_forever = false);
 	/// Posts an event to the main telling `RunCocoaEventLoop(true)` to exit
 	void StopMainThreadEventLoop();
-}
+} // namespace CocoaTools
 
 #endif // __APPLE__

--- a/common/CocoaTools.mm
+++ b/common/CocoaTools.mm
@@ -85,63 +85,7 @@ std::optional<float> CocoaTools::GetViewRefreshRate(const WindowInfo& wi)
 	return ret;
 }
 
-// MARK: - Theme Change Handlers
-
-@interface PCSX2KVOHelper : NSObject
-
-- (void)addCallback:(void*)ctx run:(void(*)(void*))callback;
-- (void)removeCallback:(void*)ctx;
-
-@end
-
-@implementation PCSX2KVOHelper
-{
-	std::vector<std::pair<void*, void(*)(void*)>> _callbacks;
-}
-
-- (void)addCallback:(void*)ctx run:(void(*)(void*))callback
-{
-	_callbacks.push_back(std::make_pair(ctx, callback));
-}
-
-- (void)removeCallback:(void*)ctx
-{
-	auto new_end = std::remove_if(_callbacks.begin(), _callbacks.end(), [ctx](const auto& entry){
-		return ctx == entry.first;
-	});
-	_callbacks.erase(new_end, _callbacks.end());
-}
-
-- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context
-{
-	for (const auto& callback : _callbacks)
-		callback.second(callback.first);
-}
-
-@end
-
-static PCSX2KVOHelper* s_themeChangeHandler;
-
-void CocoaTools::AddThemeChangeHandler(void* ctx, void(handler)(void* ctx))
-{
-	assert([NSThread isMainThread]);
-	if (!s_themeChangeHandler)
-	{
-		s_themeChangeHandler = [[PCSX2KVOHelper alloc] init];
-		NSApplication* app = [NSApplication sharedApplication];
-		[app addObserver:s_themeChangeHandler
-		      forKeyPath:@"effectiveAppearance"
-		         options:0
-		         context:nil];
-	}
-	[s_themeChangeHandler addCallback:ctx run:handler];
-}
-
-void CocoaTools::RemoveThemeChangeHandler(void* ctx)
-{
-	assert([NSThread isMainThread]);
-	[s_themeChangeHandler removeCallback:ctx];
-}
+// MARK: - Help menu
 
 void CocoaTools::MarkHelpMenu(void* menu)
 {

--- a/pcsx2-qt/Debugger/DisassemblyView.cpp
+++ b/pcsx2-qt/Debugger/DisassemblyView.cpp
@@ -939,7 +939,7 @@ inline QString DisassemblyView::DisassemblyStringFromAddress(u32 address, QFont 
 QColor DisassemblyView::GetAddressFunctionColor(u32 address)
 {
 	std::array<QColor, 6> colors;
-	if (QtUtils::IsLightTheme(palette()))
+	if (!QtHost::IsDarkApplicationTheme())
 	{
 		colors = {
 			QColor::fromRgba(0xFFFA3434),

--- a/pcsx2-qt/Debugger/Docking/DropIndicators.cpp
+++ b/pcsx2-qt/Debugger/Docking/DropIndicators.cpp
@@ -3,6 +3,7 @@
 
 #include "DropIndicators.h"
 
+#include "QtHost.h"
 #include "QtUtils.h"
 #include "Debugger/Docking/DockViews.h"
 
@@ -21,7 +22,7 @@ static std::pair<QColor, QColor> pickNiceColours(const QPalette& palette, bool h
 	QColor fill = palette.highlight().color();
 	QColor outline = palette.highlight().color();
 
-	if (QtUtils::IsLightTheme(palette))
+	if (!QtHost::IsDarkApplicationTheme())
 	{
 		fill = fill.darker(200);
 		outline = outline.darker(200);
@@ -197,7 +198,7 @@ static const constexpr int INDICATOR_MARGIN = 10;
 static bool isWayland()
 {
 	return KDDockWidgets::Core::Platform::instance()->displayType() ==
-		   KDDockWidgets::Core::Platform::DisplayType::Wayland;
+	       KDDockWidgets::Core::Platform::DisplayType::Wayland;
 }
 
 static QWidget* parentForIndicatorWindow(KDDockWidgets::Core::ClassicDropIndicatorOverlay* classic_indicators)

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -138,21 +138,11 @@ MainWindow::~MainWindow()
 #ifdef _WIN32
 	unregisterForDeviceNotifications();
 #endif
-#ifdef __APPLE__
-	CocoaTools::RemoveThemeChangeHandler(this);
-#endif
 }
 
 void MainWindow::initialize()
 {
 #ifdef __APPLE__
-	CocoaTools::AddThemeChangeHandler(this, [](void* ctx) {
-		// This handler is called *before* the style change has propagated far enough for Qt to see it
-		// Use RunOnUIThread to delay until it has
-		QtHost::RunOnUIThread([ctx = static_cast<MainWindow*>(ctx)] {
-			ctx->updateTheme(); // Qt won't notice the style change without us touching the palette in some way
-		});
-	});
 	// The cocoa backing isn't initialized yet, delay this until stuff is set up with a `RunOnUIThread` call
 	QtHost::RunOnUIThread([this] {
 		CocoaTools::MarkHelpMenu(m_ui.menuHelp->toNSMenu());

--- a/pcsx2-qt/QtUtils.cpp
+++ b/pcsx2-qt/QtUtils.cpp
@@ -90,7 +90,9 @@ namespace QtUtils
 
 		const int min_column_width = header->minimumSectionSize();
 		const int scrollbar_width = ((view->verticalScrollBar() && view->verticalScrollBar()->isVisible()) ||
-			view->verticalScrollBarPolicy() == Qt::ScrollBarAlwaysOn) ? view->verticalScrollBar()->width() : 0;
+										view->verticalScrollBarPolicy() == Qt::ScrollBarAlwaysOn) ?
+		                                view->verticalScrollBar()->width() :
+		                                0;
 		int num_flex_items = 0;
 		int total_width = 0;
 		int column_index = 0;
@@ -344,11 +346,6 @@ namespace QtUtils
 			csv += "\n";
 		}
 		return csv;
-	}
-
-	bool IsLightTheme(const QPalette& palette)
-	{
-		return palette.text().color().lightnessF() < 0.5;
 	}
 
 	bool IsCompositorManagerRunning()

--- a/pcsx2-qt/QtUtils.h
+++ b/pcsx2-qt/QtUtils.h
@@ -96,9 +96,7 @@ namespace QtUtils
 	/// Converts an abstract item model to a CSV string.
 	QString AbstractItemModelToCSV(QAbstractItemModel* model, int role = Qt::DisplayRole, bool useQuotes = false);
 
-	// Heuristic to check if the current theme is a light or dark theme.
-	bool IsLightTheme(const QPalette& palette);
-
+	/// Checks if we can use transparency effects e.g. for dock drop indicators.
 	bool IsCompositorManagerRunning();
 
 	/// Sets the scalable icon to a given label (svg icons, or icons with multiple size pixmaps)


### PR DESCRIPTION
### Description of Changes
Sets the colorScheme property of the qApp->styleHint() object whenever the theme is changed.

We're still using a palette heuristic to figure out if it's a light or dark theme since in some cases qApp->styleHints()->colourScheme() will return the wrong result (I've added comments explaining this in more detail).

This also removes some custom logic for detecting theme changes on macOS because it was conflicting with Qt's platform code (which now handles this automatically) which was causing an infinite loop.

### Rationale behind Changes
This lets Qt know that we're using a light or dark theme, which will allow it to do a better job at drawing certain widgets. For example before checkboxes looked like this (with a dark OS theme set):

<img width="643" height="137" alt="Screenshot_20251012_202908" src="https://github.com/user-attachments/assets/bcd777e9-20b7-47d7-81ec-03ead9b4a913" />

After these changes they look like this:

<img width="641" height="125" alt="Screenshot_20251012_212331" src="https://github.com/user-attachments/assets/bb4503af-575b-42b9-b2fe-46aba7e346be" />

### Suggested Testing Steps
Test on Windows and macOS with the native themes. Try changing between light and dark themes in the settings window, and try changing between light, dark and high contrast themes in the OS.

### Did you use AI to help find, test, or implement this issue or feature?
No.
