### PR TITLE
FUNDING.yml: Add Liberapay

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,4 @@
 # These are supported funding model platforms
 
 github: [PCSX2]
+liberapay: PCSX2


### PR DESCRIPTION
### Description of Changes
Add Liberapay – a platform which we've had for eight months now – to our `FUNDING.yml` [per GitHub documentation.](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository)

### Rationale behind Changes
I didn't know this was a thing and would've done it when we launched Liberapay as an option otherwise.

### Suggested Testing Steps
Make sure I didn't totally screw up the formatting. [This is our Liberapay.](https://liberapay.com/PCSX2)

### Did you use AI to help find, test, or implement this issue or feature?
No. I accidentally stumbled across this while looking into the Flatpak CI.
