### PR TITLE
MainWindow: Make Settings > Video Capture checkbox toggle correctly

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -738,45 +738,37 @@ void MainWindow::onVideoCaptureToggled(bool checked)
 {
 	if (!s_vm_valid)
 	{
+		QMessageBox msgbox(this);
+		msgbox.setIcon(QMessageBox::Question);
+		msgbox.setWindowIcon(QtHost::GetAppIcon());
+		msgbox.setWindowTitle(tr("Record On Boot"));
+		msgbox.setWindowModality(Qt::WindowModal);
+		msgbox.addButton(QMessageBox::Yes);
+		msgbox.addButton(QMessageBox::No);
+		msgbox.setDefaultButton(QMessageBox::Yes);
+
 		if (!s_record_on_start)
 		{
-			QMessageBox msgbox(this);
-			msgbox.setIcon(QMessageBox::Question);
-			msgbox.setWindowIcon(QtHost::GetAppIcon());
-			msgbox.setWindowTitle(tr("Record On Boot"));
-			msgbox.setWindowModality(Qt::WindowModal);
 			msgbox.setText(tr("Did you want to start recording on boot?"));
-			msgbox.addButton(QMessageBox::Yes);
-			msgbox.addButton(QMessageBox::No);
-			msgbox.setDefaultButton(QMessageBox::Yes);
 			if (msgbox.exec() == QMessageBox::Yes)
 			{
 				const QString container(QString::fromStdString(
 					Host::GetStringSettingValue("EmuCore/GS", "CaptureContainer", Pcsx2Config::GSOptions::DEFAULT_CAPTURE_CONTAINER)));
 				const QString filter(tr("%1 Files (*.%2)").arg(container.toUpper()).arg(container));
 
-				QString temp(QStringLiteral("%1.%2").arg(QString::fromStdString(GSGetBaseVideoFilename())).arg(container));
-				temp = QDir::toNativeSeparators(QFileDialog::getSaveFileName(this, tr("Video Capture"), temp, filter));
-				s_path_to_recording_for_record_on_start = temp;
-				if (s_path_to_recording_for_record_on_start.isEmpty())
-					return;
-				s_record_on_start = true;
+				const QString base_video_filename(QStringLiteral("%1.%2").arg(QString::fromStdString(GSGetBaseVideoFilename())).arg(container));
+				s_path_to_recording_for_record_on_start = QDir::toNativeSeparators(QFileDialog::getSaveFileName(this, tr("Video Capture"), base_video_filename, filter));
+				s_record_on_start = !s_path_to_recording_for_record_on_start.isEmpty();
 			}
 		}
 		else
 		{
-			QMessageBox msgbox(this);
-			msgbox.setIcon(QMessageBox::Question);
-			msgbox.setWindowIcon(QtHost::GetAppIcon());
-			msgbox.setWindowTitle(tr("Record On Boot"));
-			msgbox.setWindowModality(Qt::WindowModal);
 			msgbox.setText(tr("Did you want to cancel recording on boot?"));
-			msgbox.addButton(QMessageBox::Yes);
-			msgbox.addButton(QMessageBox::No);
-			msgbox.setDefaultButton(QMessageBox::Yes);
 			if (msgbox.exec() == QMessageBox::Yes)
 				s_record_on_start = false;
 		}
+		QSignalBlocker sb(m_ui.actionVideoCapture);
+		m_ui.actionVideoCapture->setChecked(s_record_on_start);
 		return;
 	}
 


### PR DESCRIPTION
### Description of Changes
Makes the video capture checkbox in `Settings` > `Video Capture` (pictured) work correctly with video capture on boot.

<img width="216" height="392" alt="image" src="https://github.com/user-attachments/assets/72027026-7239-493c-b80e-e394e4258ac7" />

### Rationale behind Changes
* Previously, the checkbox didn't account for the user's ability to say 'no' to changing the option in the dialog.
  * For example, if you clicked it but then said 'No' to record on boot, it would still be checked.
  * Likewise, if you clicked it while it was enabled but said 'No' to canceling, it would uncheck itself.
  * This did not affect the underlying functionality of video capture on boot – just the UI.
* Also, we build basically the same dialog box anyway, so there's no need to redundantly do that in separate branches.

### Suggested Testing Steps
* Make sure the checkbox responds correctly to user choice.
* Make sure video record on boot still works correctly.
* Make sure the two dialog boxes ("start" and "cancel") still work correctly.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
