### PR TITLE
Deps: Force lib directory for libjpeg-turbo build

### DIFF
--- a/.github/workflows/scripts/linux/build-dependencies-qt.sh
+++ b/.github/workflows/scripts/linux/build-dependencies-qt.sh
@@ -116,7 +116,9 @@ echo "Building libjpegturbo..."
 rm -fr "libjpeg-turbo-$LIBJPEGTURBO"
 tar xf "libjpeg-turbo-$LIBJPEGTURBO.tar.gz"
 cd "libjpeg-turbo-$LIBJPEGTURBO"
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$INSTALLDIR" -DCMAKE_INSTALL_PREFIX="$INSTALLDIR" -DENABLE_STATIC=OFF -DENABLE_SHARED=ON -B build -G Ninja
+# On non debian or debian based Linux systems, libjpeg-turbo will set CMAKE_INSTALL_DEFAULT_LIBDIR "lib64" (or libx32)
+# That will prevent CMake from finding the deps libjpeg later on. if we set CMAKE_INSTALL_DEFAULT_LIBDIR, libjpeg-turbo will leave it as is, so set it to "lib"
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$INSTALLDIR" -DCMAKE_INSTALL_PREFIX="$INSTALLDIR" -DENABLE_STATIC=OFF -DENABLE_SHARED=ON -DCMAKE_INSTALL_DEFAULT_LIBDIR="lib" -B build -G Ninja
 cmake --build build --parallel
 ninja -C build install
 cd ..


### PR DESCRIPTION
### Description of Changes
Forces libjpeg-turbo to put its libraries onto the `lib` folder

### Rationale behind Changes
On non debian or debian derived systems, libjpeg-turbo will use either `lib64` or `libx32`
For some reason, CMake is unable to find libraries placed into `deps/lib64` and instead picks the system libraries.
Despite picking the system library, CMake then uses the deps includes, leading to `Wrong JPEG library version` runtime errors.
libjpeg-turbo will skip the above if we set `CMAKE_INSTALL_DEFAULT_LIBDIR`, so set it to `lib`

For debian or debian derived systems, libjpeg-turbo has similar logic, but also checks `CMAKE_INSTALL_PREFIX`, so CI managed to avoid the issue

### Suggested Testing Steps
Build deps, build PCSX2 using deps libraries , load jpeg files (such as covers)

### Did you use AI to help find, test, or implement this issue or feature?
No
