### PR TITLE
Flatpak: Update KDE runtime to 6.10

### DIFF
--- a/.github/workflows/linux_build_flatpak.yml
+++ b/.github/workflows/linux_build_flatpak.yml
@@ -45,7 +45,7 @@ jobs:
     name: ${{ inputs.jobName }}
     runs-on: ${{ inputs.os }}
     container:
-      image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.7
+      image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.9
       options: --privileged
     timeout-minutes: 60
 

--- a/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
+++ b/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
@@ -1,15 +1,15 @@
 {
   "app-id": "net.pcsx2.PCSX2",
   "runtime": "org.kde.Platform",
-  "runtime-version": "6.9",
+  "runtime-version": "6.10",
   "sdk": "org.kde.Sdk",
   "sdk-extensions": [
-    "org.freedesktop.Sdk.Extension.llvm18"
+    "org.freedesktop.Sdk.Extension.llvm20"
   ],
   "add-extensions": {
     "org.freedesktop.Platform.ffmpeg-full": {
       "directory": "lib/ffmpeg",
-      "version": "24.08",
+      "version": "25.08",
       "add-ld-path": ".",
       "autodownload": true
     }
@@ -50,8 +50,8 @@
           "-DCMAKE_PREFIX_PATH=\"${FLATPAK_DEST}\"",
           "-DCMAKE_BUILD_TYPE=Release",
           "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON",
-          "-DCMAKE_C_COMPILER=/usr/lib/sdk/llvm18/bin/clang",
-          "-DCMAKE_CXX_COMPILER=/usr/lib/sdk/llvm18/bin/clang++",
+          "-DCMAKE_C_COMPILER=/usr/lib/sdk/llvm20/bin/clang",
+          "-DCMAKE_CXX_COMPILER=/usr/lib/sdk/llvm20/bin/clang++",
           "-DCMAKE_EXE_LINKER_FLAGS_INIT=-fuse-ld=lld",
           "-DCMAKE_MODULE_LINKER_FLAGS_INIT=-fuse-ld=lld",
           "-DCMAKE_SHARED_LINKER_FLAGS_INIT=-fuse-ld=lld",

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -108,7 +108,7 @@ disable_compiler_warnings_for_target(speex)
 
 # Find the Qt components that we need.
 if(ENABLE_QT_UI)
-	find_package(Qt6 6.7.3 COMPONENTS CoreTools Core GuiTools Gui WidgetsTools Widgets LinguistTools REQUIRED)
+	find_package(Qt6 6.10.0 COMPONENTS CoreTools Core GuiTools Gui WidgetsTools Widgets LinguistTools REQUIRED)
 endif()
 
 if (Qt6_VERSION VERSION_GREATER_EQUAL 6.10.0)


### PR DESCRIPTION
### Description of Changes
Updates the KDE runtime to 6.10 giving us Qt 6.10.0 on Flatpak.

### Rationale behind Changes
Fobes has been waiting 84 years so he can finally fix those pesky warnings.

### Suggested Testing Steps
Make sure the Flatpak still builds and doesn't break in horrible ways.

### Did you use AI to help find, test, or implement this issue or feature?
No

