### PR TITLE
Qt: Add TextBrowserInteraction to labels where appropriate

### DIFF
--- a/pcsx2-qt/AboutDialog.ui
+++ b/pcsx2-qt/AboutDialog.ui
@@ -81,6 +81,9 @@
      <property name="wordWrap">
       <bool>true</bool>
      </property>
+     <property name="textInteractionFlags">
+      <set>Qt::TextBrowserInteraction</set>
+     </property>
     </widget>
    </item>
    <item>
@@ -114,6 +117,9 @@
      </property>
      <property name="wordWrap">
       <bool>true</bool>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::TextBrowserInteraction</set>
      </property>
     </widget>
    </item>

--- a/pcsx2-qt/CoverDownloadDialog.ui
+++ b/pcsx2-qt/CoverDownloadDialog.ui
@@ -43,6 +43,9 @@
        <property name="buddy">
         <cstring>label</cstring>
        </property>
+       <property name="textInteractionFlags">
+        <set>Qt::TextBrowserInteraction</set>
+       </property>
       </widget>
      </item>
     </layout>
@@ -57,6 +60,9 @@
      </property>
      <property name="buddy">
       <cstring>urls</cstring>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::TextBrowserInteraction</set>
      </property>
     </widget>
    </item>
@@ -73,6 +79,9 @@
      </property>
      <property name="buddy">
       <cstring>useTitleFileNames</cstring>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::TextBrowserInteraction</set>
      </property>
     </widget>
    </item>

--- a/pcsx2-qt/Debugger/AnalysisOptionsDialog.ui
+++ b/pcsx2-qt/Debugger/AnalysisOptionsDialog.ui
@@ -34,6 +34,9 @@
      <property name="wordWrap">
       <bool>true</bool>
      </property>
+     <property name="textInteractionFlags">
+      <set>Qt::TextBrowserInteraction</set>
+     </property>
     </widget>
    </item>
    <item>

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1753,7 +1753,7 @@ void MainWindow::onToolsCoverDownloaderTriggered()
 {
 	// This can be invoked via big picture, so exit fullscreen.
 	VMLock lock(pauseAndLockVM());
-	CoverDownloadDialog dlg(lock.getDialogParent());
+	CoverDownloadDialog dlg(this);
 	connect(&dlg, &CoverDownloadDialog::coverRefreshRequested, m_game_list_widget, &GameListWidget::refreshGridCovers);
 	dlg.exec();
 }

--- a/pcsx2-qt/Settings/AchievementSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AchievementSettingsWidget.ui
@@ -429,6 +429,9 @@ Login token generated at:</string>
         <property name="buddy">
          <cstring>viewProfile</cstring>
         </property>
+        <property name="textInteractionFlags">
+         <set>Qt::TextBrowserInteraction</set>
+        </property>
        </widget>
       </item>
       <item>
@@ -468,6 +471,9 @@ Login token generated at:</string>
        <widget class="QLabel" name="gameInfo">
         <property name="alignment">
          <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::TextBrowserInteraction</set>
         </property>
        </widget>
       </item>

--- a/pcsx2-qt/Settings/AudioSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.ui
@@ -133,6 +133,9 @@
         <property name="alignment">
          <set>Qt::AlignmentFlag::AlignCenter</set>
         </property>
+        <property name="textInteractionFlags">
+         <set>Qt::TextBrowserInteraction</set>
+        </property>
        </widget>
       </item>
       <item row="0" column="0">

--- a/pcsx2-qt/Settings/BIOSSettingsWidget.ui
+++ b/pcsx2-qt/Settings/BIOSSettingsWidget.ui
@@ -40,6 +40,9 @@
         <property name="buddy">
          <cstring>searchDirectory</cstring>
         </property>
+        <property name="textInteractionFlags">
+         <set>Qt::TextBrowserInteraction</set>
+        </property>
        </widget>
       </item>
       <item row="1" column="0" colspan="2">

--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.ui
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.ui
@@ -64,6 +64,9 @@
         <property name="wordWrap">
          <bool>true</bool>
         </property>
+        <property name="textInteractionFlags">
+         <set>Qt::TextBrowserInteraction</set>
+        </property>
        </widget>
       </item>
      </layout>
@@ -90,6 +93,9 @@
         <property name="wordWrap">
          <bool>true</bool>
         </property>
+        <property name="textInteractionFlags">
+         <set>Qt::TextBrowserInteraction</set>
+        </property>
        </widget>
       </item>
      </layout>
@@ -108,6 +114,9 @@
         </property>
         <property name="wordWrap">
          <bool>true</bool>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::TextBrowserInteraction</set>
         </property>
        </widget>
       </item>
@@ -141,6 +150,9 @@
         </property>
         <property name="wordWrap">
          <bool>true</bool>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::TextBrowserInteraction</set>
         </property>
        </widget>
       </item>
@@ -200,8 +212,14 @@
         <property name="text">
          <string>PCSX2 allows you to use your mouse to simulate analog stick movement.</string>
         </property>
+        <property name="textInteractionFlags">
+         <set>Qt::TextBrowserInteraction</set>
+        </property>
         <property name="wordWrap">
          <bool>true</bool>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::TextBrowserInteraction</set>
         </property>
        </widget>
       </item>
@@ -239,6 +257,9 @@
        <widget class="QLabel" name="label_3">
         <property name="text">
          <string>The XInput source provides support for Xbox 360 / Xbox One / Xbox Series controllers, and third party controllers which implement the XInput protocol.</string>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::TextBrowserInteraction</set>
         </property>
         <property name="wordWrap">
          <bool>true</bool>

--- a/pcsx2-qt/Settings/ControllerMacroEditWidget.ui
+++ b/pcsx2-qt/Settings/ControllerMacroEditWidget.ui
@@ -33,12 +33,18 @@
        <widget class="QListWidget" name="bindList"/>
       </item>
       <item row="0" column="0">
-       <widget class="QLabel" name="label_2">
+       <widget class="QLabel" name="bindListLabel">
         <property name="text">
          <string>Select the buttons which you want to trigger with this macro. All buttons are activated concurrently.</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::TextBrowserInteraction</set>
+        </property>
+        <property name="buddy">
+         <cstring>bindList</cstring>
         </property>
        </widget>
       </item>
@@ -52,12 +58,18 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <widget class="QLabel" name="label_3">
+       <widget class="QLabel" name="pressureLabel">
         <property name="text">
          <string>For buttons which are pressure sensitive, this slider controls how much force will be simulated when the macro is active.</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::TextBrowserInteraction</set>
+        </property>
+        <property name="buddy">
+         <cstring>pressure</cstring>
         </property>
        </widget>
       </item>
@@ -116,6 +128,9 @@
           <property name="wordWrap">
            <bool>true</bool>
           </property>
+          <property name="textInteractionFlags">
+           <set>Qt::TextBrowserInteraction</set>
+          </property>
          </widget>
         </item>
         <item>
@@ -137,9 +152,12 @@
       <item row="2" column="0">
        <layout class="QHBoxLayout" name="deadzoneLayout" stretch="0,1,0">
         <item>
-         <widget class="QLabel" name="label_4">
+         <widget class="QLabel" name="deadzoneLabel">
           <property name="text">
            <string>Deadzone:</string>
+          </property>
+          <property name="buddy">
+           <cstring>deadzone</cstring>
           </property>
          </widget>
         </item>
@@ -189,6 +207,9 @@
          <widget class="QLabel" name="frequencyText">
           <property name="text">
            <string>Macro will toggle every N frames.</string>
+          </property>
+          <property name="textInteractionFlags">
+           <set>Qt::TextBrowserInteraction</set>
           </property>
          </widget>
         </item>

--- a/pcsx2-qt/Settings/DebugAnalysisSettingsTab.ui
+++ b/pcsx2-qt/Settings/DebugAnalysisSettingsTab.ui
@@ -28,6 +28,9 @@
      <property name="wordWrap">
       <bool>true</bool>
      </property>
+     <property name="textInteractionFlags">
+      <set>Qt::TextBrowserInteraction</set>
+     </property>
     </widget>
    </item>
    <item>

--- a/pcsx2-qt/Settings/FolderSettingsWidget.ui
+++ b/pcsx2-qt/Settings/FolderSettingsWidget.ui
@@ -49,6 +49,9 @@
         <property name="buddy">
          <cstring>cache</cstring>
         </property>
+        <property name="textInteractionFlags">
+         <set>Qt::TextBrowserInteraction</set>
+        </property>
        </widget>
       </item>
      </layout>
@@ -92,6 +95,9 @@
         <property name="buddy">
          <cstring>cheats</cstring>
         </property>
+        <property name="textInteractionFlags">
+         <set>Qt::TextBrowserInteraction</set>
+        </property>
        </widget>
       </item>
      </layout>
@@ -130,7 +136,10 @@
       <item row="0" column="0" colspan="4">
        <widget class="QLabel" name="snaphotsLabel">
         <property name="text">
-         <string>Used for screenshots and saving GS dumps.</string>
+         <string>Used for saving screenshots and GS dumps.</string>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::TextBrowserInteraction</set>
         </property>
         <property name="buddy">
          <cstring>snapshots</cstring>
@@ -160,6 +169,9 @@
         </property>
         <property name="buddy">
          <cstring>saveStates</cstring>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::TextBrowserInteraction</set>
         </property>
        </widget>
       </item>
@@ -228,6 +240,9 @@
         <property name="buddy">
          <cstring>covers</cstring>
         </property>
+        <property name="textInteractionFlags">
+         <set>Qt::TextBrowserInteraction</set>
+        </property>
        </widget>
       </item>
      </layout>
@@ -270,6 +285,9 @@
         </property>
         <property name="buddy">
          <cstring>videoDumpingDirectory</cstring>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::TextBrowserInteraction</set>
         </property>
        </widget>
       </item>

--- a/pcsx2-qt/Settings/GameListSettingsWidget.ui
+++ b/pcsx2-qt/Settings/GameListSettingsWidget.ui
@@ -39,6 +39,9 @@
           <property name="buddy">
            <cstring>searchDirectoryList</cstring>
           </property>
+          <property name="textInteractionFlags">
+           <set>Qt::TextBrowserInteraction</set>
+          </property>
          </widget>
         </item>
         <item>
@@ -117,6 +120,9 @@
           </property>
           <property name="buddy">
            <cstring>excludedPaths</cstring>
+          </property>
+          <property name="textInteractionFlags">
+           <set>Qt::TextBrowserInteraction</set>
           </property>
          </widget>
         </item>

--- a/pcsx2-qt/Settings/GraphicsTextureReplacementSettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsTextureReplacementSettingsTab.ui
@@ -103,6 +103,9 @@
         <property name="buddy">
          <cstring>texturesDirectory</cstring>
         </property>
+        <property name="textInteractionFlags">
+         <set>Qt::TextBrowserInteraction</set>
+        </property>
        </widget>
       </item>
      </layout>


### PR DESCRIPTION
### Description of Changes
* Adds `Qt::TextBrowserInteraction` to labels in order to make them highlightable where appropriate.
  * For example, you can now highlight and copy the text in the `Help` > `About PCSX2` widget.
  * Sometimes people want to be able to copy and paste instead of taking screenshots, yo.
  * More importantly, this is an accessibility feature. Being able to highlight text is how screen readers actually read the labels.
  * Didn't change the ones that already have buddies, since I'm not 100% sure about those yet. These prose-like ones without a buddy seem noncontroversial.
  * This does not affect any user who does not want to interact with it in any way. The cursor doesn't change, but if you click and drag across the text or double-click it, it'll highlight and be right-clickable.
* Fixes the modality of the cover downloader widget to actually work.
  * Previously, it was trying to grab the lock from a parent – which MainWindow lacks.
  * Thus, it would fail to get the modality from anything (it should be `this`).
  * So you were free to interact with the underlying main window in the cover downloader, which was buggy.
* Fixed a few places where I missed buddies in #13388.

### Suggested Testing Steps
* Look for places where you see a block of text that looks like it should be highlightable but isn't.
* Make sure that the modality of the cover downloader widget works now.
* Look for other missing buddies potentially.

### Did you use AI to help find, test, or implement this issue or feature?
No.
