### PR TITLE
Debugger: Fix 1 pixel gap under layout tabs on non-Windows platforms

### DIFF
--- a/pcsx2-qt/Debugger/Docking/DockMenuBar.cpp
+++ b/pcsx2-qt/Debugger/Docking/DockMenuBar.cpp
@@ -305,7 +305,6 @@ QSize DockMenuBarStyle::sizeFromContents(
 {
 	QSize size = QProxyStyle::sizeFromContents(type, option, contents_size, widget);
 
-#ifdef Q_OS_WIN32
 	// Adjust the sizes of the layout switcher tabs depending on the theme.
 	if (type == CT_TabBarTab)
 	{
@@ -336,7 +335,6 @@ QSize DockMenuBarStyle::sizeFromContents(
 				size.setWidth(size.height());
 		}
 	}
-#endif
 
 	return size;
 }


### PR DESCRIPTION
### Description of Changes
Remove a 1 pixel gap that would sometimes show up under the layout tabs in the debugger on non-Windows platforms, depending on the font size.

Before:
<img width="255" height="53" alt="Screenshot_20251105_112837" src="https://github.com/user-attachments/assets/355323f9-8a2a-4101-98b5-745ac339c921" />

After:
<img width="255" height="53" alt="Screenshot_20251105_112934" src="https://github.com/user-attachments/assets/91c9a96c-8f57-4bdf-a0b9-e6eaf489afc3" />

### Rationale behind Changes
Looks better.

### Suggested Testing Steps
Try different font sizes.

### Did you use AI to help find, test, or implement this issue or feature?
No.
