### PR TITLE
pcsx2-qt: Add buddies and tabstops

### DIFF
--- a/pcsx2-qt/AutoUpdaterDialog.ui
+++ b/pcsx2-qt/AutoUpdaterDialog.ui
@@ -3,7 +3,7 @@
  <class>AutoUpdaterDialog</class>
  <widget class="QDialog" name="AutoUpdaterDialog">
   <property name="windowModality">
-   <enum>Qt::ApplicationModal</enum>
+   <enum>Qt::WindowModality::ApplicationModal</enum>
   </property>
   <property name="geometry">
    <rect>
@@ -91,7 +91,7 @@
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -132,6 +132,12 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>updateNotes</tabstop>
+  <tabstop>downloadAndInstall</tabstop>
+  <tabstop>skipThisUpdate</tabstop>
+  <tabstop>remindMeLater</tabstop>
+ </tabstops>
  <resources>
   <include location="resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/CoverDownloadDialog.ui
+++ b/pcsx2-qt/CoverDownloadDialog.ui
@@ -28,7 +28,7 @@
         <pixmap resource="resources/resources.qrc">:/icons/black/svg/artboard-2-line.svg</pixmap>
        </property>
        <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+        <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
        </property>
       </widget>
      </item>
@@ -39,6 +39,9 @@
        </property>
        <property name="wordWrap">
         <bool>true</bool>
+       </property>
+       <property name="buddy">
+        <cstring>label</cstring>
        </property>
       </widget>
      </item>
@@ -52,6 +55,9 @@
      <property name="wordWrap">
       <bool>true</bool>
      </property>
+     <property name="buddy">
+      <cstring>urls</cstring>
+     </property>
     </widget>
    </item>
    <item>
@@ -64,6 +70,9 @@
      </property>
      <property name="wordWrap">
       <bool>true</bool>
+     </property>
+     <property name="buddy">
+      <cstring>useTitleFileNames</cstring>
      </property>
     </widget>
    </item>
@@ -110,6 +119,12 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>urls</tabstop>
+  <tabstop>useTitleFileNames</tabstop>
+  <tabstop>start</tabstop>
+  <tabstop>close</tabstop>
+ </tabstops>
  <resources>
   <include location="resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Debugger/AnalysisOptionsDialog.ui
+++ b/pcsx2-qt/Debugger/AnalysisOptionsDialog.ui
@@ -45,10 +45,10 @@
       </sizepolicy>
      </property>
      <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
+      <enum>QFrame::Shape::NoFrame</enum>
      </property>
      <property name="horizontalScrollBarPolicy">
-      <enum>Qt::ScrollBarAlwaysOff</enum>
+      <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
      </property>
      <property name="widgetResizable">
       <bool>true</bool>
@@ -80,7 +80,7 @@
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -108,6 +108,12 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>scrollArea</tabstop>
+  <tabstop>closeCheckBox</tabstop>
+  <tabstop>analyseButton</tabstop>
+  <tabstop>closeButton</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Debugger/Breakpoints/BreakpointDialog.ui
+++ b/pcsx2-qt/Debugger/Breakpoints/BreakpointDialog.ui
@@ -3,7 +3,7 @@
  <class>BreakpointDialog</class>
  <widget class="QDialog" name="BreakpointDialog">
   <property name="windowModality">
-   <enum>Qt::ApplicationModal</enum>
+   <enum>Qt::WindowModality::ApplicationModal</enum>
   </property>
   <property name="geometry">
    <rect>
@@ -56,10 +56,10 @@
     </sizepolicy>
    </property>
    <property name="orientation">
-    <enum>Qt::Horizontal</enum>
+    <enum>Qt::Orientation::Horizontal</enum>
    </property>
    <property name="standardButtons">
-    <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+    <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
    </property>
   </widget>
   <widget class="QGroupBox" name="grpType">
@@ -111,12 +111,15 @@
    </property>
    <layout class="QFormLayout" name="formLayout">
     <property name="formAlignment">
-     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
     </property>
     <item row="0" column="0">
      <widget class="QLabel" name="label">
       <property name="text">
        <string>Address</string>
+      </property>
+      <property name="buddy">
+       <cstring>txtAddress</cstring>
       </property>
      </widget>
     </item>
@@ -146,6 +149,9 @@
      <widget class="QLabel" name="label_4">
       <property name="text">
        <string>Description</string>
+      </property>
+      <property name="buddy">
+       <cstring>txtDescription</cstring>
       </property>
      </widget>
     </item>
@@ -221,6 +227,9 @@
         <property name="text">
          <string>Size</string>
         </property>
+        <property name="buddy">
+         <cstring>txtSize</cstring>
+        </property>
        </widget>
       </item>
       <item row="0" column="1">
@@ -263,6 +272,9 @@
      <widget class="QLabel" name="label_3">
       <property name="text">
        <string>Condition</string>
+      </property>
+      <property name="buddy">
+       <cstring>txtCondition</cstring>
       </property>
      </widget>
     </item>
@@ -310,6 +322,19 @@
    </layout>
   </widget>
  </widget>
+ <tabstops>
+  <tabstop>rdoMemory</tabstop>
+  <tabstop>rdoExecute</tabstop>
+  <tabstop>txtAddress</tabstop>
+  <tabstop>txtDescription</tabstop>
+  <tabstop>chkLog</tabstop>
+  <tabstop>chkEnable</tabstop>
+  <tabstop>chkRead</tabstop>
+  <tabstop>chkWrite</tabstop>
+  <tabstop>chkChange</tabstop>
+  <tabstop>txtSize</tabstop>
+  <tabstop>txtCondition</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/pcsx2-qt/Debugger/Docking/LayoutEditorDialog.ui
+++ b/pcsx2-qt/Debugger/Docking/LayoutEditorDialog.ui
@@ -21,6 +21,9 @@
        <property name="text">
         <string>Name</string>
        </property>
+       <property name="buddy">
+        <cstring>nameEditor</cstring>
+       </property>
       </widget>
      </item>
      <item row="1" column="0">
@@ -28,12 +31,18 @@
        <property name="text">
         <string>Target</string>
        </property>
+       <property name="buddy">
+        <cstring>cpuEditor</cstring>
+       </property>
       </widget>
      </item>
      <item row="2" column="0">
       <widget class="QLabel" name="initialStateLabel">
        <property name="text">
         <string>Initial State</string>
+       </property>
+       <property name="buddy">
+        <cstring>initialStateEditor</cstring>
        </property>
       </widget>
      </item>
@@ -66,10 +75,10 @@
      <item>
       <widget class="QDialogButtonBox" name="buttonBox">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="standardButtons">
-        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+        <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
        </property>
       </widget>
      </item>
@@ -77,6 +86,11 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>nameEditor</tabstop>
+  <tabstop>cpuEditor</tabstop>
+  <tabstop>initialStateEditor</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/pcsx2-qt/Debugger/Docking/NoLayoutsWidget.ui
+++ b/pcsx2-qt/Debugger/Docking/NoLayoutsWidget.ui
@@ -20,7 +20,7 @@
    <item>
     <spacer name="topSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -36,7 +36,10 @@
       <string>There are no layouts.</string>
      </property>
      <property name="alignment">
-      <set>Qt::AlignCenter</set>
+      <set>Qt::AlignmentFlag::AlignCenter</set>
+     </property>
+     <property name="buddy">
+      <cstring>createDefaultLayoutsButton</cstring>
      </property>
     </widget>
    </item>
@@ -45,7 +48,7 @@
      <item>
       <spacer name="leftSpacer">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -65,7 +68,7 @@
      <item>
       <spacer name="rightSpacer">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -80,7 +83,7 @@
    <item>
     <spacer name="bottomSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -92,6 +95,9 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>createDefaultLayoutsButton</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Debugger/Memory/MemorySearchView.ui
+++ b/pcsx2-qt/Debugger/Memory/MemorySearchView.ui
@@ -21,6 +21,9 @@
        <property name="text">
         <string>Value</string>
        </property>
+       <property name="buddy">
+        <cstring>txtSearchValue</cstring>
+       </property>
       </widget>
      </item>
      <item row="0" column="1">
@@ -30,6 +33,9 @@
       <widget class="QLabel" name="typeLabel">
        <property name="text">
         <string>Type</string>
+       </property>
+       <property name="buddy">
+        <cstring>cmbSearchType</cstring>
        </property>
       </widget>
      </item>
@@ -81,6 +87,9 @@
       <widget class="QLabel" name="hexLabel">
        <property name="text">
         <string>Hex</string>
+       </property>
+       <property name="buddy">
+        <cstring>chkSearchHex</cstring>
        </property>
       </widget>
      </item>
@@ -155,20 +164,26 @@
        <property name="text">
         <string>Comparison</string>
        </property>
+       <property name="buddy">
+        <cstring>cmbSearchComparison</cstring>
+       </property>
       </widget>
      </item>
     </layout>
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout_3">
-     <item row="0" column="0" alignment="Qt::AlignLeft">
+     <item row="0" column="0" alignment="Qt::AlignmentFlag::AlignLeft">
       <widget class="QLabel" name="startLabel">
        <property name="text">
         <string>Start</string>
        </property>
+       <property name="buddy">
+        <cstring>txtSearchStart</cstring>
+       </property>
       </widget>
      </item>
-     <item row="0" column="1" alignment="Qt::AlignLeft">
+     <item row="0" column="1" alignment="Qt::AlignmentFlag::AlignLeft">
       <widget class="QLineEdit" name="txtSearchStart">
        <property name="text">
         <string notr="true">0x00</string>
@@ -179,6 +194,9 @@
       <widget class="QLabel" name="endLabel">
        <property name="text">
         <string>End</string>
+       </property>
+       <property name="buddy">
+        <cstring>txtSearchEnd</cstring>
        </property>
       </widget>
      </item>
@@ -206,6 +224,17 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>txtSearchValue</tabstop>
+  <tabstop>cmbSearchComparison</tabstop>
+  <tabstop>cmbSearchType</tabstop>
+  <tabstop>chkSearchHex</tabstop>
+  <tabstop>txtSearchStart</tabstop>
+  <tabstop>txtSearchEnd</tabstop>
+  <tabstop>btnSearch</tabstop>
+  <tabstop>btnFilterSearch</tabstop>
+  <tabstop>listSearchResults</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/GameList/EmptyGameListWidget.ui
+++ b/pcsx2-qt/GameList/EmptyGameListWidget.ui
@@ -14,7 +14,7 @@
    <item>
     <spacer name="verticalSpacer_2">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -30,7 +30,7 @@
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;No games in supported formats were found.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please add a directory with games to begin.&lt;/p&gt;&lt;p&gt;Game dumps in the following formats will be scanned and listed:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="alignment">
-      <set>Qt::AlignCenter</set>
+      <set>Qt::AlignmentFlag::AlignCenter</set>
      </property>
     </widget>
    </item>
@@ -40,7 +40,7 @@
       <string notr="true">TextLabel</string>
      </property>
      <property name="alignment">
-      <set>Qt::AlignCenter</set>
+      <set>Qt::AlignmentFlag::AlignCenter</set>
      </property>
     </widget>
    </item>
@@ -49,7 +49,7 @@
      <item>
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -69,7 +69,7 @@
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -86,7 +86,7 @@
      <item>
       <spacer name="horizontalSpacer_3">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -106,7 +106,7 @@
      <item>
       <spacer name="horizontalSpacer_4">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -121,7 +121,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -133,6 +133,10 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>addGameDirectory</tabstop>
+  <tabstop>scanForNewGames</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/GameList/GameListWidget.ui
+++ b/pcsx2-qt/GameList/GameListWidget.ui
@@ -214,6 +214,15 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>viewGameList</tabstop>
+  <tabstop>viewGameGrid</tabstop>
+  <tabstop>viewGridTitles</tabstop>
+  <tabstop>gridScale</tabstop>
+  <tabstop>filterType</tabstop>
+  <tabstop>filterRegion</tabstop>
+  <tabstop>searchText</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/AchievementLoginDialog.ui
+++ b/pcsx2-qt/Settings/AchievementLoginDialog.ui
@@ -3,7 +3,7 @@
  <class>AchievementLoginDialog</class>
  <widget class="QDialog" name="AchievementLoginDialog">
   <property name="windowModality">
-   <enum>Qt::WindowModal</enum>
+   <enum>Qt::WindowModality::WindowModal</enum>
   </property>
   <property name="geometry">
    <rect>
@@ -44,7 +44,7 @@
         <string comment="Header text">RetroAchievements Login</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+        <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
        </property>
       </widget>
      </item>
@@ -63,7 +63,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -80,6 +80,9 @@
        <property name="text">
         <string>User Name:</string>
        </property>
+       <property name="buddy">
+        <cstring>userName</cstring>
+       </property>
       </widget>
      </item>
      <item row="0" column="1">
@@ -90,12 +93,15 @@
        <property name="text">
         <string>Password:</string>
        </property>
+       <property name="buddy">
+        <cstring>password</cstring>
+       </property>
       </widget>
      </item>
      <item row="1" column="1">
       <widget class="QLineEdit" name="password">
        <property name="echoMode">
-        <enum>QLineEdit::Password</enum>
+        <enum>QLineEdit::EchoMode::Password</enum>
        </property>
       </widget>
      </item>
@@ -113,7 +119,7 @@
      <item>
       <widget class="QDialogButtonBox" name="buttonBox">
        <property name="standardButtons">
-        <set>QDialogButtonBox::Cancel</set>
+        <set>QDialogButtonBox::StandardButton::Cancel</set>
        </property>
       </widget>
      </item>
@@ -121,6 +127,10 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>userName</tabstop>
+  <tabstop>password</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/AchievementSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AchievementSettingsWidget.ui
@@ -78,13 +78,13 @@
            <number>5</number>
           </property>
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="invertedAppearance">
            <bool>false</bool>
           </property>
           <property name="tickPosition">
-           <enum>QSlider::TicksBelow</enum>
+           <enum>QSlider::TickPosition::TicksBelow</enum>
           </property>
           <property name="tickInterval">
            <number>1</number>
@@ -124,13 +124,13 @@
            <number>5</number>
           </property>
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="invertedAppearance">
            <bool>false</bool>
           </property>
           <property name="tickPosition">
-           <enum>QSlider::TicksBelow</enum>
+           <enum>QSlider::TickPosition::TicksBelow</enum>
           </property>
           <property name="tickInterval">
            <number>1</number>
@@ -164,6 +164,9 @@
        <widget class="QLabel" name="notificationPositionLabel">
         <property name="text">
          <string>Notification Position:</string>
+        </property>
+        <property name="buddy">
+         <cstring>notificationPosition</cstring>
         </property>
        </widget>
       </item>
@@ -283,6 +286,9 @@
        <widget class="QLabel" name="overlayPositionLabel">
         <property name="text">
          <string>Overlay Position:</string>
+        </property>
+        <property name="buddy">
+         <cstring>overlayPosition</cstring>
         </property>
        </widget>
       </item>
@@ -418,7 +424,10 @@
 Login token generated at:</string>
         </property>
         <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+        </property>
+        <property name="buddy">
+         <cstring>viewProfile</cstring>
         </property>
        </widget>
       </item>
@@ -458,7 +467,7 @@ Login token generated at:</string>
       <item row="0" column="0">
        <widget class="QLabel" name="gameInfo">
         <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
         </property>
        </widget>
       </item>
@@ -471,7 +480,7 @@ Login token generated at:</string>
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;justify&quot;&gt;PCSX2 uses RetroAchievements as an achievement database and for tracking progress. To use achievements, please sign up for an account at &lt;a href=&quot;https://retroachievements.org/&quot;&gt;retroachievements.org&lt;/a&gt;.&lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;To view the achievement list in-game, press the hotkey for &lt;span style=&quot; font-weight:600;&quot;&gt;Open Pause Menu&lt;/span&gt; and select &lt;span style=&quot; font-weight:600;&quot;&gt;Achievements&lt;/span&gt; from the menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="textFormat">
-      <enum>Qt::RichText</enum>
+      <enum>Qt::TextFormat::RichText</enum>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -487,7 +496,7 @@ Login token generated at:</string>
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -499,6 +508,39 @@ Login token generated at:</string>
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>enable</tabstop>
+  <tabstop>hardcoreMode</tabstop>
+  <tabstop>encoreMode</tabstop>
+  <tabstop>spectatorMode</tabstop>
+  <tabstop>unofficialAchievements</tabstop>
+  <tabstop>achievementNotifications</tabstop>
+  <tabstop>achievementNotificationsDuration</tabstop>
+  <tabstop>leaderboardNotifications</tabstop>
+  <tabstop>leaderboardNotificationsDuration</tabstop>
+  <tabstop>soundEffects</tabstop>
+  <tabstop>notificationPosition</tabstop>
+  <tabstop>overlays</tabstop>
+  <tabstop>leaderboardOverlays</tabstop>
+  <tabstop>overlayPosition</tabstop>
+  <tabstop>notificationSound</tabstop>
+  <tabstop>notificationSoundPath</tabstop>
+  <tabstop>notificationSoundBrowse</tabstop>
+  <tabstop>notificationSoundOpen</tabstop>
+  <tabstop>notificationSoundReset</tabstop>
+  <tabstop>unlockSound</tabstop>
+  <tabstop>unlockSoundPath</tabstop>
+  <tabstop>unlockSoundBrowse</tabstop>
+  <tabstop>unlockSoundOpen</tabstop>
+  <tabstop>unlockSoundReset</tabstop>
+  <tabstop>lbSound</tabstop>
+  <tabstop>lbSoundPath</tabstop>
+  <tabstop>lbSoundBrowse</tabstop>
+  <tabstop>lbSoundOpen</tabstop>
+  <tabstop>lbSoundReset</tabstop>
+  <tabstop>viewProfile</tabstop>
+  <tabstop>loginButton</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/AdvancedSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AdvancedSettingsWidget.ui
@@ -32,6 +32,9 @@
         <property name="text">
          <string extracomment="Rounding refers here to the mathematical term.">Rounding Mode:</string>
         </property>
+        <property name="buddy">
+         <cstring>eeRoundingMode</cstring>
+        </property>
        </widget>
       </item>
       <item row="0" column="1">
@@ -63,6 +66,9 @@
         <property name="text">
          <string extracomment="Rounding refers here to the mathematical term.">Division Rounding Mode:</string>
         </property>
+        <property name="buddy">
+         <cstring>eeDivRoundingMode</cstring>
+        </property>
        </widget>
       </item>
       <item row="1" column="1">
@@ -93,6 +99,9 @@
        <widget class="QLabel" name="eeClampLabel">
         <property name="text">
          <string extracomment="Clamping: Forcing out of bounds things in bounds by changing them to the closest possible value.  In this case, this refers to clamping large PS2 floating point values (which map to infinity or NaN in PCs' IEEE754 floats) to non-infinite ones.">Clamping Mode:</string>
+        </property>
+        <property name="buddy">
+         <cstring>eeClampMode</cstring>
         </property>
        </widget>
       </item>
@@ -187,6 +196,9 @@
         <property name="text">
          <string>VU1 Rounding Mode:</string>
         </property>
+        <property name="buddy">
+         <cstring>vu1RoundingMode</cstring>
+        </property>
        </widget>
       </item>
       <item row="0" column="1">
@@ -274,6 +286,9 @@
         <property name="text">
          <string>VU0 Clamping Mode:</string>
         </property>
+        <property name="buddy">
+         <cstring>vu0ClampMode</cstring>
+        </property>
        </widget>
       </item>
       <item row="0" column="0">
@@ -281,12 +296,18 @@
         <property name="text">
          <string>VU0 Rounding Mode:</string>
         </property>
+        <property name="buddy">
+         <cstring>vu0RoundingMode</cstring>
+        </property>
        </widget>
       </item>
       <item row="3" column="0">
        <widget class="QLabel" name="vu1ClampLabel">
         <property name="text">
          <string>VU1 Clamping Mode:</string>
+        </property>
+        <property name="buddy">
+         <cstring>vu1ClampMode</cstring>
         </property>
        </widget>
       </item>
@@ -446,6 +467,9 @@
         <property name="text">
          <string>Compression Level:</string>
         </property>
+        <property name="buddy">
+         <cstring>savestateCompressionLevel</cstring>
+        </property>
        </widget>
       </item>
       <item row="3" column="0">
@@ -459,6 +483,9 @@
        <widget class="QLabel" name="savestateCompressionLabel">
         <property name="text">
          <string>Compression Method:</string>
+        </property>
+        <property name="buddy">
+         <cstring>savestateCompressionMethod</cstring>
         </property>
        </widget>
       </item>
@@ -499,6 +526,9 @@
         <property name="text">
          <string>Slot:</string>
         </property>
+        <property name="buddy">
+         <cstring>pineSlot</cstring>
+        </property>
        </widget>
       </item>
       <item row="0" column="0">
@@ -514,7 +544,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -526,6 +556,36 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>eeRoundingMode</tabstop>
+  <tabstop>eeDivRoundingMode</tabstop>
+  <tabstop>eeClampMode</tabstop>
+  <tabstop>eeRecompiler</tabstop>
+  <tabstop>eeCache</tabstop>
+  <tabstop>eeWaitLoopDetection</tabstop>
+  <tabstop>eeINTCSpinDetection</tabstop>
+  <tabstop>eeFastmem</tabstop>
+  <tabstop>pauseOnTLBMiss</tabstop>
+  <tabstop>extraMemory</tabstop>
+  <tabstop>vu0RoundingMode</tabstop>
+  <tabstop>vu0ClampMode</tabstop>
+  <tabstop>vu1RoundingMode</tabstop>
+  <tabstop>vu1ClampMode</tabstop>
+  <tabstop>vu0Recompiler</tabstop>
+  <tabstop>vu1Recompiler</tabstop>
+  <tabstop>vuFlagHack</tabstop>
+  <tabstop>instantVU1</tabstop>
+  <tabstop>iopRecompiler</tabstop>
+  <tabstop>gameFixes</tabstop>
+  <tabstop>patches</tabstop>
+  <tabstop>savestateCompressionMethod</tabstop>
+  <tabstop>savestateCompressionLevel</tabstop>
+  <tabstop>backupSaveStates</tabstop>
+  <tabstop>saveStateOnShutdown</tabstop>
+  <tabstop>savestateSelector</tabstop>
+  <tabstop>pineEnable</tabstop>
+  <tabstop>pineSlot</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/AudioExpansionSettingsDialog.ui
+++ b/pcsx2-qt/Settings/AudioExpansionSettingsDialog.ui
@@ -19,6 +19,9 @@
      <property name="text">
       <string>Circular Wrap:</string>
      </property>
+     <property name="buddy">
+      <cstring>circularWrap</cstring>
+     </property>
     </widget>
    </item>
    <item row="2" column="1">
@@ -58,6 +61,9 @@
     <widget class="QLabel" name="label_7">
      <property name="text">
       <string>Shift:</string>
+     </property>
+     <property name="buddy">
+      <cstring>shift</cstring>
      </property>
     </widget>
    </item>
@@ -99,6 +105,9 @@
      <property name="text">
       <string>Depth:</string>
      </property>
+     <property name="buddy">
+      <cstring>depth</cstring>
+     </property>
     </widget>
    </item>
    <item row="4" column="1">
@@ -138,6 +147,9 @@
     <widget class="QLabel" name="label">
      <property name="text">
       <string>Focus:</string>
+     </property>
+     <property name="buddy">
+      <cstring>focus</cstring>
      </property>
     </widget>
    </item>
@@ -179,6 +191,9 @@
      <property name="text">
       <string>Center Image:</string>
      </property>
+     <property name="buddy">
+      <cstring>centerImage</cstring>
+     </property>
     </widget>
    </item>
    <item row="6" column="1">
@@ -218,6 +233,9 @@
     <widget class="QLabel" name="label_3">
      <property name="text">
       <string>Front Separation:</string>
+     </property>
+     <property name="buddy">
+      <cstring>frontSeparation</cstring>
      </property>
     </widget>
    </item>
@@ -259,6 +277,9 @@
      <property name="text">
       <string>Rear Separation:</string>
      </property>
+     <property name="buddy">
+      <cstring>rearSeparation</cstring>
+     </property>
     </widget>
    </item>
    <item row="8" column="1">
@@ -299,6 +320,9 @@
      <property name="text">
       <string>Low Cutoff:</string>
      </property>
+     <property name="buddy">
+      <cstring>lowCutoff</cstring>
+     </property>
     </widget>
    </item>
    <item row="9" column="1">
@@ -338,6 +362,9 @@
     <widget class="QLabel" name="label_10">
      <property name="text">
       <string>High Cutoff:</string>
+     </property>
+     <property name="buddy">
+      <cstring>highCutoff</cstring>
      </property>
     </widget>
    </item>
@@ -428,6 +455,9 @@
      <property name="text">
       <string>Block Size:</string>
      </property>
+     <property name="buddy">
+      <cstring>blockSize</cstring>
+     </property>
     </widget>
    </item>
    <item row="1" column="1">
@@ -471,6 +501,18 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>blockSize</tabstop>
+  <tabstop>circularWrap</tabstop>
+  <tabstop>shift</tabstop>
+  <tabstop>depth</tabstop>
+  <tabstop>focus</tabstop>
+  <tabstop>centerImage</tabstop>
+  <tabstop>frontSeparation</tabstop>
+  <tabstop>rearSeparation</tabstop>
+  <tabstop>lowCutoff</tabstop>
+  <tabstop>highCutoff</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/AudioSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.ui
@@ -34,6 +34,9 @@
         <property name="text">
          <string>Driver:</string>
         </property>
+        <property name="buddy">
+         <cstring>driver</cstring>
+        </property>
        </widget>
       </item>
       <item row="1" column="1">
@@ -76,10 +79,10 @@
            <number>50</number>
           </property>
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="tickPosition">
-           <enum>QSlider::TicksBothSides</enum>
+           <enum>QSlider::TickPosition::TicksBothSides</enum>
           </property>
           <property name="tickInterval">
            <number>20</number>
@@ -117,6 +120,9 @@
         <property name="text">
          <string>Buffer Size:</string>
         </property>
+        <property name="buddy">
+         <cstring>bufferMS</cstring>
+        </property>
        </widget>
       </item>
       <item row="7" column="0" colspan="2">
@@ -125,7 +131,7 @@
          <string>Maximum latency: 0 frames (0.00ms)</string>
         </property>
         <property name="alignment">
-         <set>Qt::AlignCenter</set>
+         <set>Qt::AlignmentFlag::AlignCenter</set>
         </property>
        </widget>
       </item>
@@ -133,6 +139,9 @@
        <widget class="QLabel" name="label">
         <property name="text">
          <string>Backend:</string>
+        </property>
+        <property name="buddy">
+         <cstring>audioBackend</cstring>
         </property>
        </widget>
       </item>
@@ -147,10 +156,10 @@
            <number>200</number>
           </property>
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="tickPosition">
-           <enum>QSlider::TicksBothSides</enum>
+           <enum>QSlider::TickPosition::TicksBothSides</enum>
           </property>
           <property name="tickInterval">
            <number>20</number>
@@ -181,6 +190,9 @@
         <property name="text">
          <string>Output Latency:</string>
         </property>
+        <property name="buddy">
+         <cstring>outputLatencyMS</cstring>
+        </property>
        </widget>
       </item>
       <item row="2" column="1">
@@ -191,6 +203,9 @@
         <property name="text">
          <string>Output Device:</string>
         </property>
+        <property name="buddy">
+         <cstring>outputDevice</cstring>
+        </property>
        </widget>
       </item>
       <item row="3" column="0">
@@ -198,12 +213,18 @@
         <property name="text">
          <string>Expansion:</string>
         </property>
+        <property name="buddy">
+         <cstring>expansionMode</cstring>
+        </property>
        </widget>
       </item>
       <item row="4" column="0">
        <widget class="QLabel" name="label_7">
         <property name="text">
          <string>Synchronization:</string>
+        </property>
+        <property name="buddy">
+         <cstring>syncMode</cstring>
         </property>
        </widget>
       </item>
@@ -221,6 +242,9 @@
         <property name="text">
          <string>Standard Volume:</string>
         </property>
+        <property name="buddy">
+         <cstring>standardVolume</cstring>
+        </property>
        </widget>
       </item>
       <item row="0" column="1">
@@ -234,10 +258,10 @@
            <number>100</number>
           </property>
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="tickPosition">
-           <enum>QSlider::TicksBothSides</enum>
+           <enum>QSlider::TickPosition::TicksBothSides</enum>
           </property>
           <property name="tickInterval">
            <number>10</number>
@@ -256,7 +280,7 @@
            <string>100%</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignCenter</set>
+           <set>Qt::AlignmentFlag::AlignCenter</set>
           </property>
          </widget>
         </item>
@@ -283,10 +307,10 @@
            <number>100</number>
           </property>
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="tickPosition">
-           <enum>QSlider::TicksBothSides</enum>
+           <enum>QSlider::TickPosition::TicksBothSides</enum>
           </property>
           <property name="tickInterval">
            <number>10</number>
@@ -305,7 +329,7 @@
            <string>100%</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignCenter</set>
+           <set>Qt::AlignmentFlag::AlignCenter</set>
           </property>
          </widget>
         </item>
@@ -326,6 +350,9 @@
         <property name="text">
          <string>Fast Forward Volume:</string>
         </property>
+        <property name="buddy">
+         <cstring>fastForwardVolume</cstring>
+        </property>
        </widget>
       </item>
       <item row="2" column="0">
@@ -341,7 +368,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -353,6 +380,23 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>audioBackend</tabstop>
+  <tabstop>driver</tabstop>
+  <tabstop>outputDevice</tabstop>
+  <tabstop>expansionMode</tabstop>
+  <tabstop>expansionSettings</tabstop>
+  <tabstop>syncMode</tabstop>
+  <tabstop>stretchSettings</tabstop>
+  <tabstop>bufferMS</tabstop>
+  <tabstop>outputLatencyMS</tabstop>
+  <tabstop>outputLatencyMinimal</tabstop>
+  <tabstop>standardVolume</tabstop>
+  <tabstop>resetStandardVolume</tabstop>
+  <tabstop>fastForwardVolume</tabstop>
+  <tabstop>resetFastForwardVolume</tabstop>
+  <tabstop>muted</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/AudioStretchSettingsDialog.ui
+++ b/pcsx2-qt/Settings/AudioStretchSettingsDialog.ui
@@ -19,6 +19,9 @@
      <property name="text">
       <string>Sequence Length:</string>
      </property>
+     <property name="buddy">
+      <cstring>sequenceLength</cstring>
+     </property>
     </widget>
    </item>
    <item row="1" column="1">
@@ -59,6 +62,9 @@
      <property name="text">
       <string>Seekwindow Size:</string>
      </property>
+     <property name="buddy">
+      <cstring>seekWindowSize</cstring>
+     </property>
     </widget>
    </item>
    <item row="2" column="1">
@@ -98,6 +104,9 @@
     <widget class="QLabel" name="label_8">
      <property name="text">
       <string>Overlap:</string>
+     </property>
+     <property name="buddy">
+      <cstring>overlap</cstring>
      </property>
     </widget>
    </item>
@@ -199,6 +208,13 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>sequenceLength</tabstop>
+  <tabstop>seekWindowSize</tabstop>
+  <tabstop>overlap</tabstop>
+  <tabstop>useQuickSeek</tabstop>
+  <tabstop>useAAFilter</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/BIOSSettingsWidget.ui
+++ b/pcsx2-qt/Settings/BIOSSettingsWidget.ui
@@ -37,6 +37,9 @@
         <property name="wordWrap">
          <bool>true</bool>
         </property>
+        <property name="buddy">
+         <cstring>searchDirectory</cstring>
+        </property>
        </widget>
       </item>
       <item row="1" column="0" colspan="2">
@@ -74,7 +77,7 @@
         <item>
          <spacer name="horizontalSpacer">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -156,7 +159,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -168,6 +171,16 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>searchDirectory</tabstop>
+  <tabstop>browseSearchDirectory</tabstop>
+  <tabstop>resetSearchDirectory</tabstop>
+  <tabstop>fileList</tabstop>
+  <tabstop>openSearchDirectory</tabstop>
+  <tabstop>refresh</tabstop>
+  <tabstop>fastBoot</tabstop>
+  <tabstop>fastBootFastForward</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/ControllerBindingWidget_DualShock2.ui
+++ b/pcsx2-qt/Settings/ControllerBindingWidget_DualShock2.ui
@@ -418,7 +418,7 @@
      <item>
       <spacer name="verticalSpacer_5">
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -1021,7 +1021,7 @@
      <item>
       <spacer name="verticalSpacer_4">
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -1038,7 +1038,7 @@
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -1076,7 +1076,7 @@
      <item>
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -1093,7 +1093,7 @@
      <item row="2" column="0" colspan="4">
       <spacer name="verticalSpacer">
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -1255,6 +1255,36 @@
    <header>Settings/InputBindingWidget.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>Up</tabstop>
+  <tabstop>Down</tabstop>
+  <tabstop>Left</tabstop>
+  <tabstop>Right</tabstop>
+  <tabstop>Triangle</tabstop>
+  <tabstop>Cross</tabstop>
+  <tabstop>Square</tabstop>
+  <tabstop>Circle</tabstop>
+  <tabstop>L1</tabstop>
+  <tabstop>L2</tabstop>
+  <tabstop>R1</tabstop>
+  <tabstop>R2</tabstop>
+  <tabstop>LUp</tabstop>
+  <tabstop>LDown</tabstop>
+  <tabstop>LLeft</tabstop>
+  <tabstop>LRight</tabstop>
+  <tabstop>L3</tabstop>
+  <tabstop>RUp</tabstop>
+  <tabstop>RDown</tabstop>
+  <tabstop>RLeft</tabstop>
+  <tabstop>RRight</tabstop>
+  <tabstop>R3</tabstop>
+  <tabstop>Select</tabstop>
+  <tabstop>Start</tabstop>
+  <tabstop>Analog</tabstop>
+  <tabstop>LargeMotor</tabstop>
+  <tabstop>SmallMotor</tabstop>
+  <tabstop>Pressure</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/ControllerBindingWidget_Guitar.ui
+++ b/pcsx2-qt/Settings/ControllerBindingWidget_Guitar.ui
@@ -23,7 +23,7 @@
     <item>
      <spacer name="horizontalSpacer">
       <property name="orientation">
-       <enum>Qt::Horizontal</enum>
+       <enum>Qt::Orientation::Horizontal</enum>
       </property>
       <property name="sizeHint" stdset="0">
        <size>
@@ -55,7 +55,7 @@
     <item>
      <spacer name="horizontalSpacer_2">
       <property name="orientation">
-       <enum>Qt::Horizontal</enum>
+       <enum>Qt::Orientation::Horizontal</enum>
       </property>
       <property name="sizeHint" stdset="0">
        <size>
@@ -307,6 +307,19 @@
    <header>Settings/InputBindingWidget.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>Start</tabstop>
+  <tabstop>Select</tabstop>
+  <tabstop>Up</tabstop>
+  <tabstop>Down</tabstop>
+  <tabstop>Orange</tabstop>
+  <tabstop>Blue</tabstop>
+  <tabstop>Yellow</tabstop>
+  <tabstop>Red</tabstop>
+  <tabstop>Green</tabstop>
+  <tabstop>Whammy</tabstop>
+  <tabstop>Tilt</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/ControllerBindingWidget_Jogcon.ui
+++ b/pcsx2-qt/Settings/ControllerBindingWidget_Jogcon.ui
@@ -249,7 +249,7 @@
      <item>
       <spacer name="verticalSpacer_5">
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -683,7 +683,7 @@
      <item>
       <spacer name="verticalSpacer_4">
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -700,7 +700,7 @@
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -738,7 +738,7 @@
      <item>
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -799,7 +799,7 @@
      <item row="1" column="0" colspan="4">
       <spacer name="verticalSpacer">
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -825,6 +825,26 @@
    <header>Settings/InputBindingWidget.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>Up</tabstop>
+  <tabstop>Down</tabstop>
+  <tabstop>Left</tabstop>
+  <tabstop>Right</tabstop>
+  <tabstop>Triangle</tabstop>
+  <tabstop>Cross</tabstop>
+  <tabstop>Square</tabstop>
+  <tabstop>Circle</tabstop>
+  <tabstop>L1</tabstop>
+  <tabstop>L2</tabstop>
+  <tabstop>R1</tabstop>
+  <tabstop>R2</tabstop>
+  <tabstop>DialLeft</tabstop>
+  <tabstop>DialRight</tabstop>
+  <tabstop>Select</tabstop>
+  <tabstop>Start</tabstop>
+  <tabstop>LargeMotor</tabstop>
+  <tabstop>SmallMotor</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/ControllerBindingWidget_Negcon.ui
+++ b/pcsx2-qt/Settings/ControllerBindingWidget_Negcon.ui
@@ -249,7 +249,7 @@
      <item>
       <spacer name="verticalSpacer_5">
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -581,7 +581,7 @@
      <item>
       <spacer name="verticalSpacer_4">
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -598,7 +598,7 @@
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -636,7 +636,7 @@
      <item>
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -697,7 +697,7 @@
      <item row="1" column="0" colspan="4">
       <spacer name="verticalSpacer">
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -723,6 +723,23 @@
    <header>Settings/InputBindingWidget.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>Up</tabstop>
+  <tabstop>Down</tabstop>
+  <tabstop>Left</tabstop>
+  <tabstop>Right</tabstop>
+  <tabstop>I</tabstop>
+  <tabstop>II</tabstop>
+  <tabstop>A</tabstop>
+  <tabstop>B</tabstop>
+  <tabstop>L</tabstop>
+  <tabstop>R</tabstop>
+  <tabstop>TwistLeft</tabstop>
+  <tabstop>TwistRight</tabstop>
+  <tabstop>Start</tabstop>
+  <tabstop>LargeMotor</tabstop>
+  <tabstop>SmallMotor</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/ControllerBindingWidget_Popn.ui
+++ b/pcsx2-qt/Settings/ControllerBindingWidget_Popn.ui
@@ -43,7 +43,7 @@
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -81,7 +81,7 @@
      <item>
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -343,7 +343,7 @@
      <item row="1" column="0" colspan="5">
       <spacer name="verticalSpacer">
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -524,6 +524,19 @@
    <header>Settings/InputBindingWidget.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>Select</tabstop>
+  <tabstop>Start</tabstop>
+  <tabstop>YellowL</tabstop>
+  <tabstop>BlueL</tabstop>
+  <tabstop>BlueR</tabstop>
+  <tabstop>YellowR</tabstop>
+  <tabstop>WhiteL</tabstop>
+  <tabstop>GreenL</tabstop>
+  <tabstop>Red</tabstop>
+  <tabstop>GreenR</tabstop>
+  <tabstop>WhiteR</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.ui
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.ui
@@ -26,7 +26,7 @@
    <item row="7" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -159,8 +159,7 @@
            <string>Controller LED Settings</string>
           </property>
           <property name="icon">
-           <iconset theme="lightbulb-line">
-            <normaloff>.</normaloff>.</iconset>
+           <iconset theme="lightbulb-line"/>
           </property>
          </widget>
         </item>
@@ -283,6 +282,22 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>enableSDLSource</tabstop>
+  <tabstop>enableSDLEnhancedMode</tabstop>
+  <tabstop>ledSettings</tabstop>
+  <tabstop>enableSDLRawInput</tabstop>
+  <tabstop>enableSDLIOKitDriver</tabstop>
+  <tabstop>enableSDLMFIDriver</tabstop>
+  <tabstop>enableXInputSource</tabstop>
+  <tabstop>enableDInputSource</tabstop>
+  <tabstop>enableMouseMapping</tabstop>
+  <tabstop>mouseSettings</tabstop>
+  <tabstop>multitapPort1</tabstop>
+  <tabstop>multitapPort2</tabstop>
+  <tabstop>useProfileHotkeyBindings</tabstop>
+  <tabstop>deviceList</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/ControllerLEDSettingsDialog.ui
+++ b/pcsx2-qt/Settings/ControllerLEDSettingsDialog.ui
@@ -65,7 +65,7 @@
    <item row="3" column="0" colspan="4">
     <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0">
      <property name="sizeConstraint">
-      <enum>QLayout::SetDefaultConstraint</enum>
+      <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
      </property>
      <property name="bottomMargin">
       <number>0</number>
@@ -92,7 +92,7 @@
         </sizepolicy>
        </property>
        <property name="standardButtons">
-        <set>QDialogButtonBox::Close</set>
+        <set>QDialogButtonBox::StandardButton::Close</set>
        </property>
       </widget>
      </item>
@@ -107,6 +107,13 @@
    <header>ColorPickerButton.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>SDL0LED</tabstop>
+  <tabstop>SDL1LED</tabstop>
+  <tabstop>SDL2LED</tabstop>
+  <tabstop>SDL3LED</tabstop>
+  <tabstop>enableSDLPS5PlayerLED</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/ControllerMappingSettingsDialog.ui
+++ b/pcsx2-qt/Settings/ControllerMappingSettingsDialog.ui
@@ -38,10 +38,10 @@
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Controller Mapping Settings&lt;/span&gt;&lt;br/&gt;These settings fine-tune the behavior when mapping physical controllers to the emulated controllers.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="textFormat">
-        <enum>Qt::RichText</enum>
+        <enum>Qt::TextFormat::RichText</enum>
        </property>
        <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+        <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
@@ -71,6 +71,9 @@
         <property name="wordWrap">
          <bool>true</bool>
         </property>
+        <property name="buddy">
+         <cstring>ignoreInversion</cstring>
+        </property>
        </widget>
       </item>
      </layout>
@@ -79,7 +82,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -92,12 +95,15 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
+      <set>QDialogButtonBox::StandardButton::Close</set>
      </property>
     </widget>
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>ignoreInversion</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/ControllerMouseSettingsDialog.ui
+++ b/pcsx2-qt/Settings/ControllerMouseSettingsDialog.ui
@@ -17,7 +17,7 @@
    <item row="5" column="1">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
+      <set>QDialogButtonBox::StandardButton::Close</set>
      </property>
     </widget>
    </item>
@@ -39,6 +39,9 @@
        </property>
        <property name="text">
         <string>Y Speed</string>
+       </property>
+       <property name="buddy">
+        <cstring>pointerYSpeedSlider</cstring>
        </property>
       </widget>
      </item>
@@ -63,7 +66,7 @@
         <number>100</number>
        </property>
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
       </widget>
      </item>
@@ -107,6 +110,9 @@
        <property name="text">
         <string>X Speed</string>
        </property>
+       <property name="buddy">
+        <cstring>pointerXSpeedSlider</cstring>
+       </property>
       </widget>
      </item>
      <item>
@@ -130,7 +136,7 @@
         <number>100</number>
        </property>
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
       </widget>
      </item>
@@ -182,10 +188,10 @@
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Mouse Mapping Settings&lt;/span&gt;&lt;br/&gt;These settings fine-tune the behavior when mapping a mouse to the emulated controller.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="textFormat">
-        <enum>Qt::RichText</enum>
+        <enum>Qt::TextFormat::RichText</enum>
        </property>
        <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+        <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
@@ -197,7 +203,7 @@
    <item row="4" column="0" colspan="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -226,6 +232,9 @@
        <property name="text">
         <string>Inertia</string>
        </property>
+       <property name="buddy">
+        <cstring>pointerInertiaSlider</cstring>
+       </property>
       </widget>
      </item>
      <item>
@@ -249,7 +258,7 @@
         <number>100</number>
        </property>
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
       </widget>
      </item>
@@ -293,6 +302,9 @@
        <property name="text">
         <string>X Dead Zone</string>
        </property>
+       <property name="buddy">
+        <cstring>pointerXDeadZoneSlider</cstring>
+       </property>
       </widget>
      </item>
      <item>
@@ -316,7 +328,7 @@
         <number>100</number>
        </property>
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
       </widget>
      </item>
@@ -360,6 +372,9 @@
        <property name="text">
         <string>Y Dead Zone</string>
        </property>
+       <property name="buddy">
+        <cstring>pointerYDeadZoneSlider</cstring>
+       </property>
       </widget>
      </item>
      <item>
@@ -383,7 +398,7 @@
         <number>100</number>
        </property>
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
       </widget>
      </item>
@@ -410,6 +425,13 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>pointerXSpeedSlider</tabstop>
+  <tabstop>pointerXDeadZoneSlider</tabstop>
+  <tabstop>pointerYSpeedSlider</tabstop>
+  <tabstop>pointerYDeadZoneSlider</tabstop>
+  <tabstop>pointerInertiaSlider</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/DEV9DnsHostDialog.ui
+++ b/pcsx2-qt/Settings/DEV9DnsHostDialog.ui
@@ -19,6 +19,9 @@
      <property name="text">
       <string>Select Hosts</string>
      </property>
+     <property name="buddy">
+      <cstring>hostList</cstring>
+     </property>
     </widget>
    </item>
    <item>
@@ -36,7 +39,7 @@
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -64,6 +67,11 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>hostList</tabstop>
+  <tabstop>btnOK</tabstop>
+  <tabstop>btnCancel</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.ui
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.ui
@@ -37,12 +37,18 @@
         <property name="text">
          <string>Ethernet Device:</string>
         </property>
+        <property name="buddy">
+         <cstring>ethDev</cstring>
+        </property>
        </widget>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="ethDevTypeLabel">
         <property name="text">
          <string>Ethernet Device Type:</string>
+        </property>
+        <property name="buddy">
+         <cstring>ethDevType</cstring>
         </property>
        </widget>
       </item>
@@ -84,12 +90,18 @@
             <property name="text">
              <string>Subnet Mask:</string>
             </property>
+            <property name="buddy">
+             <cstring>ethNetMask</cstring>
+            </property>
            </widget>
           </item>
           <item row="3" column="0">
            <widget class="QLabel" name="ethGatewayAddrLabel">
             <property name="text">
              <string>Gateway Address:</string>
+            </property>
+            <property name="buddy">
+             <cstring>ethGatewayAddr</cstring>
             </property>
            </widget>
           </item>
@@ -104,6 +116,9 @@
            <widget class="QLabel" name="ethInterceptDHCPLabel">
             <property name="text">
              <string>Intercept DHCP:</string>
+            </property>
+            <property name="buddy">
+             <cstring>ethInterceptDHCP</cstring>
             </property>
            </widget>
           </item>
@@ -126,6 +141,9 @@
             <property name="text">
              <string>PS2 Address:</string>
             </property>
+            <property name="buddy">
+             <cstring>ethPS2Addr</cstring>
+            </property>
            </widget>
           </item>
           <item row="3" column="1">
@@ -140,6 +158,9 @@
             <property name="text">
              <string>DNS1 Address:</string>
             </property>
+            <property name="buddy">
+             <cstring>ethDNS1Addr</cstring>
+            </property>
            </widget>
           </item>
           <item row="4" column="1">
@@ -153,6 +174,9 @@
            <widget class="QLabel" name="ethDNS2AddrLabel">
             <property name="text">
              <string>DNS2 Address:</string>
+            </property>
+            <property name="buddy">
+             <cstring>ethDNS2Addr</cstring>
             </property>
            </widget>
           </item>
@@ -213,7 +237,7 @@
             <item>
              <spacer name="verticalSpacer_2">
               <property name="orientation">
-               <enum>Qt::Vertical</enum>
+               <enum>Qt::Orientation::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -230,12 +254,15 @@
             <property name="text">
              <string>Internal DNS can be selected using the DNS1/2 dropdowns, or by setting them to 192.0.2.1</string>
             </property>
+            <property name="buddy">
+             <cstring>ethHosts</cstring>
+            </property>
            </widget>
           </item>
           <item row="1" column="0">
            <widget class="QTableView" name="ethHosts">
             <property name="selectionMode">
-             <enum>QAbstractItemView::SingleSelection</enum>
+             <enum>QAbstractItemView::SelectionMode::SingleSelection</enum>
             </property>
             <property name="sortingEnabled">
              <bool>true</bool>
@@ -326,10 +353,10 @@
            <number>1</number>
           </property>
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="tickPosition">
-           <enum>QSlider::TicksBelow</enum>
+           <enum>QSlider::TickPosition::TicksBelow</enum>
           </property>
           <property name="tickInterval">
            <number>5</number>
@@ -360,12 +387,18 @@
         <property name="text">
          <string>HDD File:</string>
         </property>
+        <property name="buddy">
+         <cstring>hddFile</cstring>
+        </property>
        </widget>
       </item>
       <item row="2" column="0">
        <widget class="QLabel" name="hddSizeLabel">
         <property name="text">
          <string>HDD Size (GiB):</string>
+        </property>
+        <property name="buddy">
+         <cstring>hddSizeSlider</cstring>
         </property>
        </widget>
       </item>
@@ -382,7 +415,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -394,6 +427,35 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>ethEnabled</tabstop>
+  <tabstop>ethDevType</tabstop>
+  <tabstop>ethDev</tabstop>
+  <tabstop>ethTabWidget</tabstop>
+  <tabstop>ethInterceptDHCP</tabstop>
+  <tabstop>ethPS2Addr</tabstop>
+  <tabstop>ethNetMask</tabstop>
+  <tabstop>ethNetMaskAuto</tabstop>
+  <tabstop>ethGatewayAddr</tabstop>
+  <tabstop>ethGatewayAuto</tabstop>
+  <tabstop>ethDNS1Addr</tabstop>
+  <tabstop>ethDNS1Mode</tabstop>
+  <tabstop>ethDNS2Addr</tabstop>
+  <tabstop>ethDNS2Mode</tabstop>
+  <tabstop>ethHostAdd</tabstop>
+  <tabstop>ethHostDel</tabstop>
+  <tabstop>ethHostExport</tabstop>
+  <tabstop>ethHostImport</tabstop>
+  <tabstop>ethHostPerGame</tabstop>
+  <tabstop>ethHosts</tabstop>
+  <tabstop>hddEnabled</tabstop>
+  <tabstop>hddLBA48</tabstop>
+  <tabstop>hddFile</tabstop>
+  <tabstop>hddBrowseFile</tabstop>
+  <tabstop>hddSizeSlider</tabstop>
+  <tabstop>hddSizeSpinBox</tabstop>
+  <tabstop>hddCreate</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/DebugAnalysisSettingsTab.ui
+++ b/pcsx2-qt/Settings/DebugAnalysisSettingsTab.ui
@@ -49,6 +49,9 @@
           <property name="text">
            <string>Automatically Analyze Program:</string>
           </property>
+          <property name="buddy">
+           <cstring>analysisCondition</cstring>
+          </property>
          </widget>
         </item>
         <item row="0" column="1">
@@ -94,6 +97,10 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>analysisCondition</tabstop>
+  <tabstop>generateSymbolsForIRXExportTables</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/DebugAnalysisSettingsWidget.ui
+++ b/pcsx2-qt/Settings/DebugAnalysisSettingsWidget.ui
@@ -86,7 +86,7 @@
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="alignment">
-         <set>Qt::AlignCenter</set>
+         <set>Qt::AlignmentFlag::AlignCenter</set>
         </property>
        </widget>
       </item>
@@ -168,6 +168,9 @@
         <property name="text">
          <string>Import from file (.elf, .sym, etc):</string>
         </property>
+        <property name="buddy">
+         <cstring>symbolFileTable</cstring>
+        </property>
        </widget>
       </item>
       <item>
@@ -188,10 +191,10 @@
          <bool>true</bool>
         </property>
         <property name="selectionBehavior">
-         <enum>QAbstractItemView::SelectRows</enum>
+         <enum>QAbstractItemView::SelectionBehavior::SelectRows</enum>
         </property>
         <property name="textElideMode">
-         <enum>Qt::ElideLeft</enum>
+         <enum>Qt::TextElideMode::ElideLeft</enum>
         </property>
         <property name="wordWrap">
          <bool>false</bool>
@@ -231,7 +234,7 @@
          <item>
           <spacer name="importSymbolFileSpacer">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -279,6 +282,9 @@
          <widget class="QLabel" name="functionScanLabel">
           <property name="text">
            <string>Scan Mode:</string>
+          </property>
+          <property name="buddy">
+           <cstring>functionScanMode</cstring>
           </property>
          </widget>
         </item>
@@ -328,10 +334,10 @@
          <item>
           <spacer name="startSpacer">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeType">
-            <enum>QSizePolicy::Maximum</enum>
+            <enum>QSizePolicy::Policy::Maximum</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -346,6 +352,9 @@
            <property name="text">
             <string>Start:</string>
            </property>
+           <property name="buddy">
+            <cstring>addressRangeStart</cstring>
+           </property>
           </widget>
          </item>
          <item>
@@ -356,6 +365,9 @@
            <property name="text">
             <string>End:</string>
            </property>
+           <property name="buddy">
+            <cstring>addressRangeEnd</cstring>
+           </property>
           </widget>
          </item>
          <item>
@@ -364,10 +376,10 @@
          <item>
           <spacer name="endSpacer">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeType">
-            <enum>QSizePolicy::Maximum</enum>
+            <enum>QSizePolicy::Policy::Maximum</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -408,7 +420,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -420,6 +432,22 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>automaticallyClearSymbols</tabstop>
+  <tabstop>symbolSourceScrollArea</tabstop>
+  <tabstop>importFromElf</tabstop>
+  <tabstop>importSymFileFromDefaultLocation</tabstop>
+  <tabstop>demangleSymbols</tabstop>
+  <tabstop>demangleParameters</tabstop>
+  <tabstop>symbolFileTable</tabstop>
+  <tabstop>addSymbolFile</tabstop>
+  <tabstop>removeSymbolFile</tabstop>
+  <tabstop>functionScanMode</tabstop>
+  <tabstop>customAddressRange</tabstop>
+  <tabstop>addressRangeStart</tabstop>
+  <tabstop>addressRangeEnd</tabstop>
+  <tabstop>grayOutOverwrittenFunctions</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/DebugGSSettingsTab.ui
+++ b/pcsx2-qt/Settings/DebugGSSettingsTab.ui
@@ -85,6 +85,9 @@
         <property name="text">
          <string>Save Draw Start:</string>
         </property>
+        <property name="buddy">
+         <cstring>saveDrawStart</cstring>
+        </property>
        </widget>
       </item>
       <item row="1" column="1">
@@ -98,6 +101,9 @@
        <widget class="QLabel" name="label_2">
         <property name="text">
          <string>Save Draw Count:</string>
+        </property>
+        <property name="buddy">
+         <cstring>saveDrawCount</cstring>
         </property>
        </widget>
       </item>
@@ -116,6 +122,9 @@
         <property name="text">
          <string>Save Frame Start:</string>
         </property>
+        <property name="buddy">
+         <cstring>saveFrameStart</cstring>
+        </property>
        </widget>
       </item>
       <item row="3" column="1">
@@ -129,6 +138,9 @@
        <widget class="QLabel" name="label_4">
         <property name="text">
          <string>Save Frame Count:</string>
+        </property>
+        <property name="buddy">
+         <cstring>saveFrameCount</cstring>
         </property>
        </widget>
       </item>
@@ -147,12 +159,18 @@
         <property name="text">
          <string>Hardware Dump Directory:</string>
         </property>
+        <property name="buddy">
+         <cstring>hwDumpDirectory</cstring>
+        </property>
        </widget>
       </item>
       <item row="6" column="0">
        <widget class="QLabel" name="label_6">
         <property name="text">
          <string>Software Dump Directory:</string>
+        </property>
+        <property name="buddy">
+         <cstring>swDumpDirectory</cstring>
         </property>
        </widget>
       </item>
@@ -204,7 +222,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -216,6 +234,26 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>dumpGSData</tabstop>
+  <tabstop>saveFrame</tabstop>
+  <tabstop>saveRT</tabstop>
+  <tabstop>saveDepth</tabstop>
+  <tabstop>saveTexture</tabstop>
+  <tabstop>saveAlpha</tabstop>
+  <tabstop>saveInfo</tabstop>
+  <tabstop>saveTransferImages</tabstop>
+  <tabstop>saveDrawStart</tabstop>
+  <tabstop>saveDrawCount</tabstop>
+  <tabstop>saveFrameStart</tabstop>
+  <tabstop>saveFrameCount</tabstop>
+  <tabstop>hwDumpDirectory</tabstop>
+  <tabstop>hwDumpBrowse</tabstop>
+  <tabstop>hwDumpOpen</tabstop>
+  <tabstop>swDumpDirectory</tabstop>
+  <tabstop>swDumpBrowse</tabstop>
+  <tabstop>swDumpOpen</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/DebugLoggingSettingsTab.ui
+++ b/pcsx2-qt/Settings/DebugLoggingSettingsTab.ui
@@ -176,7 +176,7 @@
         <item>
          <spacer name="eeLoggingSpacer">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -286,7 +286,7 @@
         <item>
          <spacer name="iopLoggingSpacer">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -304,7 +304,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -316,6 +316,41 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>chkEnable</tabstop>
+  <tabstop>chkEECOP0</tabstop>
+  <tabstop>chkEECOP1</tabstop>
+  <tabstop>chkEECOP2</tabstop>
+  <tabstop>chkEER5900</tabstop>
+  <tabstop>chkEECache</tabstop>
+  <tabstop>chkEEMemory</tabstop>
+  <tabstop>chkEEMMIO</tabstop>
+  <tabstop>chkEEUNKNWNMMIO</tabstop>
+  <tabstop>chkEEDMARegs</tabstop>
+  <tabstop>chkEEDMACTRL</tabstop>
+  <tabstop>chkEEMSKPATH3</tabstop>
+  <tabstop>chkEEMFIFO</tabstop>
+  <tabstop>chkEEIPU</tabstop>
+  <tabstop>chkEECounters</tabstop>
+  <tabstop>chkEEVIFCodes</tabstop>
+  <tabstop>chkEEGIFTags</tabstop>
+  <tabstop>chkEEVIF</tabstop>
+  <tabstop>chkEEGIF</tabstop>
+  <tabstop>chkEEBIOS</tabstop>
+  <tabstop>chkEESIF</tabstop>
+  <tabstop>chkIOPCOP2</tabstop>
+  <tabstop>chkIOPR3000A</tabstop>
+  <tabstop>chkIOPMemcards</tabstop>
+  <tabstop>chkIOPPad</tabstop>
+  <tabstop>chkIOPDMARegs</tabstop>
+  <tabstop>chkIOPDMACTRL</tabstop>
+  <tabstop>chkIOPMMIO</tabstop>
+  <tabstop>chkIOPUNKNWNMMIO</tabstop>
+  <tabstop>chkIOPCounters</tabstop>
+  <tabstop>chkIOPCDVD</tabstop>
+  <tabstop>chkIOPMDEC</tabstop>
+  <tabstop>chkIOPBIOS</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/DebugUserInterfaceSettingsTab.ui
+++ b/pcsx2-qt/Settings/DebugUserInterfaceSettingsTab.ui
@@ -51,6 +51,9 @@
         <property name="text">
          <string>Refresh Interval:</string>
         </property>
+        <property name="buddy">
+         <cstring>refreshInterval</cstring>
+        </property>
        </widget>
       </item>
       <item row="0" column="1">
@@ -89,6 +92,9 @@
         <property name="text">
          <string>Drop Indicator Style:</string>
         </property>
+        <property name="buddy">
+         <cstring>dropIndicator</cstring>
+        </property>
        </widget>
       </item>
       <item row="0" column="1">
@@ -100,7 +106,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -112,6 +118,12 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>refreshInterval</tabstop>
+  <tabstop>showOnStartup</tabstop>
+  <tabstop>saveWindowGeometry</tabstop>
+  <tabstop>dropIndicator</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/EmulationSettingsWidget.ui
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.ui
@@ -22,6 +22,9 @@
         <property name="text">
          <string>Slow-Motion Speed:</string>
         </property>
+        <property name="buddy">
+         <cstring>slowMotionSpeed</cstring>
+        </property>
        </widget>
       </item>
       <item row="1" column="1">
@@ -35,12 +38,18 @@
         <property name="text">
          <string>Normal Speed:</string>
         </property>
+        <property name="buddy">
+         <cstring>normalSpeed</cstring>
+        </property>
        </widget>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_5">
         <property name="text">
          <string>Fast-Forward Speed:</string>
+        </property>
+        <property name="buddy">
+         <cstring>fastForwardSpeed</cstring>
         </property>
        </widget>
       </item>
@@ -170,12 +179,18 @@
         <property name="text">
          <string>EE Cycle Rate:</string>
         </property>
+        <property name="buddy">
+         <cstring>eeCycleRate</cstring>
+        </property>
        </widget>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_10">
         <property name="text">
          <string>EE Cycle Skipping:</string>
+        </property>
+        <property name="buddy">
+         <cstring>eeCycleSkipping</cstring>
         </property>
        </widget>
       </item>
@@ -205,6 +220,9 @@
        <widget class="QLabel" name="label_2">
         <property name="text">
          <string>Maximum Frame Latency:</string>
+        </property>
+        <property name="buddy">
+         <cstring>maxFrameLatency</cstring>
         </property>
        </widget>
       </item>
@@ -272,7 +290,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -284,6 +302,27 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>normalSpeed</tabstop>
+  <tabstop>fastForwardSpeed</tabstop>
+  <tabstop>slowMotionSpeed</tabstop>
+  <tabstop>eeCycleRate</tabstop>
+  <tabstop>eeCycleSkipping</tabstop>
+  <tabstop>MTVU</tabstop>
+  <tabstop>threadPinning</tabstop>
+  <tabstop>cheats</tabstop>
+  <tabstop>hostFilesystem</tabstop>
+  <tabstop>precacheCDVD</tabstop>
+  <tabstop>fastCDVD</tabstop>
+  <tabstop>maxFrameLatency</tabstop>
+  <tabstop>optimalFramePacing</tabstop>
+  <tabstop>syncToHostRefreshRate</tabstop>
+  <tabstop>vsync</tabstop>
+  <tabstop>useVSyncForTiming</tabstop>
+  <tabstop>skipPresentingDuplicateFrames</tabstop>
+  <tabstop>manuallySetRealTimeClock</tabstop>
+  <tabstop>rtcDateTime</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/FolderSettingsWidget.ui
+++ b/pcsx2-qt/Settings/FolderSettingsWidget.ui
@@ -46,6 +46,9 @@
         <property name="text">
          <string>Used for storing shaders, game list, and achievement data.</string>
         </property>
+        <property name="buddy">
+         <cstring>cache</cstring>
+        </property>
        </widget>
       </item>
      </layout>
@@ -85,6 +88,9 @@
        <widget class="QLabel" name="cheatsLabel">
         <property name="text">
          <string>Used for storing .pnach files containing game cheats.</string>
+        </property>
+        <property name="buddy">
+         <cstring>cheats</cstring>
         </property>
        </widget>
       </item>
@@ -126,6 +132,9 @@
         <property name="text">
          <string>Used for screenshots and saving GS dumps.</string>
         </property>
+        <property name="buddy">
+         <cstring>snapshots</cstring>
+        </property>
        </widget>
       </item>
       <item row="2" column="0" colspan="4">
@@ -148,6 +157,9 @@
        <widget class="QLabel" name="saveStatesLabel">
         <property name="text">
          <string>Used for storing save states.</string>
+        </property>
+        <property name="buddy">
+         <cstring>saveStates</cstring>
         </property>
        </widget>
       </item>
@@ -213,6 +225,9 @@
         <property name="text">
          <string>Used for storing covers in the game grid/Big Picture UIs.</string>
         </property>
+        <property name="buddy">
+         <cstring>covers</cstring>
+        </property>
        </widget>
       </item>
      </layout>
@@ -253,6 +268,9 @@
         <property name="text">
          <string>Used for storing video captures.</string>
         </property>
+        <property name="buddy">
+         <cstring>videoDumpingDirectory</cstring>
+        </property>
        </widget>
       </item>
      </layout>
@@ -261,7 +279,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -273,6 +291,33 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>cache</tabstop>
+  <tabstop>cacheBrowse</tabstop>
+  <tabstop>cacheOpen</tabstop>
+  <tabstop>cacheReset</tabstop>
+  <tabstop>cheats</tabstop>
+  <tabstop>cheatsBrowse</tabstop>
+  <tabstop>cheatsOpen</tabstop>
+  <tabstop>cheatsReset</tabstop>
+  <tabstop>snapshots</tabstop>
+  <tabstop>snapshotsBrowse</tabstop>
+  <tabstop>snapshotsOpen</tabstop>
+  <tabstop>snapshotsReset</tabstop>
+  <tabstop>organizeScreenshotsByGame</tabstop>
+  <tabstop>saveStates</tabstop>
+  <tabstop>saveStatesBrowse</tabstop>
+  <tabstop>saveStatesOpen</tabstop>
+  <tabstop>saveStatesReset</tabstop>
+  <tabstop>covers</tabstop>
+  <tabstop>coversBrowse</tabstop>
+  <tabstop>coversOpen</tabstop>
+  <tabstop>coversReset</tabstop>
+  <tabstop>videoDumpingDirectory</tabstop>
+  <tabstop>videoDumpingDirectoryBrowse</tabstop>
+  <tabstop>videoDumpingDirectoryOpen</tabstop>
+  <tabstop>videoDumpingDirectoryReset</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/GameCheatSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GameCheatSettingsWidget.ui
@@ -54,13 +54,13 @@
    <item>
     <widget class="QTreeView" name="cheatList">
      <property name="editTriggers">
-      <set>QAbstractItemView::NoEditTriggers</set>
+      <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
      </property>
      <property name="selectionMode">
-      <enum>QAbstractItemView::NoSelection</enum>
+      <enum>QAbstractItemView::SelectionMode::NoSelection</enum>
      </property>
      <property name="selectionBehavior">
-      <enum>QAbstractItemView::SelectItems</enum>
+      <enum>QAbstractItemView::SelectionBehavior::SelectItems</enum>
      </property>
     </widget>
    </item>
@@ -93,7 +93,7 @@
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -114,6 +114,15 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>enableCheats</tabstop>
+  <tabstop>searchText</tabstop>
+  <tabstop>cheatList</tabstop>
+  <tabstop>enableAll</tabstop>
+  <tabstop>disableAll</tabstop>
+  <tabstop>allCRCsCheckbox</tabstop>
+  <tabstop>reloadCheats</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/GameFixSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GameFixSettingsWidget.ui
@@ -149,7 +149,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -161,6 +161,26 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>FpuMulHack</tabstop>
+  <tabstop>SoftwareRendererFMVHack</tabstop>
+  <tabstop>SkipMPEGHack</tabstop>
+  <tabstop>GoemonTlbHack</tabstop>
+  <tabstop>EETimingHack</tabstop>
+  <tabstop>InstantDMAHack</tabstop>
+  <tabstop>OPHFlagHack</tabstop>
+  <tabstop>GIFFIFOHack</tabstop>
+  <tabstop>DMABusyHack</tabstop>
+  <tabstop>VIF1StallHack</tabstop>
+  <tabstop>VIFFIFOHack</tabstop>
+  <tabstop>FullVU0SyncHack</tabstop>
+  <tabstop>IbitHack</tabstop>
+  <tabstop>VuAddSubHack</tabstop>
+  <tabstop>VUOverflowHack</tabstop>
+  <tabstop>VUSyncHack</tabstop>
+  <tabstop>XgKickHack</tabstop>
+  <tabstop>BlitInternalFPSHack</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/GameListSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GameListSettingsWidget.ui
@@ -36,12 +36,15 @@
           <property name="text">
            <string>Search Directories (will be scanned for games)</string>
           </property>
+          <property name="buddy">
+           <cstring>searchDirectoryList</cstring>
+          </property>
          </widget>
         </item>
         <item>
          <spacer name="horizontalSpacer_2">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -66,7 +69,7 @@
            <iconset theme="folder-add-line"/>
           </property>
           <property name="toolButtonStyle">
-           <enum>Qt::ToolButtonTextBesideIcon</enum>
+           <enum>Qt::ToolButtonStyle::ToolButtonTextBesideIcon</enum>
           </property>
          </widget>
         </item>
@@ -85,7 +88,7 @@
            <iconset theme="folder-reduce-line"/>
           </property>
           <property name="toolButtonStyle">
-           <enum>Qt::ToolButtonTextBesideIcon</enum>
+           <enum>Qt::ToolButtonStyle::ToolButtonTextBesideIcon</enum>
           </property>
          </widget>
         </item>
@@ -112,12 +115,15 @@
           <property name="text">
            <string>Excluded Paths (will not be scanned)</string>
           </property>
+          <property name="buddy">
+           <cstring>excludedPaths</cstring>
+          </property>
          </widget>
         </item>
         <item>
          <spacer name="horizontalSpacer_3">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -142,7 +148,7 @@
            <iconset theme="folder-add-line"/>
           </property>
           <property name="toolButtonStyle">
-           <enum>Qt::ToolButtonTextBesideIcon</enum>
+           <enum>Qt::ToolButtonStyle::ToolButtonTextBesideIcon</enum>
           </property>
          </widget>
         </item>
@@ -161,7 +167,7 @@
            <iconset theme="file-add-line"/>
           </property>
           <property name="toolButtonStyle">
-           <enum>Qt::ToolButtonTextBesideIcon</enum>
+           <enum>Qt::ToolButtonStyle::ToolButtonTextBesideIcon</enum>
           </property>
          </widget>
         </item>
@@ -180,7 +186,7 @@
            <iconset theme="file-reduce-line"/>
           </property>
           <property name="toolButtonStyle">
-           <enum>Qt::ToolButtonTextBesideIcon</enum>
+           <enum>Qt::ToolButtonStyle::ToolButtonTextBesideIcon</enum>
           </property>
          </widget>
         </item>
@@ -194,7 +200,7 @@
         <item>
          <spacer name="horizontalSpacer">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -259,6 +265,18 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>addSearchDirectoryButton</tabstop>
+  <tabstop>removeSearchDirectoryButton</tabstop>
+  <tabstop>searchDirectoryList</tabstop>
+  <tabstop>addExcludedPath</tabstop>
+  <tabstop>addExcludedFile</tabstop>
+  <tabstop>removeExcludedPath</tabstop>
+  <tabstop>excludedPaths</tabstop>
+  <tabstop>scanForNewGames</tabstop>
+  <tabstop>rescanAllGames</tabstop>
+  <tabstop>preferEnglishGameList</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/GamePatchDetailsWidget.ui
+++ b/pcsx2-qt/Settings/GamePatchDetailsWidget.ui
@@ -44,7 +44,7 @@
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -73,7 +73,7 @@
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Author: &lt;/span&gt;Patch Author&lt;/p&gt;&lt;p&gt;Description would go here&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+      <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -82,6 +82,9 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>enabled</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/GamePatchSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GamePatchSettingsWidget.ui
@@ -66,7 +66,7 @@
    <item>
     <widget class="QScrollArea" name="scrollArea">
      <property name="horizontalScrollBarPolicy">
-      <enum>Qt::ScrollBarAlwaysOff</enum>
+      <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
      </property>
      <property name="widgetResizable">
       <bool>true</bool>
@@ -91,7 +91,7 @@
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -112,6 +112,11 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>scrollArea</tabstop>
+  <tabstop>allCRCsCheckbox</tabstop>
+  <tabstop>reload</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/GameSummaryWidget.ui
+++ b/pcsx2-qt/Settings/GameSummaryWidget.ui
@@ -12,7 +12,7 @@
   </property>
   <layout class="QFormLayout" name="detailsFormLayout">
    <property name="fieldGrowthPolicy">
-    <enum>QFormLayout::ExpandingFieldsGrow</enum>
+    <enum>QFormLayout::FieldGrowthPolicy::ExpandingFieldsGrow</enum>
    </property>
    <property name="leftMargin">
     <number>0</number>
@@ -30,6 +30,9 @@
     <widget class="QLabel" name="label_title">
      <property name="text">
       <string>Title:</string>
+     </property>
+     <property name="buddy">
+      <cstring>title</cstring>
      </property>
     </widget>
    </item>
@@ -59,6 +62,9 @@
      <property name="text">
       <string extracomment="Name for use in sorting (e.g. &quot;XXX, The&quot; for a game called &quot;The XXX&quot;)">Sorting Title:</string>
      </property>
+     <property name="buddy">
+      <cstring>titleSort</cstring>
+     </property>
     </widget>
    </item>
    <item row="1" column="1">
@@ -72,6 +78,9 @@
     <widget class="QLabel" name="label_titleEN">
      <property name="text">
       <string>English Title:</string>
+     </property>
+     <property name="buddy">
+      <cstring>titleEN</cstring>
      </property>
     </widget>
    </item>
@@ -87,6 +96,9 @@
      <property name="text">
       <string>Path:</string>
      </property>
+     <property name="buddy">
+      <cstring>path</cstring>
+     </property>
     </widget>
    </item>
    <item row="3" column="1">
@@ -100,6 +112,9 @@
     <widget class="QLabel" name="label_serial">
      <property name="text">
       <string>Serial:</string>
+     </property>
+     <property name="buddy">
+      <cstring>serial</cstring>
      </property>
     </widget>
    </item>
@@ -129,6 +144,9 @@
      <property name="text">
       <string>CRC:</string>
      </property>
+     <property name="buddy">
+      <cstring>crc</cstring>
+     </property>
     </widget>
    </item>
    <item row="5" column="1">
@@ -142,6 +160,9 @@
     <widget class="QLabel" name="label_type">
      <property name="text">
       <string>Type:</string>
+     </property>
+     <property name="buddy">
+      <cstring>type</cstring>
      </property>
     </widget>
    </item>
@@ -189,6 +210,9 @@
     <widget class="QLabel" name="label_region">
      <property name="text">
       <string>Region:</string>
+     </property>
+     <property name="buddy">
+      <cstring>region</cstring>
      </property>
     </widget>
    </item>
@@ -371,6 +395,9 @@
      <property name="text">
       <string>Compatibility:</string>
      </property>
+     <property name="buddy">
+      <cstring>compatibility</cstring>
+     </property>
     </widget>
    </item>
    <item row="8" column="1">
@@ -384,6 +411,9 @@
     <widget class="QLabel" name="label_profile">
      <property name="text">
       <string>Input Profile:</string>
+     </property>
+     <property name="buddy">
+      <cstring>inputProfile</cstring>
      </property>
     </widget>
    </item>
@@ -406,6 +436,9 @@
     <widget class="QLabel" name="label_discPath">
      <property name="text">
       <string>Disc Path:</string>
+     </property>
+     <property name="buddy">
+      <cstring>discPath</cstring>
      </property>
     </widget>
    </item>
@@ -433,7 +466,7 @@
    <item row="11" column="0" colspan="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -448,7 +481,7 @@
      <item>
       <widget class="QTableWidget" name="tracks">
        <property name="editTriggers">
-        <set>QAbstractItemView::NoEditTriggers</set>
+        <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
        </property>
        <property name="cornerButtonEnabled">
         <bool>false</bool>
@@ -463,7 +496,7 @@
        <item>
         <spacer name="verifyButtonSpacer">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -487,7 +520,7 @@
        <item row="2" column="2">
         <spacer name="verticalSpacer_2">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -529,6 +562,26 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>title</tabstop>
+  <tabstop>restoreTitle</tabstop>
+  <tabstop>titleSort</tabstop>
+  <tabstop>titleEN</tabstop>
+  <tabstop>path</tabstop>
+  <tabstop>serial</tabstop>
+  <tabstop>checkWiki</tabstop>
+  <tabstop>crc</tabstop>
+  <tabstop>type</tabstop>
+  <tabstop>region</tabstop>
+  <tabstop>restoreRegion</tabstop>
+  <tabstop>compatibility</tabstop>
+  <tabstop>inputProfile</tabstop>
+  <tabstop>discPath</tabstop>
+  <tabstop>discPathBrowse</tabstop>
+  <tabstop>discPathClear</tabstop>
+  <tabstop>tracks</tabstop>
+  <tabstop>verify</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/GraphicsAdvancedSettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsAdvancedSettingsTab.ui
@@ -31,6 +31,9 @@
         <property name="text">
          <string>Hardware Download Mode:</string>
         </property>
+        <property name="buddy">
+         <cstring>gsDownloadMode</cstring>
+        </property>
        </widget>
       </item>
       <item row="0" column="1">
@@ -61,6 +64,9 @@
        <widget class="QLabel" name="gsDumpCompressionLabel">
         <property name="text">
          <string>GS Dump Compression:</string>
+        </property>
+        <property name="buddy">
+         <cstring>gsDumpCompression</cstring>
         </property>
        </widget>
       </item>
@@ -127,6 +133,9 @@
         <property name="text">
          <string>Allow Exclusive Fullscreen:</string>
         </property>
+        <property name="buddy">
+         <cstring>exclusiveFullscreenControl</cstring>
+        </property>
        </widget>
       </item>
       <item row="6" column="1">
@@ -172,6 +181,9 @@
         <property name="text">
          <string>Texture Preloading:</string>
         </property>
+        <property name="buddy">
+         <cstring>texturePreloading</cstring>
+        </property>
        </widget>
       </item>
      </layout>
@@ -187,6 +199,9 @@
        <widget class="QLabel" name="ntscLabel">
         <property name="text">
          <string>NTSC Frame Rate:</string>
+        </property>
+        <property name="buddy">
+         <cstring>ntscFrameRate</cstring>
         </property>
        </widget>
       </item>
@@ -210,6 +225,9 @@
        <widget class="QLabel" name="palLabel">
         <property name="text">
          <string>PAL Frame Rate:</string>
+        </property>
+        <property name="buddy">
+         <cstring>palFrameRate</cstring>
         </property>
        </widget>
       </item>
@@ -248,6 +266,9 @@
        <widget class="QLabel" name="barriersLabel">
         <property name="text">
          <string>Override Texture Barriers:</string>
+        </property>
+        <property name="buddy">
+         <cstring>overrideTextureBarriers</cstring>
         </property>
        </widget>
       </item>
@@ -308,7 +329,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -320,6 +341,24 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>gsDownloadMode</tabstop>
+  <tabstop>gsDumpCompression</tabstop>
+  <tabstop>texturePreloading</tabstop>
+  <tabstop>exclusiveFullscreenControl</tabstop>
+  <tabstop>useBlitSwapChain</tabstop>
+  <tabstop>extendedUpscales</tabstop>
+  <tabstop>disableMailboxPresentation</tabstop>
+  <tabstop>spinCPUDuringReadbacks</tabstop>
+  <tabstop>spinGPUDuringReadbacks</tabstop>
+  <tabstop>ntscFrameRate</tabstop>
+  <tabstop>palFrameRate</tabstop>
+  <tabstop>overrideTextureBarriers</tabstop>
+  <tabstop>useDebugDevice</tabstop>
+  <tabstop>disableFramebufferFetch</tabstop>
+  <tabstop>disableShaderCache</tabstop>
+  <tabstop>disableVertexShaderExpand</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/GraphicsDisplaySettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsDisplaySettingsTab.ui
@@ -25,6 +25,9 @@
      <property name="text">
       <string>Deinterlacing:</string>
      </property>
+     <property name="buddy">
+      <cstring>interlacing</cstring>
+     </property>
     </widget>
    </item>
    <item row="0" column="1">
@@ -64,7 +67,7 @@
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="QCheckBox" name="DisableInterlaceOffset">
+      <widget class="QCheckBox" name="disableInterlaceOffset">
        <property name="text">
         <string>Disable Interlace Offset</string>
        </property>
@@ -90,6 +93,9 @@
     <widget class="QLabel" name="fmvAspectRatioLabel">
      <property name="text">
       <string>FMV Aspect Ratio Override:</string>
+     </property>
+     <property name="buddy">
+      <cstring>fmvAspectRatio</cstring>
      </property>
     </widget>
    </item>
@@ -146,6 +152,9 @@
      <property name="text">
       <string>Vertical Stretch:</string>
      </property>
+     <property name="buddy">
+      <cstring>stretchY</cstring>
+     </property>
     </widget>
    </item>
    <item row="0" column="0">
@@ -153,12 +162,18 @@
      <property name="text">
       <string>Fullscreen Mode:</string>
      </property>
+     <property name="buddy">
+      <cstring>fullscreenModes</cstring>
+     </property>
     </widget>
    </item>
    <item row="4" column="0">
     <widget class="QLabel" name="billinearLabel">
      <property name="text">
       <string>Bilinear Filtering:</string>
+     </property>
+     <property name="buddy">
+      <cstring>bilinearFiltering</cstring>
      </property>
     </widget>
    </item>
@@ -202,6 +217,9 @@
     <widget class="QLabel" name="aspectRatioLabel">
      <property name="text">
       <string>Aspect Ratio:</string>
+     </property>
+     <property name="buddy">
+      <cstring>aspectRatio</cstring>
      </property>
     </widget>
    </item>
@@ -275,7 +293,7 @@
    <item row="8" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -302,12 +320,18 @@
        <property name="text">
         <string extracomment="Warning: short space constraints. Abbreviate if necessary.">Top:</string>
        </property>
+       <property name="buddy">
+        <cstring>cropTop</cstring>
+       </property>
       </widget>
      </item>
      <item row="0" column="0">
       <widget class="QLabel" name="cropLeftLabel">
        <property name="text">
         <string extracomment="Warning: short space constraints. Abbreviate if necessary.">Left:</string>
+       </property>
+       <property name="buddy">
+        <cstring>cropLeft</cstring>
        </property>
       </widget>
      </item>
@@ -326,6 +350,9 @@
        <property name="text">
         <string extracomment="Warning: short space constraints. Abbreviate if necessary.">Right:</string>
        </property>
+       <property name="buddy">
+        <cstring>cropRight</cstring>
+       </property>
       </widget>
      </item>
      <item row="1" column="1">
@@ -343,6 +370,9 @@
        <property name="text">
         <string extracomment="Warning: short space constraints. Abbreviate if necessary.">Bottom:</string>
        </property>
+       <property name="buddy">
+        <cstring>cropBottom</cstring>
+       </property>
       </widget>
      </item>
      <item row="1" column="3">
@@ -359,6 +389,25 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>fullscreenModes</tabstop>
+  <tabstop>aspectRatio</tabstop>
+  <tabstop>fmvAspectRatio</tabstop>
+  <tabstop>interlacing</tabstop>
+  <tabstop>bilinearFiltering</tabstop>
+  <tabstop>stretchY</tabstop>
+  <tabstop>cropLeft</tabstop>
+  <tabstop>cropRight</tabstop>
+  <tabstop>cropTop</tabstop>
+  <tabstop>cropBottom</tabstop>
+  <tabstop>widescreenPatches</tabstop>
+  <tabstop>noInterlacingPatches</tabstop>
+  <tabstop>PCRTCAntiBlur</tabstop>
+  <tabstop>integerScaling</tabstop>
+  <tabstop>PCRTCOffsets</tabstop>
+  <tabstop>disableInterlaceOffset</tabstop>
+  <tabstop>PCRTCOverscan</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/GraphicsHardwareFixesSettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsHardwareFixesSettingsTab.ui
@@ -38,12 +38,18 @@
      <property name="text">
       <string>Texture Inside RT:</string>
      </property>
+     <property name="buddy">
+      <cstring>textureInsideRt</cstring>
+     </property>
     </widget>
    </item>
    <item row="5" column="0">
     <widget class="QLabel" name="skipDrawLabel">
      <property name="text">
       <string>Skip Draw Range:</string>
+     </property>
+     <property name="buddy">
+      <cstring>skipDrawStart</cstring>
      </property>
     </widget>
    </item>
@@ -178,6 +184,9 @@
      <property name="text">
       <string>Software CLUT Render:</string>
      </property>
+     <property name="buddy">
+      <cstring>cpuCLUTRender</cstring>
+     </property>
     </widget>
    </item>
    <item row="6" column="0" colspan="2">
@@ -252,12 +261,18 @@
      <property name="text">
       <string>Auto Flush:</string>
      </property>
+     <property name="buddy">
+      <cstring>hwAutoFlush</cstring>
+     </property>
     </widget>
    </item>
    <item row="2" column="0">
     <widget class="QLabel" name="gpuTargetCLUTLabel">
      <property name="text">
       <string extracomment="CLUT: Color Look Up Table, often referred to as a palette in non-PS2 things.  GPU Target CLUT: GPU handling of when a game uses data from a render target as a CLUT.">GPU Target CLUT:</string>
+     </property>
+     <property name="buddy">
+      <cstring>gpuTargetCLUTMode</cstring>
      </property>
     </widget>
    </item>
@@ -285,6 +300,9 @@
      <property name="text">
       <string>CPU Sprite Render Size:</string>
      </property>
+     <property name="buddy">
+      <cstring>cpuSpriteRenderBW</cstring>
+     </property>
     </widget>
    </item>
    <item row="5" column="1">
@@ -308,7 +326,7 @@
    <item row="7" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -320,6 +338,25 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>cpuSpriteRenderBW</tabstop>
+  <tabstop>cpuSpriteRenderLevel</tabstop>
+  <tabstop>cpuCLUTRender</tabstop>
+  <tabstop>gpuTargetCLUTMode</tabstop>
+  <tabstop>hwAutoFlush</tabstop>
+  <tabstop>textureInsideRt</tabstop>
+  <tabstop>skipDrawStart</tabstop>
+  <tabstop>skipDrawEnd</tabstop>
+  <tabstop>disableDepthEmulation</tabstop>
+  <tabstop>frameBufferConversion</tabstop>
+  <tabstop>disablePartialInvalidation</tabstop>
+  <tabstop>gpuPaletteConversion</tabstop>
+  <tabstop>disableSafeFeatures</tabstop>
+  <tabstop>preloadFrameData</tabstop>
+  <tabstop>disableRenderFixes</tabstop>
+  <tabstop>readTCOnClose</tabstop>
+  <tabstop>estimateTextureRegion</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/GraphicsHardwareRenderingSettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsHardwareRenderingSettingsTab.ui
@@ -19,6 +19,9 @@
      <property name="text">
       <string>Texture Filtering:</string>
      </property>
+     <property name="buddy">
+      <cstring>textureFiltering</cstring>
+     </property>
     </widget>
    </item>
    <item row="4" column="1">
@@ -68,6 +71,9 @@
      <property name="text">
       <string>Anisotropic Filtering:</string>
      </property>
+     <property name="buddy">
+      <cstring>anisotropicFiltering</cstring>
+     </property>
     </widget>
    </item>
    <item row="3" column="1">
@@ -77,6 +83,9 @@
     <widget class="QLabel" name="internalResLabel">
      <property name="text">
       <string>Internal Resolution:</string>
+     </property>
+     <property name="buddy">
+      <cstring>upscaleMultiplier</cstring>
      </property>
     </widget>
    </item>
@@ -111,6 +120,9 @@
     <widget class="QLabel" name="ditheringLabel">
      <property name="text">
       <string>Dithering:</string>
+     </property>
+     <property name="buddy">
+      <cstring>dithering</cstring>
      </property>
     </widget>
    </item>
@@ -177,6 +189,9 @@
      <property name="text">
       <string>Blending Accuracy:</string>
      </property>
+     <property name="buddy">
+      <cstring>blending</cstring>
+     </property>
     </widget>
    </item>
    <item row="2" column="0">
@@ -184,12 +199,15 @@
      <property name="text">
       <string>Trilinear Filtering:</string>
      </property>
+     <property name="buddy">
+      <cstring>trilinearFiltering</cstring>
+     </property>
     </widget>
    </item>
    <item row="7" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -201,6 +219,16 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>upscaleMultiplier</tabstop>
+  <tabstop>textureFiltering</tabstop>
+  <tabstop>trilinearFiltering</tabstop>
+  <tabstop>anisotropicFiltering</tabstop>
+  <tabstop>dithering</tabstop>
+  <tabstop>blending</tabstop>
+  <tabstop>mipmapping</tabstop>
+  <tabstop>enableHWFixes</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/GraphicsMediaCaptureSettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsMediaCaptureSettingsTab.ui
@@ -27,6 +27,9 @@
           <property name="text">
            <string>Resolution:</string>
           </property>
+          <property name="buddy">
+           <cstring>screenshotSize</cstring>
+          </property>
          </widget>
         </item>
         <item>
@@ -78,6 +81,9 @@
           <property name="text">
            <string>Quality:</string>
           </property>
+          <property name="buddy">
+           <cstring>screenshotQuality</cstring>
+          </property>
          </widget>
         </item>
         <item>
@@ -112,6 +118,9 @@
         <property name="text">
          <string>Container:</string>
         </property>
+        <property name="buddy">
+         <cstring>captureContainer</cstring>
+        </property>
        </widget>
       </item>
       <item row="0" column="1">
@@ -145,6 +154,9 @@
              <property name="text">
               <string>Codec:</string>
              </property>
+             <property name="buddy">
+              <cstring>audioCaptureCodec</cstring>
+             </property>
             </widget>
            </item>
            <item row="0" column="1">
@@ -154,6 +166,9 @@
             <widget class="QLabel" name="audioCaptureBitrateLabel">
              <property name="text">
               <string>Bitrate:</string>
+             </property>
+             <property name="buddy">
+              <cstring>audioCaptureBitrate</cstring>
              </property>
             </widget>
            </item>
@@ -213,6 +228,9 @@
              <property name="text">
               <string>Codec:</string>
              </property>
+             <property name="buddy">
+              <cstring>videoCaptureCodec</cstring>
+             </property>
             </widget>
            </item>
            <item row="0" column="1">
@@ -223,6 +241,9 @@
              <property name="text">
               <string>Format:</string>
              </property>
+             <property name="buddy">
+              <cstring>videoCaptureFormat</cstring>
+             </property>
             </widget>
            </item>
            <item row="1" column="1">
@@ -232,6 +253,9 @@
             <widget class="QLabel" name="videoCaptureBitrateLabel">
              <property name="text">
               <string>Bitrate:</string>
+             </property>
+             <property name="buddy">
+              <cstring>videoCaptureBitrate</cstring>
              </property>
             </widget>
            </item>
@@ -255,6 +279,9 @@
             <widget class="QLabel" name="videoCaptureResolutionLabel">
              <property name="text">
               <string>Resolution:</string>
+             </property>
+             <property name="buddy">
+              <cstring>videoCaptureWidth</cstring>
              </property>
             </widget>
            </item>
@@ -280,6 +307,9 @@
               <widget class="QLabel" name="xLabel">
                <property name="text">
                 <string>x</string>
+               </property>
+               <property name="buddy">
+                <cstring>videoCaptureHeight</cstring>
                </property>
               </widget>
              </item>
@@ -336,7 +366,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -348,6 +378,26 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>screenshotSize</tabstop>
+  <tabstop>screenshotFormat</tabstop>
+  <tabstop>screenshotQuality</tabstop>
+  <tabstop>captureContainer</tabstop>
+  <tabstop>enableVideoCapture</tabstop>
+  <tabstop>videoCaptureCodec</tabstop>
+  <tabstop>videoCaptureFormat</tabstop>
+  <tabstop>videoCaptureBitrate</tabstop>
+  <tabstop>videoCaptureWidth</tabstop>
+  <tabstop>videoCaptureHeight</tabstop>
+  <tabstop>videoCaptureResolutionAuto</tabstop>
+  <tabstop>enableVideoCaptureArguments</tabstop>
+  <tabstop>videoCaptureArguments</tabstop>
+  <tabstop>enableAudioCapture</tabstop>
+  <tabstop>audioCaptureCodec</tabstop>
+  <tabstop>audioCaptureBitrate</tabstop>
+  <tabstop>enableAudioCaptureArguments</tabstop>
+  <tabstop>audioCaptureArguments</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/GraphicsOnScreenDisplaySettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsOnScreenDisplaySettingsTab.ui
@@ -25,6 +25,9 @@
         <property name="text">
          <string>OSD Messages Position:</string>
         </property>
+        <property name="buddy">
+         <cstring>messagesPos</cstring>
+        </property>
        </widget>
       </item>
       <item row="0" column="1">
@@ -265,6 +268,9 @@
         <property name="text">
          <string>OSD Scale:</string>
         </property>
+        <property name="buddy">
+         <cstring>scale</cstring>
+        </property>
        </widget>
       </item>
       <item row="2" column="1">
@@ -342,6 +348,9 @@
         <property name="text">
          <string>OSD Performance Position:</string>
         </property>
+        <property name="buddy">
+         <cstring>performancePos</cstring>
+        </property>
        </widget>
       </item>
      </layout>
@@ -362,6 +371,28 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>scale</tabstop>
+  <tabstop>messagesPos</tabstop>
+  <tabstop>performancePos</tabstop>
+  <tabstop>showSpeed</tabstop>
+  <tabstop>showFPS</tabstop>
+  <tabstop>showVPS</tabstop>
+  <tabstop>showResolution</tabstop>
+  <tabstop>showGSStats</tabstop>
+  <tabstop>showFrameTimes</tabstop>
+  <tabstop>showCPU</tabstop>
+  <tabstop>showGPU</tabstop>
+  <tabstop>showHardwareInfo</tabstop>
+  <tabstop>showVersion</tabstop>
+  <tabstop>showIndicators</tabstop>
+  <tabstop>showSettings</tabstop>
+  <tabstop>showPatches</tabstop>
+  <tabstop>showInputs</tabstop>
+  <tabstop>showVideoCapture</tabstop>
+  <tabstop>showInputRec</tabstop>
+  <tabstop>warnAboutUnsafeSettings</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/GraphicsPostProcessingSettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsPostProcessingSettingsTab.ui
@@ -25,6 +25,9 @@
         <property name="text">
          <string extracomment="You might find an official translation for this on AMD's website (Spanish version linked): https://www.amd.com/es/technologies/radeon-software-fidelityfx">Contrast Adaptive Sharpening:</string>
         </property>
+        <property name="buddy">
+         <cstring>casMode</cstring>
+        </property>
        </widget>
       </item>
       <item row="0" column="1">
@@ -60,6 +63,9 @@
            <widget class="QLabel" name="casSharpnessLabel">
             <property name="text">
              <string>Sharpness:</string>
+            </property>
+            <property name="buddy">
+             <cstring>casSharpness</cstring>
             </property>
            </widget>
           </item>
@@ -110,6 +116,9 @@
           <property name="text">
            <string>Brightness:</string>
           </property>
+          <property name="buddy">
+           <cstring>shadeBoostBrightness</cstring>
+          </property>
          </widget>
         </item>
         <item row="0" column="3">
@@ -126,6 +135,9 @@
          <widget class="QLabel" name="contrastLabel">
           <property name="text">
            <string>Contrast:</string>
+          </property>
+          <property name="buddy">
+           <cstring>shadeBoostContrast</cstring>
           </property>
          </widget>
         </item>
@@ -144,6 +156,9 @@
           <property name="text">
            <string>Gamma:</string>
           </property>
+          <property name="buddy">
+           <cstring>shadeBoostGamma</cstring>
+          </property>
          </widget>
         </item>
         <item row="1" column="1">
@@ -160,6 +175,9 @@
          <widget class="QLabel" name="saturationLabel">
           <property name="text">
            <string>Saturation:</string>
+          </property>
+          <property name="buddy">
+           <cstring>shadeBoostSaturation</cstring>
           </property>
          </widget>
         </item>
@@ -179,6 +197,9 @@
        <widget class="QLabel" name="tvShaderLabel">
         <property name="text">
          <string>TV Shader:</string>
+        </property>
+        <property name="buddy">
+         <cstring>tvShader</cstring>
         </property>
        </widget>
       </item>
@@ -232,7 +253,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -244,6 +265,17 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>casMode</tabstop>
+  <tabstop>casSharpness</tabstop>
+  <tabstop>fxaa</tabstop>
+  <tabstop>tvShader</tabstop>
+  <tabstop>shadeBoost</tabstop>
+  <tabstop>shadeBoostBrightness</tabstop>
+  <tabstop>shadeBoostContrast</tabstop>
+  <tabstop>shadeBoostGamma</tabstop>
+  <tabstop>shadeBoostSaturation</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/GraphicsSettingsHeader.ui
+++ b/pcsx2-qt/Settings/GraphicsSettingsHeader.ui
@@ -25,6 +25,9 @@
         <property name="text">
          <string>Graphics API:</string>
         </property>
+        <property name="buddy">
+         <cstring>rendererDropdown</cstring>
+        </property>
        </widget>
       </item>
       <item row="0" column="1">
@@ -34,6 +37,9 @@
        <widget class="QLabel" name="adapterText">
         <property name="text">
          <string>Adapter:</string>
+        </property>
+        <property name="buddy">
+         <cstring>adapterDropdown</cstring>
         </property>
        </widget>
       </item>
@@ -45,6 +51,10 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>rendererDropdown</tabstop>
+  <tabstop>adapterDropdown</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -87,7 +87,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_display.PCRTCOffsets, "EmuCore/GS", "pcrtc_offsets", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_display.PCRTCOverscan, "EmuCore/GS", "pcrtc_overscan", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_display.PCRTCAntiBlur, "EmuCore/GS", "pcrtc_antiblur", true);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_display.DisableInterlaceOffset, "EmuCore/GS", "disable_interlace_offset", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_display.disableInterlaceOffset, "EmuCore/GS", "disable_interlace_offset", false);
 	SettingWidgetBinder::BindWidgetToIntSetting(
 		sif, m_capture.screenshotSize, "EmuCore/GS", "ScreenshotSize", static_cast<int>(GSScreenshotSize::WindowResolution));
 	SettingWidgetBinder::BindWidgetToIntSetting(
@@ -438,7 +438,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 		dialog()->registerWidgetHelp(m_display.noInterlacingPatches, tr("Enable No-Interlacing Patches"), tr("Unchecked"),
 			tr("Automatically loads and applies no-interlacing patches on game start. Can cause issues."));
 
-		dialog()->registerWidgetHelp(m_display.DisableInterlaceOffset, tr("Disable Interlace Offset"), tr("Unchecked"),
+		dialog()->registerWidgetHelp(m_display.disableInterlaceOffset, tr("Disable Interlace Offset"), tr("Unchecked"),
 			tr("Disables interlacing offset which may reduce blurring in some situations."));
 
 		dialog()->registerWidgetHelp(m_display.bilinearFiltering, tr("Bilinear Filtering"), tr("Bilinear (Smooth)"),

--- a/pcsx2-qt/Settings/GraphicsSoftwareRenderingSettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsSoftwareRenderingSettingsTab.ui
@@ -19,12 +19,18 @@
      <property name="text">
       <string>Software Rendering Threads:</string>
      </property>
+     <property name="buddy">
+      <cstring>extraSWThreads</cstring>
+     </property>
     </widget>
    </item>
    <item row="0" column="0">
     <widget class="QLabel" name="swTextureFilteringLabel">
      <property name="text">
       <string>Texture Filtering:</string>
+     </property>
+     <property name="buddy">
+      <cstring>swTextureFiltering</cstring>
      </property>
     </widget>
    </item>
@@ -52,7 +58,7 @@
       <bool>true</bool>
      </property>
      <property name="layoutDirection">
-      <enum>Qt::LeftToRight</enum>
+      <enum>Qt::LayoutDirection::LeftToRight</enum>
      </property>
      <item>
       <property name="text">
@@ -86,7 +92,7 @@
    <item row="3" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -98,6 +104,12 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>swTextureFiltering</tabstop>
+  <tabstop>extraSWThreads</tabstop>
+  <tabstop>swAutoFlush</tabstop>
+  <tabstop>swMipmap</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/GraphicsTextureReplacementSettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsTextureReplacementSettingsTab.ui
@@ -100,6 +100,9 @@
         <property name="text">
          <string>PCSX2 will dump and load texture replacements from this directory.</string>
         </property>
+        <property name="buddy">
+         <cstring>texturesDirectory</cstring>
+        </property>
        </widget>
       </item>
      </layout>
@@ -108,7 +111,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -120,6 +123,18 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>loadTextureReplacements</tabstop>
+  <tabstop>dumpReplaceableTextures</tabstop>
+  <tabstop>loadTextureReplacementsAsync</tabstop>
+  <tabstop>dumpReplaceableMipmaps</tabstop>
+  <tabstop>precacheTextureReplacements</tabstop>
+  <tabstop>dumpTexturesWithFMVActive</tabstop>
+  <tabstop>texturesDirectory</tabstop>
+  <tabstop>texturesBrowse</tabstop>
+  <tabstop>texturesOpen</tabstop>
+  <tabstop>texturesReset</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/GraphicsUpscalingFixesSettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsUpscalingFixesSettingsTab.ui
@@ -51,6 +51,9 @@
      <property name="text">
       <string>Half Pixel Offset:</string>
      </property>
+     <property name="buddy">
+      <cstring>halfPixelOffset</cstring>
+     </property>
     </widget>
    </item>
    <item row="0" column="1">
@@ -91,6 +94,9 @@
     <widget class="QLabel" name="nativeScalingLabel">
      <property name="text">
       <string>Native Scaling</string>
+     </property>
+     <property name="buddy">
+      <cstring>nativeScaling</cstring>
      </property>
     </widget>
    </item>
@@ -146,6 +152,9 @@
        <property name="text">
         <string>X:</string>
        </property>
+       <property name="buddy">
+        <cstring>textureOffsetX</cstring>
+       </property>
       </widget>
      </item>
      <item>
@@ -159,6 +168,9 @@
       <widget class="QLabel" name="textureOffsetYLabel">
        <property name="text">
         <string>Y:</string>
+       </property>
+       <property name="buddy">
+        <cstring>textureOffsetY</cstring>
        </property>
       </widget>
      </item>
@@ -175,6 +187,9 @@
     <widget class="QLabel" name="bilinearHackLabel">
      <property name="text">
       <string>Bilinear Dirty Upscale:</string>
+     </property>
+     <property name="buddy">
+      <cstring>bilinearHack</cstring>
      </property>
     </widget>
    </item>
@@ -202,12 +217,15 @@
      <property name="text">
       <string>Round Sprite:</string>
      </property>
+     <property name="buddy">
+      <cstring>roundSprite</cstring>
+     </property>
     </widget>
    </item>
    <item row="6" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -219,6 +237,18 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>halfPixelOffset</tabstop>
+  <tabstop>nativeScaling</tabstop>
+  <tabstop>roundSprite</tabstop>
+  <tabstop>bilinearHack</tabstop>
+  <tabstop>textureOffsetX</tabstop>
+  <tabstop>textureOffsetY</tabstop>
+  <tabstop>alignSprite</tabstop>
+  <tabstop>nativePaletteDraw</tabstop>
+  <tabstop>mergeSprite</tabstop>
+  <tabstop>forceEvenSpritePosition</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/InputBindingDialog.ui
+++ b/pcsx2-qt/Settings/InputBindingDialog.ui
@@ -3,7 +3,7 @@
  <class>InputBindingDialog</class>
  <widget class="QDialog" name="InputBindingDialog">
   <property name="windowModality">
-   <enum>Qt::WindowModal</enum>
+   <enum>Qt::WindowModality::WindowModal</enum>
   </property>
   <property name="geometry">
    <rect>
@@ -24,6 +24,9 @@
     <widget class="QLabel" name="title">
      <property name="text">
       <string>Bindings for Controller0/ButtonCircle</string>
+     </property>
+     <property name="buddy">
+      <cstring>bindingList</cstring>
      </property>
     </widget>
    </item>
@@ -50,6 +53,9 @@
         <property name="text">
          <string>Sensitivity:</string>
         </property>
+        <property name="buddy">
+         <cstring>sensitivity</cstring>
+        </property>
        </widget>
       </item>
       <item row="0" column="1">
@@ -64,10 +70,10 @@
          <number>100</number>
         </property>
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="tickPosition">
-         <enum>QSlider::TicksBelow</enum>
+         <enum>QSlider::TickPosition::TicksBelow</enum>
         </property>
        </widget>
       </item>
@@ -83,6 +89,9 @@
         <property name="text">
          <string>Deadzone:</string>
         </property>
+        <property name="buddy">
+         <cstring>deadzone</cstring>
+        </property>
        </widget>
       </item>
       <item row="1" column="1">
@@ -97,10 +106,10 @@
          <number>1</number>
         </property>
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="tickPosition">
-         <enum>QSlider::TicksBelow</enum>
+         <enum>QSlider::TickPosition::TicksBelow</enum>
         </property>
         <property name="tickInterval">
          <number>5</number>
@@ -150,7 +159,7 @@
      <item>
       <widget class="QDialogButtonBox" name="buttonBox">
        <property name="standardButtons">
-        <set>QDialogButtonBox::Close</set>
+        <set>QDialogButtonBox::StandardButton::Close</set>
        </property>
       </widget>
      </item>
@@ -158,6 +167,14 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>bindingList</tabstop>
+  <tabstop>sensitivity</tabstop>
+  <tabstop>deadzone</tabstop>
+  <tabstop>addBinding</tabstop>
+  <tabstop>removeBinding</tabstop>
+  <tabstop>clearBindings</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
@@ -153,6 +153,9 @@
         <property name="text">
          <string>Language:</string>
         </property>
+        <property name="buddy">
+         <cstring>language</cstring>
+        </property>
        </widget>
       </item>
       <item row="0" column="1">
@@ -163,12 +166,18 @@
         <property name="text">
          <string>Theme:</string>
         </property>
+        <property name="buddy">
+         <cstring>theme</cstring>
+        </property>
        </widget>
       </item>
       <item row="2" column="0">
        <widget class="QLabel" name="backgroundLabel">
         <property name="text">
          <string>Game List Background:</string>
+        </property>
+        <property name="buddy">
+         <cstring>backgroundBrowse</cstring>
         </property>
        </widget>
       </item>
@@ -207,6 +216,9 @@
           </property>
           <property name="text">
            <string>Opacity:</string>
+          </property>
+          <property name="buddy">
+           <cstring>backgroundOpacity</cstring>
           </property>
          </widget>
         </item>
@@ -260,6 +272,9 @@
        <widget class="QLabel" name="updaterChannelLabel">
         <property name="text">
          <string>Update Channel:</string>
+        </property>
+        <property name="buddy">
+         <cstring>autoUpdateTag</cstring>
         </property>
        </widget>
       </item>
@@ -316,6 +331,31 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>confirmShutdown</tabstop>
+  <tabstop>pauseOnFocusLoss</tabstop>
+  <tabstop>inhibitScreensaver</tabstop>
+  <tabstop>pauseOnStart</tabstop>
+  <tabstop>discordPresence</tabstop>
+  <tabstop>pauseOnControllerDisconnection</tabstop>
+  <tabstop>mouseLock</tabstop>
+  <tabstop>startFullscreen</tabstop>
+  <tabstop>doubleClickTogglesFullscreen</tabstop>
+  <tabstop>renderToSeparateWindow</tabstop>
+  <tabstop>hideMainWindow</tabstop>
+  <tabstop>disableWindowResizing</tabstop>
+  <tabstop>hideMouseCursor</tabstop>
+  <tabstop>startFullscreenUI</tabstop>
+  <tabstop>language</tabstop>
+  <tabstop>theme</tabstop>
+  <tabstop>backgroundBrowse</tabstop>
+  <tabstop>backgroundReset</tabstop>
+  <tabstop>backgroundOpacity</tabstop>
+  <tabstop>backgroundFill</tabstop>
+  <tabstop>autoUpdateTag</tabstop>
+  <tabstop>autoUpdateEnabled</tabstop>
+  <tabstop>checkForUpdates</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/MemoryCardConvertDialog.ui
+++ b/pcsx2-qt/Settings/MemoryCardConvertDialog.ui
@@ -89,7 +89,7 @@
       <string>&lt;center&gt;&lt;strong&gt;Note:&lt;/strong&gt; Converting a Memory Card creates a &lt;strong&gt;COPY&lt;/strong&gt; of your existing Memory Card. It does &lt;strong&gt;NOT delete, modify, or replace&lt;/strong&gt; your existing Memory Card.&lt;/center&gt;</string>
      </property>
      <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+      <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -115,7 +115,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -128,12 +128,15 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
      </property>
     </widget>
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>conversionTypeSelect</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/MemoryCardCreateDialog.ui
+++ b/pcsx2-qt/Settings/MemoryCardCreateDialog.ui
@@ -43,7 +43,7 @@
         <pixmap resource="../resources/resources.qrc">:/icons/black/svg/memcard-line.svg</pixmap>
        </property>
        <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+        <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
        </property>
       </widget>
      </item>
@@ -53,10 +53,10 @@
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Create Memory Card&lt;/span&gt;&lt;br /&gt;Enter the name of the Memory Card you wish to create, and choose a size. We recommend either using 8MB Memory Cards, or folder Memory Cards for best compatibility.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="textFormat">
-        <enum>Qt::RichText</enum>
+        <enum>Qt::TextFormat::RichText</enum>
        </property>
        <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+        <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
@@ -71,6 +71,9 @@
       <widget class="QLabel" name="label_3">
        <property name="text">
         <string>Memory Card Name:</string>
+       </property>
+       <property name="buddy">
+        <cstring>name</cstring>
        </property>
       </widget>
      </item>
@@ -97,10 +100,13 @@
         <string>This is the standard Sony-provisioned size, and is supported by all games and BIOS versions.</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+        <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
+       </property>
+       <property name="buddy">
+        <cstring>size8MB</cstring>
        </property>
       </widget>
      </item>
@@ -121,10 +127,13 @@
         <string>A typical size for third-party Memory Cards which should work with most games.</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+        <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
+       </property>
+       <property name="buddy">
+        <cstring>size16MB</cstring>
        </property>
       </widget>
      </item>
@@ -145,10 +154,13 @@
         <string>A typical size for third-party Memory Cards which should work with most games.</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+        <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
+       </property>
+       <property name="buddy">
+        <cstring>size32MB</cstring>
        </property>
       </widget>
      </item>
@@ -169,10 +181,13 @@
         <string>Low compatibility warning: yes, it's very big, but may not work with many games.</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+        <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
+       </property>
+       <property name="buddy">
+        <cstring>size64MB</cstring>
        </property>
       </widget>
      </item>
@@ -193,10 +208,13 @@
         <string>Store Memory Card contents in the host filesystem instead of a file.</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+        <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
+       </property>
+       <property name="buddy">
+        <cstring>sizeFolder</cstring>
        </property>
       </widget>
      </item>
@@ -217,10 +235,13 @@
         <string>This is the standard Sony-provisioned size PS1 Memory Card, and only compatible with PS1 games.</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+        <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
+       </property>
+       <property name="buddy">
+        <cstring>size128KB</cstring>
        </property>
       </widget>
      </item>
@@ -244,7 +265,7 @@
         <string>NTFS compression is built-in, fast, and completely reliable. Typically compresses Memory Cards (highly recommended).</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+        <set>Qt::AlignmentFlag::AlignBottom|Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft</set>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
@@ -256,7 +277,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -269,15 +290,25 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::RestoreDefaults</set>
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok|QDialogButtonBox::StandardButton::RestoreDefaults</set>
      </property>
     </widget>
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>name</tabstop>
+  <tabstop>size8MB</tabstop>
+  <tabstop>size16MB</tabstop>
+  <tabstop>size32MB</tabstop>
+  <tabstop>size64MB</tabstop>
+  <tabstop>sizeFolder</tabstop>
+  <tabstop>size128KB</tabstop>
+  <tabstop>ntfsCompression</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.ui
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.ui
@@ -62,6 +62,9 @@
           <property name="text">
            <string>Folder:</string>
           </property>
+          <property name="buddy">
+           <cstring>directory</cstring>
+          </property>
          </widget>
         </item>
         <item>
@@ -129,7 +132,7 @@
         <item>
          <spacer name="horizontalSpacer">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -197,6 +200,19 @@
    <header>Settings/MemoryCardSettingsWidget.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>directory</tabstop>
+  <tabstop>browse</tabstop>
+  <tabstop>open</tabstop>
+  <tabstop>reset</tabstop>
+  <tabstop>cardList</tabstop>
+  <tabstop>refreshCard</tabstop>
+  <tabstop>createCard</tabstop>
+  <tabstop>renameCard</tabstop>
+  <tabstop>convertCard</tabstop>
+  <tabstop>deleteCard</tabstop>
+  <tabstop>automaticManagement</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/PatchDetailsWidget.ui
+++ b/pcsx2-qt/Settings/PatchDetailsWidget.ui
@@ -29,7 +29,7 @@
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -58,12 +58,15 @@
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Author: &lt;/span&gt;Patch Author&lt;/p&gt;&lt;p&gt;Description would go here&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+      <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
      </property>
     </widget>
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>enabled</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Settings/SettingsWindow.ui
+++ b/pcsx2-qt/Settings/SettingsWindow.ui
@@ -135,6 +135,14 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>settingsCategory</tabstop>
+  <tabstop>helpText</tabstop>
+  <tabstop>restoreDefaultsButton</tabstop>
+  <tabstop>copyGlobalSettingsButton</tabstop>
+  <tabstop>clearGameSettingsButton</tabstop>
+  <tabstop>closeButton</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/USBBindingWidget_Buzz.ui
+++ b/pcsx2-qt/Settings/USBBindingWidget_Buzz.ui
@@ -32,7 +32,13 @@
    <item row="0" column="0">
     <spacer name="horizontalSpacer0">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
      </property>
     </spacer>
    </item>
@@ -891,14 +897,26 @@
    <item row="0" column="5">
     <spacer name="horizontalSpacer5">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
      </property>
     </spacer>
    </item>
    <item row="1" column="1" colspan="4">
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
      </property>
     </spacer>
    </item>
@@ -911,6 +929,28 @@
    <header>Settings/InputBindingWidget.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>Red1</tabstop>
+  <tabstop>Blue1</tabstop>
+  <tabstop>Orange1</tabstop>
+  <tabstop>Green1</tabstop>
+  <tabstop>Yellow1</tabstop>
+  <tabstop>Red2</tabstop>
+  <tabstop>Blue2</tabstop>
+  <tabstop>Orange2</tabstop>
+  <tabstop>Green2</tabstop>
+  <tabstop>Yellow2</tabstop>
+  <tabstop>Red3</tabstop>
+  <tabstop>Blue3</tabstop>
+  <tabstop>Orange3</tabstop>
+  <tabstop>Green3</tabstop>
+  <tabstop>Yellow3</tabstop>
+  <tabstop>Red4</tabstop>
+  <tabstop>Blue4</tabstop>
+  <tabstop>Orange4</tabstop>
+  <tabstop>Green4</tabstop>
+  <tabstop>Yellow4</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/USBBindingWidget_DenshaCon.ui
+++ b/pcsx2-qt/Settings/USBBindingWidget_DenshaCon.ui
@@ -748,6 +748,20 @@
    <header>Settings/InputBindingWidget.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>Power</tabstop>
+  <tabstop>Brake</tabstop>
+  <tabstop>Up</tabstop>
+  <tabstop>Down</tabstop>
+  <tabstop>Left</tabstop>
+  <tabstop>Right</tabstop>
+  <tabstop>D</tabstop>
+  <tabstop>B</tabstop>
+  <tabstop>A</tabstop>
+  <tabstop>C</tabstop>
+  <tabstop>Select</tabstop>
+  <tabstop>Start</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/USBBindingWidget_DrivingForce.ui
+++ b/pcsx2-qt/Settings/USBBindingWidget_DrivingForce.ui
@@ -346,7 +346,7 @@
      <item>
       <spacer name="verticalSpacer_2">
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -399,7 +399,7 @@
      <item>
       <spacer name="verticalSpacer_5">
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -502,7 +502,7 @@
        <item>
         <spacer name="horizontalSpacer">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -546,7 +546,7 @@
        <item>
         <spacer name="horizontalSpacer_2">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -642,7 +642,7 @@
      <item>
       <spacer name="verticalSpacer">
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -908,7 +908,7 @@
      <item>
       <spacer name="verticalSpacer_7">
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -961,7 +961,7 @@
      <item>
       <spacer name="verticalSpacer_4">
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -982,6 +982,27 @@
    <header>Settings/InputBindingWidget.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>SteeringLeft</tabstop>
+  <tabstop>SteeringRight</tabstop>
+  <tabstop>Brake</tabstop>
+  <tabstop>Throttle</tabstop>
+  <tabstop>DPadUp</tabstop>
+  <tabstop>DPadDown</tabstop>
+  <tabstop>DPadLeft</tabstop>
+  <tabstop>DPadRight</tabstop>
+  <tabstop>Triangle</tabstop>
+  <tabstop>Cross</tabstop>
+  <tabstop>Square</tabstop>
+  <tabstop>Circle</tabstop>
+  <tabstop>L1</tabstop>
+  <tabstop>L2</tabstop>
+  <tabstop>R1</tabstop>
+  <tabstop>R2</tabstop>
+  <tabstop>Select</tabstop>
+  <tabstop>Start</tabstop>
+  <tabstop>FFDevice</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/USBBindingWidget_GTForce.ui
+++ b/pcsx2-qt/Settings/USBBindingWidget_GTForce.ui
@@ -103,7 +103,7 @@
      <item>
       <spacer name="verticalSpacer_3">
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -196,7 +196,7 @@
      <item>
       <spacer name="verticalSpacer_2">
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -249,7 +249,7 @@
      <item>
       <spacer name="verticalSpacer_5">
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -352,7 +352,7 @@
        <item>
         <spacer name="horizontalSpacer">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -390,7 +390,7 @@
        <item>
         <spacer name="horizontalSpacer_2">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -489,7 +489,7 @@
      <item>
       <spacer name="verticalSpacer">
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -506,7 +506,7 @@
      <item>
       <spacer name="verticalSpacer_6">
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -599,7 +599,7 @@
      <item>
       <spacer name="verticalSpacer_7">
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -652,7 +652,7 @@
      <item>
       <spacer name="verticalSpacer_4">
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -673,6 +673,19 @@
    <header>Settings/InputBindingWidget.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>SteeringLeft</tabstop>
+  <tabstop>SteeringRight</tabstop>
+  <tabstop>Brake</tabstop>
+  <tabstop>Throttle</tabstop>
+  <tabstop>MenuDown</tabstop>
+  <tabstop>MenuUp</tabstop>
+  <tabstop>X</tabstop>
+  <tabstop>A</tabstop>
+  <tabstop>Y</tabstop>
+  <tabstop>B</tabstop>
+  <tabstop>FFDevice</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/USBBindingWidget_Gametrak.ui
+++ b/pcsx2-qt/Settings/USBBindingWidget_Gametrak.ui
@@ -32,7 +32,13 @@
    <item row="0" column="0">
     <spacer name="horizontalSpacer0">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
      </property>
     </spacer>
    </item>
@@ -87,7 +93,7 @@
               <string>Left=0 / Right=0x3ff</string>
              </property>
              <property name="alignment">
-              <set>Qt::AlignCenter</set>
+              <set>Qt::AlignmentFlag::AlignCenter</set>
              </property>
             </widget>
            </item>
@@ -137,7 +143,7 @@
               <string>Back=0 / Front=0x3ff</string>
              </property>
              <property name="alignment">
-              <set>Qt::AlignCenter</set>
+              <set>Qt::AlignmentFlag::AlignCenter</set>
              </property>
             </widget>
            </item>
@@ -187,7 +193,7 @@
               <string>Top=0 / Bottom=0xfff</string>
              </property>
              <property name="alignment">
-              <set>Qt::AlignCenter</set>
+              <set>Qt::AlignmentFlag::AlignCenter</set>
              </property>
             </widget>
            </item>
@@ -294,7 +300,7 @@
               <string>Left=0 / Right=0x3ff</string>
              </property>
              <property name="alignment">
-              <set>Qt::AlignCenter</set>
+              <set>Qt::AlignmentFlag::AlignCenter</set>
              </property>
             </widget>
            </item>
@@ -344,7 +350,7 @@
               <string>Back=0 / Front=0x3ff</string>
              </property>
              <property name="alignment">
-              <set>Qt::AlignCenter</set>
+              <set>Qt::AlignmentFlag::AlignCenter</set>
              </property>
             </widget>
            </item>
@@ -394,7 +400,7 @@
               <string>Top=0 / Bottom=0xfff</string>
              </property>
              <property name="alignment">
-              <set>Qt::AlignCenter</set>
+              <set>Qt::AlignmentFlag::AlignCenter</set>
              </property>
             </widget>
            </item>
@@ -409,14 +415,26 @@
    <item row="0" column="4">
     <spacer name="horizontalSpacer4">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
      </property>
     </spacer>
    </item>
    <item row="1" column="1" colspan="3">
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
      </property>
     </spacer>
    </item>
@@ -429,6 +447,15 @@
    <header>Settings/InputBindingWidget.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>LeftX</tabstop>
+  <tabstop>LeftY</tabstop>
+  <tabstop>LeftZ</tabstop>
+  <tabstop>RightX</tabstop>
+  <tabstop>RightY</tabstop>
+  <tabstop>RightZ</tabstop>
+  <tabstop>FootPedal</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/USBBindingWidget_GunCon2.ui
+++ b/pcsx2-qt/Settings/USBBindingWidget_GunCon2.ui
@@ -415,7 +415,7 @@
 &lt;p&gt;If you want to use a controller, or lightgun which simulates a controller instead of a mouse, then you should bind it to Relative Aiming. Otherwise, Relative Aiming should be &lt;strong&gt;left unbound&lt;/strong&gt;.&lt;/p&gt;</string>
         </property>
         <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
@@ -428,7 +428,7 @@
    <item row="0" column="4" rowspan="3">
     <spacer name="horizontalSpacer">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -441,7 +441,7 @@
    <item row="0" column="0" rowspan="3">
     <spacer name="horizontalSpacer_2">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -750,7 +750,7 @@
    <item row="3" column="0" colspan="5">
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -769,6 +769,24 @@
    <header>Settings/InputBindingWidget.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>Trigger</tabstop>
+  <tabstop>ShootOffscreen</tabstop>
+  <tabstop>Recalibrate</tabstop>
+  <tabstop>RelativeUp</tabstop>
+  <tabstop>RelativeDown</tabstop>
+  <tabstop>RelativeLeft</tabstop>
+  <tabstop>RelativeRight</tabstop>
+  <tabstop>Up</tabstop>
+  <tabstop>Down</tabstop>
+  <tabstop>Left</tabstop>
+  <tabstop>Right</tabstop>
+  <tabstop>A</tabstop>
+  <tabstop>B</tabstop>
+  <tabstop>C</tabstop>
+  <tabstop>Start</tabstop>
+  <tabstop>Select</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/USBBindingWidget_RealPlay.ui
+++ b/pcsx2-qt/Settings/USBBindingWidget_RealPlay.ui
@@ -472,21 +472,39 @@
    <item row="0" column="0" rowspan="4">
     <spacer name="horizontalSpacer0">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
      </property>
     </spacer>
    </item>
    <item row="0" column="8" rowspan="4">
     <spacer name="horizontalSpacer8">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
      </property>
     </spacer>
    </item>
    <item row="4" column="1" colspan="7">
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
      </property>
     </spacer>
    </item>
@@ -499,6 +517,19 @@
    <header>Settings/InputBindingWidget.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>DPadUp</tabstop>
+  <tabstop>DPadDown</tabstop>
+  <tabstop>DPadLeft</tabstop>
+  <tabstop>DPadRight</tabstop>
+  <tabstop>Red</tabstop>
+  <tabstop>Green</tabstop>
+  <tabstop>Yellow</tabstop>
+  <tabstop>Blue</tabstop>
+  <tabstop>AccelX</tabstop>
+  <tabstop>AccelY</tabstop>
+  <tabstop>AccelZ</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/USBBindingWidget_RyojouhenCon.ui
+++ b/pcsx2-qt/Settings/USBBindingWidget_RyojouhenCon.ui
@@ -755,6 +755,21 @@
    <header>Settings/InputBindingWidget.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>Power</tabstop>
+  <tabstop>LeftDoor</tabstop>
+  <tabstop>RightDoor</tabstop>
+  <tabstop>Brake</tabstop>
+  <tabstop>Up</tabstop>
+  <tabstop>Down</tabstop>
+  <tabstop>Left</tabstop>
+  <tabstop>Right</tabstop>
+  <tabstop>Select</tabstop>
+  <tabstop>Start</tabstop>
+  <tabstop>Camera</tabstop>
+  <tabstop>Announce</tabstop>
+  <tabstop>Horn</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/USBBindingWidget_ShinkansenCon.ui
+++ b/pcsx2-qt/Settings/USBBindingWidget_ShinkansenCon.ui
@@ -57,7 +57,7 @@
      <item>
       <widget class="QGroupBox" name="groupBox_32">
        <property name="title">
-	    <string extracomment="Power refers to the train's accelerator which causes the train to increase speed.">Power Lever</string>
+        <string extracomment="Power refers to the train's accelerator which causes the train to increase speed.">Power Lever</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_31">
         <property name="leftMargin">
@@ -730,6 +730,20 @@
    <header>Settings/InputBindingWidget.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>Power</tabstop>
+  <tabstop>Brake</tabstop>
+  <tabstop>Up</tabstop>
+  <tabstop>Down</tabstop>
+  <tabstop>Left</tabstop>
+  <tabstop>Right</tabstop>
+  <tabstop>D</tabstop>
+  <tabstop>B</tabstop>
+  <tabstop>A</tabstop>
+  <tabstop>C</tabstop>
+  <tabstop>Select</tabstop>
+  <tabstop>Start</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/USBBindingWidget_TranceVibrator.ui
+++ b/pcsx2-qt/Settings/USBBindingWidget_TranceVibrator.ui
@@ -38,7 +38,13 @@
    <item row="0" column="0">
     <spacer name="horizontalSpacer0">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
      </property>
     </spacer>
    </item>
@@ -89,14 +95,26 @@
    <item row="0" column="2">
     <spacer name="horizontalSpacer1">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
      </property>
     </spacer>
    </item>
    <item row="1" column="1">
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
      </property>
     </spacer>
    </item>
@@ -109,6 +127,9 @@
    <header>Settings/InputBindingWidget.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>Motor</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/Settings/USBDeviceWidget.ui
+++ b/pcsx2-qt/Settings/USBDeviceWidget.ui
@@ -43,14 +43,13 @@
            <string>Bindings</string>
           </property>
           <property name="icon">
-           <iconset theme="controller-line">
-            <normaloff>.</normaloff>.</iconset>
+           <iconset theme="controller-line"/>
           </property>
           <property name="checkable">
            <bool>true</bool>
           </property>
           <property name="toolButtonStyle">
-           <enum>Qt::ToolButtonTextBesideIcon</enum>
+           <enum>Qt::ToolButtonStyle::ToolButtonTextBesideIcon</enum>
           </property>
           <property name="autoRaise">
            <bool>true</bool>
@@ -63,14 +62,13 @@
            <string>Settings</string>
           </property>
           <property name="icon">
-           <iconset theme="checkbox-multiple-blank-line">
-            <normaloff>.</normaloff>.</iconset>
+           <iconset theme="checkbox-multiple-blank-line"/>
           </property>
           <property name="checkable">
            <bool>true</bool>
           </property>
           <property name="toolButtonStyle">
-           <enum>Qt::ToolButtonTextBesideIcon</enum>
+           <enum>Qt::ToolButtonStyle::ToolButtonTextBesideIcon</enum>
           </property>
           <property name="autoRaise">
            <bool>true</bool>
@@ -82,7 +80,7 @@
       <item>
        <spacer name="horizontalSpacer">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -100,11 +98,10 @@
            <string>Automatic Mapping</string>
           </property>
           <property name="icon">
-           <iconset theme="controller-line">
-            <normaloff>.</normaloff>.</iconset>
+           <iconset theme="controller-line"/>
           </property>
           <property name="toolButtonStyle">
-           <enum>Qt::ToolButtonTextBesideIcon</enum>
+           <enum>Qt::ToolButtonStyle::ToolButtonTextBesideIcon</enum>
           </property>
          </widget>
         </item>
@@ -114,11 +111,10 @@
            <string>Clear Mapping</string>
           </property>
           <property name="icon">
-           <iconset theme="trash-fill">
-            <normaloff>.</normaloff>.</iconset>
+           <iconset theme="trash-fill"/>
           </property>
           <property name="toolButtonStyle">
-           <enum>Qt::ToolButtonTextBesideIcon</enum>
+           <enum>Qt::ToolButtonStyle::ToolButtonTextBesideIcon</enum>
           </property>
          </widget>
         </item>
@@ -132,6 +128,14 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>deviceType</tabstop>
+  <tabstop>deviceSubtype</tabstop>
+  <tabstop>bindings</tabstop>
+  <tabstop>settings</tabstop>
+  <tabstop>automaticBinding</tabstop>
+  <tabstop>clearBindings</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/SetupWizardDialog.ui
+++ b/pcsx2-qt/SetupWizardDialog.ui
@@ -103,7 +103,7 @@
      <item>
       <spacer name="verticalSpacer">
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -143,7 +143,7 @@
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;h1 style=&quot; margin-top:18px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:xx-large; font-weight:700;&quot;&gt;Welcome to PCSX2!&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;This wizard will help guide you through the configuration steps required to use the application. It is recommended if this is your first time installing PCSX2 that you view the setup guide &lt;a href=&quot;https://pcsx2.net/docs/&quot;&gt;here&lt;/a&gt;.&lt;/p&gt;&lt;p&gt;By default, PCSX2 will connect to the server at &lt;a href=&quot;https://pcsx2.net/&quot;&gt;pcsx2.net&lt;/a&gt; to check for updates, and if available and confirmed, download update packages from &lt;a href=&quot;https://github.com/&quot;&gt;github.com&lt;/a&gt;. If you do not wish for PCSX2 to make any network connections on startup, you should uncheck the Automatic Updates option now. The Automatic Update setting can be changed later at any time in Interface Settings.&lt;/p&gt;&lt;p&gt;Please choose a language and theme to begin.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+          <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
          </property>
          <property name="wordWrap">
           <bool>true</bool>
@@ -152,16 +152,19 @@
           <bool>true</bool>
          </property>
          <property name="textInteractionFlags">
-          <set>Qt::TextBrowserInteraction</set>
+          <set>Qt::TextInteractionFlag::TextBrowserInteraction</set>
          </property>
         </widget>
        </item>
        <item>
         <layout class="QFormLayout" name="formLayout_3">
          <item row="0" column="0">
-          <widget class="QLabel" name="label_3">
+          <widget class="QLabel" name="languageLabel">
            <property name="text">
             <string>Language:</string>
+           </property>
+           <property name="buddy">
+            <cstring>language</cstring>
            </property>
           </widget>
          </item>
@@ -176,9 +179,12 @@
           </widget>
          </item>
          <item row="1" column="0">
-          <widget class="QLabel" name="label_5">
+          <widget class="QLabel" name="themeLabel">
            <property name="text">
             <string>Theme:</string>
+           </property>
+           <property name="buddy">
+            <cstring>theme</cstring>
            </property>
           </widget>
          </item>
@@ -188,7 +194,7 @@
          <item row="3" column="1">
           <spacer name="verticalSpacer_3">
            <property name="orientation">
-            <enum>Qt::Vertical</enum>
+            <enum>Qt::Orientation::Vertical</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -229,7 +235,7 @@
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;PCSX2 requires a PS2 BIOS in order to run.&lt;/p&gt;&lt;p&gt;For legal reasons, you must obtain a BIOS &lt;strong&gt;from an actual PS2 unit that you own&lt;/strong&gt; (borrowing doesn't count).&lt;/p&gt;&lt;p&gt;Once dumped, this BIOS image should be placed in the bios folder within the data directory shown below, or you can instruct PCSX2 to scan an alternative directory.&lt;/p&gt;&lt;p&gt;A guide for dumping your BIOS can be found &lt;a href=&quot;https://pcsx2.net/docs/setup/bios/&quot;&gt;here&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+          <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
          </property>
          <property name="wordWrap">
           <bool>true</bool>
@@ -238,16 +244,19 @@
           <bool>true</bool>
          </property>
          <property name="textInteractionFlags">
-          <set>Qt::TextBrowserInteraction</set>
+          <set>Qt::TextInteractionFlag::TextBrowserInteraction</set>
          </property>
         </widget>
        </item>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_3">
          <item>
-          <widget class="QLabel" name="label_10">
+          <widget class="QLabel" name="biosSearchDirectoryLabel">
            <property name="text">
             <string>BIOS Directory:</string>
+           </property>
+           <property name="buddy">
+            <cstring>biosSearchDirectory</cstring>
            </property>
           </widget>
          </item>
@@ -298,7 +307,7 @@
          <item>
           <spacer name="horizontalSpacer_4">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -346,7 +355,7 @@
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;PCSX2 will automatically scan and identify games from the selected directories below, and populate the game list.&lt;br&gt;These games should be dumped from discs you own. Guides for dumping discs can be found &lt;a href=&quot;https://pcsx2.net/docs/setup/dumping&quot;&gt;here&lt;/a&gt;.&lt;/p&gt;&lt;p&gt;Supported formats for dumps include:&lt;/p&gt;&lt;p&gt;&lt;ul&gt;&lt;li&gt;.bin/.iso (ISO Disc Images)&lt;/li&gt;&lt;li&gt;.mdf (Media Descriptor File)&lt;/li&gt;&lt;li&gt;.chd (Compressed Hunks of Data)&lt;/li&gt;&lt;li&gt;.cso (Compressed ISO)&lt;/li&gt;&lt;li&gt;.zso (Compressed ISO)&lt;/li&gt;&lt;li&gt;.gz (Gzip Compressed ISO)&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+          <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
          </property>
          <property name="wordWrap">
           <bool>true</bool>
@@ -355,23 +364,26 @@
           <bool>true</bool>
          </property>
          <property name="textInteractionFlags">
-          <set>Qt::TextBrowserInteraction</set>
+          <set>Qt::TextInteractionFlag::TextBrowserInteraction</set>
          </property>
         </widget>
        </item>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_4">
          <item>
-          <widget class="QLabel" name="label_7">
+          <widget class="QLabel" name="searchDirectoryListLabel">
            <property name="text">
             <string>Search Directories (will be scanned for games)</string>
+           </property>
+           <property name="buddy">
+            <cstring>searchDirectoryList</cstring>
            </property>
           </widget>
          </item>
          <item>
           <spacer name="horizontalSpacer_5">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -393,11 +405,10 @@
             <string>Add...</string>
            </property>
            <property name="icon">
-            <iconset theme="folder-add-line">
-             <normaloff>.</normaloff>.</iconset>
+            <iconset theme="folder-add-line"/>
            </property>
            <property name="toolButtonStyle">
-            <enum>Qt::ToolButtonTextBesideIcon</enum>
+            <enum>Qt::ToolButtonStyle::ToolButtonTextBesideIcon</enum>
            </property>
           </widget>
          </item>
@@ -413,11 +424,10 @@
             <string>Remove</string>
            </property>
            <property name="icon">
-            <iconset theme="folder-reduce-line">
-             <normaloff>.</normaloff>.</iconset>
+            <iconset theme="folder-reduce-line"/>
            </property>
            <property name="toolButtonStyle">
-            <enum>Qt::ToolButtonTextBesideIcon</enum>
+            <enum>Qt::ToolButtonStyle::ToolButtonTextBesideIcon</enum>
            </property>
           </widget>
          </item>
@@ -490,6 +500,9 @@
             <property name="text">
              <string>Controller Type:</string>
             </property>
+            <property name="buddy">
+             <cstring>controller1Type</cstring>
+            </property>
            </widget>
           </item>
           <item row="1" column="1">
@@ -504,7 +517,7 @@
             <item>
              <spacer name="horizontalSpacer_6">
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -524,7 +537,7 @@
                 <normaloff>Settings</normaloff>Settings</iconset>
               </property>
               <property name="toolButtonStyle">
-               <enum>Qt::ToolButtonTextBesideIcon</enum>
+               <enum>Qt::ToolButtonStyle::ToolButtonTextBesideIcon</enum>
               </property>
              </widget>
             </item>
@@ -543,6 +556,9 @@
            <widget class="QLabel" name="label_13">
             <property name="text">
              <string>Controller Type:</string>
+            </property>
+            <property name="buddy">
+             <cstring>controller2Type</cstring>
             </property>
            </widget>
           </item>
@@ -568,7 +584,7 @@
             <item>
              <spacer name="horizontalSpacer_8">
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -588,7 +604,7 @@
                 <normaloff>Settings</normaloff>Settings</iconset>
               </property>
               <property name="toolButtonStyle">
-               <enum>Qt::ToolButtonTextBesideIcon</enum>
+               <enum>Qt::ToolButtonStyle::ToolButtonTextBesideIcon</enum>
               </property>
              </widget>
             </item>
@@ -600,7 +616,7 @@
        <item>
         <spacer name="verticalSpacer_4">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -632,7 +648,7 @@
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;h1 style=&quot; margin-top:18px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:xx-large; font-weight:700;&quot;&gt;Setup Complete!&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;You are now ready to run games.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Warning: Do not run untrusted programs in PCSX2. It is not a sandbox and cannot protect your computer from malicious software.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Further options are available under the settings menu. You can also use the Big Picture UI for navigation entirely with a gamepad.&lt;/p&gt;&lt;p&gt;We hope you enjoy using PCSX2.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+          <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
          </property>
          <property name="wordWrap">
           <bool>true</bool>
@@ -651,7 +667,7 @@
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>

--- a/pcsx2-qt/Tools/InputRecording/InputRecordingViewer.ui
+++ b/pcsx2-qt/Tools/InputRecording/InputRecordingViewer.ui
@@ -69,6 +69,9 @@
   </action>
  </widget>
  <layoutdefault spacing="6" margin="9"/>
+ <tabstops>
+  <tabstop>tableWidget</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/pcsx2-qt/Tools/InputRecording/NewInputRecordingDlg.ui
+++ b/pcsx2-qt/Tools/InputRecording/NewInputRecordingDlg.ui
@@ -76,6 +76,9 @@
        <property name="text">
         <string>Select File Path</string>
        </property>
+       <property name="buddy">
+        <cstring>m_filePathInput</cstring>
+       </property>
       </widget>
      </item>
      <item>
@@ -97,6 +100,9 @@
        <property name="text">
         <string>Enter Author Name</string>
        </property>
+       <property name="buddy">
+        <cstring>m_authorInput</cstring>
+       </property>
       </widget>
      </item>
      <item>
@@ -111,10 +117,10 @@
         </sizepolicy>
        </property>
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="standardButtons">
-        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+        <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
        </property>
        <property name="centerButtons">
         <bool>true</bool>
@@ -125,6 +131,13 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>m_recTypePowerOn</tabstop>
+  <tabstop>m_recTypeSaveState</tabstop>
+  <tabstop>m_filePathInput</tabstop>
+  <tabstop>m_filePathBrowseBtn</tabstop>
+  <tabstop>m_authorInput</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>


### PR DESCRIPTION
### Description of Changes
Adds buddies and tabstops to interactive elements in the Qt UI for accessibility, polish, and consistency.

### Rationale behind Changes

#### Buddies
Buddies are a property in Qt which associate a label with an interactive element. For example, if I have a UI looking like `label1: [spinbox1]`, Qt will associate spinbox1 with label1 when label1 is given spinbox1 as its buddy. This is transparent for most users, but for users with a screen reader, this means you can actually tell what an interactive element does. It's a win for accessibility with minimal maintenance overhead and arguably better self-documentation.

Currently, for example, focusing a spinbox will just say that you've focused a spinbox without saying what it's supposed to be for – rendering much of our UI totally unusable. With a buddy, it will read out the label on top of the element type. As an example, with buddies, the OSD scale option will read approximately as "OSD Scale: Spin Box 100", but without, it will only read "Spin Box 100". There is no way to focus the labels either, so it's unlikely they can be read out without buddies.

These are easy to follow in the raw XML, and the Qt Widgets Designer has an easy interface for them under `Edit` > `Edit Buddies`.

<img width="741" height="546" alt="image" src="https://github.com/user-attachments/assets/44c30a40-a9c4-478f-ac0b-b50fe94ab70c" />

<img width="440" height="190" alt="image" src="https://github.com/user-attachments/assets/861e0301-30d0-44e1-8a2e-90239f27cdd5" />

#### Tabstops
Tabstops are another property of Qt which allows an explicit ordering of elements when tabbing through a widget (i.e. focusing on one element then pressing `Tab`). Without them, the tab order is subject to the physical ordering of the elements in XML, which 1) does not inherently correspond to the row/column order displayed and 2) is highly chaotic and unrealistic to maintain, especially when a file is run through the Qt Widgets Designer.

Currently, tab orders in almost every menu are complete nonsense (see e.g. the global controller settings, various settings menus, etc.), which is a problem for both accessibility and polish.

These are trivial to understand in the raw XML, because they're represented as one singular list, and the Qt Widgets Designer has an easy interface for them under `Edit` > `Edit Tab Order`.

<img width="739" height="539" alt="image" src="https://github.com/user-attachments/assets/3599f148-087f-4006-8c77-da1376118f06" />

<img width="374" height="360" alt="image" src="https://github.com/user-attachments/assets/fb7b7d80-6ae4-4510-bce1-41f9a3a41927" />

I chose the Graphics Display widget at random. Here is the current tab ordering without tabstops:

<img width="732" height="545" alt="image" src="https://github.com/user-attachments/assets/5bdcdea5-f307-4a06-951d-8e0d84f2ac12" />

### Suggested Testing Steps
* Make sure on each page with interactive elements that tabbing through is consistent and sensible.
* Make sure when using a screen reader that interactive elements with a label are read out.

### Did you use AI to help find, test, or implement this issue or feature?
No.