### PR TITLE
QtHost: Fix locale crash on non-Windows machines

### DIFF
--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -2328,7 +2328,12 @@ int main(int argc, char* argv[])
 {
 	CrashHandler::Install();
 
+// Exceptions are disabled, so we can't try/catch this.
+// Timestamps in some locales showed up wrong on Windows.
+// Qt already applies the user locale on Unix-like systems.
+#ifdef _WIN32
 	std::locale::global(std::locale(""));
+#endif
 
 	QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
 	QtHost::RegisterTypes();


### PR DESCRIPTION
### Description of Changes
Fixes a crash on non-Windows machines caused by calling `std::locale::global(std::locale(""))`. Reported by @GovanifY and caused by #12637 (v2.5.21).

### Rationale behind Changes
See code comments. `#ifdef _WIN32` instead of revert because this did fix a legitimate issue on Windows; however, we can't try/catch on Windows because our exceptions are disabled.

### Suggested Testing Steps
Make sure that PCSX2 no longer crashes on non-Windows machines like Linux (untested on macOS). Make sure you can't create a weird Windows locale that crashes this.

### Did you use AI to help find, test, or implement this issue or feature?
No.
