### PR TITLE
GHActions: Reduce ccache max size

### DIFF
--- a/.github/workflows/linux_build_qt.yml
+++ b/.github/workflows/linux_build_qt.yml
@@ -55,7 +55,7 @@ jobs:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       CCACHE_COMPRESS: true
       CCACHE_COMPRESSLEVEL: 9
-      CCACHE_MAXSIZE: 500M
+      CCACHE_MAXSIZE: 100M
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -42,7 +42,7 @@ jobs:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       CCACHE_COMPRESS: true
       CCACHE_COMPRESSLEVEL: 9
-      CCACHE_MAXSIZE: 500M
+      CCACHE_MAXSIZE: 100M
       # Only way to use a secret in an if statement
       SIGN_KEY: ${{ secrets.APPLE_SIGN_P12_B64 }}
 


### PR DESCRIPTION
### Description of Changes
Reduces the max ccache size from 500M to 100M.  A single build currently uses about 50M of cache, so this allows one complete change of all files to be cached before things start getting evicted.

### Rationale behind Changes
GH Actions cache entries can't replace each other (please, GH?), so we put each ccache entry under a unique key.

This means they pile up, and quickly go through our cache allowance, evicting more important caches.

We can't tell GH to prioritize the others, so the next best thing is to just prevent these from getting too big.

### Suggested Testing Steps
Nothing you can see before this is merged

### Did you use AI to help find, test, or implement this issue or feature?
No
