### PR TITLE
[WIP] DEV9: Sockets, allow forwading UDP port for LAN hosting

### DIFF
--- a/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
@@ -137,12 +137,12 @@ DEV9SettingsWidget::DEV9SettingsWidget(SettingsWindow* settings_dialog, QWidget*
 	//////////////////////////////////////////////////////////////////////////
 	m_ethHost_model = new QStandardItemModel(0, 4, m_ui.ethHosts);
 
-	QStringList headers;
-	headers.push_back(tr("Name"));
-	headers.push_back(tr("Hostname"));
-	headers.push_back(tr("Address"));
-	headers.push_back(tr("Enabled"));
-	m_ethHost_model->setHorizontalHeaderLabels(headers);
+	QStringList hostHeaders;
+	hostHeaders.push_back(tr("Name"));
+	hostHeaders.push_back(tr("Hostname"));
+	hostHeaders.push_back(tr("Address"));
+	hostHeaders.push_back(tr("Enabled"));
+	m_ethHost_model->setHorizontalHeaderLabels(hostHeaders);
 
 	connect(m_ethHost_model, &QStandardItemModel::itemChanged, this, &DEV9SettingsWidget::onEthHostEdit);
 
@@ -163,6 +163,36 @@ DEV9SettingsWidget::DEV9SettingsWidget(SettingsWindow* settings_dialog, QWidget*
 	connect(m_ui.ethHostImport, &QPushButton::clicked, this, &DEV9SettingsWidget::onEthHostImport);
 
 	connect(m_ui.ethHostPerGame, &QPushButton::clicked, this, &DEV9SettingsWidget::onEthHostPerGame);
+
+	//////////////////////////////////////////////////////////////////////////
+	// Port Settings
+	//////////////////////////////////////////////////////////////////////////
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.ethLanMode, "DEV9/Eth", "LanMode", false);
+
+	m_ethPort_model = new QStandardItemModel(0, 4, m_ui.ethOpenPorts);
+
+	QStringList portHeaders;
+	portHeaders.push_back(tr("Name"));
+	portHeaders.push_back(tr("Protocol"));
+	portHeaders.push_back(tr("Port"));
+	portHeaders.push_back(tr("Enabled"));
+	m_ethPort_model->setHorizontalHeaderLabels(portHeaders);
+
+	connect(m_ethPort_model, QOverload<QStandardItem*>::of(&QStandardItemModel::itemChanged), this, &DEV9SettingsWidget::onEthPortEdit);
+
+	m_ethPorts_proxy = new QSortFilterProxyModel(m_ui.ethOpenPorts);
+	m_ethPorts_proxy->setSourceModel(m_ethPort_model);
+
+	m_ui.ethOpenPorts->setModel(m_ethPorts_proxy);
+	m_ui.ethOpenPorts->setItemDelegateForColumn(1, new ComboBoxItemDelegate(m_ui.ethOpenPorts, Pcsx2Config::DEV9Options::PortModeNames, "DEV9SettingsWidget"));
+	m_ui.ethOpenPorts->setItemDelegateForColumn(2, new SpinBoxItemDelegate(m_ui.ethOpenPorts, 0, UINT16_MAX));
+
+	RefreshPortList();
+
+	m_ui.ethOpenPorts->installEventFilter(this);
+
+	connect(m_ui.ethPortAdd, &QPushButton::clicked, this, &DEV9SettingsWidget::onEthPortAdd);
+	connect(m_ui.ethPortDel, &QPushButton::clicked, this, &DEV9SettingsWidget::onEthPortDel);
 
 	//////////////////////////////////////////////////////////////////////////
 	// HDD Settings
@@ -305,6 +335,8 @@ void DEV9SettingsWidget::onEthDeviceTypeChanged(int index)
 	m_ui.ethInterceptDHCPLabel->setEnabled((m_adapter_options & AdapterOptions::DHCP_ForcedOn) == AdapterOptions::None);
 	m_ui.ethInterceptDHCP->setEnabled((m_adapter_options & AdapterOptions::DHCP_ForcedOn) == AdapterOptions::None);
 	onEthDHCPInterceptChanged(m_ui.ethInterceptDHCP->checkState());
+	
+	m_ui.ethTabWidget->setTabVisible(2, (m_adapter_options & AdapterOptions::HasPortForwarding) == AdapterOptions::HasPortForwarding);
 }
 
 void DEV9SettingsWidget::onEthDeviceChanged(int index)
@@ -628,6 +660,102 @@ void DEV9SettingsWidget::onEthHostEdit(QStandardItem* item)
 	}
 }
 
+void DEV9SettingsWidget::onEthPortAdd()
+{
+	PortEntryUi port;
+	port.Desc = "New Port";
+	port.Protocol = "UDP";
+	port.Enabled = false;
+	AddNewPortConfig(port);
+
+	//Select new Item
+	const QModelIndex viewIndex = m_ethPorts_proxy->mapFromSource(m_ethPort_model->index(m_ethPort_model->rowCount() - 1, 1));
+	m_ui.ethOpenPorts->scrollTo(viewIndex, QAbstractItemView::EnsureVisible);
+	m_ui.ethOpenPorts->selectionModel()->setCurrentIndex(viewIndex, QItemSelectionModel::ClearAndSelect);
+}
+
+void DEV9SettingsWidget::onEthPortDel()
+{
+	if (m_ui.ethOpenPorts->selectionModel()->hasSelection())
+	{
+		const QModelIndex selectedIndex = m_ui.ethOpenPorts->selectionModel()->currentIndex();
+		const int modelRow = m_ethPorts_proxy->mapToSource(selectedIndex).row();
+		DeletePortConfig(modelRow);
+	}
+}
+
+void DEV9SettingsWidget::onEthPortPerGame()
+{
+	const std::optional<int> portLengthOpt = dialog()->getIntValue("DEV9/Eth/Ports", "Count", std::nullopt);
+	if (!portLengthOpt.has_value())
+	{
+		QMessageBox::StandardButton ret = QMessageBox::question(this, tr("Per Game Port list"),
+			tr("Copy global settings?"),
+			QMessageBox::StandardButton::Yes | QMessageBox::StandardButton::No | QMessageBox::StandardButton::Cancel, QMessageBox::StandardButton::Yes);
+
+		switch (ret)
+		{
+			case QMessageBox::StandardButton::No:
+				dialog()->setIntSettingValue("DEV9/Eth/Ports", "Count", 0);
+				break;
+
+			case QMessageBox::StandardButton::Yes:
+			{
+				dialog()->setIntSettingValue("DEV9/Eth/Ports", "Count", 0);
+				std::vector<PortEntryUi> ports = ListBasePortsConfig();
+				for (size_t i = 0; i < ports.size(); i++)
+					AddNewPortConfig(ports[i]);
+				break;
+			}
+
+			case QMessageBox::StandardButton::Cancel:
+				return;
+
+			default:
+				return;
+		}
+	}
+	else
+	{
+		QMessageBox::StandardButton ret = QMessageBox::question(this, tr("Per Game Port list"),
+			tr("Delete per game port list?"),
+			QMessageBox::StandardButton::Yes | QMessageBox::StandardButton::Cancel, QMessageBox::StandardButton::Yes);
+
+		if (ret == QMessageBox::StandardButton::Yes)
+		{
+			const int hostLength = CountPortsConfig();
+			for (int i = hostLength - 1; i >= 0; i--)
+				DeletePortConfig(i);
+		}
+		dialog()->setIntSettingValue("DEV9/Eth/Ports", nullptr, std::nullopt);
+	}
+
+	RefreshHostList();
+}
+
+void DEV9SettingsWidget::onEthPortEdit(QStandardItem* item)
+{
+	const int row = item->row();
+	std::string section = "DEV9/Eth/Ports/Port" + std::to_string(row);
+	switch (item->column())
+	{
+		case 0: //Name
+			dialog()->setStringSettingValue(section.c_str(), "Desc", item->text().toUtf8().constData());
+			break;
+		case 1: //Protocol
+			dialog()->setStringSettingValue(section.c_str(), "Protocol", item->text().toUtf8().constData());
+			break;
+		case 2: //Port
+			dialog()->setIntSettingValue(section.c_str(), "Port", item->data(Qt::EditRole).toInt());
+			break;
+		case 3: //Enabled
+			dialog()->setBoolSettingValue(section.c_str(), "Enabled", item->checkState() == Qt::CheckState::Checked);
+			break;
+		default:
+			break;
+	}
+}
+
 void DEV9SettingsWidget::onHddEnabledChanged(Qt::CheckState state)
 {
 	const bool enabled = state == Qt::CheckState::PartiallyChecked ? Host::GetBaseBoolSettingValue("DEV9/Hdd", "HddEnable", false) : state;
@@ -843,6 +971,14 @@ bool DEV9SettingsWidget::eventFilter(QObject* object, QEvent* event)
 			QtUtils::ResizeColumnsForTableView(m_ui.ethHosts, {-1, 170, 90, 80});
 		else if (event->type() == QEvent::Show)
 			QtUtils::ResizeColumnsForTableView(m_ui.ethHosts, {-1, 170, 90, 80});
+	}
+	if (object == m_ui.ethOpenPorts)
+	{
+		//Check isVisible to avoind an unnessecery call to ResizeColumnsForTableView()
+		if (event->type() == QEvent::Resize && m_ui.ethOpenPorts->isVisible())
+			QtUtils::ResizeColumnsForTableView(m_ui.ethOpenPorts, {-1, 90, 170, 80});
+		else if (event->type() == QEvent::Show)
+			QtUtils::ResizeColumnsForTableView(m_ui.ethOpenPorts, {-1, 90, 170, 80});
 	}
 	return false;
 }
@@ -1117,6 +1253,173 @@ void DEV9SettingsWidget::DeleteHostConfig(int index)
 
 	dialog()->setIntSettingValue("DEV9/Eth/Hosts", "Count", hostLength - 1);
 	RefreshHostList();
+}
+
+void DEV9SettingsWidget::RefreshPortList()
+{
+	while (m_ethPort_model->rowCount() > 0)
+		m_ethPort_model->removeRow(0);
+
+	bool enableHostsUi;
+
+	std::vector<PortEntryUi> ports;
+
+	if (dialog()->isPerGameSettings())
+	{
+		m_ui.ethPortPerGame->setVisible(true);
+
+		std::optional<std::vector<PortEntryUi>> portOpt = ListPortsConfig();
+		if (portOpt.has_value())
+		{
+			m_ui.ethPortPerGame->setText(tr("Use Global"));
+			ports = portOpt.value();
+			enableHostsUi = true;
+		}
+		else
+		{
+			m_ui.ethPortPerGame->setText(tr("Override"));
+			ports = ListBasePortsConfig();
+			enableHostsUi = false;
+		}
+	}
+	else
+	{
+		m_ui.ethPortPerGame->setVisible(false);
+		ports = ListPortsConfig().value();
+		enableHostsUi = true;
+	}
+
+	m_ui.ethOpenPorts->setEnabled(enableHostsUi);
+	m_ui.ethPortAdd->setEnabled(enableHostsUi);
+	m_ui.ethPortDel->setEnabled(enableHostsUi);
+
+	//Load list
+	for (size_t i = 0; i < ports.size(); i++)
+	{
+		PortEntryUi entry = ports[i];
+		const int row = m_ethPort_model->rowCount();
+		m_ethPort_model->insertRow(row);
+
+		QSignalBlocker sb(m_ethPort_model);
+
+		QStandardItem* nameItem = new QStandardItem();
+		nameItem->setText(QString::fromStdString(entry.Desc));
+		m_ethPort_model->setItem(row, 0, nameItem);
+
+		QStandardItem* protocolItem = new QStandardItem();
+		protocolItem->setText(QString::fromStdString(entry.Protocol));
+		protocolItem->setEditable(false); // Only UDP Supported
+		m_ethPort_model->setItem(row, 1, protocolItem);
+
+		QStandardItem* addressItem = new QStandardItem();
+		addressItem->setData(entry.Port, Qt::EditRole);
+		m_ethPort_model->setItem(row, 2, addressItem);
+
+		QStandardItem* enabledItem = new QStandardItem();
+		enabledItem->setEditable(false);
+		enabledItem->setCheckable(true);
+		enabledItem->setCheckState(entry.Enabled ? Qt::CheckState::Checked : Qt::CheckState::Unchecked);
+		m_ethPort_model->setItem(row, 3, enabledItem);
+	}
+
+	m_ui.ethOpenPorts->sortByColumn(0, Qt::AscendingOrder);
+}
+
+int DEV9SettingsWidget::CountPortsConfig()
+{
+	return dialog()->getIntValue("DEV9/Eth/Ports", "Count", 0).value();
+}
+
+std::optional<std::vector<PortEntryUi>> DEV9SettingsWidget::ListPortsConfig()
+{
+	std::vector<PortEntryUi> ports;
+
+	std::optional<int> hostLengthOpt;
+	if (dialog()->isPerGameSettings())
+	{
+		hostLengthOpt = dialog()->getIntValue("DEV9/Eth/Ports", "Count", std::nullopt);
+		if (!hostLengthOpt.has_value())
+			return std::nullopt;
+	}
+	else
+		hostLengthOpt = dialog()->getIntValue("DEV9/Eth/Ports", "Count", 0);
+
+	const int hostLength = hostLengthOpt.value();
+	for (int i = 0; i < hostLength; i++)
+	{
+		std::string section = "DEV9/Eth/Ports/Port" + std::to_string(i);
+
+		PortEntryUi entry;
+		entry.Protocol = dialog()->getStringValue(section.c_str(), "Protocol", "UDP").value();
+		entry.Desc = dialog()->getStringValue(section.c_str(), "Desc", "").value();
+		entry.Port = dialog()->getIntValue(section.c_str(), "Port", 0).value();
+		entry.Enabled = dialog()->getBoolValue(section.c_str(), "Enabled", false).value();
+		ports.push_back(entry);
+	}
+
+	return ports;
+}
+
+std::vector<PortEntryUi> DEV9SettingsWidget::ListBasePortsConfig()
+{
+	std::vector<PortEntryUi> hosts;
+
+	const int hostLength = Host::GetBaseIntSettingValue("DEV9/Eth/Ports", "Count", 0);
+	for (int i = 0; i < hostLength; i++)
+	{
+		std::string section = "DEV9/Eth/Ports/Port" + std::to_string(i);
+
+		PortEntryUi entry;
+		entry.Protocol = Host::GetBaseStringSettingValue(section.c_str(), "Protocol", "UDP");
+		entry.Desc = Host::GetBaseStringSettingValue(section.c_str(), "Desc", "");
+		entry.Port = Host::GetBaseIntSettingValue(section.c_str(), "Address", 0);
+		entry.Enabled = Host::GetBaseBoolSettingValue(section.c_str(), "Enabled", false);
+		hosts.push_back(entry);
+	}
+
+	return hosts;
+}
+
+void DEV9SettingsWidget::AddNewPortConfig(const PortEntryUi& port)
+{
+	const int portLength = CountPortsConfig();
+	std::string section = "DEV9/Eth/Ports/Port" + std::to_string(portLength);
+	// clang-format off
+	dialog()->setIntSettingValue   (section.c_str(), "Port",     port.Port);
+	dialog()->setStringSettingValue(section.c_str(), "Desc",     port.Desc.c_str());
+	dialog()->setStringSettingValue(section.c_str(), "Protocol", port.Protocol.c_str());
+	dialog()->setBoolSettingValue  (section.c_str(), "Enabled",  port.Enabled);
+	// clang-format on
+	dialog()->setIntSettingValue("DEV9/Eth/Ports", "Count", portLength + 1);
+	RefreshPortList();
+}
+
+void DEV9SettingsWidget::DeletePortConfig(int index)
+{
+	const int portLength = CountPortsConfig();
+
+	//Shuffle entries down to ovewrite deleted entry
+	for (int i = index; i < portLength - 1; i++)
+	{
+		std::string section = "DEV9/Eth/Ports/Port" + std::to_string(i);
+		std::string sectionAhead = "DEV9/Eth/Ports/Port" + std::to_string(i + 1);
+
+		// clang-format off
+		dialog()->setIntSettingValue   (section.c_str(), "Port",     dialog()->getIntValue   (sectionAhead.c_str(), "Url",     0).value());
+		dialog()->setStringSettingValue(section.c_str(), "Desc",     dialog()->getStringValue(sectionAhead.c_str(), "Desc",    "").value().c_str());
+		dialog()->setStringSettingValue(section.c_str(), "Protocol", dialog()->getStringValue(sectionAhead.c_str(), "Address", "UDP").value().c_str());
+		dialog()->setBoolSettingValue  (section.c_str(), "Enabled",	 dialog()->getBoolValue  (sectionAhead.c_str(), "Enabled", false).value());
+		// clang-format on
+	}
+
+	//Delete last entry
+	std::string section = "DEV9/Eth/Ports/Port" + std::to_string(portLength - 1);
+	//Specifying a value of nullopt will delete the key
+	//if the key is a nullptr, the whole section is deleted
+	dialog()->setStringSettingValue(section.c_str(), nullptr, std::nullopt);
+
+	dialog()->setIntSettingValue("DEV9/Eth/Ports", "Count", portLength - 1);
+	RefreshPortList();
 }
 
 DEV9SettingsWidget::~DEV9SettingsWidget() = default;

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.h
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.h
@@ -31,6 +31,10 @@ private Q_SLOTS:
 	void onEthHostImport();
 	void onEthHostPerGame();
 	void onEthHostEdit(QStandardItem* item);
+	void onEthPortAdd();
+	void onEthPortDel();
+	void onEthPortPerGame();
+	void onEthPortEdit(QStandardItem* item);
 
 	void onHddEnabledChanged(Qt::CheckState state);
 	void onHddBrowseFileClicked();
@@ -59,6 +63,13 @@ private:
 	void AddNewHostConfig(const HostEntryUi& host);
 	void DeleteHostConfig(int index);
 
+	void RefreshPortList();
+	int CountPortsConfig();
+	std::optional<std::vector<PortEntryUi>> ListPortsConfig();
+	std::vector<PortEntryUi> ListBasePortsConfig();
+	void AddNewPortConfig(const PortEntryUi& port);
+	void DeletePortConfig(int index);
+
 	void UpdateHddSizeUIEnabled();
 	void UpdateHddSizeUIValues();
 
@@ -68,6 +79,9 @@ private:
 
 	QStandardItemModel* m_ethHost_model;
 	QSortFilterProxyModel* m_ethHosts_proxy;
+
+	QStandardItemModel* m_ethPort_model;
+	QSortFilterProxyModel* m_ethPorts_proxy;
 
 	bool m_adaptersLoaded{false};
 	std::vector<Pcsx2Config::DEV9Options::NetApi> m_api_list;

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.ui
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.ui
@@ -277,6 +277,81 @@
           </item>
          </layout>
         </widget>
+        <widget class="QWidget" name="tab_3">
+         <attribute name="title">
+          <string>Open Ports</string>
+         </attribute>
+         <layout class="QGridLayout" name="gridLayout_5">
+          <item row="0" column="0" colspan="2">
+           <widget class="QLabel" name="label_12">
+            <property name="text">
+             <string>Open UDP ports for incoming connections</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QTableView" name="ethOpenPorts">
+            <property name="selectionMode">
+             <enum>QAbstractItemView::SelectionMode::SingleSelection</enum>
+            </property>
+            <property name="sortingEnabled">
+             <bool>true</bool>
+            </property>
+            <attribute name="horizontalHeaderHighlightSections">
+             <bool>false</bool>
+            </attribute>
+            <attribute name="verticalHeaderVisible">
+             <bool>false</bool>
+            </attribute>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <layout class="QVBoxLayout" name="verticalLayout_3">
+            <item>
+             <widget class="QPushButton" name="ethPortAdd">
+              <property name="text">
+               <string>Add</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="ethPortDel">
+              <property name="text">
+               <string>Delete</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="ethPortPerGame">
+              <property name="text">
+               <string>Per game</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item row="1" column="0" colspan="2">
+           <widget class="QCheckBox" name="ethLanMode">
+            <property name="text">
+             <string>Lan Mode (Requred for hosting LAN lobbies, but prevents connections to servers running on the host PC)</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
        </widget>
       </item>
       <item row="1" column="1" colspan="2">

--- a/pcsx2-qt/Settings/DEV9UiCommon.cpp
+++ b/pcsx2-qt/Settings/DEV9UiCommon.cpp
@@ -1,7 +1,10 @@
 // SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
 // SPDX-License-Identifier: GPL-3.0+
 
+#include <QtWidgets/QApplication>
 #include <QtWidgets/QLineEdit>
+#include <QtWidgets/QComboBox>
+#include <QtWidgets/QSpinBox>
 
 #include "DEV9UiCommon.h"
 
@@ -65,6 +68,76 @@ void IPItemDelegate::setModelData(QWidget* editor, QAbstractItemModel* model, co
 }
 
 void IPItemDelegate::updateEditorGeometry(QWidget* editor, const QStyleOptionViewItem& option, const QModelIndex& index) const
+{
+	editor->setGeometry(option.rect);
+}
+
+ComboBoxItemDelegate::ComboBoxItemDelegate(QObject* parent, const char** items, const char* translation_ctx)
+	: QStyledItemDelegate(parent)
+	, m_items{items}
+	, m_translation_ctx{translation_ctx}
+{
+}
+
+QWidget* ComboBoxItemDelegate::createEditor(QWidget* parent, const QStyleOptionViewItem& option, const QModelIndex& index) const
+{
+	QComboBox* editor = new QComboBox(parent);
+
+	for (int i = 0; m_items[i] != nullptr; i++)
+		editor->addItem(m_translation_ctx ? qApp->translate(m_translation_ctx, m_items[i]) : QString::fromUtf8(m_items[i]));
+
+	return editor;
+}
+
+void ComboBoxItemDelegate::setEditorData(QWidget* editor, const QModelIndex& index) const
+{
+	QString value = index.model()->data(index, Qt::EditRole).toString();
+	QComboBox* cBox = static_cast<QComboBox*>(editor);
+	cBox->setCurrentIndex(cBox->findText(value));
+}
+
+void ComboBoxItemDelegate::setModelData(QWidget* editor, QAbstractItemModel* model, const QModelIndex& index) const
+{
+	QComboBox* cBox = static_cast<QComboBox*>(editor);
+	QString value = cBox->currentText();
+	model->setData(index, value, Qt::EditRole);
+}
+
+void ComboBoxItemDelegate::updateEditorGeometry(QWidget* editor, const QStyleOptionViewItem& option, const QModelIndex& index) const
+{
+	editor->setGeometry(option.rect);
+}
+
+SpinBoxItemDelegate::SpinBoxItemDelegate(QObject* parent, int min, int max)
+	: QStyledItemDelegate(parent)
+	, m_min{min}
+	, m_max{max}
+{
+}
+
+QWidget* SpinBoxItemDelegate::createEditor(QWidget* parent, const QStyleOptionViewItem& option, const QModelIndex& index) const
+{
+	QSpinBox* editor = new QSpinBox(parent);
+	editor->setMinimum(m_min);
+	editor->setMaximum(m_max);
+	return editor;
+}
+
+void SpinBoxItemDelegate::setEditorData(QWidget* editor, const QModelIndex& index) const
+{
+	int value = index.model()->data(index, Qt::EditRole).toInt();
+	QSpinBox* sBox = static_cast<QSpinBox*>(editor);
+	sBox->setValue(value);
+}
+
+void SpinBoxItemDelegate::setModelData(QWidget* editor, QAbstractItemModel* model, const QModelIndex& index) const
+{
+	QSpinBox* sBox = static_cast<QSpinBox*>(editor);
+	int value = sBox->value();
+	model->setData(index, value, Qt::EditRole);
+}
+
+void SpinBoxItemDelegate::updateEditorGeometry(QWidget* editor, const QStyleOptionViewItem& option, const QModelIndex& index) const
 {
 	editor->setGeometry(option.rect);
 }

--- a/pcsx2-qt/Settings/DEV9UiCommon.h
+++ b/pcsx2-qt/Settings/DEV9UiCommon.h
@@ -6,11 +6,21 @@
 #include <QtGui/QValidator>
 #include <QtWidgets/QStyledItemDelegate>
 
+#include "common/Pcsx2Types.h"
+
 struct HostEntryUi
 {
 	std::string Url;
 	std::string Desc;
 	std::string Address = "0.0.0.0";
+	bool Enabled;
+};
+
+struct PortEntryUi
+{
+	std::string Protocol;
+	std::string Desc;
+	u16 Port = 0;
 	bool Enabled;
 };
 
@@ -35,6 +45,43 @@ class IPItemDelegate : public QStyledItemDelegate
 
 public:
 	explicit IPItemDelegate(QObject* parent = nullptr);
+
+protected:
+	QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& option, const QModelIndex& index) const;
+	void setEditorData(QWidget* editor, const QModelIndex& index) const;
+	void setModelData(QWidget* editor, QAbstractItemModel* model, const QModelIndex& index) const;
+	void updateEditorGeometry(QWidget* editor, const QStyleOptionViewItem& option, const QModelIndex& index) const;
+};
+
+class ComboBoxItemDelegate : public QStyledItemDelegate
+{
+	Q_OBJECT
+
+private:
+	const char** m_items;
+	const char* m_translation_ctx;
+
+public:
+	// items & translation_ctx needs be valid for the lifetime of QItemDelegate
+	explicit ComboBoxItemDelegate(QObject* parent, const char** items, const char* translation_ctx);
+
+protected:
+	QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& option, const QModelIndex& index) const;
+	void setEditorData(QWidget* editor, const QModelIndex& index) const;
+	void setModelData(QWidget* editor, QAbstractItemModel* model, const QModelIndex& index) const;
+	void updateEditorGeometry(QWidget* editor, const QStyleOptionViewItem& option, const QModelIndex& index) const;
+};
+
+class SpinBoxItemDelegate : public QStyledItemDelegate
+{
+	Q_OBJECT
+
+private:
+	int m_min;
+	int m_max;
+
+public:
+	explicit SpinBoxItemDelegate(QObject* parent, int min, int max);
 
 protected:
 	QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& option, const QModelIndex& index) const;

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -358,6 +358,7 @@ set(pcsx2DEV9Headers
 	DEV9/Sessions/UDP_Session/UDP_Common.h
 	DEV9/Sessions/UDP_Session/UDP_FixedPort.h
 	DEV9/Sessions/UDP_Session/UDP_BaseSession.h
+	DEV9/Sessions/UDP_Session/UDP_ServerSession.h
 	DEV9/Sessions/UDP_Session/UDP_Session.h
 	DEV9/SimpleQueue.h
 	DEV9/smap.h

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1037,6 +1037,13 @@ struct Pcsx2Config
 		};
 		static const char* DnsModeNames[];
 
+		enum struct PortMode : int
+		{
+			UDP = 0,
+			TCP = 1,
+		};
+		static const char* PortModeNames[];
+
 		struct HostEntry
 		{
 			std::string Url;
@@ -1046,6 +1053,17 @@ struct Pcsx2Config
 
 			bool operator==(const HostEntry& right) const;
 			bool operator!=(const HostEntry& right) const;
+		};
+
+		struct PortEntry
+		{
+			uint Port{};
+			std::string Desc;
+			PortMode Protocol;
+			bool Enabled;
+
+			bool operator==(const PortEntry& right) const;
+			bool operator!=(const PortEntry& right) const;
 		};
 
 		bool EthEnable{false};
@@ -1066,6 +1084,9 @@ struct Pcsx2Config
 		DnsMode ModeDNS2{DnsMode::Auto};
 
 		std::vector<HostEntry> EthHosts;
+
+		bool LanMode{false};
+		std::vector<PortEntry> OpenPorts;
 
 		bool HddEnable{false};
 		std::string HddFile;

--- a/pcsx2/DEV9/AdapterUtils.h
+++ b/pcsx2/DEV9/AdapterUtils.h
@@ -50,7 +50,7 @@ namespace AdapterUtils
 
 	std::optional<PacketReader::MAC_Address> GetAdapterMAC(const Adapter* adapter);
 	std::optional<PacketReader::IP::IP_Address> GetAdapterIP(const Adapter* adapter);
-	// Mask.
+	std::optional<PacketReader::IP::IP_Address> GetNetmask(const Adapter* adapter);
 	std::vector<PacketReader::IP::IP_Address> GetGateways(const Adapter* adapter);
 	std::vector<PacketReader::IP::IP_Address> GetDNS(const Adapter* adapter);
 }; // namespace AdapterUtils

--- a/pcsx2/DEV9/InternalServers/DHCP_Server.cpp
+++ b/pcsx2/DEV9/InternalServers/DHCP_Server.cpp
@@ -98,34 +98,15 @@ namespace InternalServers
 
 #ifdef _WIN32
 	void DHCP_Server::AutoNetmask(PIP_ADAPTER_ADDRESSES adapter)
-	{
-		if (adapter != nullptr)
-		{
-			PIP_ADAPTER_UNICAST_ADDRESS address = adapter->FirstUnicastAddress;
-			while (address != nullptr && address->Address.lpSockaddr->sa_family != AF_INET)
-				address = address->Next;
-
-			if (address != nullptr)
-			{
-				ULONG mask;
-				if (ConvertLengthToIpv4Mask(address->OnLinkPrefixLength, &mask) == NO_ERROR)
-					netmask.integer = mask;
-			}
-		}
-	}
 #elif defined(__POSIX__)
 	void DHCP_Server::AutoNetmask(ifaddrs* adapter)
-	{
-		if (adapter != nullptr)
-		{
-			if (adapter->ifa_netmask != nullptr && adapter->ifa_netmask->sa_family == AF_INET)
-			{
-				sockaddr_in* sockaddr = (sockaddr_in*)adapter->ifa_netmask;
-				netmask = *(IP_Address*)&sockaddr->sin_addr;
-			}
-		}
-	}
 #endif
+	{
+		std::optional<IP_Address> mask = AdapterUtils::GetNetmask(adapter);
+
+		if (mask.has_value())
+			netmask = mask.value();
+	}
 
 #ifdef _WIN32
 	void DHCP_Server::AutoGateway(PIP_ADAPTER_ADDRESSES adapter)

--- a/pcsx2/DEV9/Sessions/UDP_Session/UDP_FixedPort.cpp
+++ b/pcsx2/DEV9/Sessions/UDP_Session/UDP_FixedPort.cpp
@@ -162,6 +162,19 @@ namespace Sessions
 		return s;
 	}
 
+	UDP_ServerSession* UDP_FixedPort::NewListenSession(ConnectionKey parNewKey)
+	{
+		UDP_ServerSession* s = new UDP_ServerSession(parNewKey, adapterIP);
+
+		s->AddConnectionClosedHandler([&](BaseSession* session) { HandleChildConnectionClosed(session); });
+
+		{
+			std::lock_guard numberlock(connectionSentry);
+			connections.push_back(s);
+		}
+		return s;
+	}
+
 	void UDP_FixedPort::HandleChildConnectionClosed(BaseSession* sender)
 	{
 		std::lock_guard numberlock(connectionSentry);

--- a/pcsx2/DEV9/Sessions/UDP_Session/UDP_FixedPort.h
+++ b/pcsx2/DEV9/Sessions/UDP_Session/UDP_FixedPort.h
@@ -14,6 +14,7 @@
 #include "DEV9/Sessions/BaseSession.h"
 #include "UDP_BaseSession.h"
 #include "UDP_Session.h"
+#include "UDP_ServerSession.h"
 
 namespace Sessions
 {
@@ -45,6 +46,7 @@ namespace Sessions
 		virtual void Reset();
 
 		UDP_Session* NewClientSession(ConnectionKey parNewKey, bool parIsBrodcast, bool parIsMulticast);
+		UDP_ServerSession* NewListenSession(ConnectionKey parNewKey);
 
 		virtual ~UDP_FixedPort();
 

--- a/pcsx2/DEV9/Sessions/UDP_Session/UDP_ServerSession.h
+++ b/pcsx2/DEV9/Sessions/UDP_Session/UDP_ServerSession.h
@@ -1,0 +1,40 @@
+/*  PCSX2 - PS2 Emulator for PCs
+ *  Copyright (C) 2002-2021  PCSX2 Dev Team
+ *
+ *  PCSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  PCSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with PCSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "UDP_BaseSession.h"
+
+namespace Sessions
+{
+	class UDP_ServerSession : public UDP_BaseSession
+	{
+	public:
+		UDP_ServerSession(ConnectionKey parKey, PacketReader::IP::IP_Address parAdapterIP)
+			: UDP_BaseSession(parKey, parAdapterIP)
+		{
+		}
+
+		virtual std::optional<ReceivedPayload> Recv() { return std::nullopt; }
+		virtual bool Send(PacketReader::IP::IP_Payload* payload)
+		{
+			pxAssert(false);
+			return false;
+		}
+		virtual void Reset(){};
+
+		virtual bool WillRecive(PacketReader::IP::IP_Address parDestIP) { return true; };
+	};
+} // namespace Sessions

--- a/pcsx2/DEV9/net.h
+++ b/pcsx2/DEV9/net.h
@@ -66,6 +66,7 @@ enum struct AdapterOptions : int
 	DHCP_OverrideIP = 1 << 1,
 	DHCP_OverideSubnet = 1 << 2,
 	DHCP_OverideGateway = 1 << 3,
+	HasPortForwarding = 1 << 4,
 };
 
 constexpr enum AdapterOptions operator|(const enum AdapterOptions selfValue, const enum AdapterOptions inValue)

--- a/pcsx2/DEV9/sockets.h
+++ b/pcsx2/DEV9/sockets.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "net.h"
+#include "AdapterUtils.h"
 
 #include "PacketReader/IP/IP_Packet.h"
 #include "PacketReader/EthernetFrame.h"
@@ -52,6 +53,13 @@ public:
 	static AdapterOptions GetAdapterOptions();
 
 private:
+#ifdef _WIN32
+	void GetDHCPOverrides(PIP_ADAPTER_ADDRESSES adapter, PacketReader::IP::IP_Address& ps2IP, PacketReader::IP::IP_Address& subnet, PacketReader::IP::IP_Address& gateway);
+#elif defined(__POSIX__)
+	void GetDHCPOverrides(ifaddrs* adapter, PacketReader::IP::IP_Address& ps2IP, PacketReader::IP::IP_Address& subnet, PacketReader::IP::IP_Address& gateway);
+#endif
+
+
 	bool SendIP(PacketReader::IP::IP_Packet* ipPkt);
 	bool SendICMP(Sessions::ConnectionKey Key, PacketReader::IP::IP_Packet* ipPkt);
 	bool SendIGMP(Sessions::ConnectionKey Key, PacketReader::IP::IP_Packet* ipPkt);

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1310,6 +1310,11 @@ const char* Pcsx2Config::DEV9Options::DnsModeNames[] = {
 	"Internal",
 	nullptr};
 
+const char* Pcsx2Config::DEV9Options::PortModeNames[] = {
+	"UDP",
+	"TCP",
+	nullptr};
+
 Pcsx2Config::DEV9Options::DEV9Options()
 {
 	HddFile = "DEV9hdd.raw";
@@ -1358,10 +1363,15 @@ void Pcsx2Config::DEV9Options::LoadSave(SettingsWrapper& wrap)
 		SettingsWrapEntry(AutoGateway);
 		SettingsWrapEnumEx(ModeDNS1, "ModeDNS1", DnsModeNames);
 		SettingsWrapEnumEx(ModeDNS2, "ModeDNS2", DnsModeNames);
+
+		SettingsWrapEntry(LanMode);
 	}
 
 	if (wrap.IsLoading())
+	{
 		EthHosts.clear();
+		OpenPorts.clear();
+	}
 
 	int hostCount = static_cast<int>(EthHosts.size());
 	{
@@ -1399,6 +1409,31 @@ void Pcsx2Config::DEV9Options::LoadSave(SettingsWrapper& wrap)
 		}
 	}
 
+	int portCount = static_cast<int>(OpenPorts.size());
+	{
+		SettingsWrapSection("DEV9/Eth/Ports");
+		SettingsWrapEntry(LanMode);
+		SettingsWrapEntryEx(portCount, "Count");
+	}
+
+	for (int i = 0; i < portCount; i++)
+	{
+		std::string section = "DEV9/Eth/Ports/Port" + std::to_string(i);
+		SettingsWrapSection(section.c_str());
+
+		PortEntry entry;
+		if (wrap.IsSaving())
+			entry = OpenPorts[i];
+
+		SettingsWrapEntryEx(entry.Port, "Port");
+		SettingsWrapEntryEx(entry.Desc, "Desc");
+		SettingsWrapEnumEx(entry.Protocol, "Protocol", PortModeNames);
+		SettingsWrapEntryEx(entry.Enabled, "Enabled");
+
+		if (wrap.IsLoading())
+			OpenPorts.push_back(entry);
+	}
+
 	{
 		SettingsWrapSection("DEV9/Hdd");
 		SettingsWrapEntry(HddEnable);
@@ -1432,6 +1467,8 @@ bool Pcsx2Config::DEV9Options::operator==(const DEV9Options& right) const
 
 		   OpEqu(EthHosts) &&
 
+		   OpEqu(OpenPorts) &&
+
 		   OpEqu(HddEnable) &&
 		   OpEqu(HddFile);
 }
@@ -1457,6 +1494,19 @@ bool Pcsx2Config::DEV9Options::HostEntry::operator==(const HostEntry& right) con
 }
 
 bool Pcsx2Config::DEV9Options::HostEntry::operator!=(const HostEntry& right) const
+{
+	return !this->operator==(right);
+}
+
+bool Pcsx2Config::DEV9Options::PortEntry::operator==(const PortEntry& right) const
+{
+	return OpEqu(Port) &&
+		   OpEqu(Desc) &&
+		   OpEqu(Protocol) &&
+		   OpEqu(Enabled);
+}
+
+bool Pcsx2Config::DEV9Options::PortEntry::operator!=(const PortEntry& right) const
 {
 	return !this->operator==(right);
 }

--- a/pcsx2/pcsx2.vcxproj
+++ b/pcsx2/pcsx2.vcxproj
@@ -642,6 +642,7 @@
     <ClInclude Include="DEV9\Sessions\UDP_Session\UDP_Common.h" />
     <ClInclude Include="DEV9\Sessions\UDP_Session\UDP_FixedPort.h" />
     <ClInclude Include="DEV9\Sessions\UDP_Session\UDP_BaseSession.h" />
+    <ClInclude Include="DEV9\Sessions\UDP_Session\UDP_ServerSession.h" />
     <ClInclude Include="DEV9\Sessions\UDP_Session\UDP_Session.h" />
     <ClInclude Include="DEV9\SimpleQueue.h" />
     <ClInclude Include="DEV9\smap.h" />

--- a/pcsx2/pcsx2.vcxproj.filters
+++ b/pcsx2/pcsx2.vcxproj.filters
@@ -1829,6 +1829,9 @@
     <ClInclude Include="DEV9\Sessions\UDP_Session\UDP_BaseSession.h">
       <Filter>System\Ps2\DEV9\Sessions\UDP_Session</Filter>
     </ClInclude>
+    <ClInclude Include="DEV9\Sessions\UDP_Session\UDP_ServerSession.h">
+      <Filter>System\Ps2\DEV9\Sessions\UDP_Session</Filter>
+    </ClInclude>
     <ClInclude Include="DEV9\Sessions\UDP_Session\UDP_Session.h">
       <Filter>System\Ps2\DEV9\Sessions\UDP_Session</Filter>
     </ClInclude>


### PR DESCRIPTION
### Description of Changes
Adds the ability to forward UDP ports, and configure Sockets for better compatibility with hosting LAN games

### Rationale behind Changes
On Linux, AppImage and flatpak don't properly support pcap
On other platforms, pcap and TAP are harder to configure.
This is an experiment to see if adding additional configuration options to Sockets for LAN is easier than configuring TAP/pcap

### Suggested Testing Steps
Using Sockets
On the instance that will be hosting, configure ports in the new "Open Ports" tab in the Network and HDD settings page
    Jak X would need port 3658, for other games you would check the logs for ports when attempted connecting to a server.
With a second PC (or a PS2) connect to the hosted game
Experiment to see if LAN mode is needed for a given title

### Did you use AI to help find, test, or implement this issue or feature?
No
