### PR TITLE
GameListModel: Remove dead, nonsense switch case

### DIFF
--- a/pcsx2-qt/GameList/GameListModel.cpp
+++ b/pcsx2-qt/GameList/GameListModel.cpp
@@ -335,46 +335,6 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
 			}
 		}
 
-		case Qt::InitialSortOrderRole:
-		{
-			switch (index.column())
-			{
-				case Column_Type:
-					return static_cast<int>(ge->type);
-
-				case Column_Serial:
-					return QString::fromStdString(ge->serial);
-
-				case Column_Title:
-				case Column_Cover:
-					return QString::fromStdString(ge->GetTitleSort(m_prefer_english_titles));
-
-				case Column_FileTitle:
-					return QtUtils::StringViewToQString(Path::GetFileTitle(ge->path));
-
-				case Column_CRC:
-					return static_cast<int>(ge->crc);
-
-				case Column_TimePlayed:
-					return static_cast<qlonglong>(ge->total_played_time);
-
-				case Column_LastPlayed:
-					return static_cast<qlonglong>(ge->last_played_time);
-
-				case Column_Region:
-					return static_cast<int>(ge->region);
-
-				case Column_Compatibility:
-					return static_cast<int>(ge->compatibility_rating);
-
-				case Column_Size:
-					return static_cast<qulonglong>(ge->total_size);
-
-				default:
-					return {};
-			}
-		}
-
 		case Qt::DecorationRole:
 		{
 			switch (index.column())
@@ -413,10 +373,10 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
 				default:
 					return {};
 			}
-
-			default:
-				return {};
 		}
+		
+		default:
+			return {};
 	}
 }
 

--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -260,7 +260,7 @@ void GameListWidget::initialize()
 	connect(m_table_view->horizontalHeader(), &QHeaderView::customContextMenuRequested, this,
 		&GameListWidget::onTableViewHeaderContextMenuRequested);
 	connect(m_table_view->horizontalHeader(), &QHeaderView::sortIndicatorChanged, this,
-		&GameListWidget::onTableViewHeaderSortIndicatorChanged);
+		&GameListWidget::saveTableViewColumnSortSettings);
 
 	m_ui.stack->insertWidget(0, m_table_view);
 
@@ -571,11 +571,6 @@ void GameListWidget::onTableViewHeaderContextMenuRequested(const QPoint& point)
 	menu.exec(m_table_view->mapToGlobal(point));
 }
 
-void GameListWidget::onTableViewHeaderSortIndicatorChanged(int, Qt::SortOrder)
-{
-	saveTableViewColumnSortSettings();
-}
-
 void GameListWidget::onCoverScaleChanged()
 {
 	m_model->updateCacheSize(width(), height());
@@ -804,18 +799,15 @@ void GameListWidget::loadTableViewColumnSortSettings()
 		hv->setSortIndicator(sort_column, sort_order);
 }
 
-void GameListWidget::saveTableViewColumnSortSettings()
+void GameListWidget::saveTableViewColumnSortSettings(const int sort_column, const Qt::SortOrder sort_order)
 {
-	const int sort_column = m_table_view->horizontalHeader()->sortIndicatorSection();
-	const bool sort_descending = (m_table_view->horizontalHeader()->sortIndicatorOrder() == Qt::DescendingOrder);
-
 	if (sort_column >= 0 && sort_column < GameListModel::Column_Count)
 	{
 		Host::SetBaseStringSettingValue(
 			"GameListTableView", "SortColumn", GameListModel::getColumnName(static_cast<GameListModel::Column>(sort_column)));
 	}
 
-	Host::SetBaseBoolSettingValue("GameListTableView", "SortDescending", sort_descending);
+	Host::SetBaseBoolSettingValue("GameListTableView", "SortDescending", sort_order == Qt::DescendingOrder);
 	Host::CommitBaseSettingChanges();
 }
 

--- a/pcsx2-qt/GameList/GameListWidget.h
+++ b/pcsx2-qt/GameList/GameListWidget.h
@@ -81,7 +81,6 @@ private Q_SLOTS:
 	void onTableViewItemActivated(const QModelIndex& index);
 	void onTableViewContextMenuRequested(const QPoint& point);
 	void onTableViewHeaderContextMenuRequested(const QPoint& point);
-	void onTableViewHeaderSortIndicatorChanged(int, Qt::SortOrder);
 	void onListViewItemActivated(const QModelIndex& index);
 	void onListViewContextMenuRequested(const QPoint& point);
 	void onCoverScaleChanged();
@@ -106,7 +105,7 @@ private:
 	void saveTableViewColumnVisibilitySettings();
 	void saveTableViewColumnVisibilitySettings(int column);
 	void loadTableViewColumnSortSettings();
-	void saveTableViewColumnSortSettings();
+	void saveTableViewColumnSortSettings(const int sort_column, const Qt::SortOrder sort_order);
 	void listZoom(float delta);
 	void updateToolbar();
 


### PR DESCRIPTION
### Description of Changes
Remove the `Qt::InitialSortOrderRole` switch case in `data()` for the game list model.

### Rationale behind Changes
* Code is nonfunctional. You can see this by removing it and changing the column sort or by looking at `GameListWidget::loadTableViewColumnSortSettings()` which appears to actually handle this.
* Return values are completely nonsensical. I can't think of a different role this may have been made for because of its inconsistent return type, so I'm left to assume this was made with a fundamental misunderstanding of what this role is.
  * A `Qt::InitialSortOrderRole` is supposed to be a [`Qt::SortOrder`](https://doc.qt.io/qt-6/qt.html#SortOrder-enum), which is either `Qt::AscendingOrder` (0) or `Qt::DescendingOrder` (1). No strings, no qlonglongs, just an enum with two possible values.

Credit to @Pesa for pointing this out.

### Suggested Testing Steps
Make sure sorting still works as intended.

### Did you use AI to help find, test, or implement this issue or feature?
No.
