### PR TITLE
CDVD: Fix crash when launching game during hash verification

### DIFF
--- a/pcsx2/CDVD/IsoHasher.h
+++ b/pcsx2/CDVD/IsoHasher.h
@@ -8,6 +8,7 @@
 
 #include <string>
 #include <vector>
+#include <atomic>
 
 class Error;
 
@@ -40,10 +41,14 @@ public:
 
 	void ComputeHashes(ProgressCallback* callback = ProgressCallback::NullProgressCallback);
 
+	static bool IsComputingHash() { return s_is_computing_hash; }
+
 private:
 	bool ComputeTrackHash(Track& track, ProgressCallback* callback);
 
 	std::vector<Track> m_tracks;
 	bool m_is_open = false;
 	bool m_is_cd = false;
+
+	static std::atomic<bool> s_is_computing_hash;
 };


### PR DESCRIPTION
Fixes #13462 
### Description of Changes
Fixed crash when launching a game through big picture mode while verifying ISO hash.

### Rationale behind Changes
When hash verification is running on the UI thread and a user launches a game from big picture mode (CPU thread), both threads simultaneously access non-reentrant CDVD functions that modify global state, causing a race condition crash.

### Suggested Testing Steps
* Open game properties for a PS2 disc image
* Click "Verify" to start hash verification
* While verification is running, launch a game from big picture mode
* What should happen is: verification stops, popup appears with message "Hash verification was cancelled because a game was launched. Please try again when no game is running."
* Make sure no crash occurs

### Did you use AI to help find, test, or implement this issue or feature?
No.