### PR TITLE
VMManager: More helpful error message on no BIOS present

### DIFF
--- a/pcsx2/SupportURLs.h
+++ b/pcsx2/SupportURLs.h
@@ -8,5 +8,6 @@
 #define PCSX2_GITHUB_URL "https://github.com/PCSX2/pcsx2"
 #define PCSX2_LICENSE_URL "https://github.com/PCSX2/pcsx2/blob/master/pcsx2/Docs/License.txt"
 #define PCSX2_DOCUMENTATION_URL "https://pcsx2.net/docs"
+#define PCSX2_DOCUMENTATION_BIOS_URL_SHORTENED "pcsx2.net/docs/setup/bios"
 #define PCSX2_WIKI_URL "https://wiki.pcsx2.net/Main_Page"
 #define PCSX2_DISCORD_URL "https://pcsx2.net/discord"

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -37,6 +37,7 @@
 #include "SIO/Sio0.h"
 #include "SIO/Sio2.h"
 #include "SPU2/spu2.h"
+#include "SupportURLs.h"
 #include "USB/USB.h"
 #include "Vif_Dynarec.h"
 #include "VMManager.h"
@@ -1353,14 +1354,13 @@ bool VMManager::Initialize(VMBootParameters boot_params)
 		Console.WriteLn("Loading BIOS...");
 		if (!LoadBIOS())
 		{
-			Host::ReportErrorAsync(TRANSLATE_SV("VMManager", "Error"),
-				TRANSLATE_SV("VMManager",
-					"PCSX2 requires a PS2 BIOS in order to run.\n\n"
-					"For legal reasons, you *must* obtain a BIOS from an actual PS2 unit that you own (borrowing "
-					"doesn't count).\n\n"
-					"Once dumped, this BIOS image should be placed in the bios folder within the data directory "
-					"(Tools Menu -> Open Data Directory).\n\n"
-					"Please consult the FAQs and Guides for further instructions."));
+			Host::ReportErrorAsync(TRANSLATE_SV("VMManager", "Error – No BIOS Present"),
+				fmt::format(TRANSLATE_FS("VMManager",
+					"PCSX2 requires a PlayStation 2 BIOS in order to run.\n\n"
+					"For legal reasons, you will need to obtain this BIOS from a PlayStation 2 unit which you own.\n\n"
+					"For step-by-step help with this process, please consult the setup guide at {}.\n\n"
+					"PCSX2 will be able to run once you've placed your BIOS image inside the folder named \"bios\" within the data directory "
+					"(Tools Menu -> Open Data Directory)."), PCSX2_DOCUMENTATION_BIOS_URL_SHORTENED));
 			return false;
 		}
 


### PR DESCRIPTION
### Screenshots

Current nightly:
<img width="630" height="380" alt="Current nightly message" src="https://github.com/user-attachments/assets/bc76b68c-61f1-48ae-9acf-c8f404be0169" />

PR:
<img width="630" height="416" alt="image" src="https://github.com/user-attachments/assets/a9338681-1c38-4576-ab5d-3f138ce7fb47" />

### Description and Rationale
Rewrites the error message presented when a user attempts to lauch a game and no BIOS image is present. Meant to fix this a while back, but I remembered after the guide rewrite.

* Add a title "Error – No BIOS Present" rather than a generic "Error".
  * Good form to have an actual error title if we know exactly what the error is ahead of time.
* Change "Please consult the FAQs and Guides for further instructions" to "please consult the setup guide at {}", where {} is currently "pcsx2.net/docs/setup/bios".
  * Use a variable from `SetupURLs.h` instead of hardcoding it so it's easier to fix if we ever move it.
  * Give a concrete place the user can go instead of "the FAQs and Guides"
    * "the FAQs" implies we have one, let alone that it's actually useful for this.
    * "the Guides" gives no specific location or name.
    * "the FAQs and Guides" taken together sound like we don't actually know and are throwing whatever we can at the wall hoping something helps.
* Change "further instructions" to "step-by-step help with this process".
  * Much more comforting and reassuring to a user who likely has no idea what's going on.
* Place the docs link sentence directly after the one telling the user they'll need to dump their BIOS.
  * More chronologically relevant to this sentence than it is to the one about where to place your BIOS.
  * Directly reassures the user after telling them they'll have to do this complex-sounding thing.
* Change "For legal reasons, you \*must\* obtain a BIOS from an actual PS2 unit that you own (borrowing doesn't count)" to "For legal reasons, you will need to obtain this BIOS from a PlayStation 2 unit which you own".
  * "(borrowing doesn't count)" is already directly stated by "which you own".
    * Borrowing is not and has never been ownership legally or colloquially.
    * It also reads like Randall Weems from Recess wrote it.
  * "actual" modifying "PS2 unit which you own" is superfluous.
  * Just don't yell at the user, man; they did nothing wrong.
* Change "Once dumped, the BIOS image should be..." to "PCSX2 will be able to run once you've placed your BIOS image..."
  * Tells the user directly that this is the last step they need rather than implying.
  * "should be" is needlessly nagging language; just tell them why it should be instead.

### TL;DR
Much of the previous message reads like a giant nag with needlessly vague instructions – the exact combination that turns a user off from listening to what we have to say. I think it's the same reason why, after publishing [the rewritten setup guide](https://pcsx2.net/docs/setup/bios/), we've seen so many users suddenly start asking for clarification about the BIOS dumping steps we give – namely that it's reassuring and gives concrete steps to find further assistance instead of "you must, so good luck".

This message is more helpful and reassuring while still precisely communicating the user's exact legal responsibility to dump and use their own BIOS.

### What I did not change
The user can theoretically change their BIOS directory away from the one we describe in both current nightly and PR. I don't think it's worth overcomplicating things and making this message flexible to the user's choice of custom directory if they have one. It's assumed that a user:

1) Who actually needs this message is probably a new user that doesn't know about, let alone use, custom directories.
2) Who has gone way out of their way to set a custom BIOS directory understands that this message no longer applies.

### Suggested Testing Steps
Make sure that the message works and is free of typos.

### Did you use AI to help find, test, or implement this issue or feature?
No.
