### PR TITLE
GS/SW: Mask color gradients to prevent incorrect clamping.

### DIFF
--- a/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
@@ -323,10 +323,11 @@ void GSDrawScanline::CSetupPrim(const GSVertexSW* vertex, const u16* index, cons
 	{
 		if (sel.iip)
 		{
+			constexpr VectorI mask16 = VectorI::cxpr(0xFFFF);
 #if _M_SSE >= 0x501
-			GSVector4i::storel(&local.d8.c, GSVector4i(dscan.c * step_shift).xzyw().ps32());
+			GSVector4i::storel(&local.d8.c, (GSVector4i(dscan.c * step_shift) & GSVector4i::cast(mask16)).xzyw().pu32());
 #else
-			local.d4.c = GSVector4i(dscan.c * step_shift).xzyw().ps32();
+			local.d4.c = (GSVector4i(dscan.c * step_shift) & mask16).xzyw().pu32();
 #endif
 			VectorF dc(dscan.c);
 
@@ -335,8 +336,8 @@ void GSDrawScanline::CSetupPrim(const GSVertexSW* vertex, const u16* index, cons
 
 			for (int i = 0; i < vlen; i++)
 			{
-				VectorI r = VectorI(dr * shift[1 + i]).ps32();
-				VectorI b = VectorI(db * shift[1 + i]).ps32();
+				VectorI r = (VectorI(dr * shift[1 + i]) & mask16).pu32();
+				VectorI b = (VectorI(db * shift[1 + i]) & mask16).pu32();
 
 				local.d[i].rb = r.upl16(b);
 			}
@@ -346,8 +347,8 @@ void GSDrawScanline::CSetupPrim(const GSVertexSW* vertex, const u16* index, cons
 
 			for (int i = 0; i < vlen; i++)
 			{
-				VectorI g = VectorI(dg * shift[1 + i]).ps32();
-				VectorI a = VectorI(da * shift[1 + i]).ps32();
+				VectorI g = (VectorI(dg * shift[1 + i]) & mask16).pu32();
+				VectorI a = (VectorI(da * shift[1 + i]) & mask16).pu32();
 
 				local.d[i].ga = g.upl16(a);
 			}

--- a/pcsx2/GS/Renderers/SW/GSSetupPrimCodeGenerator.arm64.cpp
+++ b/pcsx2/GS/Renderers/SW/GSSetupPrimCodeGenerator.arm64.cpp
@@ -225,13 +225,16 @@ void GSSetupPrimCodeGenerator::Color()
 		// GSVector4 c = dscan.c;
 		armAsm->Ldr(v16, MemOperand(_dscan, offsetof(GSVertexSW, c)));
 
-		// m_local.d4.c = GSVector4i(c * 4.0f).xzyw().ps32();
+		// constexpr VectorI mask16 = VectorI::cxpr(0xFFFF);
+		armAsm->Movi(v17.V4S(), 0xFFFF);
 
+		// local.d4.c = (GSVector4i(dscan.c * step_shift) & mask16).xzyw().pu32();
 		armAsm->Fmul(v2.V4S(), v16.V4S(), v3.V4S());
 		armAsm->Fcvtzs(v2.V4S(), v2.V4S());
+		armAsm->And(v2.V4S(), v17.V4S());
 		armAsm->Rev64(_vscratch.V4S(), v2.V4S());
 		armAsm->Uzp1(v2.V4S(), v2.V4S(), _vscratch.V4S());
-		armAsm->Sqxtn(v2.V4H(), v2.V4S());
+		armAsm->Uqxtn(v2.V4H(), v2.V4S());
 		armAsm->Dup(v2.V2D(), v2.V2D(), 0);
 		armAsm->Str(v2, MemOperand(_locals, offsetof(GSScanlineLocalData, d4.c)));
 
@@ -243,18 +246,20 @@ void GSSetupPrimCodeGenerator::Color()
 
 		for (int i = 0; i < (m_sel.notest ? 1 : 4); i++)
 		{
-			// GSVector4i r = GSVector4i(dr * m_shift[i]).ps32();
+			// VectorI r = (VectorI(dr * shift[1 + i]) & mask16).pu32();
 
 			armAsm->Fmul(v2.V4S(), v0.V4S(), VRegister(4 + i, kFormat4S));
 			armAsm->Fcvtzs(v2.V4S(), v2.V4S());
-			armAsm->Sqxtn(v2.V4H(), v2.V4S());
+			armAsm->And(v2.V4S(), v17.V4S());
+			armAsm->Uqxtn(v2.V4H(), v2.V4S());
 			armAsm->Dup(v2.V2D(), v2.V2D(), 0);
 
-			// GSVector4i b = GSVector4i(db * m_shift[i]).ps32();
+			// VectorI b = (VectorI(db * shift[1 + i]) & mask16).pu32();
 
 			armAsm->Fmul(v3.V4S(), v1.V4S(), VRegister(4 + i, kFormat4S));
 			armAsm->Fcvtzs(v3.V4S(), v3.V4S());
-			armAsm->Sqxtn(v3.V4H(), v3.V4S());
+			armAsm->And(v3.V4S(), v17.V4S());
+			armAsm->Uqxtn(v3.V4H(), v3.V4S());
 			armAsm->Dup(v3.V2D(), v3.V2D(), 0);
 
 			// m_local.d[i].rb = r.upl16(b);
@@ -273,18 +278,20 @@ void GSSetupPrimCodeGenerator::Color()
 
 		for (int i = 0; i < (m_sel.notest ? 1 : 4); i++)
 		{
-			// GSVector4i g = GSVector4i(dg * m_shift[i]).ps32();
+			// VectorI g = (VectorI(dg * shift[1 + i]) & mask16).pu32();
 
 			armAsm->Fmul(v2.V4S(), v0.V4S(), VRegister(4 + i, kFormat4S));
 			armAsm->Fcvtzs(v2.V4S(), v2.V4S());
-			armAsm->Sqxtn(v2.V4H(), v2.V4S());
+			armAsm->And(v2.V4S(), v17.V4S());
+			armAsm->Uqxtn(v2.V4H(), v2.V4S());
 			armAsm->Dup(v2.V2D(), v2.V2D(), 0);
 
-			// GSVector4i a = GSVector4i(da * m_shift[i]).ps32();
+			// VectorI a = (VectorI(da * shift[1 + i]) & mask16).pu32();
 
 			armAsm->Fmul(v3.V4S(), v1.V4S(), VRegister(4 + i, kFormat4S));
 			armAsm->Fcvtzs(v3.V4S(), v3.V4S());
-			armAsm->Sqxtn(v3.V4H(), v3.V4S());
+			armAsm->And(v3.V4S(), v17.V4S());
+			armAsm->Uqxtn(v3.V4H(), v3.V4S());
 			armAsm->Dup(v3.V2D(), v3.V2D(), 0);
 
 			// m_local.d[i].ga = g.upl16(a);


### PR DESCRIPTION
### Description of Changes
Mask color gradients before converting 32->16 bit in prim setup to prevent unwanted clamping.

### Rationale behind Changes
When gradients are too large to fit in the fix point format, rolling them over will still preserve the correct colors in the scanline renderer. This makes sure the roll over happens correctly to prevent graphical bugs.

Fixes https://github.com/PCSX2/pcsx2/issues/6459
Fixes https://github.com/PCSX2/pcsx2/issues/10210.

### Suggested Testing Steps
Testing any games with the SW renderer on both SSE and AVX2 builds.

### Did you use AI to help find, test, or implement this issue or feature?
Looking up aarch64 instructions.

### Credits
Co-authored-by: TellowKrinkle