### PR TITLE
RTC: Add option to choose between system locale and yyyy-MM-dd HH:mm:ss

### DIFF
--- a/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
@@ -51,7 +51,10 @@ EmulationSettingsWidget::EmulationSettingsWidget(SettingsWindow* settings_dialog
 		m_ui.rtcDateTime->setDateRange(QDate(2000, 1, 1), QDate(2099, 12, 31));
 		SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.manuallySetRealTimeClock, "EmuCore", "ManuallySetRealTimeClock", false);
 		connect(m_ui.manuallySetRealTimeClock, &QCheckBox::checkStateChanged, this, &EmulationSettingsWidget::onManuallySetRealTimeClockChanged);
+		SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.rtcUseSystemLocaleFormat, "EmuCore", "UseSystemLocaleFormat", false);
+		connect(m_ui.rtcUseSystemLocaleFormat, &QCheckBox::checkStateChanged, this, &EmulationSettingsWidget::onUseSystemLocaleFormatChanged);
 		EmulationSettingsWidget::onManuallySetRealTimeClockChanged();
+		EmulationSettingsWidget::onUseSystemLocaleFormatChanged();
 
 		m_ui.eeCycleRate->insertItem(0,
 			tr("Use Global Setting [%1]")
@@ -159,10 +162,12 @@ EmulationSettingsWidget::EmulationSettingsWidget(SettingsWindow* settings_dialog
 	dialog()->registerWidgetHelp(m_ui.manuallySetRealTimeClock, tr("Manually Set Real-Time Clock"), tr("Unchecked"),
 		tr("Manually set a real-time clock to use for the virtual PlayStation 2 instead of using your OS' system clock."));
 	dialog()->registerWidgetHelp(m_ui.rtcDateTime, tr("Real-Time Clock"), tr("Current date and time"),
-		tr("Real-time clock (RTC) used by the virtual PlayStation 2. Date format is the same as the one used by your OS. "
-		   "This time is only applied upon booting the PS2; changing it while in-game will have no effect. "
-		   "NOTE: This assumes you have your PS2 set to the default timezone of GMT+0 and default DST of Summer Time. "
+		tr("Real-time clock (RTC) used by the virtual PlayStation 2.<br>"
+		   "This time is only applied upon booting the PS2; changing it while in-game will have no effect.<br>"
+		   "NOTE: This assumes you have your PS2 set to the default timezone of GMT+0 and default DST of Summer Time.<br>"
 		   "Some games require an RTC date/time set after their release date."));
+	dialog()->registerWidgetHelp(m_ui.rtcUseSystemLocaleFormat, tr("Use System Locale Format"), tr("User Preference"),
+		tr("Uses the operating system's date/time format rather than \"yyyy-MM-dd HH:mm:ss\". May exclude seconds."));
 
 	updateOptimalFramePacing();
 	updateUseVSyncForTimingEnabled();
@@ -314,4 +319,11 @@ void EmulationSettingsWidget::onManuallySetRealTimeClockChanged()
 {
 	const bool enabled = dialog()->getEffectiveBoolValue("EmuCore", "ManuallySetRealTimeClock", false);
 	m_ui.rtcDateTime->setEnabled(enabled);
+	m_ui.rtcUseSystemLocaleFormat->setEnabled(enabled);
+}
+
+void EmulationSettingsWidget::onUseSystemLocaleFormatChanged()
+{
+	const bool enabled = dialog()->getEffectiveBoolValue("EmuCore", "UseSystemLocaleFormat", false);
+	m_ui.rtcDateTime->setDisplayFormat(enabled ? QLocale::system().dateTimeFormat(QLocale::ShortFormat) : "yyyy-MM-dd HH:mm:ss");
 }

--- a/pcsx2-qt/Settings/EmulationSettingsWidget.h
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.h
@@ -24,6 +24,7 @@ private:
 	void updateOptimalFramePacing();
 	void updateUseVSyncForTimingEnabled();
 	void onManuallySetRealTimeClockChanged();
+	void onUseSystemLocaleFormatChanged();
 
 	Ui::EmulationSettingsWidget m_ui;
 };

--- a/pcsx2-qt/Settings/EmulationSettingsWidget.ui
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.ui
@@ -266,6 +266,13 @@
       <item row="0" column="1">
        <widget class="QDateTimeEdit" name="rtcDateTime"/>
       </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="rtcUseSystemLocaleFormat">
+        <property name="text">
+         <string>Use System Locale Format</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1315,6 +1315,7 @@ struct Pcsx2Config
 		BackupSavestate : 1,
 		McdFolderAutoManage : 1,
 		ManuallySetRealTimeClock : 1,
+		UseSystemLocaleFormat : 1, // presents OS time format instead of yyyy-MM-dd HH:mm:ss for manual RTC
 
 		HostFs : 1,
 

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1924,6 +1924,7 @@ Pcsx2Config::Pcsx2Config()
 	WarnAboutUnsafeSettings = true;
 	EnableDiscordPresence = false;
 	ManuallySetRealTimeClock = false;
+	UseSystemLocaleFormat = false;
 
 	// To be moved to FileMemoryCard pluign (someday)
 	for (uint slot = 0; slot < 8; ++slot)
@@ -1973,6 +1974,7 @@ void Pcsx2Config::LoadSaveCore(SettingsWrapper& wrap)
 	SettingsWrapBitBool(WarnAboutUnsafeSettings);
 
 	SettingsWrapBitBool(ManuallySetRealTimeClock);
+	SettingsWrapBitBool(UseSystemLocaleFormat);
 
 	// Process various sub-components:
 


### PR DESCRIPTION
### Description of Changes
Adds an option under `Emulation` > `Real-Time Clock` called `Use System Locale Format`. When enabled, the QDateTimeEdit uses the user's QLocale derived from their operating system (current behavior in master). When disabled, the QDateTimeEdit uses the standard format `yyyy-MM-dd HH:mm:ss`. The option is disabled by default.

<img width="725" height="115" alt="image" src="https://github.com/user-attachments/assets/13ae0253-3572-42c8-8d15-2818e6cd007a" />

<img width="711" height="119" alt="image" src="https://github.com/user-attachments/assets/6338f2a7-9929-4fe2-a14b-63a1e067d56b" />

### Rationale behind Changes
* A standard `yyyy-MM-dd HH:mm:ss` format is important as a sane default because many users do not include `ss` in their system's locale. I do, and when I made this feature, I incorrectly assumed this information was always present in the locale but simply truncated in e.g. a user's clock widget. This came up recently when someone trying to do RNG manipulation couldn't access the seconds and had to resort to 1) changing their system locale and rebooting or 2) using the `.ini` file direclty.
* Allowing the user to use their own locale (current master behavior) is good to retain as people generally prefer or are more comfortable with their own format. Even if the user lacks `ss` in their format, that level of granularity is useless for some of the biggest use cases for this feature.

### Suggested Testing Steps
* Make sure that disabling `Manually Set Real-Time Clock` also disables the new option `Use System Locale Format`.
* Make sure that `Use System Locale Format` 1) starts off as `yyyy-MM-dd HH:mm:ss` without the option enabled and 2) changes to your system format with it enabled. Keep in mind that your QLocale is likely only changed upon system reboot, so changing your system's locale then trying to see if PCSX2 responds to that is out of our hands.
* Make sure that the tooltip for the new option is sane and doesn't exclude important information.

### Did you use AI to help find, test, or implement this issue or feature?
I reset until I found the seed with this PR in it.
