### PR TITLE
GS/MAD: Try to reconstruct centre line if previous version was weaved

### DIFF
--- a/bin/resources/shaders/opengl/interlace.glsl
+++ b/bin/resources/shaders/opengl/interlace.glsl
@@ -173,8 +173,32 @@ void ps_main4()
 			// high motion -> interpolate pixels above and below
 			SV_Target0 = (hn + ln) / 2.0f;
 		else
-			// low motion -> weave
-			SV_Target0 = cn;
+		{
+			// Check if it's completely static first, we don't need to mess with any of that.
+			if((mh_max != -motion_thr.x) || (ml_max != -motion_thr.x) || (mc_max != -motion_thr.x))
+			{
+				// Check the diff with the above and below lines, if the difference is smaller between the new high and low lines
+				// compared to the new centre line and the high line (with some threshold of about 25 color steps), then reconstruct.
+				vec3 mhln = hn.rgb - ln.rgb;
+				vec3 mchn = hn.rgb - cn.rgb;
+				
+				mhln = max(mhln, -mhln) - motion_thr;
+				mchn = max(mchn, -mchn) - motion_thr;
+				
+				float mhln_max = max(max(mhln.x, mhln.y), mhln.z);
+				float mchn_max = max(max(mchn.x, mchn.y), mchn.z);
+
+				// The new centre line is a fair chunk different from those surrounding it, so quite likely incorrect.
+				if (mhln_max < 0.0f && mchn_max >= (mhln_max * 0.90f))
+					SV_Target0 = (hn + ln) / 2.0f;
+				else
+					// low motion -> weave
+					SV_Target0 = cn;
+			}
+			else
+				// low motion -> weave
+				SV_Target0 = cn;
+		}
 	}
 }
 

--- a/bin/resources/shaders/vulkan/interlace.glsl
+++ b/bin/resources/shaders/vulkan/interlace.glsl
@@ -194,8 +194,32 @@ void ps_main4()
 			// high motion -> interpolate pixels above and below
 			o_col0 = (hn + ln) / 2.0f;
 		else
-			// low motion -> weave
-			o_col0 = cn;
+		{
+			// Check if it's completely static first, we don't need to mess with any of that.
+			if((mh_max != -motion_thr.x) || (ml_max != -motion_thr.x) || (mc_max != -motion_thr.x))
+			{
+				// Check the diff with the above and below lines, if the difference is smaller between the new high and low lines
+				// compared to the new centre line and the high line (with some threshold of about 25 color steps), then reconstruct.
+				vec3 mhln = hn.rgb - ln.rgb;
+				vec3 mchn = hn.rgb - cn.rgb;
+				
+				mhln = max(mhln, -mhln) - motion_thr;
+				mchn = max(mchn, -mchn) - motion_thr;
+				
+				float mhln_max = max(max(mhln.x, mhln.y), mhln.z);
+				float mchn_max = max(max(mchn.x, mchn.y), mchn.z);
+
+				// The new centre line is a fair chunk different from those surrounding it, so quite likely incorrect.
+				if (mhln_max < 0.0f && mchn_max >= (mhln_max * 0.90f))
+					o_col0 = (hn + ln) / 2.0f;
+				else
+					// low motion -> weave
+					o_col0 = cn;
+			}
+			else
+				// low motion -> weave
+				o_col0 = cn;
+		}
 	}
 }
 #endif

--- a/pcsx2/GS/Renderers/Metal/interlace.metal
+++ b/pcsx2/GS/Renderers/Metal/interlace.metal
@@ -166,8 +166,32 @@ fragment float4 ps_interlace4(ConvertShaderData data [[stage_in]], ConvertPSRes 
 			// high motion -> interpolate pixels above and below
 			return (hn + ln) / 2.0f;
 		else
-			// low motion -> weave
-			return cn;
+		{
+			// Check if it's completely static first, we don't need to mess with any of that.
+			if((mh_max != -motion_thr.x) || (ml_max != -motion_thr.x) || (mc_max != -motion_thr.x))
+			{
+				// Check the diff with the above and below lines, if the difference is smaller between the new high and low lines
+				// compared to the new centre line and the high line (with some threshold of about 25 color steps), then reconstruct.
+				float3 mhln = hn.rgb - ln.rgb;
+				float3 mchn = hn.rgb - cn.rgb;
+				
+				mhln = max(mhln, -mhln) - motion_thr;
+				mchn = max(mchn, -mchn) - motion_thr;
+				
+				float mhln_max = max(max(mhln.x, mhln.y), mhln.z);
+				float mchn_max = max(max(mchn.x, mchn.y), mchn.z);
+
+				// The new centre line is a fair chunk different from those surrounding it, so quite likely incorrect.
+				if (mhln_max < 0.0f && mchn_max >= (mhln_max * 0.90f))
+					return (hn + ln) / 2.0f;
+				else
+					// low motion -> weave
+					return cn;
+			}
+			else
+				// low motion -> weave
+				return cn;
+		}
 	}
 
 	return float4(0.0f, 0.0f, 0.0f, 0.0f);

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 75;
+static constexpr u32 SHADER_CACHE_VERSION = 76;


### PR DESCRIPTION
### Description of Changes
Attempts to guess if the new line should be weaved or interpolated based on the surrounding two lines, if the colour difference is too great, then interpolate the new color.

### Rationale behind Changes
Previously if MAD had skipped the previous line due to weaving and used an old colour assuming it used the old colour, the information could be completely incorrect when the scene is in high motion, so this attempts to recognise when the interlace line is too different it should be interpolated, massively reducing the horrible artifacts that MAD gives off that look like patches of different color. There is still some artifacts sometimes, but in most cases they are generally not visible unless you're analysing the frame closely.

### Suggested Testing Steps
Test any games which had (or didn't) have interlacing artifacts.  Try games like the GT ones, Shin Megami, Baldurs Gate, stuff like that, make sure everything looks okay.

### Did you use AI to help find, test, or implement this issue or feature?
Nope.

Superseeds and replaces the need for #13395 I was trying to think of a better way to do it, and figured I might as well just do it while I was there, this isn't me returning!

Note on Gran Turismo text scroll: This is kind of the same issue, but the updated information is happening horizontally in high motion, so this causes pixels to not think anything has changed, so it tries to weave and makes a mess of it.  Master is worse, but this isn't going to be solvable with this PR.

Here's some examples, not limited to this, however.

Klonoa:
Master:
<img width="1415" height="1188" alt="image" src="https://github.com/user-attachments/assets/2f20f258-4382-4dd5-99e5-c0be40a502b1" />

PR:
<img width="1454" height="1269" alt="image" src="https://github.com/user-attachments/assets/e9025cc8-4188-4f48-9245-13e15136e61b" />

Transformers:
Master:
<img width="1415" height="1188" alt="image" src="https://github.com/user-attachments/assets/ed503b65-5bfb-455c-ab10-bd6087a0cf5b" />

PR:
<img width="1454" height="1269" alt="image" src="https://github.com/user-attachments/assets/4ed26b68-9b64-4642-9db8-e400515398e5" />
