### PR TITLE
MacOS: Patch Tahoe unclickable buttons

### DIFF
--- a/.github/workflows/scripts/macos/build-dependencies.sh
+++ b/.github/workflows/scripts/macos/build-dependencies.sh
@@ -237,6 +237,9 @@ cd "qtbase-everywhere-src-$QT"
 # Patch Qt to support macOS 11
 patch -p1 < "$SCRIPTDIR/qt-macos11compat.patch"
 
+# Patch Qt to fix a bug with message boxes on Tahoe
+patch -p1 < "$SCRIPTDIR/clickbutton.patch"
+
 # since we don't have a direct reference to QtSvg, it doesn't deployed directly from the main binary
 # (only indirectly from iconengines), and the libqsvg.dylib imageformat plugin does not get deployed.
 # We could run macdeployqt twice, but that's even more janky than patching it.

--- a/.github/workflows/scripts/macos/clickbutton.patch
+++ b/.github/workflows/scripts/macos/clickbutton.patch
@@ -1,0 +1,16 @@
+--- a/src/plugins/platforms/cocoa/qcocoamessagedialog.mm
++++ b/src/plugins/platforms/cocoa/qcocoamessagedialog.mm
+@@ -88,6 +88,11 @@ bool QCocoaMessageDialog::show(Qt::WindowModality windowModality)
+         qCWarning(lcQpaDialogs, "Cannot run window modal dialog without parent window");
+         return false;
+     }
++
++    // Tahoe has issues with window-modal alert buttons not responding to mouse
++    if (windowModality == Qt::WindowModal
++        && QOperatingSystemVersion::current() >= QOperatingSystemVersion::MacOSTahoe)
++        return false;
+
+     // And without options we don't know what to show
+     if (!options())
+
+# Source https://codereview.qt-project.org/c/qt/qtbase/+/689796


### PR DESCRIPTION
### Description of Changes
Fixes certain message box buttons being unclickable on MacOS 26 Tahoe due to a Qt bug.

### Rationale behind Changes
An OS update breaking our buttons is kinda bad and should be fixed.

### Suggested Testing Steps
Test to see if message box buttons can now be clicked using your mouse.

### Did you use AI to help find, test, or implement this issue or feature?
No
