### PR TITLE
CDVD: Synchronise access from different threads

### DIFF
--- a/pcsx2-qt/GameList/GameListRefreshThread.h
+++ b/pcsx2-qt/GameList/GameListRefreshThread.h
@@ -14,7 +14,7 @@ class GameListRefreshThread;
 class AsyncRefreshProgressCallback : public BaseProgressCallback
 {
 public:
-	AsyncRefreshProgressCallback(GameListRefreshThread* parent);
+	AsyncRefreshProgressCallback(bool popup_on_error, GameListRefreshThread* parent);
 
 	void Cancel();
 
@@ -38,6 +38,7 @@ private:
 	QString m_status_text;
 	int m_last_range = 1;
 	int m_last_value = 0;
+	bool m_popup_on_error = false;
 };
 
 class GameListRefreshThread final : public QThread
@@ -45,7 +46,7 @@ class GameListRefreshThread final : public QThread
 	Q_OBJECT
 
 public:
-	GameListRefreshThread(bool invalidate_cache);
+	GameListRefreshThread(bool invalidate_cache, bool popup_on_error);
 	~GameListRefreshThread();
 
 	void cancel();
@@ -60,4 +61,5 @@ protected:
 private:
 	AsyncRefreshProgressCallback m_progress;
 	bool m_invalidate_cache;
+	bool m_popup_on_error;
 };

--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -294,7 +294,7 @@ void GameListWidget::initialize()
 	m_empty_ui.setupUi(m_empty_widget);
 	m_empty_ui.supportedFormats->setText(qApp->translate("GameListWidget", SUPPORTED_FORMATS_STRING));
 	connect(m_empty_ui.addGameDirectory, &QPushButton::clicked, this, [this]() { emit addGameDirectoryRequested(); });
-	connect(m_empty_ui.scanForNewGames, &QPushButton::clicked, this, [this]() { refresh(false); });
+	connect(m_empty_ui.scanForNewGames, &QPushButton::clicked, this, [this]() { refresh(false, true); });
 	connect(qApp, &QGuiApplication::applicationStateChanged, this, [this]() { GameListWidget::updateCustomBackgroundState(); });
 	m_ui.stack->insertWidget(2, m_empty_widget);
 
@@ -453,11 +453,11 @@ bool GameListWidget::getShowGridCoverTitles() const
 	return m_model->getShowCoverTitles();
 }
 
-void GameListWidget::refresh(bool invalidate_cache)
+void GameListWidget::refresh(bool invalidate_cache, bool popup_on_error)
 {
 	cancelRefresh();
 
-	m_refresh_thread = new GameListRefreshThread(invalidate_cache);
+	m_refresh_thread = new GameListRefreshThread(invalidate_cache, popup_on_error);
 	connect(m_refresh_thread, &GameListRefreshThread::refreshProgress, this, &GameListWidget::onRefreshProgress,
 		Qt::QueuedConnection);
 	connect(m_refresh_thread, &GameListRefreshThread::refreshComplete, this, &GameListWidget::onRefreshComplete,

--- a/pcsx2-qt/GameList/GameListWidget.h
+++ b/pcsx2-qt/GameList/GameListWidget.h
@@ -46,7 +46,7 @@ public:
 	void initialize();
 	void resizeTableViewColumnsToFit();
 
-	void refresh(bool invalidate_cache);
+	void refresh(bool invalidate_cache, bool popup_on_error);
 	void cancelRefresh();
 	void reloadThemeSpecificImages();
 	void setCustomBackground(bool force = false);

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -113,7 +113,7 @@ public:
 	void checkMousePosition(int x, int y);
 public Q_SLOTS:
 	void checkForUpdates(bool display_message, bool force_check);
-	void refreshGameList(bool invalidate_cache);
+	void refreshGameList(bool invalidate_cache, bool popup_on_error);
 	void cancelGameListRefresh();
 	void reportInfo(const QString& title, const QString& message);
 	void reportError(const QString& title, const QString& message);

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -1152,7 +1152,7 @@ void Host::OpenHostFileSelectorAsync(std::string_view title, bool select_directo
 	if (!filters.empty())
 	{
 		filters_str.append(QStringLiteral("All File Types (%1)")
-				.arg(QString::fromStdString(StringUtil::JoinString(filters.begin(), filters.end(), " "))));
+							   .arg(QString::fromStdString(StringUtil::JoinString(filters.begin(), filters.end(), " "))));
 		for (const std::string& filter : filters)
 		{
 			filters_str.append(
@@ -2385,7 +2385,7 @@ int main(int argc, char* argv[])
 
 	// When running in batch mode, ensure game list is loaded, but don't scan for any new files.
 	if (!s_batch_mode)
-		g_main_window->refreshGameList(false);
+		g_main_window->refreshGameList(false, false);
 	else
 		GameList::Refresh(false, true);
 

--- a/pcsx2-qt/Settings/GameListSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GameListSettingsWidget.cpp
@@ -63,7 +63,7 @@ bool GameListSettingsWidget::addExcludedPath(const std::string& path)
 
 	Host::CommitBaseSettingChanges();
 	m_ui.excludedPaths->addItem(QString::fromStdString(path));
-	g_main_window->refreshGameList(false);
+	g_main_window->refreshGameList(false, true);
 	return true;
 }
 
@@ -152,7 +152,7 @@ void GameListSettingsWidget::addSearchDirectory(const QString& path, bool recurs
 	Host::AddBaseValueToStringList("GameList", recursive ? "RecursivePaths" : "Paths", spath.c_str());
 	Host::CommitBaseSettingChanges();
 	refreshDirectoryList();
-	g_main_window->refreshGameList(false);
+	g_main_window->refreshGameList(false, true);
 }
 
 void GameListSettingsWidget::removeSearchDirectory(const QString& path)
@@ -166,7 +166,7 @@ void GameListSettingsWidget::removeSearchDirectory(const QString& path)
 
 	Host::CommitBaseSettingChanges();
 	refreshDirectoryList();
-	g_main_window->refreshGameList(false);
+	g_main_window->refreshGameList(false, true);
 }
 
 void GameListSettingsWidget::onDirectoryListContextMenuRequested(const QPoint& point)
@@ -261,7 +261,7 @@ void GameListSettingsWidget::onRemoveExcludedPathButtonClicked()
 
 	delete item;
 
-	g_main_window->refreshGameList(false);
+	g_main_window->refreshGameList(false, true);
 }
 
 void GameListSettingsWidget::onExcludedPathsSelectionChanged()
@@ -271,10 +271,10 @@ void GameListSettingsWidget::onExcludedPathsSelectionChanged()
 
 void GameListSettingsWidget::onRescanAllGamesClicked()
 {
-	g_main_window->refreshGameList(true);
+	g_main_window->refreshGameList(true, true);
 }
 
 void GameListSettingsWidget::onScanForNewGamesClicked()
 {
-	g_main_window->refreshGameList(false);
+	g_main_window->refreshGameList(false, true);
 }

--- a/pcsx2-qt/Settings/GameSummaryWidget.cpp
+++ b/pcsx2-qt/Settings/GameSummaryWidget.cpp
@@ -280,7 +280,8 @@ void GameSummaryWidget::onVerifyClicked()
 	Error error;
 	if (!hasher.Open(m_entry_path, &error))
 	{
-		setVerifyResult(QString::fromStdString(error.GetDescription()));
+		QString message(QString::fromStdString(error.GetDescription()));
+		QMessageBox::critical(QtUtils::GetRootWidget(this), tr("Error"), message);
 		return;
 	}
 

--- a/pcsx2/CDVD/CDVDcommon.cpp
+++ b/pcsx2/CDVD/CDVDcommon.cpp
@@ -21,6 +21,7 @@
 #include <ctype.h>
 #include <exception>
 #include <memory>
+#include <mutex>
 #include <time.h>
 
 #include "fmt/format.h"
@@ -270,6 +271,23 @@ static void DetectDiskType()
 
 static std::string m_SourceFilename[3];
 static CDVD_SourceType m_CurrentSourceType = CDVD_SourceType::NoDisc;
+static std::mutex s_cdvd_lock;
+
+bool cdvdLock(Error* error)
+{
+	if (!s_cdvd_lock.try_lock())
+	{
+		Error::SetString(error, TRANSLATE_STR("CDVD", "The CDVD system is currently in use."));
+		return false;
+	}
+
+	return true;
+}
+
+void cdvdUnlock()
+{
+	s_cdvd_lock.unlock();
+}
 
 void CDVDsys_SetFile(CDVD_SourceType srctype, std::string newfile)
 {
@@ -579,7 +597,7 @@ static s32 NODISCdummyS32()
 	return 0;
 }
 
-static void NODISCnewDiskCB(void (*/* callback */)())
+static void NODISCnewDiskCB(void (* /* callback */)())
 {
 }
 

--- a/pcsx2/CDVD/CDVDcommon.h
+++ b/pcsx2/CDVD/CDVDcommon.h
@@ -20,7 +20,6 @@ struct cdvdTrackIndex
 	u8 discM; // current minute location on the disc (BCD encoded)
 	u8 discS; // current sector location on the disc (BCD encoded)
 	u8 discF; // current frame location on the disc (BCD encoded)
-
 };
 
 struct cdvdTrack
@@ -187,6 +186,13 @@ extern const CDVD_API CDVDapi_NoDisc;
 extern u8 strack;
 extern u8 etrack;
 extern std::array<cdvdTrack, 100> tracks;
+
+/// Try to take the CDVD lock, return false if it's already in use.
+/// Must be called before your first CDVD call.
+extern bool cdvdLock(Error* error = nullptr);
+
+/// Release the CDVD lock. Must be called after you're done with CDVD.
+extern void cdvdUnlock();
 
 extern void CDVDsys_ChangeSource(CDVD_SourceType type);
 extern void CDVDsys_SetFile(CDVD_SourceType srctype, std::string newfile);

--- a/pcsx2/CDVD/IsoHasher.h
+++ b/pcsx2/CDVD/IsoHasher.h
@@ -28,6 +28,9 @@ public:
 	IsoHasher();
 	~IsoHasher();
 
+	IsoHasher(const IsoHasher&) = delete;
+	IsoHasher& operator=(const IsoHasher&) = delete;
+
 	static std::string_view GetTrackTypeString(u32 type);
 
 	u32 GetTrackCount() const { return static_cast<u32>(m_tracks.size()); }
@@ -44,6 +47,7 @@ private:
 	bool ComputeTrackHash(Track& track, ProgressCallback* callback);
 
 	std::vector<Track> m_tracks;
+	bool m_is_locked = false;
 	bool m_is_open = false;
 	bool m_is_cd = false;
 };

--- a/pcsx2/DebugTools/SymbolImporter.cpp
+++ b/pcsx2/DebugTools/SymbolImporter.cpp
@@ -163,6 +163,9 @@ void SymbolImporter::Reset()
 
 void SymbolImporter::LoadAndAnalyseElf(Pcsx2Config::DebugAnalysisOptions options)
 {
+	if (!VMManager::HasValidVM())
+		return;
+
 	const std::string& elf_path = VMManager::GetCurrentELF();
 
 	Error error;
@@ -192,6 +195,9 @@ void SymbolImporter::AnalyseElf(
 	Pcsx2Config::DebugAnalysisOptions options,
 	bool wait_until_elf_is_loaded)
 {
+	if (!VMManager::HasValidVM())
+		return;
+
 	// Search for a .sym file to load symbols from.
 	std::string nocash_path;
 	CDVD_SourceType source_type = CDVDsys_GetSourceType();

--- a/pcsx2/GameList.cpp
+++ b/pcsx2/GameList.cpp
@@ -16,6 +16,7 @@
 #include "common/HeterogeneousContainers.h"
 #include "common/Path.h"
 #include "common/ProgressCallback.h"
+#include "common/ScopedGuard.h"
 #include "common/StringUtil.h"
 
 #include <algorithm>
@@ -825,6 +826,15 @@ void GameList::Refresh(bool invalidate_cache, bool only_cache, ProgressCallback*
 {
 	if (!progress)
 		progress = ProgressCallback::NullProgressCallback;
+
+	Error cdvd_lock_error;
+	if (!cdvdLock(&cdvd_lock_error))
+	{
+		progress->DisplayError(cdvd_lock_error.GetDescription().c_str());
+		return;
+	}
+
+	ScopedGuard unlock_cdvd = &cdvdUnlock;
 
 	if (invalidate_cache)
 		DeleteCacheFile();

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -485,7 +485,7 @@ void VMManager::UpdateLoggingSettings(SettingsInterface& si)
 	if (system_console_enabled != Log::IsConsoleOutputEnabled())
 		Log::SetConsoleOutputLevel(system_console_enabled ? level : LOGLEVEL_NONE);
 
-	// Debug console only exists on Windows.
+		// Debug console only exists on Windows.
 #ifdef _WIN32
 	const bool debug_console_enabled = IsDebuggerPresent() && si.GetBoolValue("Logging", "EnableDebugConsole", false);
 	Log::SetDebugOutputLevel(debug_console_enabled ? level : LOGLEVEL_NONE);
@@ -776,8 +776,8 @@ std::string VMManager::GetGameSettingsPath(const std::string_view game_serial, u
 	std::string sanitized_serial(Path::SanitizeFileName(game_serial));
 
 	return game_serial.empty() ?
-			   Path::Combine(EmuFolders::GameSettings, fmt::format("{:08X}.ini", game_crc)) :
-			   Path::Combine(EmuFolders::GameSettings, fmt::format("{}_{:08X}.ini", sanitized_serial, game_crc));
+	           Path::Combine(EmuFolders::GameSettings, fmt::format("{:08X}.ini", game_crc)) :
+	           Path::Combine(EmuFolders::GameSettings, fmt::format("{}_{:08X}.ini", sanitized_serial, game_crc));
 }
 
 std::string VMManager::GetDiscOverrideFromGameSettings(const std::string& elf_path)
@@ -1324,6 +1324,15 @@ bool VMManager::Initialize(VMBootParameters boot_params)
 		}
 	}
 
+	Error cdvd_lock_error;
+	if (!cdvdLock(&cdvd_lock_error))
+	{
+		Host::ReportErrorAsync("Startup Error", cdvd_lock_error.GetDescription());
+		return false;
+	}
+
+	ScopedGuard unlock_cdvd = &cdvdUnlock;
+
 	// resolve source type
 	if (boot_params.source_type.has_value())
 	{
@@ -1355,12 +1364,14 @@ bool VMManager::Initialize(VMBootParameters boot_params)
 		if (!LoadBIOS())
 		{
 			Host::ReportErrorAsync(TRANSLATE_SV("VMManager", "Error – No BIOS Present"),
-				fmt::format(TRANSLATE_FS("VMManager",
-					"PCSX2 requires a PlayStation 2 BIOS in order to run.\n\n"
-					"For legal reasons, you will need to obtain this BIOS from a PlayStation 2 unit which you own.\n\n"
-					"For step-by-step help with this process, please consult the setup guide at {}.\n\n"
-					"PCSX2 will be able to run once you've placed your BIOS image inside the folder named \"bios\" within the data directory "
-					"(Tools Menu -> Open Data Directory)."), PCSX2_DOCUMENTATION_BIOS_URL_SHORTENED));
+				fmt::format(
+					TRANSLATE_FS("VMManager",
+						"PCSX2 requires a PlayStation 2 BIOS in order to run.\n\n"
+						"For legal reasons, you will need to obtain this BIOS from a PlayStation 2 unit which you own.\n\n"
+						"For step-by-step help with this process, please consult the setup guide at {}.\n\n"
+						"PCSX2 will be able to run once you've placed your BIOS image inside the folder named \"bios\" within the data directory "
+						"(Tools Menu -> Open Data Directory)."),
+					PCSX2_DOCUMENTATION_BIOS_URL_SHORTENED));
 			return false;
 		}
 
@@ -1559,6 +1570,7 @@ bool VMManager::Initialize(VMBootParameters boot_params)
 	close_memcards.Cancel();
 	close_cdvd.Cancel();
 	close_cdvd_files.Cancel();
+	unlock_cdvd.Cancel();
 	close_state.Cancel();
 
 	if (EmuConfig.CdvdPrecache)
@@ -1666,6 +1678,8 @@ void VMManager::Shutdown(bool save_resume_state)
 		GSDumpReplayer::Shutdown();
 	else
 		cdvdSaveNVRAM();
+
+	cdvdUnlock();
 
 	s_state.store(VMState::Shutdown, std::memory_order_release);
 	FullscreenUI::OnVMDestroyed();


### PR DESCRIPTION
### Description of Changes
Wrap the CDVD system in a lock so that multiple threads can't access it at the same time.

I've added cdvdLock and cdvdUnlock functions for this purpose. Not the cleanest, but DoCDVDopen usually isn't the first CDVD function a thread calls (if it does at all), so I think this is okay as a temporary measure.

### Rationale behind Changes
Fixes #13462 and some other related issues (e.g. trying to refresh the game list and verifying a game at the same time).

Hopefully this will just be temporary and eventually we can make CDVD not rely on so much global state.

Previously the only attempts to prevent race conditions were some half-hearted if statements. I think this is a better fix than what is currently on #13463 and I want to get this sorted sooner than later.

### Suggested Testing Steps
Test starting/shutting down the VM, refreshing the game list, and verifying the hashes of ISO files, all at the same time and in different orders.

### Did you use AI to help find, test, or implement this issue or feature?
No.
