### PR TITLE
GS/HW/Shaders: Fix afail shader typo.

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -1197,7 +1197,7 @@ PS_OUTPUT ps_main(PS_INPUT input)
 #if !PS_NO_COLOR1
 	output.c1 = alpha_blend;
 #endif
-#if PS_AFAIL == 3 && !PS_NO_COLOR1 // RGB_ONLY, no dual src blend
+#if PS_AFAIL == 3 && PS_NO_COLOR1 // RGB_ONLY, no dual src blend
 	if (!atst_pass)
 	{
 		float RTa = NEEDS_RT_FOR_AFAIL ? RtTexture.Load(int3(input.p.xy, 0)).a : 0.0f;

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -1134,7 +1134,7 @@ void ps_main()
 	#else
 		SV_Target0.rgb = C.rgb / 255.0f;
 	#endif
-	#if PS_AFAIL == 3 && !PS_NO_COLOR1 // RGB_ONLY, no dual src blend
+	#if PS_AFAIL == 3 && PS_NO_COLOR1 // RGB_ONLY, no dual src blend
 		if (!atst_pass)
 			SV_Target0.a = sample_from_rt().a;
 	#endif

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 74;
+static constexpr u32 SHADER_CACHE_VERSION = 75;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/HW/Shaders: Fix afail shader typo.
No dual source blend means PS_NO_COLOR1 is true, no output on target 1.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Regression fix/bugfix from https://github.com/PCSX2/pcsx2/pull/12437

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test 007 From Russia with love on max blending on dx11/12/gl, see if the minimap works properly now.
[From Russia With Love_1.gs.zip](https://github.com/user-attachments/files/22903523/From.Russia.With.Love_1.gs.zip)
Edit dump run on dx11 looks fine.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.
