### PR TITLE
Patch: Fix some incorrect format strings

### DIFF
--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -902,12 +902,12 @@ void Patch::PatchFunc::patch(PatchGroup* group, const std::string_view cmd, cons
 	}
 	if (!cpu.has_value())
 	{
-		PATCH_ERROR("Unrecognized CPU Target: '%.*s'", pieces[1]);
+		PATCH_ERROR("Unrecognized CPU Target: '{}'", pieces[1]);
 		return;
 	}
 	if (!type.has_value())
 	{
-		PATCH_ERROR("Unrecognized Operand Size: '%.*s'", pieces[3]);
+		PATCH_ERROR("Unrecognized Operand Size: '{}'", pieces[3]);
 		return;
 	}
 	if (type.value() != BYTES_T)


### PR DESCRIPTION
### Description of Changes
Fix some format strings.

### Rationale behind Changes
Someone forgot to change %.*s to {}.

### Suggested Testing Steps
Create a patch with an invalid CPU or type.

### Did you use AI to help find, test, or implement this issue or feature?
No.
