### PR TITLE
GameDB: Ore no Shita de Agake fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -61582,8 +61582,11 @@ SLPS-25795:
 SLPS-25796:
   name: "俺の下でAGAKE"
   name-sort: "おれのしたであがけ"
-  name-en: "Ore no Shite Agake"
+  name-en: "Ore no Shita de Agake"
   region: "NTSC-J"
+  gsHWFixes:
+    gpuTargetCLUT: 1 # Fixes incorrect rendering and some missing text.
+    cpuCLUTRender: 1 # Fixes the rest of the incorrect rendering and missing text.
 SLPS-25797:
   name: "一騎当千 Shining Dragon [限定爆裂パック]"
   name-sort: "いっきとうせん Shining Dragon [げんていばくれつぱっく]"


### PR DESCRIPTION
### Description of Changes
Fixes the absolute broken mess that is this game by using CPU CLUT and GPU CLUT.

Fixes #13506 

### Rationale behind Changes
The game is broken without these and totally unplayable.

### Suggested Testing Steps
CI Passes.

### Did you use AI to help find, test, or implement this issue or feature?
No
