### PR TITLE
GS: Add MAD deinterlacer sensitivity modifier setting

### DIFF
--- a/pcsx2-qt/Settings/GraphicsDisplaySettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsDisplaySettingsTab.ui
@@ -206,17 +206,17 @@
      </item>
     </widget>
    </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="cropLabel">
+   <item row="2" column="0">
+    <widget class="QLabel" name="fmvAspectRatioLabel">
      <property name="text">
-      <string>Crop:</string>
+      <string>FMV Aspect Ratio Override:</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="aspectRatioLabel">
+   <item row="8" column="0">
+    <widget class="QLabel" name="cropLabel">
      <property name="text">
-      <string>Aspect Ratio:</string>
+      <string>Crop:</string>
      </property>
      <property name="buddy">
       <cstring>aspectRatio</cstring>
@@ -277,16 +277,10 @@
      </item>
     </widget>
    </item>
-   <item row="5" column="1">
-    <widget class="QSpinBox" name="stretchY">
-     <property name="suffix">
-      <string extracomment="Percentage sign that shows next to a value. You might want to add a space before if your language requires it.">%</string>
-     </property>
-     <property name="minimum">
-      <number>1</number>
-     </property>
-     <property name="maximum">
-      <number>300</number>
+   <item row="5" column="0">
+    <widget class="QLabel" name="billinearLabel">
+     <property name="text">
+      <string>Bilinear Filtering:</string>
      </property>
     </widget>
    </item>
@@ -386,6 +380,177 @@
       </widget>
      </item>
     </layout>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="interlacingLabel">
+     <property name="text">
+      <string>Deinterlacing:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="fsModeLabel">
+     <property name="text">
+      <string>Fullscreen Mode:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="9" column="0" colspan="2">
+    <layout class="QGridLayout" name="displayGridLayout">
+     <item row="1" column="1">
+      <widget class="QCheckBox" name="integerScaling">
+       <property name="text">
+        <string>Integer Scaling</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QCheckBox" name="widescreenPatches">
+       <property name="text">
+        <string>Apply Widescreen Patches</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QCheckBox" name="noInterlacingPatches">
+       <property name="text">
+        <string>Apply No-Interlacing Patches</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QCheckBox" name="PCRTCAntiBlur">
+       <property name="text">
+        <string>Anti-Blur</string>
+       </property>
+       <property name="shortcut">
+        <string>Ctrl+S</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QCheckBox" name="DisableInterlaceOffset">
+       <property name="text">
+        <string>Disable Interlace Offset</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QCheckBox" name="PCRTCOffsets">
+       <property name="text">
+        <string>Screen Offsets</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QCheckBox" name="PCRTCOverscan">
+       <property name="text">
+        <string>Show Overscan</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="7" column="1">
+    <widget class="QSpinBox" name="stretchY">
+     <property name="suffix">
+      <string extracomment="Percentage sign that shows next to a value. You might want to add a space before if your language requires it.">%</string>
+     </property>
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>300</number>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QComboBox" name="fullscreenModes"/>
+   </item>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="aspectRatio">
+     <item>
+      <property name="text">
+       <string>Fit to Window / Fullscreen</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Auto Standard (4:3 Interlaced / 3:2 Progressive)</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Standard (4:3)</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Widescreen (16:9)</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Native/Full (10:7)</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="verticalStretchLabel">
+     <property name="text">
+      <string>Vertical Stretch:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="aspectRatioLabel">
+     <property name="text">
+      <string>Aspect Ratio:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="AdaptiveDeinterlacingSensitivityLabel">
+     <property name="text">
+      <string>Adaptive Deinterlacing Sensitivity</string>
+     </property>
+     <property name="buddy">
+      <cstring>AdaptiveDeinterlacingSensitivity</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QComboBox" name="AdaptiveDeinterlacingSensitivity">
+     <item>
+      <property name="text">
+       <string>Low</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Default</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>High</string>
+      </property>
+     </item>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -80,6 +80,8 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 		Pcsx2Config::GSOptions::FMVAspectRatioSwitchNames, FMVAspectRatioSwitchType::Off);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_display.interlacing, "EmuCore/GS", "deinterlace_mode", DEFAULT_INTERLACE_MODE);
 	SettingWidgetBinder::BindWidgetToIntSetting(
+		sif, m_display.AdaptiveDeinterlacingSensitivity, "EmuCore/GS", "MADMode", static_cast<int>(GSMADMode::Default));
+	SettingWidgetBinder::BindWidgetToIntSetting(
 		sif, m_display.bilinearFiltering, "EmuCore/GS", "linear_present_mode", static_cast<int>(GSPostBilinearMode::BilinearSmooth));
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_display.widescreenPatches, "EmuCore", "EnableWideScreenPatches", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_display.noInterlacingPatches, "EmuCore", "EnableNoInterlacingPatches", false);
@@ -440,6 +442,10 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 
 		dialog()->registerWidgetHelp(m_display.disableInterlaceOffset, tr("Disable Interlace Offset"), tr("Unchecked"),
 			tr("Disables interlacing offset which may reduce blurring in some situations."));
+
+		dialog()->registerWidgetHelp(m_display.AdaptiveDeinterlacingSensitivity, tr("Adaptive Deinterlacing Sensitivity"), tr("Default"),
+			tr("Changes the adaptive deinterlacing algorithm's sensitivity to recent, localized motion around pixels.<br>"
+			   "Higher sensitivity makes the algorithm more responsive to changes in pixel color."));
 
 		dialog()->registerWidgetHelp(m_display.bilinearFiltering, tr("Bilinear Filtering"), tr("Bilinear (Smooth)"),
 			tr("Enables bilinear post processing filter. Smooths the overall picture as it is displayed on the screen. Corrects "

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -303,6 +303,13 @@ enum class GSInterlaceMode : u8
 	Count
 };
 
+enum class GSMADMode : u8
+{
+	Low,
+	Default,
+	High,
+};
+
 enum class GSPostBilinearMode : u8
 {
 	Off,
@@ -801,6 +808,7 @@ struct Pcsx2Config
 		AspectRatioType AspectRatio = DEFAULT_ASPECT_RATIO;
 		FMVAspectRatioSwitchType FMVAspectRatioSwitch = FMVAspectRatioSwitchType::Off;
 		GSInterlaceMode InterlaceMode = DEFAULT_INTERLACE_MODE;
+		GSMADMode MADMode = GSMADMode::Default;
 		GSPostBilinearMode LinearPresent = GSPostBilinearMode::BilinearSmooth;
 
 		float StretchY = 100.0f;

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -881,7 +881,9 @@ private:
 
 protected:
 	static constexpr int NUM_INTERLACE_SHADERS = 5;
-	static constexpr float MAD_SENSITIVITY = 0.08f;
+	static constexpr float LOW_MAD_SENSITIVITY = 0.08f;
+	static constexpr float DEFAULT_MAD_SENSITIVITY = 0.02f;
+	static constexpr float HIGH_MAD_SENSITIVITY = 0.0035f;
 	static constexpr u32 MAX_POOLED_TARGETS = 300;
 	static constexpr u32 MAX_TARGET_AGE = 20;
 	static constexpr u32 MAX_POOLED_TEXTURES = 300;

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -4330,6 +4330,11 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 		FSUI_NSTR("Adaptive (Top Field First)"),
 		FSUI_NSTR("Adaptive (Bottom Field First)"),
 	};
+	static constexpr const char* s_mad_sensitivity_options[] = {
+		FSUI_NSTR("Low"),
+		FSUI_NSTR("Default"),
+		FSUI_NSTR("High"),
+	};
 	static const char* s_resolution_options[] = {
 		FSUI_NSTR("Native (PS2)"),
 		FSUI_NSTR("2x Native (~720px/HD)"),
@@ -4445,21 +4450,21 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 
 	MenuHeading(FSUI_CSTR("Display"));
 	DrawStringListSetting(bsi, FSUI_ICONSTR(ICON_FA_COMPRESS, "Aspect Ratio"), FSUI_CSTR("Selects the aspect ratio to display the game content at."),
-		"EmuCore/GS", "AspectRatio", "Auto 4:3/3:2", Pcsx2Config::GSOptions::AspectRatioNames, Pcsx2Config::GSOptions::AspectRatioNames, 0,
-		false);
+		"EmuCore/GS", "AspectRatio", "Auto 4:3/3:2", Pcsx2Config::GSOptions::AspectRatioNames, Pcsx2Config::GSOptions::AspectRatioNames, 0, false);
 	DrawStringListSetting(bsi, FSUI_ICONSTR(ICON_FA_VIDEO, "FMV Aspect Ratio Override"),
 		FSUI_CSTR("Selects the aspect ratio for display when a FMV is detected as playing."), "EmuCore/GS", "FMVAspectRatioSwitch",
 		"Auto 4:3/3:2", Pcsx2Config::GSOptions::FMVAspectRatioSwitchNames, Pcsx2Config::GSOptions::FMVAspectRatioSwitchNames, 0, false);
 	DrawIntListSetting(bsi, FSUI_ICONSTR(ICON_FA_TV, "Deinterlacing"),
 		FSUI_CSTR("Selects the algorithm used to convert the PS2's interlaced output to progressive for display."), "EmuCore/GS",
-		"deinterlace_mode", static_cast<int>(GSInterlaceMode::Automatic), s_deinterlacing_options, std::size(s_deinterlacing_options),
-		true);
-	DrawIntListSetting(bsi, FSUI_ICONSTR(ICON_FA_ARROWS_UP_DOWN_LEFT_RIGHT, "Screenshot Size"), FSUI_CSTR("Determines the resolution at which screenshots will be saved."),
-		"EmuCore/GS", "ScreenshotSize", static_cast<int>(GSScreenshotSize::WindowResolution), s_screenshot_sizes,
-		std::size(s_screenshot_sizes), true);
+		"deinterlace_mode", static_cast<int>(GSInterlaceMode::Automatic), s_deinterlacing_options, std::size(s_deinterlacing_options), true);
+	DrawIntListSetting(bsi, FSUI_ICONSTR(ICON_FA_ARROWS_TO_EYE, "Adaptive Deinterlacing Sensitivity"),
+		FSUI_CSTR("Changes the adaptive deinterlacing algorithm's sensitivity to recent, localized motion around pixels."), "EmuCore/GS",
+		"MADMode", static_cast<int>(GSMADMode::Default), s_mad_sensitivity_options, std::size(s_mad_sensitivity_options), true);
+	DrawIntListSetting(bsi, FSUI_ICONSTR(ICON_FA_ARROWS_UP_DOWN_LEFT_RIGHT, "Screenshot Size"),
+		FSUI_CSTR("Determines the resolution at which screenshots will be saved."), "EmuCore/GS", "ScreenshotSize",
+		static_cast<int>(GSScreenshotSize::WindowResolution), s_screenshot_sizes, std::size(s_screenshot_sizes), true);
 	DrawIntListSetting(bsi, FSUI_ICONSTR(ICON_FA_PHOTO_FILM, "Screenshot Format"), FSUI_CSTR("Selects the format which will be used to save screenshots."),
-		"EmuCore/GS", "ScreenshotFormat", static_cast<int>(GSScreenshotFormat::PNG), s_screenshot_formats, std::size(s_screenshot_formats),
-		true);
+		"EmuCore/GS", "ScreenshotFormat", static_cast<int>(GSScreenshotFormat::PNG), s_screenshot_formats, std::size(s_screenshot_formats), true);
 	DrawIntRangeSetting(bsi, FSUI_ICONSTR(ICON_FA_GAUGE, "Screenshot Quality"), FSUI_CSTR("Selects the quality at which screenshots will be compressed."),
 		"EmuCore/GS", "ScreenshotQuality", 90, 1, 100, FSUI_CSTR("%d%%"));
 	DrawIntRangeSetting(bsi, FSUI_ICONSTR(ICON_FA_ARROW_RIGHT_ARROW_LEFT, "Vertical Stretch"), FSUI_CSTR("Increases or decreases the virtual picture size vertically."),
@@ -9020,6 +9025,7 @@ TRANSLATE_NOOP("FullscreenUI", "Display");
 TRANSLATE_NOOP("FullscreenUI", "Selects the aspect ratio to display the game content at.");
 TRANSLATE_NOOP("FullscreenUI", "Selects the aspect ratio for display when a FMV is detected as playing.");
 TRANSLATE_NOOP("FullscreenUI", "Selects the algorithm used to convert the PS2's interlaced output to progressive for display.");
+TRANSLATE_NOOP("FullscreenUI", "Changes the adaptive deinterlacing algorithm's sensitivity to recent, localized motion around pixels.");
 TRANSLATE_NOOP("FullscreenUI", "Determines the resolution at which screenshots will be saved.");
 TRANSLATE_NOOP("FullscreenUI", "Selects the format which will be used to save screenshots.");
 TRANSLATE_NOOP("FullscreenUI", "Selects the quality at which screenshots will be compressed.");
@@ -9463,6 +9469,9 @@ TRANSLATE_NOOP("FullscreenUI", "Blend (Top Field First, Half FPS)");
 TRANSLATE_NOOP("FullscreenUI", "Blend (Bottom Field First, Half FPS)");
 TRANSLATE_NOOP("FullscreenUI", "Adaptive (Top Field First)");
 TRANSLATE_NOOP("FullscreenUI", "Adaptive (Bottom Field First)");
+TRANSLATE_NOOP("FullscreenUI", "Low");
+TRANSLATE_NOOP("FullscreenUI", "Default");
+TRANSLATE_NOOP("FullscreenUI", "High");
 TRANSLATE_NOOP("FullscreenUI", "Native (PS2)");
 TRANSLATE_NOOP("FullscreenUI", "2x Native (~720px/HD)");
 TRANSLATE_NOOP("FullscreenUI", "3x Native (~1080px/FHD)");
@@ -9661,6 +9670,7 @@ TRANSLATE_NOOP("FullscreenUI", "Use Host VSync Timing");
 TRANSLATE_NOOP("FullscreenUI", "Aspect Ratio");
 TRANSLATE_NOOP("FullscreenUI", "FMV Aspect Ratio Override");
 TRANSLATE_NOOP("FullscreenUI", "Deinterlacing");
+TRANSLATE_NOOP("FullscreenUI", "Adaptive Deinterlacing Sensitivity");
 TRANSLATE_NOOP("FullscreenUI", "Screenshot Size");
 TRANSLATE_NOOP("FullscreenUI", "Screenshot Format");
 TRANSLATE_NOOP("FullscreenUI", "Screenshot Quality");

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -716,6 +716,8 @@ Pcsx2Config::GSOptions::GSOptions()
 	PCRTCOffsets = false;
 	PCRTCOverscan = false;
 	IntegerScaling = false;
+	InterlaceMode = GSInterlaceMode::Automatic;
+	MADMode = GSMADMode::Default;
 	LinearPresent = GSPostBilinearMode::BilinearSmooth;
 	UseDebugDevice = false;
 	UseBlitSwapChain = false;
@@ -723,6 +725,7 @@ Pcsx2Config::GSOptions::GSOptions()
 	DisableFramebufferFetch = false;
 	DisableVertexShaderExpand = false;
 	SkipDuplicateFrames = false;
+
 	OsdMessagesPos = OsdOverlayPos::TopLeft;
 	OsdPerformancePos = OsdOverlayPos::TopRight;
 	OsdShowSpeed = false;
@@ -798,10 +801,12 @@ bool Pcsx2Config::GSOptions::operator==(const GSOptions& right) const
 bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 {
 	return (
-		OpEqu(bitset) &&
+		OpEqu(bitset[0]) &&
+		OpEqu(bitset[1]) &&
 
 		OpEqu(InterlaceMode) &&
 		OpEqu(LinearPresent) &&
+		OpEqu(MADMode) &&
 
 		OpEqu(StretchY) &&
 		OpEqu(Crop[0]) &&
@@ -943,6 +948,7 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitBool(DisableFramebufferFetch);
 	SettingsWrapBitBool(DisableVertexShaderExpand);
 	SettingsWrapBitBool(SkipDuplicateFrames);
+
 	SettingsWrapBitBool(OsdShowSpeed);
 	SettingsWrapBitBool(OsdShowFPS);
 	SettingsWrapBitBool(OsdShowVPS);
@@ -1005,8 +1011,9 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitBool(EnableAudioCapture);
 	SettingsWrapBitBool(EnableAudioCaptureParameters);
 
-	SettingsWrapIntEnumEx(LinearPresent, "linear_present_mode");
 	SettingsWrapIntEnumEx(InterlaceMode, "deinterlace_mode");
+	SettingsWrapIntEnumEx(MADMode, "MADMode");
+	SettingsWrapIntEnumEx(LinearPresent, "linear_present_mode");
 
 	SettingsWrapEntry(OsdScale);
 	SettingsWrapIntEnumEx(OsdMessagesPos, "OsdMessagesPos");


### PR DESCRIPTION
### Description of Changes
Adds a modifier for MADs sensitivity to hopefully reduce artifacting in various situations.

### Rationale behind Changes
Games can sometimes have rather distracting motion artifacts this change hopefully should reduce the occurrence of them.

Right current value Left adjusted values:

<img width="1633" height="840" alt="image" src="https://github.com/user-attachments/assets/8a684032-3e53-4245-956b-b95694f5447e" />

### Suggested Testing Steps
Test basically any interlaced game and see if this ends up making it worse than how it currently is.

### Did you use AI to help find, test, or implement this issue or feature?
No
