### PR TITLE
Qt: Fix typo in Windows dependencies build script

### DIFF
--- a/.github/workflows/scripts/windows/build-dependencies.bat
+++ b/.github/workflows/scripts/windows/build-dependencies.bat
@@ -235,7 +235,7 @@ ninja install || goto error
 cd ..\.. || goto error
 
 echo Building Qt Tools...
-rmdir /S /Q "qtimageformats-everywhere-src-%QT%"
+rmdir /S /Q "qttools-everywhere-src-%QT%"
 %SEVENZIP% x "qttools-everywhere-src-%QT%.zip" || goto error
 cd "qttools-everywhere-src-%QT%" || goto error
 mkdir build || goto error


### PR DESCRIPTION
### Description of Changes
Fixes a copy/paste error.

### Rationale behind Changes
It's pretty obvious that this was not intentional.

### Suggested Testing Steps
Build dependencies on Windows.

### Did you use AI to help find, test, or implement this issue or feature?
No.
