### PR TITLE
MacOS: Fix Mac OS build

### DIFF
--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Use Xcode 26.0.1
         run: sudo xcode-select -s /Applications/Xcode_26.0.1.app
 
+      - name: Install Metal Toolchain
+        run: xcodebuild -downloadComponent MetalToolchain
+
       - name: Prepare Artifact Metadata
         id: artifact-metadata
         shell: bash


### PR DESCRIPTION
### Description of Changes
Fixes the Mac OS building failing on missing Metal toolchain.

### Rationale behind Changes
Seems like we need it now since updating to xcode 26 so let's install it.

### Suggested Testing Steps
Confirm the CI now works and the builds function.

### Did you use AI to help find, test, or implement this issue or feature?
No
