### PR TITLE
GS/HW: Reintroduce slightly more aggressive region offset for ATN

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -6717,7 +6717,9 @@ __ri void GSRendererHW::EmulateTextureSampler(const GSTextureCache::Target* rt, 
 		// Bigger problem when WH is 1024x1024 and the target is only small.
 		// This "fixes" a lot of the rainbow garbage in games when upscaling (and xenosaga shadows + VP2 forest seem quite happy).
 		// Note that this is done on the original texture scale, during upscales it can mess up otherwise.
-		const GSVector4 region_clamp_offset = GSVector4::cxpr(0.5f, 0.5f, 0.1f, 0.1f);
+		const GSVector4 region_clamp_offset = ((GSConfig.UserHacks_HalfPixelOffset == GSHalfPixelOffset::Native && tex->GetScale() > 1.0f) && !m_channel_shuffle) ? 
+												(GSVector4::cxpr(1.0f, 1.0f, 0.1f, 0.1f) + (GSVector4::cxpr(0.1f, 0.1f, 0.0f, 0.0f) * tex->GetScale())) :
+		                                         GSVector4::cxpr(0.5f, 0.5f, 0.1f, 0.1f);
 
 		const GSVector4 region_clamp = (GSVector4(clamp) + region_clamp_offset) / WH.xyxy();
 		if (wms >= CLAMP_REGION_CLAMP)


### PR DESCRIPTION
### Description of Changes
Brings back the region offset removed in #13491 but just for ATN

### Rationale behind Changes
This offset was originally brought in for Align to Native as it tends to offset by 1 pixel (or so depending on upscale) but it was never completely sufficient for Valkyrie Profile 2 at lower resolutions, a game it was intended for, so this makes it slightly more aggressive, defaulting to 1 pixel offset to fix that issue.

### Suggested Testing Steps
Test games using Align to Native, make sure they look ok.

### Did you use AI to help find, test, or implement this issue or feature?
No

Fixes line in Valkyrie Profile 2.


Dump run not completed, maybe @lightningterror would like to do that.
