### PR TITLE
Qt: Improve custom background scaling option

### DIFF
--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -7,6 +7,7 @@
 #include "QtHost.h"
 #include "QtUtils.h"
 
+#include "Settings/InterfaceSettingsWidget.h"
 #include "pcsx2/GameList.h"
 #include "pcsx2/Host.h"
 
@@ -310,84 +311,30 @@ void GameListWidget::initialize()
 	setCustomBackground();
 }
 
-static void resizeAndPadImage(QImage* image, int expected_width, int expected_height, bool fill_with_top_left, bool expand_to_fill)
+void GameListWidget::setCustomBackground()
 {
-	const qreal dpr = image->devicePixelRatio();
-	const int dpr_expected_width = static_cast<int>(static_cast<qreal>(expected_width) * dpr);
-	const int dpr_expected_height = static_cast<int>(static_cast<qreal>(expected_height) * dpr);
-	if (image->width() == dpr_expected_width && image->height() == dpr_expected_height)
-		return;
-
-	// Resize
-	if (((static_cast<float>(image->width()) / static_cast<float>(image->height())) >=
-			(static_cast<float>(dpr_expected_width) / static_cast<float>(dpr_expected_height))) != expand_to_fill)
-	{
-		*image = image->scaledToWidth(dpr_expected_width, Qt::SmoothTransformation);
-	}
-	else
-	{
-		*image = image->scaledToHeight(dpr_expected_height, Qt::SmoothTransformation);
-	}
-
-	if (image->width() == dpr_expected_width && image->height() == dpr_expected_height)
-		return;
-
-	// Padding
-	int xoffs = 0;
-	int yoffs = 0;
-	const int image_width = image->width();
-	const int image_height = image->height();
-	if ((image_width < dpr_expected_width) != expand_to_fill)
-		xoffs = static_cast<int>(static_cast<qreal>((dpr_expected_width - image_width) / 2) / dpr);
-	if ((image_height < dpr_expected_height) != expand_to_fill)
-		yoffs = static_cast<int>(static_cast<qreal>((dpr_expected_height - image_height) / 2) / dpr);
-
-	QImage padded_image(dpr_expected_width, dpr_expected_height, QImage::Format_ARGB32);
-	padded_image.setDevicePixelRatio(dpr);
-	if (fill_with_top_left)
-		padded_image.fill(image->pixel(0, 0));
-	else
-		padded_image.fill(Qt::transparent);
-
-	// Painting
-	QPainter painter;
-	const float opacity = Host::GetBaseFloatSettingValue("UI", "GameListBackgroundOpacity");
-	if (painter.begin(&padded_image))
-	{
-		painter.setOpacity((static_cast<float>(opacity / 100.0f))); // Qt expects the range to be from 0.0 to 1.0
-		painter.setCompositionMode(QPainter::CompositionMode_Source);
-		painter.drawImage(xoffs, yoffs, *image);
-		painter.end();
-	}
-
-	*image = std::move(padded_image);
-}
-
-void GameListWidget::setCustomBackground(bool force_refresh)
-{
-	std::string path = Host::GetBaseStringSettingValue("UI", "GameListBackgroundPath");
-	bool enabled = Host::GetBaseBoolSettingValue("UI", "GameListBackgroundEnabled");
-	bool fill = Host::GetBaseBoolSettingValue("UI", "GameListBackgroundFill");
-
 	// Cleanup old animation if it still exists on gamelist
 	if (m_background_movie != nullptr)
 	{
+		m_background_movie->disconnect(this);
 		delete m_background_movie;
 		m_background_movie = nullptr;
 	}
 
+	std::string path = Host::GetBaseStringSettingValue("UI", "GameListBackgroundPath");
 	if (!Path::IsAbsolute(path))
 		path = Path::Combine(EmuFolders::DataRoot, path);
 
-	// Only try to create background both if path are valid and custom background are enabled
-	if ((!path.empty() && FileSystem::FileExists(path.c_str())) && enabled)
+	// Only try to create background if path are valid
+	if (!path.empty() && FileSystem::FileExists(path.c_str()))
 	{
 		QMovie* new_movie;
-		if (Path::GetExtension(path) == "png")
+		QString img_path = QString::fromStdString(path);
+		if (img_path.endsWith(".png", Qt::CaseInsensitive))
 			// Use apng plugin
-			new_movie = new QMovie(QString::fromStdString(path), "apng", this);
+			new_movie = new QMovie(img_path, "apng", this);
 		else
-			new_movie = new QMovie(QString::fromStdString(path), QByteArray(), this);
+			new_movie = new QMovie(img_path, QByteArray(), this);
 
 		if (new_movie->isValid())
 			m_background_movie = new_movie;
@@ -398,7 +345,7 @@ void GameListWidget::setCustomBackground(bool force_refresh)
 		}
 	}
 
-	// If there is no valid background then reset fallback to UI state
+	// If there is no valid background then reset fallback to default UI state
 	if (!m_background_movie)
 	{
 		m_ui.stack->setPalette(QApplication::palette());
@@ -406,36 +353,60 @@ void GameListWidget::setCustomBackground(bool force_refresh)
 		return;
 	}
 
-	// Background is valid, connect the signals and start animation in gamelist
-	connect(m_background_movie, &QMovie::frameChanged, this, [this, fill]() { processBackgroundFrames(fill); });
-	updateCustomBackgroundState(force_refresh);
+	// Retrieve scaling setting
+	m_background_scaling = QtUtils::ScalingMode::Fit;
+	const std::string ar_value = Host::GetBaseStringSettingValue("UI", "GameListBackgroundMode", InterfaceSettingsWidget::BACKGROUND_SCALE_NAMES[static_cast<u8>(QtUtils::ScalingMode::Fit)]);
+	for (u8 i = 0; i < static_cast<u8>(QtUtils::ScalingMode::MaxCount); i++)
+	{
+		if (!(InterfaceSettingsWidget::BACKGROUND_SCALE_NAMES[i] == nullptr))
+		{
+			if (ar_value == InterfaceSettingsWidget::BACKGROUND_SCALE_NAMES[i])
+			{
+				m_background_scaling = static_cast<QtUtils::ScalingMode>(i);
+				break;
+			}
+		}
+	}
 
+	// Retrieve opacity setting
+	m_background_opacity = Host::GetBaseFloatSettingValue("UI", "GameListBackgroundOpacity", 100.0f);
+
+	// Selected Custom background is valid, connect the signals and start animation in gamelist
+	connect(m_background_movie, &QMovie::frameChanged, this, &GameListWidget::processBackgroundFrames, Qt::UniqueConnection);
+	updateCustomBackgroundState(true);
 	m_table_view->setAlternatingRowColors(false);
 }
 
-void GameListWidget::updateCustomBackgroundState(bool force_start)
+void GameListWidget::updateCustomBackgroundState(const bool force_start)
 {
-	if (m_background_movie)
+	if (m_background_movie && m_background_movie->isValid())
 	{
 		if ((isVisible() && (isActiveWindow() || force_start)) && qGuiApp->applicationState() == Qt::ApplicationActive)
-			m_background_movie->start();
+			m_background_movie->setPaused(false);
 		else
-			m_background_movie->stop();
+			m_background_movie->setPaused(true);
 	}
 }
 
-void GameListWidget::processBackgroundFrames(bool fill_area)
+void GameListWidget::processBackgroundFrames()
 {
-	QImage img = m_background_movie->currentImage();
-	img.setDevicePixelRatio(devicePixelRatioF());
-	const int widget_width = m_ui.stack->width();
-	const int widget_height = m_ui.stack->height();
+	if (m_background_movie && m_background_movie->isValid())
+	{
+		const int widget_width = m_ui.stack->width();
+		const int widget_height = m_ui.stack->height();
 
-	resizeAndPadImage(&img, widget_width, widget_height, false, fill_area);
+		if (widget_width <= 0 || widget_height <= 0)
+			return;
 
-	QPalette new_palette(m_ui.stack->palette());
-	new_palette.setBrush(QPalette::Base, img);
-	m_ui.stack->setPalette(new_palette);
+		QPixmap pm = m_background_movie->currentPixmap();
+		const qreal dpr = devicePixelRatioF();
+
+		QtUtils::resizeAndScalePixmap(&pm, widget_width, widget_height, dpr, m_background_scaling, m_background_opacity);
+
+		QPalette bg_palette(m_ui.stack->palette());
+		bg_palette.setBrush(QPalette::Base, pm);
+		m_ui.stack->setPalette(bg_palette);
+	}
 }
 
 bool GameListWidget::isShowingGameList() const
@@ -708,7 +679,7 @@ void GameListWidget::resizeEvent(QResizeEvent* event)
 	QWidget::resizeEvent(event);
 	resizeTableViewColumnsToFit();
 	m_model->updateCacheSize(width(), height());
-	setCustomBackground();
+	processBackgroundFrames();
 }
 
 bool GameListWidget::event(QEvent* event)

--- a/pcsx2-qt/GameList/GameListWidget.h
+++ b/pcsx2-qt/GameList/GameListWidget.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "QtUtils.h"
 #include "ui_EmptyGameListWidget.h"
 #include "ui_GameListWidget.h"
 
@@ -49,9 +50,9 @@ public:
 	void refresh(bool invalidate_cache, bool popup_on_error);
 	void cancelRefresh();
 	void reloadThemeSpecificImages();
-	void setCustomBackground(bool force = false);
-	void updateCustomBackgroundState(bool force_start = false);
-	void processBackgroundFrames(bool fill_area);
+	void setCustomBackground();
+	void updateCustomBackgroundState(const bool force_start = false);
+	void processBackgroundFrames();
 
 	bool isShowingGameList() const;
 	bool isShowingGameGrid() const;
@@ -122,4 +123,6 @@ private:
 	GameListRefreshThread* m_refresh_thread = nullptr;
 
 	QMovie* m_background_movie = nullptr;
+	QtUtils::ScalingMode m_background_scaling = QtUtils::ScalingMode::Fit;
+	float m_background_opacity = 100.0f;
 };

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -2630,7 +2630,7 @@ SettingsWindow* MainWindow::getSettingsWindow()
 		m_settings_window = new SettingsWindow();
 		connect(m_settings_window->getInterfaceSettingsWidget(), &InterfaceSettingsWidget::themeChanged, this, &MainWindow::onThemeChanged);
 		connect(m_settings_window->getInterfaceSettingsWidget(), &InterfaceSettingsWidget::languageChanged, this, &MainWindow::onLanguageChanged);
-		connect(m_settings_window->getInterfaceSettingsWidget(), &InterfaceSettingsWidget::backgroundChanged, m_game_list_widget, [this] { m_game_list_widget->setCustomBackground(true); });
+		connect(m_settings_window->getInterfaceSettingsWidget(), &InterfaceSettingsWidget::backgroundChanged, m_game_list_widget, [this] { m_game_list_widget->setCustomBackground(); });
 		connect(m_settings_window->getGameListSettingsWidget(), &GameListSettingsWidget::preferEnglishGameListChanged, this, [] {
 			g_main_window->m_game_list_widget->refreshGridCovers();
 		});

--- a/pcsx2-qt/QtUtils.h
+++ b/pcsx2-qt/QtUtils.h
@@ -58,6 +58,20 @@ namespace QtUtils
 	void ResizeColumnsForTableView(QTableView* view, const std::initializer_list<int>& widths);
 	void ResizeColumnsForTreeView(QTreeView* view, const std::initializer_list<int>& widths);
 
+	enum struct ScalingMode
+	{
+		Fit,
+		Fill,
+		Stretch,
+		Center,
+		Tile,
+
+		MaxCount
+	};
+
+	/// Resize and scale a given Pixmap (and optionally adjust opacity)
+	void resizeAndScalePixmap(QPixmap* pm, const int expected_width, const int expected_height, const qreal dpr, const ScalingMode scaling_mode, const float opacity);
+
 	/// Returns a key id for a key event, including any modifiers that we need (e.g. Keypad).
 	/// NOTE: Defined in QtKeyCodes.cpp, not QtUtils.cpp.
 	u32 KeyEventToCode(const QKeyEvent* ev);

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.h
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.h
@@ -33,4 +33,6 @@ private:
 public:
 	static const char* THEME_NAMES[];
 	static const char* THEME_VALUES[];
+	static const char* BACKGROUND_SCALE_NAMES[];
+	static const char* IMAGE_FILE_FILTER;
 };

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>725</width>
-    <height>617</height>
+    <height>625</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -224,9 +224,6 @@
         </item>
         <item>
          <widget class="QSpinBox" name="backgroundOpacity">
-          <property name="wrapping">
-           <bool>false</bool>
-          </property>
           <property name="buttonSymbols">
            <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
           </property>
@@ -251,10 +248,54 @@
          </widget>
         </item>
         <item>
-         <widget class="QCheckBox" name="backgroundFill">
-          <property name="text">
-           <string>Fill Image</string>
+         <widget class="QLabel" name="backgroundScaleLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
+          <property name="text">
+           <string>Scaling:</string>
+          </property>
+          <property name="buddy">
+           <cstring>backgroundScale</cstring>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="backgroundScale">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <item>
+           <property name="text">
+            <string>Fit</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Fill</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Stretch</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Center</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Tile</string>
+           </property>
+          </item>
          </widget>
         </item>
        </layout>
@@ -351,7 +392,7 @@
   <tabstop>backgroundBrowse</tabstop>
   <tabstop>backgroundReset</tabstop>
   <tabstop>backgroundOpacity</tabstop>
-  <tabstop>backgroundFill</tabstop>
+  <tabstop>backgroundScale</tabstop>
   <tabstop>autoUpdateTag</tabstop>
   <tabstop>autoUpdateEnabled</tabstop>
   <tabstop>checkForUpdates</tabstop>


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

This PR improves upon #12722. Which adds more scaling option to the Game List Custom Background:

- Fit: Preserve aspect ratio, fit on screen (letterbox/pillarbox if needed)
- Fill: Preserve aspect ratio, fill screen (crop if needed)
- Stretch: Ignore aspect ratio, stretch to fill the image
- Center: Centers the image without any scaling
- Tile: Repeat the image to fill the screen

Preview:

https://github.com/user-attachments/assets/01a38945-c7e6-4c64-b198-6a39ea0ef752

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
More flexibility to choose the background scaling style.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Check if all the scaling option works properly.
Since this changes also touches the cover, check if the cover are displayed properly.

### Did you use AI to help find, test, or implement this issue or feature?
Nggak
