### PR TITLE
Debugger: Respond to OS colour scheme changes

### DIFF
--- a/pcsx2-qt/Debugger/DebuggerWindow.cpp
+++ b/pcsx2-qt/Debugger/DebuggerWindow.cpp
@@ -238,6 +238,12 @@ int DebuggerWindow::fontSize()
 
 void DebuggerWindow::updateTheme()
 {
+	// Detect recursive StyleChange events caused by updating the stylesheet.
+	if (m_is_updating_theme)
+		return;
+
+	m_is_updating_theme = true;
+
 	// TODO: Migrate away from stylesheets to improve performance.
 	setStyleSheet(QString("font-size: %1pt;").arg(m_font_size));
 
@@ -248,6 +254,8 @@ void DebuggerWindow::updateTheme()
 		setStyleSheet(QString());
 
 	dockManager().updateTheme();
+
+	m_is_updating_theme = false;
 }
 
 void DebuggerWindow::saveWindowGeometry()
@@ -533,6 +541,12 @@ void DebuggerWindow::onStepOut()
 	});
 
 	this->repaint();
+}
+
+void DebuggerWindow::changeEvent(QEvent* event)
+{
+	if (event->type() == QEvent::PaletteChange || event->type() == QEvent::StyleChange)
+		updateTheme();
 }
 
 void DebuggerWindow::closeEvent(QCloseEvent* event)

--- a/pcsx2-qt/Debugger/DebuggerWindow.h
+++ b/pcsx2-qt/Debugger/DebuggerWindow.h
@@ -60,7 +60,8 @@ Q_SIGNALS:
 	void onVMActuallyPaused();
 
 protected:
-	void closeEvent(QCloseEvent* event);
+	void changeEvent(QEvent* event) override;
+	void closeEvent(QCloseEvent* event) override;
 
 private:
 	DebugInterface* currentCPU();
@@ -75,6 +76,8 @@ private:
 	int m_font_size;
 	static const constexpr int MINIMUM_FONT_SIZE = 5;
 	static const constexpr int MAXIMUM_FONT_SIZE = 30;
+
+	bool m_is_updating_theme = false;
 };
 
 extern DebuggerWindow* g_debugger_window;

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1803,9 +1803,6 @@ void MainWindow::updateTheme()
 {
 	QtHost::UpdateApplicationTheme();
 	reloadThemeSpecificImages();
-
-	if (g_debugger_window)
-		g_debugger_window->updateTheme();
 }
 
 void MainWindow::reloadThemeSpecificImages()


### PR DESCRIPTION
### Description of Changes
Update the debugger's theme in response to a PaletteChange or StyleChange event rather than calling it from MainWindow::updateTheme.

### Rationale behind Changes
In my docking PR I made it so the debugger's theme would be updated when the theme was changed via the PCSX2 settings window, but I forgot to make it so that the theme would be updated when the colour scheme is changed via the OS.

### Suggested Testing Steps
Test on Windows and macOS.

### Did you use AI to help find, test, or implement this issue or feature?
No.
