### PR TITLE
Qt/BPM: Improve memory card shutdown warning messages for clarity 

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1162,12 +1162,20 @@ bool MainWindow::shouldAbortForMemcardBusy(const VMLock& lock)
 {
 	if (MemcardBusy::IsBusy() && !GSDumpReplayer::IsReplayingDump())
 	{
-		const QMessageBox::StandardButton res = QMessageBox::critical(
-			lock.getDialogParent(),
-			tr("WARNING: Memory Card Busy"),
-			tr("WARNING: Your memory card is still writing data. Shutting down now <b>WILL IRREVERSIBLY DESTROY YOUR MEMORY CARD.</b> It is strongly recommended to resume your game and let it finish writing to your memory card.<br><br>Do you wish to shutdown anyways and <b>IRREVERSIBLY DESTROY YOUR MEMORY CARD?</b>"), QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+		QMessageBox msgbox(lock.getDialogParent());
+		msgbox.setIcon(QMessageBox::Warning);
+		msgbox.setWindowTitle(tr("WARNING: Memory Card Busy"));
+		msgbox.setWindowIcon(QtHost::GetAppIcon());
+		msgbox.setWindowModality(Qt::WindowModal);
+		msgbox.setTextFormat(Qt::RichText);
+		msgbox.setText(tr("Your memory card is still saving data."));
+		msgbox.setInformativeText(tr("WARNING: Shutting down now can <b>IRREVERSIBLY CORRUPT YOUR MEMORY CARD.</b><br><br>"
+									 "You are strongly advised to select 'No' and let the save finish.<br><br>"
+									 "Do you want to shutdown anyway and <b>IRREVERSIBLY CORRUPT YOUR MEMORY CARD</b>?"));
+		msgbox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+		msgbox.setDefaultButton(QMessageBox::No);
 
-		if (res != QMessageBox::Yes)
+		if (msgbox.exec() != QMessageBox::Yes)
 		{
 			return true;
 		}

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -1390,8 +1390,14 @@ void FullscreenUI::ConfirmShutdownIfMemcardBusy(std::function<void(bool)> callba
 	}
 
 	OpenConfirmMessageDialog(FSUI_ICONSTR(ICON_PF_MEMORY_CARD, "WARNING: Memory Card Busy"),
-		FSUI_STR("WARNING: Your memory card is still writing data. Shutting down now will IRREVERSIBLY DESTROY YOUR MEMORY CARD. It is strongly recommended to resume your game and let it finish writing to your memory card.\n\nDo you wish to shutdown anyways and IRREVERSIBLY DESTROY YOUR MEMORY CARD?"),
-		std::move(callback));
+		FSUI_STR("Your memory card is still saving data.\n\n"
+			"WARNING: Shutting down now can IRREVERSIBLY CORRUPT YOUR MEMORY CARD.\n\n"
+			"You are strongly advised to select 'No' and let the save finish.\n\n"
+			"Do you want to shutdown anyway and IRREVERSIBLY CORRUPT YOUR MEMORY CARD?"),
+		[callback = std::move(callback)](bool result) {
+			callback(!result);
+		},
+		FSUI_ICONSTR(ICON_FA_XMARK, "No"), FSUI_ICONSTR(ICON_FA_CHECK, "Yes"));
 }
 
 bool FullscreenUI::ShouldDefaultToGameList()


### PR DESCRIPTION
<img width="424" height="273" alt="image" src="https://github.com/user-attachments/assets/01eb9e88-6bfb-4c35-abb1-9447771a11d0" />
<img width="687" height="440" alt="image" src="https://github.com/user-attachments/assets/2ba2a6b3-2a2c-4b09-9007-1eb6b6309e11" />

Fixes #13131

### Description of Changes
- Improved the memory card busy warning dialog message for better clarity and urgency on Qt, and BPM
- on BPM Swapped the button order in the dialog so "No" (the safe option) appears first and is focused by default
- Updated message text to be more direct and user-friendly
- On Qt made the message a Warning rather then an error

### Rationale behind Changes
The default button selection in the memory card busy dialog was previously set to "Yes" (shut down anyway), which could have lead to accidental memory card corruption if users quickly pressed the confirm button without reading the warning carefully. 

By making "No" (don't shut down) the default selection on FSUI users are less likely to accidentally corrupt their memory cards. And making the Qt box a warning rather then an error makes more sense in my opinion since it's just *warning* the user that it's saving not that it failed to save.

### Suggested Testing Steps
1. Start a game or BIOS in PCSX2
2. Trigger a memory card save operation (save in-game or BIOS)
3. While the save is in progress (within ~5 seconds), attempt to shut down via the pause menu or hotkey
4. Verify that:
   - The warning dialog appears with the new text on FSUI and Qt
   - On FSUI the 'No' option is first
  
### Did you use AI to help find, test, or implement this issue or feature?
No.