### PR TITLE
Snapshots: Clean up per-game snapshots folder code

### DIFF
--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -275,7 +275,7 @@ private:
 	void setGameListEntryCoverImage(const GameList::Entry* entry);
 	void clearGameListEntryPlayTime(const GameList::Entry* entry, const time_t entry_played_time);
 	void goToWikiPage(const GameList::Entry* entry);
-	void openScreenshotsFolderForGame(const GameList::Entry* entry);
+	void openSnapshotsFolderForGame(const GameList::Entry* entry);
 
 	std::optional<bool> promptForResumeState(const QString& save_state_path);
 	void loadSaveStateSlot(s32 slot, bool load_backup = false);

--- a/pcsx2-qt/Settings/FolderSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/FolderSettingsWidget.cpp
@@ -19,14 +19,13 @@ FolderSettingsWidget::FolderSettingsWidget(SettingsWindow* settings_dialog, QWid
 	SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.cheats, m_ui.cheatsBrowse, m_ui.cheatsOpen, m_ui.cheatsReset, "Folders", "Cheats", Path::Combine(EmuFolders::DataRoot, "cheats"));
 	SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.covers, m_ui.coversBrowse, m_ui.coversOpen, m_ui.coversReset, "Folders", "Covers", Path::Combine(EmuFolders::DataRoot, "covers"));
 	SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.snapshots, m_ui.snapshotsBrowse, m_ui.snapshotsOpen, m_ui.snapshotsReset, "Folders", "Snapshots", Path::Combine(EmuFolders::DataRoot, "snaps"));
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.organizeScreenshotsByGame, "EmuCore/GS", "OrganizeScreenshotsByGame", false);
-	connect(m_ui.organizeScreenshotsByGame, &QCheckBox::checkStateChanged, this, [](int state) {
-		GSConfig.OrganizeScreenshotsByGame = (state == Qt::Checked);
-	});
-	SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.saveStates, m_ui.saveStatesBrowse, m_ui.saveStatesOpen, m_ui.saveStatesReset, "Folders", "SaveStates", Path::Combine(EmuFolders::DataRoot, "sstates"));
-	SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.videoDumpingDirectory, m_ui.videoDumpingDirectoryBrowse, m_ui.videoDumpingDirectoryOpen, m_ui.videoDumpingDirectoryReset, "Folders", "Videos", Path::Combine(EmuFolders::DataRoot, "videos"));
-	dialog()->registerWidgetHelp(m_ui.organizeScreenshotsByGame, tr("Organize Screenshots by Game"), tr("Unchecked"),
-		tr("When enabled, screenshots will be saved in a folder with the game's name, instead of all being saved in the Snapshots folder"));
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.organizeSnapshotsByGame, "EmuCore/GS", "OrganizeScreenshotsByGame", false);
+	SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.saveStates, m_ui.saveStatesBrowse, m_ui.saveStatesOpen, m_ui.saveStatesReset,
+		"Folders", "SaveStates", Path::Combine(EmuFolders::DataRoot, "sstates"));
+	SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.videoDumpingDirectory, m_ui.videoDumpingDirectoryBrowse, m_ui.videoDumpingDirectoryOpen, m_ui.videoDumpingDirectoryReset,
+		"Folders", "Videos", Path::Combine(EmuFolders::DataRoot, "videos"));
+	dialog()->registerWidgetHelp(m_ui.organizeSnapshotsByGame, tr("Organize Snapshots by Game"), tr("Unchecked"),
+ 		tr("Saves snapshots to per-game subfolders instead of a shared folder."));
 }
 
 FolderSettingsWidget::~FolderSettingsWidget() = default;

--- a/pcsx2-qt/Settings/FolderSettingsWidget.ui
+++ b/pcsx2-qt/Settings/FolderSettingsWidget.ui
@@ -138,7 +138,7 @@
        </widget>
       </item>
       <item row="2" column="0" colspan="4">
-       <widget class="QCheckBox" name="organizeScreenshotsByGame">
+       <widget class="QCheckBox" name="organizeSnapshotsByGame">
         <property name="text">
          <string>Save Snapshots in Game-Specific Folders</string>
         </property>
@@ -304,7 +304,7 @@
   <tabstop>snapshotsBrowse</tabstop>
   <tabstop>snapshotsOpen</tabstop>
   <tabstop>snapshotsReset</tabstop>
-  <tabstop>organizeScreenshotsByGame</tabstop>
+  <tabstop>organizeSnapshotsByGame</tabstop>
   <tabstop>saveStates</tabstop>
   <tabstop>saveStatesBrowse</tabstop>
   <tabstop>saveStatesOpen</tabstop>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -789,7 +789,7 @@ struct Pcsx2Config
 					VideoCaptureAutoResolution : 1,
 					EnableAudioCapture : 1,
 					EnableAudioCaptureParameters : 1,
-					OrganizeScreenshotsByGame : 1;
+					OrganizeSnapshotsByGame : 1;
 			};
 		};
 

--- a/pcsx2/GS/Renderers/Common/GSRenderer.h
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.h
@@ -59,7 +59,7 @@ public:
 	bool SaveSnapshotToMemory(u32 window_width, u32 window_height, bool apply_aspect, bool crop_borders,
 		u32* width, u32* height, std::vector<u32>* pixels);
 
-	void QueueSnapshot(const std::string& path, u32 gsdump_frames);
+	void QueueSnapshot(const std::string& path, const u32 gsdump_frames);
 	void StopGSDump();
 	void PresentCurrentFrame();
 	bool BeginCapture(std::string filename, const GSVector2i& size = GSVector2i(0, 0));

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -923,7 +923,7 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapIntEnumEx(ScreenshotSize, "ScreenshotSize");
 	SettingsWrapIntEnumEx(ScreenshotFormat, "ScreenshotFormat");
 	SettingsWrapEntry(ScreenshotQuality);
-	SettingsWrapBitBool(OrganizeScreenshotsByGame);
+	SettingsWrapBitBoolEx(OrganizeSnapshotsByGame, "OrganizeScreenshotsByGame");
 	SettingsWrapEntry(StretchY);
 	SettingsWrapEntryEx(Crop[0], "CropLeft");
 	SettingsWrapEntryEx(Crop[1], "CropTop");


### PR DESCRIPTION
### Description of Changes
Cleans up some of the per-game snapshots folder code introduced in #12934.

* Makes "Open Screenshots Folder" to "Open Snapshots Folder" consistent.
  * We call them snapshots, and it's because this works for both screenshots and GS dumps.
  * This was never made consistent in the original PR. For example, the option in `Folders` is `Save Snapshots [...]`, while the option on right-click is `Open Screenshots Folder`.
* Removed a 'connect' which appears to have been created by accident. The only thing that the 'connect' did was change the underlying setting on checkbox clicked, but this is already what `BindWidgetToBoolSetting()` does. Basically, we were setting the same setting twice.
* Move `if (!EmuConfig.GS.OrganizeSnapshotsByGame)` to the top of `openSnapshotsFolderForGame()` because per-game folders users will have to run that check regardless and this is a very common case (assuming null entry or empty title on right-click is a comparatively very rare case). Just put all these conditions in one conditional.
* Because logical AND *does* short-circuit, we can put the folder creation if the directory doesn't exist inside of the same conditional.
* Make `GSGetBaseSnapshotFilename()` more succinct, elegant, and marginally more efficient.
* Make sure that `GSGetBaseSnapshotFilename()` doesn't YOLO folder creation and just hope it works; use a sensible default if it doesn't.
* Remove magic `resize(219)` for the game name.
  * This was likely obtained from `GSGetBaseFilename()` without fully understanding what it does.
    * To be fair, neither do I fully; it looks like it's trying to compensate for Windows' MAX_PATH of 260, but 1) it should be `#ifdef`'d then, and 2) it's still a weird, weird number and should've been named).
  * The base path which it's combined with is already resized around up to 240-ish chars, so if it's for MAX_PATH, that check doesn't work.
  * If it's not for MAX_PATH, then I have no idea why we're trying to make sure our game-specific folder path is specifically less than ~450 chars.

### Suggested Testing Steps
Make sure game-specific folders still work.

### Did you use AI to help find, test, or implement this issue or feature?
No, and I don't think the technology exists yet to help me figure out the magic number.
