### PR TITLE
Debugger: Improve symbol tree enum editing

### DIFF
--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeNode.cpp
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeNode.cpp
@@ -390,15 +390,13 @@ QString SymbolTreeNode::generateDisplayString(
 		}
 		case ccc::ast::ENUM:
 		{
-			s32 value = (s32)location.read32(cpu);
+			s32 value = static_cast<s32>(location.read32(cpu));
 			const auto& enum_type = physical_type.as<ccc::ast::Enum>();
-			for (auto [test_value, name] : enum_type.constants)
-			{
+			for (const auto& [test_value, name] : enum_type.constants)
 				if (test_value == value)
 					return QString::fromStdString(name);
-			}
 
-			break;
+			return display_options.signedIntegerToString(value, 32);
 		}
 		case ccc::ast::POINTER_OR_REFERENCE:
 		{


### PR DESCRIPTION
### Description of Changes
If the value of an enum isn't equal to any of the named constants, create a combo box item for that value instead of just defaulting to the first one.

### Rationale behind Changes
It was previously very easy to accidentally change the values of enums with "invalid" values.

### Suggested Testing Steps
You could test enum editing with a game that has .mdebug symbols.

### Did you use AI to help find, test, or implement this issue or feature?
No.
