### PR TITLE
QtHost: fix bigpicture mode not starting correctly when fullscreen mode is on

### DIFF
--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -2399,8 +2399,11 @@ int main(int argc, char* argv[])
 
 	// Initialize big picture mode if requested by command line or settings.
 	if (s_start_fullscreen_ui || Host::GetBaseBoolSettingValue("UI", "StartBigPictureMode", false))
-		g_emu_thread->startFullscreenUI(s_start_fullscreen_ui_fullscreen);
-
+	{
+		// Get start fullscreen flag to make sure whether we want the big picture mode to run with full screen mode
+		const bool start_fullscreen = s_start_fullscreen_ui_fullscreen || Host::GetBaseBoolSettingValue("UI", "StartFullscreen", false);
+		g_emu_thread->startFullscreenUI(start_fullscreen);
+	}
 	if (s_boot_and_debug || DebuggerWindow::shouldShowOnStartup())
 	{
 		DebugInterface::setPauseOnEntry(s_boot_and_debug);


### PR DESCRIPTION
### Description of Changes
This fixes the issue described here: https://github.com/PCSX2/pcsx2/issues/13228, where when users enable both Start Fullscreen and Start Big Picture UI options, PCSX2 app will stay in windowed mode while showing the Big Picture UI, whereas it should be showing the Big Picture UI in Fullscreen mode.

### Rationale behind Changes
The changes are rather simple. The issue was caused by the variable s_start_fullscreen_ui_fullscreen currently always resolves to false when the app is not ran with command line argument -fullscreen, so it will always start big picture UI in windowed mode, regardless whether the fullscreen option in Settings is enabled. So we need to fetch the StartFullscreen flag to make sure that the correct setting is passed to big picture UI logic.

### Suggested Testing Steps
Just need to run the app, test with following scenarios:
1. Start Fullscreen on & Start Big Picture UI on -> should start big picture UI in fullscreen mode (currently in windowed mode)
2. Start Fullscreen on & Start Big Picture UI off -> should start desktop UI in fullscreen mode (currently working as intended)
3. Start Fullscreen off & Start Big Picture UI off -> should start big picture UI in windowed mode (currently working as intended)

### Did you use AI to help find, test, or implement this issue or feature?
Nope.
