### PR TITLE
Mac OS: Bump runner versions

### DIFF
--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -62,8 +62,8 @@ jobs:
           echo "#define DEFAULT_UPDATER_CHANNEL \"stable\"" > ./pcsx2-qt/DefaultUpdaterChannel.h
           cat ./pcsx2-qt/DefaultUpdaterChannel.h
 
-      - name: Use Xcode 16.4
-        run: sudo xcode-select -s /Applications/Xcode_16.4.app
+      - name: Use Xcode 26.0.1
+        run: sudo xcode-select -s /Applications/Xcode_26.0.1.app
 
       - name: Prepare Artifact Metadata
         id: artifact-metadata


### PR DESCRIPTION
### Description of Changes
Bumps the Mac OS runner to Mac OS 26 and Xcode to 26.0.1.

### Rationale behind Changes
Keeping things up to date is nice.

### Suggested Testing Steps
Make sure the builds still work and it compiles correctly.

### Did you use AI to help find, test, or implement this issue or feature?
No
