### PR TITLE
Shortcuts: Clean up code and fix bugs

### DIFF
--- a/common/FileSystem.h
+++ b/common/FileSystem.h
@@ -13,6 +13,11 @@
 #include <vector>
 #include <sys/stat.h>
 
+#if defined(_WIN32)
+#include "common/RedtapeWindows.h"
+#include <guiddef.h>
+#endif
+
 class Error;
 class ProgressCallback;
 
@@ -194,9 +199,20 @@ namespace FileSystem
 	bool DeleteSymbolicLink(const char* path, Error* error = nullptr);
 
 #ifdef _WIN32
-	// Path limit remover, but also converts to a wide string at the same time.
+	/// Path limit remover, but also converts to a wide string at the same time.
 	bool GetWin32Path(std::wstring* dest, std::string_view str);
 	std::wstring GetWin32Path(std::string_view str);
+
+	/// Creates an IShellLink (.lnk shortcut file); path_suffix assumed absolute path if no base_directory_ID supplied.
+	bool CreateWin32IShellLink(std::string_view path_suffix, std::string_view launch_arguments,
+		std::string_view description = "", const GUID& base_directory_ID = {0});
+#endif
+
+#if defined(__linux__) or defined(__FreeBSD__)
+	/// Creates a Linux desktop file (.desktop). Also usable on FreeBSD, as FreeBSD uses Linux DEs.
+	bool CreateLinuxDesktopFile(std::string_view destination, std::string_view exec, std::string_view name,
+		std::string_view comment, std::string_view icon = "net.pcsx2.PCSX2",
+		std::string_view categories = "Game;Emulator;", std::string_view terminal = "false");
 #endif
 
 	/// Abstracts a POSIX file lock.

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1728,9 +1728,10 @@ void MainWindow::onCreateGameShortcutTriggered()
 		return;
 
 	const QString title = QString::fromStdString(entry->GetTitle());
+	const QString serial = QString::fromStdString(entry->serial);
 	const QString path = QString::fromStdString(entry->path);
 	VMLock lock(pauseAndLockVM());
-	ShortcutCreationDialog dlg(lock.getDialogParent(), title, path);
+	ShortcutCreationDialog dlg(lock.getDialogParent(), title, serial, path);
 	dlg.exec();
 }
 #endif

--- a/pcsx2-qt/ShortcutCreationDialog.cpp
+++ b/pcsx2-qt/ShortcutCreationDialog.cpp
@@ -13,25 +13,36 @@
 #include "VMManager.h"
 
 #if defined(_WIN32)
-#include <Windows.h>
-#include <shlobj.h>
-#include <winnls.h>
-#include <shobjidl.h>
-#include <objbase.h>
-#include <objidl.h>
-#include <shlguid.h>
-#include <comdef.h>
-
-#include <wrl/client.h>
+#include "common/RedtapeWindows.h"
+#include <Knownfolders.h>
 #endif
 
-ShortcutCreationDialog::ShortcutCreationDialog(QWidget* parent, const QString& title, const QString& path)
+ShortcutCreationDialog::ShortcutCreationDialog(QWidget* parent, const QString& game_title, const QString& game_serial, const QString& game_path)
 	: QDialog(parent)
-	, m_title(title)
-	, m_path(path)
+	, m_game_title(Path::SanitizeFileName(game_title.toStdString()))
+	, m_game_serial(game_serial.toStdString())
+	, m_game_path(game_path.toStdString())
 {
+	if (m_game_title.empty())
+	{
+		Console.Error("Cannot create shortcut: Game title is empty.");
+		QMessageBox::critical(this, tr("Cannot create shortcut"), tr("Game title is empty."),
+			QMessageBox::StandardButton::Ok, QMessageBox::StandardButton::Ok);
+		QTimer::singleShot(0, this, &QDialog::reject);
+		return;
+	}
+
+	if (m_game_path.empty())
+	{
+		Console.Error("Cannot create shortcut: Game path is empty.");
+		QMessageBox::critical(this, tr("Cannot create shortcut"), tr("Game path is empty."),
+			QMessageBox::StandardButton::Ok, QMessageBox::StandardButton::Ok);
+		QTimer::singleShot(0, this, &QDialog::reject);
+		return;
+	}
+
 	m_ui.setupUi(this);
-	this->setWindowTitle(tr("Create Shortcut For %1").arg(title));
+	this->setWindowTitle(tr("Create Shortcut For %1").arg(game_title));
 	this->setWindowIcon(QtHost::GetAppIcon());
 
 #if defined(_WIN32)
@@ -40,20 +51,22 @@ ShortcutCreationDialog::ShortcutCreationDialog(QWidget* parent, const QString& t
 	m_ui.shortcutStartMenu->setText(tr("Application Launcher"));
 #endif
 
-	connect(m_ui.overrideBootELFButton, &QPushButton::clicked, [&]() {
-		const QString path = QFileDialog::getOpenFileName(this, tr("Select ELF File"), QString(), tr("ELF Files (*.elf);;All Files (*.*)"));
-		if (!path.isEmpty())
-			m_ui.overrideBootELFPath->setText(Path::ToNativePath(path.toStdString()).c_str());
+	connect(m_ui.overrideBootELFBrowse, &QPushButton::clicked, [&]() {
+		const QString elf_file_path = QFileDialog::getOpenFileName(this, tr("Select ELF File"),
+			QString(), tr("ELF Files (*.elf);;All Files (*.*)"));
+		if (!elf_file_path.isEmpty())
+			m_ui.overrideBootELFPath->setText(Path::ToNativePath(elf_file_path.toStdString()).c_str());
 	});
 
 	connect(m_ui.loadStateFileBrowse, &QPushButton::clicked, [&]() {
-		const QString path = QFileDialog::getOpenFileName(this, tr("Select Save State File"), QString(), tr("Save States (*.p2s);;All Files (*.*)"));
-		if (!path.isEmpty())
-			m_ui.loadStateFilePath->setText(Path::ToNativePath(path.toStdString()).c_str());
+		const QString state_file_path = QFileDialog::getOpenFileName(this, tr("Select Save State File"),
+			QString(), tr("Save States (*.p2s);;All Files (*.*)"));
+		if (!state_file_path.isEmpty())
+			m_ui.loadStateFilePath->setText(Path::ToNativePath(state_file_path.toStdString()).c_str());
 	});
 
 	connect(m_ui.overrideBootELFToggle, &QCheckBox::toggled, m_ui.overrideBootELFPath, &QLineEdit::setEnabled);
-	connect(m_ui.overrideBootELFToggle, &QCheckBox::toggled, m_ui.overrideBootELFButton, &QPushButton::setEnabled);
+	connect(m_ui.overrideBootELFToggle, &QCheckBox::toggled, m_ui.overrideBootELFBrowse, &QPushButton::setEnabled);
 	connect(m_ui.gameArgsToggle, &QCheckBox::toggled, m_ui.gameArgs, &QLineEdit::setEnabled);
 	connect(m_ui.loadStateIndexToggle, &QCheckBox::toggled, m_ui.loadStateIndex, &QSpinBox::setEnabled);
 	connect(m_ui.loadStateFileToggle, &QCheckBox::toggled, m_ui.loadStateFilePath, &QLineEdit::setEnabled);
@@ -61,18 +74,9 @@ ShortcutCreationDialog::ShortcutCreationDialog(QWidget* parent, const QString& t
 	connect(m_ui.bootOptionToggle, &QCheckBox::toggled, m_ui.bootOptionDropdown, &QPushButton::setEnabled);
 	connect(m_ui.fullscreenMode, &QCheckBox::toggled, m_ui.fullscreenModeDropdown, &QPushButton::setEnabled);
 
-	m_ui.shortcutDesktop->setChecked(true);
-	m_ui.overrideBootELFPath->setEnabled(false);
-	m_ui.overrideBootELFButton->setEnabled(false);
-	m_ui.gameArgs->setEnabled(false);
-	m_ui.bootOptionDropdown->setEnabled(false);
-	m_ui.fullscreenModeDropdown->setEnabled(false);
-	m_ui.loadStateIndex->setEnabled(false);
-	m_ui.loadStateFileBrowse->setEnabled(false);
-	m_ui.loadStateFilePath->setEnabled(false);
-
 	m_ui.loadStateIndex->setMaximum(VMManager::NUM_SAVE_STATE_SLOTS);
 
+	// Check for Flatpak environment.
 	if (std::getenv("container"))
 	{
 		m_ui.portableModeToggle->setEnabled(false);
@@ -80,364 +84,174 @@ ShortcutCreationDialog::ShortcutCreationDialog(QWidget* parent, const QString& t
 		m_ui.shortcutStartMenu->setEnabled(false);
 	}
 
+	connect(m_ui.dialogButtons, &QDialogButtonBox::rejected, this, &QDialog::reject);
 	connect(m_ui.dialogButtons, &QDialogButtonBox::accepted, this, [&]() {
-		std::vector<std::string> args;
+		std::vector<std::string> standard_arguments;
+		ShortcutCreationDialog::FillArgumentsList(standard_arguments);
 
-		if (m_ui.portableModeToggle->isChecked())
-			args.push_back("-portable");
-
-		if (m_ui.overrideBootELFToggle->isChecked() && !m_ui.overrideBootELFPath->text().isEmpty())
-		{
-			args.push_back("-elf");
-			args.push_back(m_ui.overrideBootELFPath->text().toStdString());
-		}
-
-		if (m_ui.gameArgsToggle->isChecked() && !m_ui.gameArgs->text().isEmpty())
-		{
-			args.push_back("-gameargs");
-			args.push_back(m_ui.gameArgs->text().toStdString());
-		}
-
-		if (m_ui.bootOptionToggle->isChecked())
-			args.push_back(m_ui.bootOptionDropdown->currentIndex() ? "-slowboot" : "-fastboot");
-
-		if (m_ui.loadStateIndexToggle->isChecked())
-		{
-			const s32 load_state_index = m_ui.loadStateIndex->value();
-			if (load_state_index >= 1 && load_state_index <= VMManager::NUM_SAVE_STATE_SLOTS)
-			{
-				args.push_back("-state");
-				args.push_back(StringUtil::ToChars(load_state_index));
-			}
-		}
-
-		if (m_ui.fullscreenMode->isChecked())
-			args.push_back(m_ui.fullscreenModeDropdown->currentIndex() ? "-nofullscreen" : "-fullscreen");
-
-		if (m_ui.bigPictureModeToggle->isChecked())
-			args.push_back("-bigpicture");
-
-		m_desktop = m_ui.shortcutDesktop->isChecked();
-
-		std::string custom_args = m_ui.customArgsInput->text().toStdString();
-
-		ShortcutCreationDialog::CreateShortcut(title.toStdString(), path.toStdString(), args, custom_args, m_desktop);
+		ShortcutCreationDialog::CreateGameShortcut(standard_arguments, m_ui.customArgsInput->text().toStdString(), m_ui.shortcutDesktop->isChecked());
 
 		accept();
 	});
-	connect(m_ui.dialogButtons, &QDialogButtonBox::rejected, this, &QDialog::reject);
 }
 
-void ShortcutCreationDialog::CreateShortcut(const std::string name, const std::string game_path, std::vector<std::string> passed_cli_args, std::string custom_args, bool is_desktop)
+
+void ShortcutCreationDialog::CreateGameShortcut(std::vector<std::string>& standard_arguments, std::string custom_arguments, const bool is_desktop)
 {
+	std::string shortcut_comment;
+	switch (m_save_state_type)
+	{
+		case StateType::None:
+			shortcut_comment = tr("Start %1 (%2) on PCSX2.")
+			                       .arg(m_game_title, m_game_serial)
+			                       .toStdString();
+			break;
+		case StateType::Index:
+			shortcut_comment = tr("Start %1 (%2) on PCSX2 from save state index %3.")
+			                       .arg(m_game_title, m_game_serial, m_save_state_name)
+			                       .toStdString();
+			break;
+		case StateType::File:
+			shortcut_comment = tr("Start %1 (%2) on PCSX2 from save state file %3.")
+			                       .arg(m_game_title, m_game_serial, m_save_state_name)
+			                       .toStdString();
+			break;
+		default:
+			shortcut_comment = "";
+			break;
+	}
+
 #if defined(_WIN32)
-	if (name.empty())
+	// Sanitize provided command line arguments and attach custom arguments afterward.
+	for (std::string& argument : standard_arguments)
+		ShortcutCreationDialog::EscapeCommandLineArgumentWindows(argument);
+
+	if (!custom_arguments.empty())
+		standard_arguments.push_back(custom_arguments);
+
+	ShortcutCreationDialog::EscapeCommandLineArgumentWindows(m_game_path);
+
+	const std::string combined_launch_arguments =
+		fmt::format("{} -- {}", StringUtil::JoinString(standard_arguments.begin(), standard_arguments.end(), " "), m_game_path);
+
+	const std::string shortcut_destination = is_desktop ? fmt::format("{}.lnk", m_game_title) : fmt::format("PCSX2\\{}.lnk", m_game_title);
+
+	// Write to .lnk file.
+	if (!FileSystem::CreateWin32IShellLink(shortcut_destination, combined_launch_arguments, shortcut_comment, is_desktop ? FOLDERID_Desktop : FOLDERID_Programs))
+		QMessageBox::critical(this, tr("Failed to create shortcut"), tr("Failed to create a shortcut. See the log for more information."),
+			QMessageBox::StandardButton::Ok, QMessageBox::StandardButton::Ok);
+#else
+	// Locate home directory.
+	const char* home = std::getenv("HOME");
+	if (!home)
 	{
-		Console.Error("Cannot create shortcuts without a name.");
+		Console.Error("Failed to create shortcut: Home path is empty.");
+		QMessageBox::critical(this, tr("Failed to create shortcut"), tr("Home path is empty."),
+			QMessageBox::StandardButton::Ok, QMessageBox::StandardButton::Ok);
 		return;
 	}
 
-	// Sanitize filename
-	const std::string clean_name = Path::SanitizeFileName(name).c_str();
-	std::string clean_path = Path::ToNativePath(Path::RealPath(game_path)).c_str();
-	if (!Path::IsValidFileName(clean_name))
+	// Create initial file path for shortcut (suggested to user).
+	std::string shortcut_destination;
+	const char* xdg_data_home = std::getenv("XDG_DATA_HOME");
+	if (is_desktop)
 	{
-		QMessageBox::critical(this, tr("Failed to create shortcut"), tr("Filename contains illegal character."), QMessageBox::StandardButton::Ok, QMessageBox::StandardButton::Ok);
-		return;
-	}
-
-	// Locate home directory
-	std::string link_file;
-	if (const char* home = std::getenv("USERPROFILE"))
-	{
-		if (is_desktop)
-			link_file = Path::ToNativePath(fmt::format("{}/Desktop/{}.lnk", home, clean_name));
+		const char* xdg_desktop_dir = std::getenv("XDG_DESKTOP_DIR");
+		if (xdg_desktop_dir)
+			shortcut_destination = fmt::format("{}/{}.desktop", xdg_desktop_dir, m_game_title);
 		else
-		{
-			const std::string start_menu_dir = Path::ToNativePath(fmt::format("{}/AppData/Roaming/Microsoft/Windows/Start Menu/Programs/PCSX2", home));
-			if (!FileSystem::EnsureDirectoryExists(start_menu_dir.c_str(), false))
-			{
-				QMessageBox::critical(this, tr("Failed to create shortcut"), tr("Could not create start menu directory."), QMessageBox::StandardButton::Ok, QMessageBox::StandardButton::Ok);
-				return;
-			}
-
-			link_file = Path::ToNativePath(fmt::format("{}/{}.lnk", start_menu_dir, clean_name));
-		}
+			shortcut_destination = fmt::format("{}/Desktop/{}.desktop", home, m_game_title);
 	}
 	else
 	{
-		QMessageBox::critical(this, tr("Failed to create shortcut"), tr("Home path is empty."), QMessageBox::StandardButton::Ok, QMessageBox::StandardButton::Ok);
-		return;
+		if (xdg_data_home)
+			shortcut_destination = fmt::format("{}/applications/{}.desktop", xdg_data_home, m_game_title);
+		else
+			shortcut_destination = fmt::format("{}/.local/share/applications/{}.desktop", home, m_game_title);
 	}
 
-	// Check if the same shortcut already exists
-	if (FileSystem::FileExists(link_file.c_str()))
+	// Locate executable path and, on AppImage, copy PCSX2 icon.
+	std::string executable_path;
+	if (std::getenv("container"))
+		executable_path = "flatpak run net.pcsx2.PCSX2";
+	else
 	{
-		QMessageBox::critical(this, tr("Failed to create shortcut"), tr("A shortcut with the same name already exists."), QMessageBox::StandardButton::Ok, QMessageBox::StandardButton::Ok);
-		return;
-	}
-
-	// Shortcut CmdLine Args
-	bool lossless = true;
-	for (std::string& arg : passed_cli_args)
-		lossless &= ShortcutCreationDialog::EscapeShortcutCommandLine(&arg);
-
-	if (!lossless)
-		QMessageBox::warning(this, tr("Failed to create shortcut"), tr("File path contains invalid character(s). The resulting shortcut may not work."), QMessageBox::StandardButton::Ok, QMessageBox::StandardButton::Ok);
-
-	ShortcutCreationDialog::EscapeShortcutCommandLine(&clean_path);
-	std::string combined_args = StringUtil::JoinString(passed_cli_args.begin(), passed_cli_args.end(), " ");
-	std::string final_args = fmt::format("{} {} -- {}", combined_args, custom_args, clean_path);
-
-	Console.WriteLnFmt("Creating a shortcut '{}' with arguments '{}'", link_file, final_args);
-
-	const auto str_error = [](HRESULT hr) -> std::string {
-		_com_error err(hr);
-		const TCHAR* errMsg = err.ErrorMessage();
-		return fmt::format("{} [{}]", StringUtil::WideStringToUTF8String(errMsg), hr);
-	};
-
-	// Construct the shortcut
-	// https://stackoverflow.com/questions/3906974/how-to-programmatically-create-a-shortcut-using-win32
-	HRESULT res = CoInitialize(NULL);
-	if (FAILED(res))
-	{
-		Console.ErrorFmt("Failed to create shortcut: CoInitialize failed ({})", str_error(res));
-		QMessageBox::critical(this, tr("Failed to create shortcut"), tr("CoInitialize failed (%1").arg(str_error(res)), QMessageBox::StandardButton::Ok, QMessageBox::StandardButton::Ok);
-		return;
-	}
-
-	Microsoft::WRL::ComPtr<IShellLink> pShellLink;
-	Microsoft::WRL::ComPtr<IPersistFile> pPersistFile;
-
-	const auto cleanup = [&](bool return_value, const QString& fail_reason) -> bool {
-		if (!return_value)
+		executable_path = FileSystem::GetPackagePath();
+		if (executable_path.empty())
 		{
-			Console.ErrorFmt("Failed to create shortcut: {}", fail_reason.toStdString());
-			QMessageBox::critical(this, tr("Failed to create shortcut"), fail_reason, QMessageBox::StandardButton::Ok, QMessageBox::StandardButton::Ok);
-		}
-		CoUninitialize();
-		return return_value;
-	};
-
-	res = CoCreateInstance(__uuidof(ShellLink), NULL, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&pShellLink));
-	if (FAILED(res))
-	{
-		cleanup(false, tr("CoCreateInstance failed"));
-		return;
-	}
-
-	// Set path to the executable
-	const std::wstring target_file = StringUtil::UTF8StringToWideString(FileSystem::GetProgramPath());
-	res = pShellLink->SetPath(target_file.c_str());
-	if (FAILED(res))
-	{
-		cleanup(false, tr("SetPath failed (%1)").arg(str_error(res)));
-		return;
-	}
-
-	// Set the working directory
-	const std::wstring working_dir = StringUtil::UTF8StringToWideString(FileSystem::GetWorkingDirectory());
-	res = pShellLink->SetWorkingDirectory(working_dir.c_str());
-	if (FAILED(res))
-	{
-		cleanup(false, tr("SetWorkingDirectory failed (%1)").arg(str_error(res)));
-		return;
-	}
-
-	// Set the launch arguments
-	if (!final_args.empty())
-	{
-		const std::wstring target_cli_args = StringUtil::UTF8StringToWideString(final_args);
-		res = pShellLink->SetArguments(target_cli_args.c_str());
-		if (FAILED(res))
-		{
-			cleanup(false, tr("SetArguments failed (%1)").arg(str_error(res)));
+			Console.Error("Failed to create shortcut: Executable path is empty.");
+			QMessageBox::critical(this, tr("Failed to create shortcut"), tr("Executable path is empty."),
+				QMessageBox::StandardButton::Ok, QMessageBox::StandardButton::Ok);
 			return;
 		}
-	}
+		ShortcutCreationDialog::EscapeCommandLineArgumentLinux(executable_path);
 
-	// Set the icon
-	std::string icon_path = Path::ToNativePath(Path::Combine(Path::GetDirectory(FileSystem::GetProgramPath()), "resources/icons/AppIconLarge.ico"));
-	const std::wstring w_icon_path = StringUtil::UTF8StringToWideString(icon_path);
-	res = pShellLink->SetIconLocation(w_icon_path.c_str(), 0);
-	if (FAILED(res))
-	{
-		cleanup(false, tr("SetIconLocation failed (%1)").arg(str_error(res)));
-		return;
-	}
-
-	// Use the IPersistFile object to save the shell link
-	res = pShellLink.As(&pPersistFile);
-	if (FAILED(res))
-	{
-		cleanup(false, tr("QueryInterface failed (%1)").arg(str_error(res)));
-		return;
-	}
-
-	// Save shortcut link to disk
-	const std::wstring w_link_file = StringUtil::UTF8StringToWideString(link_file);
-	res = pPersistFile->Save(w_link_file.c_str(), TRUE);
-	if (FAILED(res))
-	{
-		cleanup(false, tr("Failed to save the shortcut (%1)").arg(str_error(res)));
-		return;
-	}
-
-	cleanup(true, {});
-
-#else
-
-	if (name.empty())
-	{
-		QMessageBox::critical(this, tr("Failed to create shortcut"), tr("Cannot create a shortcut without a title."), QMessageBox::StandardButton::Ok, QMessageBox::StandardButton::Ok);
-		return;
-	}
-
-	bool is_flatpak = (std::getenv("container"));
-
-	// Sanitize filename and game path
-	const std::string clean_name = Path::SanitizeFileName(name);
-	std::string clean_path = Path::Canonicalize(Path::RealPath(game_path));
-	if (!Path::IsValidFileName(clean_name))
-	{
-		QMessageBox::critical(this, tr("Failed to create shortcut"), tr("Filename contains illegal character."), QMessageBox::StandardButton::Ok, QMessageBox::StandardButton::Ok);
-		return;
-	}
-
-	// Find the executable path
-	std::string executable_path = FileSystem::GetPackagePath();
-	if (executable_path.empty())
-	{
-		QMessageBox::critical(this, tr("Failed to create shortcut"), tr("Executable path is empty."), QMessageBox::StandardButton::Ok, QMessageBox::StandardButton::Ok);
-		return;
-	}
-
-	if (is_flatpak) // Flatpak
-		executable_path = "flatpak run net.pcsx2.PCSX2";
-
-	// Find home directory
-	std::string link_path;
-	const char* home = std::getenv("HOME");
-	const char* xdg_desktop_dir = std::getenv("XDG_DESKTOP_DIR");
-	const char* xdg_data_home = std::getenv("XDG_DATA_HOME");
-	if (home)
-	{
-		if (is_desktop)
-		{
-			if (xdg_desktop_dir)
-				link_path = fmt::format("{}/{}.desktop", xdg_desktop_dir, clean_name);
-			else
-				link_path = fmt::format("{}/Desktop/{}.desktop", home, clean_name);
-		}
-		else
-		{
-			if (xdg_data_home)
-				link_path = fmt::format("{}/applications/{}.desktop", xdg_data_home, clean_name);
-			else
-				link_path = fmt::format("{}/.local/share/applications/{}.desktop", home, clean_name);
-		}
-	}
-	else
-	{
-		QMessageBox::critical(this, tr("Failed to create shortcut"), tr("Home path is empty."), QMessageBox::StandardButton::Ok, QMessageBox::StandardButton::Ok);
-		return;
-	}
-
-	// Checks if a shortcut already exist
-	if (FileSystem::FileExists(link_path.c_str()))
-	{
-		QMessageBox::critical(this, tr("Failed to create shortcut"), tr("A shortcut with the same name already exists."), QMessageBox::StandardButton::Ok, QMessageBox::StandardButton::Ok);
-		return;
-	}
-
-	// Shortcut CmdLine Args
-	bool lossless = true;
-	for (std::string& arg : passed_cli_args)
-		lossless &= ShortcutCreationDialog::EscapeShortcutCommandLine(&arg);
-
-	if (!lossless)
-		QMessageBox::warning(this, tr("Failed to create shortcut"), tr("File path contains invalid character(s). The resulting shortcut may not work."), QMessageBox::StandardButton::Ok, QMessageBox::StandardButton::Ok);
-
-	std::string cmdline = StringUtil::JoinString(passed_cli_args.begin(), passed_cli_args.end(), " ");
-
-	if (!is_flatpak)
-	{
-		// Copy PCSX2 icon
-		std::string icon_dest;
+		std::string icon_destination_directory;
 		if (xdg_data_home)
-			icon_dest = fmt::format("{}/icons/hicolor/512x512/apps/", xdg_data_home);
+			icon_destination_directory = fmt::format("{}/icons/hicolor/512x512/apps/", xdg_data_home);
 		else
-			icon_dest = fmt::format("{}/.local/share/icons/hicolor/512x512/apps/", home);
+			icon_destination_directory = fmt::format("{}/.local/share/icons/hicolor/512x512/apps/", home);
 
-		std::string icon_name = "PCSX2.png";
-		std::string icon_path = fmt::format("{}/{}", icon_dest, icon_name).c_str();
-		if (FileSystem::EnsureDirectoryExists(icon_dest.c_str(), true))
-			FileSystem::CopyFilePath(Path::Combine(EmuFolders::Resources, "icons/AppIconLarge.png").c_str(), icon_path.c_str(), false);
+		const std::string icon_destination_path = fmt::format("{}/PCSX2.png", icon_destination_directory);
+		if (FileSystem::EnsureDirectoryExists(icon_destination_directory.c_str(), true) && !FileSystem::FileExists(icon_destination_path.c_str()))
+			FileSystem::CopyFilePath(Path::Combine(EmuFolders::Resources, "icons/AppIconLarge.png").c_str(), icon_destination_path.c_str(), false);
 	}
 
-	// Further string sanitization
-	if (!is_flatpak)
-		ShortcutCreationDialog::EscapeShortcutCommandLine(&executable_path);
-	ShortcutCreationDialog::EscapeShortcutCommandLine(&clean_path);
-
-	// Assembling the .desktop file
-	std::string final_args;
-	final_args = fmt::format("{} {} {} -- {}", executable_path, cmdline, custom_args, clean_path);
-	std::string file_content =
-		"[Desktop Entry]\n"
-		"Encoding=UTF-8\n"
-		"Version=1.0\n"
-		"Type=Application\n"
-		"Terminal=false\n"
-		"StartupWMClass=PCSX2\n"
-		"Exec=" + final_args + "\n"
-		"Name=" + clean_name + "\n"
-		"Icon=net.pcsx2.PCSX2\n"
-		"Categories=Game;Emulator;\n";
-	std::string_view sv(file_content);
-
-	// Prompt user for shortcut saving destination
-	QString final_path(QStringLiteral("%1").arg(QString::fromStdString(link_path)));
-	const QString filter(tr("Desktop Shortcut Files (*.desktop)"));
-
-	final_path = QDir::toNativeSeparators(QFileDialog::getSaveFileName(this, tr("Select Shortcut Save Destination"), final_path, filter));
-
-	if (final_path.isEmpty())
-		return;
-
-	// Write to .desktop file
-	if (!FileSystem::WriteStringToFile(final_path.toStdString().c_str(), sv))
+	// Sanitize provided command line arguments and attach custom arguments afterward.
+	bool lossless = true;
+	for (std::string& arg : standard_arguments)
 	{
-		QMessageBox::critical(this, tr("Failed to create shortcut"), tr("Failed to create .desktop file"), QMessageBox::StandardButton::Ok, QMessageBox::StandardButton::Ok);
-		return;
+		// Only print warning once for lossy escape.
+		if (!ShortcutCreationDialog::EscapeCommandLineArgumentLinux(arg) && lossless)
+		{
+			Console.Warning("File path contains invalid character(s). The resulting shortcut may not work.");
+			QMessageBox::warning(this, tr("Problem creating shortcut"),
+				tr("File path contains invalid character(s). The resulting shortcut may not work."),
+				QMessageBox::StandardButton::Ok, QMessageBox::StandardButton::Ok);
+			lossless = false;
+		}
 	}
 
-	if (chmod(final_path.toStdString().c_str(), S_IRWXU) != 0) // enables user to execute file
-		Console.ErrorFmt("Failed to change file permissions for .desktop file: {} ({})", strerror(errno), errno);
+	if (!custom_arguments.empty())
+		standard_arguments.push_back(custom_arguments);
+
+	ShortcutCreationDialog::EscapeCommandLineArgumentLinux(m_game_path);
+
+	// Prompt user for shortcut destination, starting at the "suggested" directory made earlier.
+	shortcut_destination = QDir::toNativeSeparators(QFileDialog::getSaveFileName(this, tr("Select Shortcut Save Destination"), QString::fromStdString(shortcut_destination),
+														tr("Desktop Shortcut Files (*.desktop)")))
+	                           .toStdString();
+
+	const std::string shortcut_exec = fmt::format("{} {} -- {}", executable_path, StringUtil::JoinString(standard_arguments.begin(), standard_arguments.end(), " "), m_game_path);
+
+	if (!FileSystem::CreateLinuxDesktopFile(shortcut_destination, shortcut_exec, m_game_title, shortcut_comment))
+	{
+		QMessageBox::critical(this, tr("Failed to create shortcut"), tr("Could not create .desktop file."),
+			QMessageBox::StandardButton::Ok, QMessageBox::StandardButton::Ok);
+	}
 #endif
 }
 
-bool ShortcutCreationDialog::EscapeShortcutCommandLine(std::string* arg)
+#if defined(_WIN32)
+void ShortcutCreationDialog::EscapeCommandLineArgumentWindows(std::string& cli_argument)
 {
-#ifdef _WIN32
-	if (!arg->empty() && arg->find_first_of(" \t\n\v\"") == std::string::npos)
-		return true;
+	if (!cli_argument.empty() && cli_argument.find_first_of(" \t\n\v\"") == std::string::npos)
+		return;
 
 	std::string temp;
-	temp.reserve(arg->length() + 10);
+	temp.reserve(cli_argument.length() + 10);
 	temp += '"';
 
-	for (auto it = arg->begin();; ++it)
+	for (auto it = cli_argument.begin();; ++it)
 	{
 		int backslash_count = 0;
-		while (it != arg->end() && *it == '\\')
+		while (it != cli_argument.end() && *it == '\\')
 		{
 			++it;
 			++backslash_count;
 		}
 
-		if (it == arg->end())
+		if (it == cli_argument.end())
 		{
 			temp.append(backslash_count * 2, '\\');
 			break;
@@ -456,14 +270,17 @@ bool ShortcutCreationDialog::EscapeShortcutCommandLine(std::string* arg)
 	}
 
 	temp += '"';
-	*arg = std::move(temp);
-	return true;
+	cli_argument = std::move(temp);
+	return;
+}
 #else
-	const char* carg = arg->c_str();
-	const char* cend = carg + arg->size();
-	const char* RESERVED_CHARS = " \t\n\\\"'\\\\><~|%&;$*?#()`"
-								 "\x01\x02\x03\x04\x05\x06\x07\x08\x0b\x0c\x0d\x0e\x0f"
-								 "\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f\x7f";
+bool ShortcutCreationDialog::EscapeCommandLineArgumentLinux(std::string& cli_argument)
+{
+	const char* carg = cli_argument.c_str();
+	const char* cend = carg + cli_argument.size();
+	constexpr const char* RESERVED_CHARS = " \t\n\\\"'\\\\><~|%&;$*?#()`"
+										   "\x01\x02\x03\x04\x05\x06\x07\x08\x0b\x0c\x0d\x0e\x0f"
+										   "\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f\x7f";
 	const char* next = carg + std::strcspn(carg, RESERVED_CHARS);
 
 	if (next == cend)
@@ -471,9 +288,9 @@ bool ShortcutCreationDialog::EscapeShortcutCommandLine(std::string* arg)
 
 	bool lossless = true;
 	std::string temp = "\"";
-	const char* NOT_VALID_IN_QUOTE = "%`$\"\\\n"
-									 "\x01\x02\x03\x04\x05\x06\x07\x08\x0b\x0c\x0d\x0e\x0f"
-									 "\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f\x7f";
+	constexpr const char* NOT_VALID_IN_QUOTE = "%`$\"\\\n"
+											   "\x01\x02\x03\x04\x05\x06\x07\x08\x0b\x0c\x0d\x0e\x0f"
+											   "\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f\x7f";
 
 	while (true)
 	{
@@ -512,7 +329,55 @@ bool ShortcutCreationDialog::EscapeShortcutCommandLine(std::string* arg)
 	}
 
 	temp.push_back('"');
-	*arg = std::move(temp);
+	cli_argument = std::move(temp);
 	return lossless;
+}
 #endif
+
+void ShortcutCreationDialog::FillArgumentsList(std::vector<std::string>& arg_list)
+{
+	if (m_ui.portableModeToggle->isChecked())
+		arg_list.push_back("-portable");
+
+	if (m_ui.overrideBootELFToggle->isChecked() && !m_ui.overrideBootELFPath->text().isEmpty())
+	{
+		arg_list.push_back("-elf");
+		arg_list.push_back(Path::ToNativePath(Path::RealPath(m_ui.overrideBootELFPath->text().toStdString())));
+	}
+
+	if (m_ui.gameArgsToggle->isChecked() && !m_ui.gameArgs->text().isEmpty())
+	{
+		arg_list.push_back("-gameargs");
+		arg_list.push_back(m_ui.gameArgs->text().toStdString());
+	}
+
+	if (m_ui.bootOptionToggle->isChecked())
+		arg_list.push_back(m_ui.bootOptionDropdown->currentIndex() ? "-slowboot" : "-fastboot");
+
+	if (m_ui.loadStateIndexToggle->isChecked())
+	{
+		// Bounds are enforced by the UI, but check just in case.
+		const s32 load_state_index = m_ui.loadStateIndex->value();
+		if (load_state_index > 0 && load_state_index <= VMManager::NUM_SAVE_STATE_SLOTS)
+		{
+			m_save_state_type = StateType::Index;
+			m_save_state_name = StringUtil::ToChars(load_state_index);
+			arg_list.push_back("-state");
+			arg_list.push_back(m_save_state_name);
+		}
+	}
+	else if (m_ui.loadStateFileToggle->isChecked() && !m_ui.loadStateFilePath->text().isEmpty())
+	{
+		m_save_state_type = StateType::File;
+		const std::string save_state_file_path = Path::ToNativePath(Path::RealPath(m_ui.loadStateFilePath->text().toStdString()));
+		m_save_state_name = Path::GetFileName(save_state_file_path);
+		arg_list.push_back("-statefile");
+		arg_list.push_back(save_state_file_path);
+	}
+
+	if (m_ui.fullscreenMode->isChecked())
+		arg_list.push_back(m_ui.fullscreenModeDropdown->currentIndex() ? "-nofullscreen" : "-fullscreen");
+
+	if (m_ui.bigPictureModeToggle->isChecked())
+		arg_list.push_back("-bigpicture");
 }

--- a/pcsx2-qt/ShortcutCreationDialog.h
+++ b/pcsx2-qt/ShortcutCreationDialog.h
@@ -11,19 +11,38 @@ class ShortcutCreationDialog final : public QDialog
 	Q_OBJECT
 
 public:
-	ShortcutCreationDialog(QWidget* parent, const QString& title, const QString& path);
+	ShortcutCreationDialog(QWidget* parent, const QString& game_title, const QString& game_serial, const QString& game_path);
 	~ShortcutCreationDialog() = default;
 
-	/// Create desktop shortcut for games
-	void CreateShortcut(const std::string name, const std::string game_path, std::vector<std::string> passed_cli_args, std::string custom_args, bool is_desktop);
+	/// Creates shortcut for a game with user-specified launch arguments.
+	void CreateGameShortcut(std::vector<std::string>& launch_arguments, std::string custom_arguments, bool is_desktop);
 
-	/// Escapes the given string for use with command line arguments.
-	/// Returns a bool that indicates whether the escaping operation are lossless or not.
-	bool EscapeShortcutCommandLine(std::string* cmdline);
+#if defined(_WIN32)
+	/// Escapes a command line argument on Windows.
+	static void EscapeCommandLineArgumentWindows(std::string& cli_argument);
+#else
+	/// Escapes a command line argument on Linux.
+	/// Return value indicates whether the escaping operation is lossless.
+	static bool EscapeCommandLineArgumentLinux(std::string& cli_argument);
+#endif
 
-protected:
-	QString m_title;
-	QString m_path;
-	bool m_desktop;
+	/// Fills a list with CLI arguments based on user selections.
+	void FillArgumentsList(std::vector<std::string>& arg_list);
+
+private:
+	const std::string m_game_title;
+	const std::string m_game_serial;
+	std::string m_game_path;
+
+	enum class StateType : uint8_t
+	{
+		None,
+		Index,
+		File
+	};
+
+	StateType m_save_state_type = StateType::None;
+	std::string m_save_state_name = "";
+
 	Ui::ShortcutCreationDialog m_ui;
 };

--- a/pcsx2-qt/ShortcutCreationDialog.ui
+++ b/pcsx2-qt/ShortcutCreationDialog.ui
@@ -69,6 +69,9 @@
              <string>Force Disable</string>
             </property>
            </item>
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
           </widget>
          </item>
          <item row="1" column="0">
@@ -82,7 +85,11 @@
        </widget>
       </item>
       <item row="3" column="2" colspan="2">
-       <widget class="QLineEdit" name="gameArgs"/>
+       <widget class="QLineEdit" name="gameArgs">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+       </widget>
       </item>
       <item row="4" column="2" colspan="2">
        <widget class="QComboBox" name="bootOptionDropdown">
@@ -96,6 +103,9 @@
           <string>Full Boot</string>
          </property>
         </item>
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
        </widget>
       </item>
       <item row="4" column="0">
@@ -106,14 +116,21 @@
        </widget>
       </item>
       <item row="2" column="3">
-       <widget class="QPushButton" name="overrideBootELFButton">
+       <widget class="QPushButton" name="overrideBootELFBrowse">
         <property name="text">
          <string>Browse...</string>
+        </property>
+        <property name="enabled">
+         <bool>false</bool>
         </property>
        </widget>
       </item>
       <item row="2" column="2">
-       <widget class="QLineEdit" name="overrideBootELFPath"/>
+       <widget class="QLineEdit" name="overrideBootELFPath">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+       </widget>
       </item>
       <item row="10" column="0" colspan="4">
        <widget class="QGroupBox" name="saveStateGroup">
@@ -129,10 +146,17 @@
            <property name="minimum">
             <number>1</number>
            </property>
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
           </widget>
          </item>
          <item row="2" column="1">
-          <widget class="QLineEdit" name="loadStateFilePath"/>
+          <widget class="QLineEdit" name="loadStateFilePath">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+          </widget>
          </item>
          <item row="0" column="0">
           <widget class="QRadioButton" name="loadStateNone">
@@ -162,6 +186,9 @@
           <widget class="QPushButton" name="loadStateFileBrowse">
            <property name="text">
             <string>Browse...</string>
+           </property>
+           <property name="enabled">
+            <bool>false</bool>
            </property>
           </widget>
          </item>
@@ -194,7 +221,7 @@
          <item row="0" column="0">
           <widget class="QLabel" name="customArgsInstruction">
            <property name="text">
-            <string>You may add additional (space-separated) &lt;a href=&quot;https://pcsx2.net/docs/post/cli/&quot;&gt;custom arguments&lt;/a&gt; that are not listed above here:</string>
+            <string>You may add additional (space-separated) &lt;a href=&quot;https://pcsx2.net/docs/advanced/cli/&quot;&gt;custom arguments&lt;/a&gt; that are not listed above here:</string>
            </property>
            <property name="textFormat">
             <enum>Qt::TextFormat::RichText</enum>
@@ -256,17 +283,20 @@
       <string/>
      </property>
      <layout class="QGridLayout" name="shortcutTypeLayout">
-      <item row="2" column="0">
-       <widget class="QRadioButton" name="shortcutStartMenu">
-        <property name="text">
-         <string>Launcher</string>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="0">
        <widget class="QRadioButton" name="shortcutDesktop">
         <property name="text">
          <string>Desktop</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QRadioButton" name="shortcutStartMenu">
+        <property name="text">
+         <string>Launcher</string>
         </property>
        </widget>
       </item>
@@ -294,7 +324,7 @@
   <tabstop>portableModeToggle</tabstop>
   <tabstop>overrideBootELFToggle</tabstop>
   <tabstop>overrideBootELFPath</tabstop>
-  <tabstop>overrideBootELFButton</tabstop>
+  <tabstop>overrideBootELFBrowse</tabstop>
   <tabstop>gameArgsToggle</tabstop>
   <tabstop>gameArgs</tabstop>
   <tabstop>bootOptionToggle</tabstop>


### PR DESCRIPTION
### Description of Changes
Large rewrite of `ShortcutCreationDialog.cpp`. The UI file was fine already.

* Rename `title` and `name` to `game_title` for consistency and clarity.
  * Renamed `path` to `game_path` for the same reason.
* Move a long series of conditionals into a function called `FillArgumentsList()`.
  * Only called once, but it's nice for organization.
* Fix an issue where the load save state from file functionality wasn't working.
  * This was never being loaded into the CLI argument list.
* Split `EscapeShortcutCommandLine()` into `EscapeShortcutCommandLineWindows()` and `EscapeShortcutCommandLineLinux()`.
  * Totally different functions with no interleaving and only ever called within WIN32 or Linux-specific code.
  * Remove the return value for `EscapeShortcutCommandLineWindows()`, as it always returned `true`.
* Pass the string vector `launch_arguments` by reference instead of by value.
* In Windows, use `SHGetKnownFolderPath` to get desktop or start menu directory.
  * Safer and more elegant than hardcoding a path.
  * Hopefully improves the situation in #13455, but no guarantees.
* Rearrange some of the Linux logic to be more efficient and readable.
* For AppImage, when copying icon, check if copied icon already exists first.
  * It should exist if a shortcut has already been made before).
* Changed "Failed to create shortcut" if escape not lossless to "Problem creating shortcut".
  * We already treat this as a warning and continue rather than a critical failure and return.
* Moved the invalid game title and empty path logic into the constructor.
  * There's no reason to let a user select options if we know 100% for certain it will fail.
* Move Windows and Linux shortcut creation functionality into `FileSystem.cpp`.
  * This is more generalizable functionality than just creating a game shortcut.
  * Windows stuff is relatively advanced for what `ShortcutCreationDialog.cpp` is doing.
* Add a description to both Linux and Windows.
  * For Linux, this'll show up on hover for desktop and as a subtitle for the Application Launcher.
  * On Windows, this'll be show up as hover text only.
* Sanitize override ELF and load state file paths to real path and native separators.
  * They were being escaped before, but that's it.
  * "Path::ToNativePath" seriously needs to be renamed.
    * Ideally to "Path::ToNativeSeparators" or "Path::ToNativePathSeparators".
    * It's a terribly ambiguous name for no reason.
* Moves some setEnabled/setChecked logic in the dialog from `.cpp` to `.ui`.
  * These are entirely unconditional after UI setup.
  * UI setup in the `.cpp` should only be reserved for conditional or variable behavior.

### Screenshots
<img width="453" height="79" alt="image" src="https://github.com/user-attachments/assets/c1a0ed76-ba4d-43be-8507-e220b21ee47c" />
<img width="641" height="71" alt="image" src="https://github.com/user-attachments/assets/b8ad36ad-eaaf-4fed-bce2-eb6655f2e60c" />

### What this did not change
`EscapeShortcutCommandLineWindows()` and `EscapeShortcutCommandLineLinux()` are basically left entirely alone. I can make a PR for them in the future, but the hurdle preventing me from touching them in this one is that they're totally undocumented and *ad hoc* workarounds for OS-specific quirks. I'd therefore prefer to quarantine that to a separate PR so any mistakes I make are self-contained.

### Suggested Testing Steps
* Make sure shortcut creation and the various options still work on Windows and Linux.
* Make sure that choosing a file for the save state now works.

Please pay especially close attention to the Windows logic, as I am not presently able to test it.

### Did you use AI to help find, test, or implement this issue or feature?
No.
