### PR TITLE
Core: Bump savestate version.

### DIFF
--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -25,7 +25,7 @@ enum class FreezeAction
 // [SAVEVERSION+]
 // This informs the auto updater that the users savestates will be invalidated.
 
-static const u32 g_SaveVersion = (0x9A54 << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A55 << 16) | 0x0000;
 
 
 // the freezing data between submodules and core


### PR DESCRIPTION
### Description of Changes
Bumps the savestate version that was missed before #13331 was merged.

### Rationale behind Changes
Broken savestates crashing is bad.

### Suggested Testing Steps
NA

### Did you use AI to help find, test, or implement this issue or feature?
No
