### PR TITLE
RTC: Automatically detect timezone

### DIFF
--- a/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
@@ -164,7 +164,6 @@ EmulationSettingsWidget::EmulationSettingsWidget(SettingsWindow* settings_dialog
 	dialog()->registerWidgetHelp(m_ui.rtcDateTime, tr("Real-Time Clock"), tr("Current date and time"),
 		tr("Real-time clock (RTC) used by the virtual PlayStation 2.<br>"
 		   "This time is only applied upon booting the PS2; changing it while in-game will have no effect.<br>"
-		   "NOTE: This assumes you have your PS2 set to the default timezone of GMT+0 and default DST of Summer Time.<br>"
 		   "Some games require an RTC date/time set after their release date."));
 	dialog()->registerWidgetHelp(m_ui.rtcUseSystemLocaleFormat, tr("Use System Locale Format"), tr("User Preference"),
 		tr("Uses the operating system's date/time format rather than \"yyyy-MM-dd HH:mm:ss\". May exclude seconds."));

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1314,7 +1314,7 @@ struct Pcsx2Config
 		InhibitScreensaver : 1,
 		BackupSavestate : 1,
 		McdFolderAutoManage : 1,
-		ManuallySetRealTimeClock : 1,
+		ManuallySetRealTimeClock : 1, // passes user-set real-time clock information to cdvd at startup
 		UseSystemLocaleFormat : 1, // presents OS time format instead of yyyy-MM-dd HH:mm:ss for manual RTC
 
 		HostFs : 1,

--- a/pcsx2/ps2/BiosTools.cpp
+++ b/pcsx2/ps2/BiosTools.cpp
@@ -68,6 +68,9 @@ void ReadOSDConfigParames()
 
 	// Region settings for time/date and extended language
 	configParams2.UC[1] = ((u32)params[3] & 0x78) << 1; // Daylight Savings, 24hr clock, Date format
+	configParams2.daylightSavings = configParams2.UC[1] & 0x10 ? 1 : 0;
+	configParams2.timeFormat = configParams2.UC[1] & 0x20 ? 1 : 0;
+	configParams2.dateFormat = configParams2.UC[1] & 0x80 ? 2 : (configParams2.UC[1] & 0x40 ? 1 : 0);
 	// FIXME: format, version and language are set manually by the bios. Not sure if any game needs them, but it seems to set version to 2 and duplicate the language value.
 	configParams2.version = 2;
 	configParams2.language = configParams1.language;

--- a/pcsx2/ps2/BiosTools.h
+++ b/pcsx2/ps2/BiosTools.h
@@ -43,7 +43,7 @@ typedef struct
 			/** LANGUAGE_??? value */
 			/*16*/ u32 language : 5;
 			/** timezone minutes offset from gmt */
-			/*21*/ u32 timezoneOffset : 11;
+			/*21*/ s32 timezoneOffset : 11;
 		};
 
 		u8  UC[4];
@@ -63,7 +63,7 @@ typedef struct
 
 			/*00*/ u8 reserved : 4;
 			/** 0=standard(winter), 1=daylight savings(summer) */
-			/*04*/ u8 daylightSaving : 1;
+			/*04*/ u8 daylightSavings : 1;
 			/** 0=24 hour, 1=12 hour */
 			/*05*/ u8 timeFormat : 1;
 			/** 0=YYYYMMDD, 1=MMDDYYYY, 2=DDMMYYYY */


### PR DESCRIPTION
### Description of Changes
Automatically detects the user's timezone and DST when computing manual RTC date/time. Adds date/time information to the emulog on CDVD reset.

<img width="136" height="96" alt="image" src="https://github.com/user-attachments/assets/90919002-44c5-42c4-928e-f714bfaf5b1f" />

<img width="452" height="106" alt="image" src="https://github.com/user-attachments/assets/39212cae-26f7-4ea4-962c-3ba9e695ed74" />

<img width="677" height="267" alt="image" src="https://github.com/user-attachments/assets/6512f192-a061-4605-a53d-17d59b204491" />

### Rationale behind Changes
* The current manual RTC implementation requires the user to set their BIOS timezone and DST to an assumed value of GMT+0 and Summer. There's no reason for this other than as a bodge when I didn't know how to access this information in the NVM file. This automatically accounts for whatever the timezone and DST is set to in the BIOS.
* Having this information in the emulog for debugging, especially regarding RTC, could be useful in the future.

### Suggested Testing Steps
* Testing timezones and DST is rough to test because there's no global option for RTC, and thus the `Start BIOS` feature can't see this. The easiest option is to transfer the six values from a per-game `.ini` file into the global one under "EmuCore". I've tested this on my end with GMT+0, GMT+2, GMT+5:45, GMT-8, (edit: now GMT-3:30), etc.
* Under the console log, the time information is in green text right after "Resetting host memory for virtual systems..." Make sure that the information comports with your setup. Timezone, DST, Date Format, and Time Format are what you have in your BIOS. System Time Basis is where PCSX2 is drawing the system time from. System time is what the system time should be on boot.

### Did you use AI to help find, test, or implement this issue or feature?
No.
