### PR TITLE
Qt: Add "Controller Test" in the "Tools" menu

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -376,6 +376,7 @@ void MainWindow::connectSignals()
 	connect(m_ui.actionCheckForUpdates, &QAction::triggered, this, [this]() { checkForUpdates(true, true); });
 	connect(m_ui.actionOpenDataDirectory, &QAction::triggered, this, &MainWindow::onToolsOpenDataDirectoryTriggered);
 	connect(m_ui.actionCoverDownloader, &QAction::triggered, this, &MainWindow::onToolsCoverDownloaderTriggered);
+	connect(m_ui.actionControllerTest, &QAction::triggered, g_emu_thread, &EmuThread::startControllerTest);
 	connect(m_ui.actionGridViewShowTitles, &QAction::triggered, m_game_list_widget, &GameListWidget::setShowCoverTitles);
 	connect(m_ui.actionGridViewZoomIn, &QAction::triggered, m_game_list_widget, [this]() {
 		if (isShowingGameList())
@@ -930,6 +931,7 @@ void MainWindow::updateEmulationActions(bool starting, bool running, bool stoppi
 	m_ui.actionToolbarStartBios->setDisabled(starting_or_running_or_stopping);
 	m_ui.actionStartFullscreenUI->setDisabled(starting_or_running_or_stopping);
 	m_ui.actionToolbarStartFullscreenUI->setDisabled(starting_or_running_or_stopping);
+	m_ui.actionControllerTest->setDisabled(starting_or_running_or_stopping);
 
 	m_ui.actionPowerOff->setEnabled(running);
 	m_ui.actionPowerOffWithoutSaving->setEnabled(running);

--- a/pcsx2-qt/MainWindow.ui
+++ b/pcsx2-qt/MainWindow.ui
@@ -200,6 +200,7 @@
     </widget>
     <addaction name="actionOpenDataDirectory"/>
     <addaction name="actionCoverDownloader"/>
+    <addaction name="actionControllerTest"/>
     <addaction name="actionToggleSoftwareRendering"/>
     <addaction name="separator"/>
     <addaction name="actionEditCheats"/>
@@ -1064,6 +1065,14 @@
    </property>
    <property name="text">
     <string>Edit &amp;Patches...</string>
+   </property>
+  </action>
+  <action name="actionControllerTest">
+   <property name="icon">
+    <iconset theme="controller-line"/>
+   </property>
+   <property name="text">
+    <string>Controller Test</string>
    </property>
   </action>
  </widget>

--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -112,6 +112,7 @@ public Q_SLOTS:
 	void queueSnapshot(quint32 gsdump_frames);
 	void beginCapture(const QString& path);
 	void endCapture();
+	void startControllerTest();
 
 Q_SIGNALS:
 	bool messageConfirmed(const QString& title, const QString& message);


### PR DESCRIPTION
### Description of Changes
Adds a Tools > Controller Test menu which will launch padtest if found in the "resources" folder, if not it will ask to download it first. Greyed out when VM is running.

At first I wanted to open a feature request but I looked at DuckStation code and it seemed pretty simple to backport, so here we go.

### Rationale behind Changes
Makes it faster and easier to launch padtest, either for quick testing (new controller/bindings, testing deadzone or whatever) or for troubleshooting, no need to ask the user to download the file then launch it manually.
Sure you can simply add it to your game list currently, but I always thought it looked "off" in the middle of games :p 

### Suggested Testing Steps
Mess with the new Tools > Controller Test menu.

### Did you use AI to help find, test, or implement this issue or feature?
Nope, like I said above this is just a simple backport.
