### PR TITLE
FSUI: Allow specifying default button in message dialogs

### DIFF
--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -1943,7 +1943,7 @@ void Achievements::ConfirmHardcoreModeDisableAsync(const char* trigger, std::fun
 			fmt::format(TRANSLATE_FS("Achievements", "{0} cannot be performed while hardcore mode is active. Do you "
 													 "want to disable hardcore mode? {0} will be cancelled if you select No."),
 				trigger),
-			std::move(real_callback), fmt::format(ICON_FA_CHECK " {}", TRANSLATE_SV("Achievements", "Yes")),
+			std::move(real_callback), true, fmt::format(ICON_FA_CHECK " {}", TRANSLATE_SV("Achievements", "Yes")),
 			fmt::format(ICON_FA_XMARK " {}", TRANSLATE_SV("Achievements", "No")));
 	});
 }

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -1394,10 +1394,7 @@ void FullscreenUI::ConfirmShutdownIfMemcardBusy(std::function<void(bool)> callba
 			"WARNING: Shutting down now can IRREVERSIBLY CORRUPT YOUR MEMORY CARD.\n\n"
 			"You are strongly advised to select 'No' and let the save finish.\n\n"
 			"Do you want to shutdown anyway and IRREVERSIBLY CORRUPT YOUR MEMORY CARD?"),
-		[callback = std::move(callback)](bool result) {
-			callback(!result);
-		},
-		FSUI_ICONSTR(ICON_FA_XMARK, "No"), FSUI_ICONSTR(ICON_FA_CHECK, "Yes"));
+		std::move(callback), false);
 }
 
 bool FullscreenUI::ShouldDefaultToGameList()

--- a/pcsx2/ImGui/ImGuiFullscreen.cpp
+++ b/pcsx2/ImGui/ImGuiFullscreen.cpp
@@ -127,6 +127,7 @@ namespace ImGuiFullscreen
 	static std::string s_message_dialog_message;
 	static std::array<std::string, 3> s_message_dialog_buttons;
 	static MessageDialogCallbackVariant s_message_dialog_callback;
+	static s32 s_message_dialog_default_index = 0;
 
 	static ImAnimatedVec2 s_menu_button_frame_min_animated;
 	static ImAnimatedVec2 s_menu_button_frame_max_animated;
@@ -278,6 +279,7 @@ void ImGuiFullscreen::Shutdown(bool clear_state)
 		s_message_dialog_message = {};
 		s_message_dialog_buttons = {};
 		s_message_dialog_callback = {};
+		s_message_dialog_default_index = 0;
 	}
 }
 
@@ -2566,7 +2568,7 @@ bool ImGuiFullscreen::IsMessageBoxDialogOpen()
 }
 
 void ImGuiFullscreen::OpenConfirmMessageDialog(
-	std::string title, std::string message, ConfirmMessageDialogCallback callback, std::string yes_button_text, std::string no_button_text)
+	std::string title, std::string message, ConfirmMessageDialogCallback callback, bool default_yes, std::string yes_button_text, std::string no_button_text)
 {
 	CloseMessageDialog();
 
@@ -2576,6 +2578,7 @@ void ImGuiFullscreen::OpenConfirmMessageDialog(
 	s_message_dialog_callback = std::move(callback);
 	s_message_dialog_buttons[0] = std::move(yes_button_text);
 	s_message_dialog_buttons[1] = std::move(no_button_text);
+	s_message_dialog_default_index = default_yes ? 0 : 1;
 	QueueResetFocus(FocusResetType::PopupOpened);
 }
 
@@ -2589,10 +2592,11 @@ void ImGuiFullscreen::OpenInfoMessageDialog(
 	s_message_dialog_message = std::move(message);
 	s_message_dialog_callback = std::move(callback);
 	s_message_dialog_buttons[0] = std::move(button_text);
+	s_message_dialog_default_index = 0;
 	QueueResetFocus(FocusResetType::PopupOpened);
 }
 
-void ImGuiFullscreen::OpenMessageDialog(std::string title, std::string message, MessageDialogCallback callback,
+void ImGuiFullscreen::OpenMessageDialog(std::string title, std::string message, MessageDialogCallback callback, s32 default_index,
 	std::string first_button_text, std::string second_button_text, std::string third_button_text)
 {
 	CloseMessageDialog();
@@ -2604,6 +2608,8 @@ void ImGuiFullscreen::OpenMessageDialog(std::string title, std::string message, 
 	s_message_dialog_buttons[0] = std::move(first_button_text);
 	s_message_dialog_buttons[1] = std::move(second_button_text);
 	s_message_dialog_buttons[2] = std::move(third_button_text);
+	pxAssert(default_index < 3);
+	s_message_dialog_default_index = default_index;
 	QueueResetFocus(FocusResetType::PopupOpened);
 }
 
@@ -2617,6 +2623,7 @@ void ImGuiFullscreen::CloseMessageDialog()
 	s_message_dialog_message = {};
 	s_message_dialog_buttons = {};
 	s_message_dialog_callback = {};
+	s_message_dialog_default_index = 0;
 	QueueResetFocus(FocusResetType::PopupClosed);
 }
 
@@ -2660,6 +2667,8 @@ void ImGuiFullscreen::DrawMessageDialog()
 				result = button_index;
 				ImGui::CloseCurrentPopup();
 			}
+			if (button_index == s_message_dialog_default_index)
+				ImGui::SetItemDefaultFocus();
 		}
 
 		EndMenuButtons();

--- a/pcsx2/ImGui/ImGuiFullscreen.h
+++ b/pcsx2/ImGui/ImGuiFullscreen.h
@@ -263,11 +263,11 @@ namespace ImGuiFullscreen
 	using InfoMessageDialogCallback = std::function<void()>;
 	using MessageDialogCallback = std::function<void(s32)>;
 	bool IsMessageBoxDialogOpen();
-	void OpenConfirmMessageDialog(std::string title, std::string message, ConfirmMessageDialogCallback callback,
+	void OpenConfirmMessageDialog(std::string title, std::string message, ConfirmMessageDialogCallback callback, bool default_yes = true,
 		std::string yes_button_text = ICON_FA_CHECK " Yes", std::string no_button_text = ICON_FA_XMARK " No");
 	void OpenInfoMessageDialog(std::string title, std::string message, InfoMessageDialogCallback callback = {},
 		std::string button_text = ICON_FA_SQUARE_XMARK " Close");
-	void OpenMessageDialog(std::string title, std::string message, MessageDialogCallback callback, std::string first_button_text,
+	void OpenMessageDialog(std::string title, std::string message, MessageDialogCallback callback, s32 default_index, std::string first_button_text,
 		std::string second_button_text, std::string third_button_text);
 	void CloseMessageDialog();
 


### PR DESCRIPTION
### Description of Changes
Add the ability to specify the default button for message dialogs (such as the MC warning)

### Rationale behind Changes
Avoids having to reorder yes/no buttons to achieve the same result.
Fixes the MC dialog treating closing as accepting (due to performing the above workaround).

### Suggested Testing Steps
Test confirmation dialogs, such as the Memory Card conformation dialog.

### Did you use AI to help find, test, or implement this issue or feature?
No
