### PR TITLE
GS Hotkeys: Improve upscale and downscale hotkeys

### DIFF
--- a/pcsx2/MTGS.h
+++ b/pcsx2/MTGS.h
@@ -54,7 +54,7 @@ namespace MTGS
 	/// the current frame with the correct proportions. Should only be called from the CPU thread.
 	void PresentCurrentFrame();
 
-	// Waits for the GS to empty out the entire ring buffer contents.
+	/// Waits for the GS to empty out the entire ring buffer contents.
 	void WaitGS(bool syncRegs = true, bool weakWait = false, bool isMTVU = false);
 	void ResetGS(bool hardware_reset);
 


### PR DESCRIPTION
### Description of Changes
* Makes the maximum upscale logic directly mirror `GraphicsSettingsWidget::populateUpscaleMultipliers()`.
  * This was a hardcoded 8 previously.
  * Now it's a minimum 10, maximum 12, and maximum 25 if extended multipliers are enabled in advanced graphics (dependent on user hardware capability).
* Adds a FontAwesome (FA) icon to the OSD message like other hotkey messages (e.g. audio).
  * The icon is the same one we use in the BPM settings.
* Customizes the message if at native resolution or at maximum upscale.
  * Otherwise, now tells the user whether they've decreased or increased the resolution.
* Reports a target resolution alongside the scale.
* Sets the minimum bound in `GS::GSClampUpscaleMultiplier()` from 1.0f to 0.0f.
  * A value below 1.0f is never attainable in the UI.
  * If the value is below 1.0f, we have a warning message in place.
  * Scales below native exist and do render.
  * If a user is changing this in the `.ini` file, they probably either know what they're doing or at minimum don't want to have a native floor programmatically enforced on them through the GS code.
  * The hotkey will continue to use a 1.0f floor. 

### Screenshots of Changes
<img width="365" height="43" alt="OSD message reading: Upscale multiplier set to native resolution. (512 x 448)" src="https://github.com/user-attachments/assets/af67d0ea-6222-46ee-9475-975a59537f90" />
<img width="346" height="44" alt="OSD message reading: Upscale multiplier maximized to 25x. (12800 x 11200)" src="https://github.com/user-attachments/assets/0f3fd2fd-a2d3-42a6-a562-49a516df2ea7" />
<img width="329" height="42" alt="OSD message reading: Upscale multiplier decreased to 9x. (4608 x 4032) " src="https://github.com/user-attachments/assets/93fbfdcd-6e66-441a-8d88-5d18b13e0b04" />
<img width="323" height="37" alt="OSD message reading: Upscale multiplier increased to 3x (1536 x 1344)" src="https://github.com/user-attachments/assets/e09d2176-ab6a-435f-a278-1cc738dd3f2c" />
<img width="352" height="39" alt="image" src="https://github.com/user-attachments/assets/cbfae4da-254b-402d-8b6f-f5d43ae3e2b1" />

Previous:
<img width="180" height="40" alt="OSD message reading: Upscale multiplier set to 4x." src="https://github.com/user-attachments/assets/5e08c28c-4590-4255-8d0e-8fe01ddafda1" />

### Rationale behind Changes
* There was no good reason for the cap not to correspond to the options seen in Qt/BPM.
* Other hotkey messages like volume similarly have an icon.
* Like the prior change to the volume settings, giving the user more feedback like "increased/decreased" or telling them they've hit the min/max makes it more intuitive at a glance.
* Resolution is generally useful, but especially if fullscreened. Helps the user make a more informed choice.

### Suggested Testing Steps
* Test games with odd resolutions, I suppose (literally numbers with odd parity)?
* Make sure you can't go past at most 12x if Graphics > Advanced > Extended multipliers is off.
* Just try messing around with the hotkeys otherwise.

NOTE: Turning extended upscaling multpliers on currently resets resolution to native if it was changed via hotkeys (but not via Qt/BPM). This is a bug present on the latest nightly, and this code does not affect it.

### Did you use AI to help find, test, or implement this issue or feature?
No, but I acted like one while trying to solve the problem.