### PR TITLE
SPU2: Accumulate key on/off requests instead of overwriting them

### DIFF
--- a/pcsx2/SPU2/spu2sys.cpp
+++ b/pcsx2/SPU2/spu2sys.cpp
@@ -1034,6 +1034,19 @@ static void RegWrite_Core(u16 value)
 
 	switch (omem)
 	{
+		// Cannot use the default case for these as they are cumulative triggers.
+		case REG_S_KON:
+			thiscore.KeyOn |= value;
+			break;
+		case REG_S_KON + 2:
+			thiscore.KeyOn |= value << 16;
+			break;
+		case REG_S_KOFF:
+			thiscore.KeyOff |= value;
+			break;
+		case REG_S_KOFF + 2:
+			thiscore.KeyOff |= value << 16;
+			break;
 		case REG__1AC:
 			// ----------------------------------------------------------------------------
 			// 0x1ac / 0x5ac : direct-write to DMA address : special register (undocumented)


### PR DESCRIPTION
### Description of Changes
Changes Key On/Off handling on SPU2 to accumilate requests.

### Rationale behind Changes
These registers are triggers, and since we are delaying their processing until the next tick, they have to build up. However due to the recent changes in #13331 , the behaviour was changed to the default of overwriting the contents, meaning any pending requests written more than once in a tick were removed.

### Suggested Testing Steps
Test any games fixed/broken by #13331, Dragon Quest V background music, Battlefield 2 car engine noises, and any here https://github.com/PCSX2/pcsx2/pull/13331#issuecomment-3432537771

### Did you use AI to help find, test, or implement this issue or feature?
No

Fixes #13486