### PR TITLE
OSD: More relevant save state timestamps

### DIFF
--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -893,9 +893,20 @@ namespace SaveStateSelectorUI
 	static void RefreshHotkeyLegend();
 	static void Draw();
 	static void ShowSlotOSDMessage();
+	static std::string GetSaveStateTimestampSummary(const std::time_t& modification_time);
 	bool IsOpen();
 
-	static constexpr const char* DATE_TIME_FORMAT = TRANSLATE_NOOP("ImGuiOverlays", "Saved at {0:%H:%M} on {0:%a} {0:%Y/%m/%d}.");
+	static constexpr const char* SAVED_AGO_DAYS_TIME_DATE =
+		TRANSLATE_NOOP("ImGuiOverlays", "Saved {0} days ago at {1:%H:%M} on {1:%a} {1:%Y/%m/%d}");
+	static constexpr const char* SAVED_FUTURE_TIME_DATE =
+		TRANSLATE_NOOP("ImGuiOverlays", "Saved in the future at {0:%H:%M} on {0:%a} {0:%Y/%m/%d}");
+	static constexpr const char* SAVED_AGO_HOURS_MINUTES =
+		TRANSLATE_NOOP("ImGuiOverlays", "Saved {0} hours, {1} minutes ago at {2:%H:%M}");
+	static constexpr const char* SAVED_AGO_MINUTES = TRANSLATE_NOOP("ImGuiOverlays", "Saved {0} minutes ago at {1:%H:%M}");
+	static constexpr const char* SAVED_AGO_SECONDS = TRANSLATE_NOOP("ImGuiOverlays", "Saved {} seconds ago");
+	static constexpr const char* SAVED_AGO_NOW = TRANSLATE_NOOP("ImGuiOverlays", "Saved just now");
+	static constexpr std::time_t ONE_HOUR = 60 * 60; // 3600
+	static constexpr std::time_t TWENTY_FOUR_HOURS = ONE_HOUR * 24; // 86400
 
 	static std::shared_ptr<GSTexture> s_placeholder_texture;
 	static std::string s_load_legend;
@@ -1073,14 +1084,7 @@ void SaveStateSelectorUI::InitializeListEntry(const std::string& serial, u32 crc
 	}
 
 	li->title = fmt::format(TRANSLATE_FS("ImGuiOverlays", "Save Slot {0}"), slot);
-
-	std::tm tm_local = {};
-#ifdef _MSC_VER
-	localtime_s(&tm_local, &sd.ModificationTime);
-#else
-	localtime_r(&sd.ModificationTime, &tm_local);
-#endif
-	li->summary = fmt::format(TRANSLATE_FS("ImGuiOverlays", DATE_TIME_FORMAT), tm_local);
+	li->summary = GetSaveStateTimestampSummary(sd.ModificationTime);
 	li->filename = Path::GetFileName(path);
 
 	u32 screenshot_width, screenshot_height;
@@ -1102,7 +1106,7 @@ void SaveStateSelectorUI::InitializeListEntry(const std::string& serial, u32 crc
 void SaveStateSelectorUI::InitializePlaceholderListEntry(ListEntry* li, std::string path, s32 slot)
 {
 	li->title = fmt::format(TRANSLATE_FS("ImGuiOverlays", "Save Slot {0}"), slot);
-	li->summary = TRANSLATE_STR("ImGuiOverlays", "No save present in this slot.");
+	li->summary = TRANSLATE_STR("ImGuiOverlays", "No save present in this slot");
 	li->filename = Path::GetFileName(path);
 }
 
@@ -1278,26 +1282,15 @@ void SaveStateSelectorUI::ShowSlotOSDMessage()
 	const std::string serial = VMManager::GetDiscSerial();
 	const std::string filename = VMManager::GetSaveStateFileName(serial.c_str(), crc, slot);
 	FILESYSTEM_STAT_DATA sd;
-	std::string date;
-	
-	std::tm tm_local = {};
+	std::string timestamp_summary;
 
 	if (!filename.empty() && FileSystem::StatFile(filename.c_str(), &sd))
-	{
-#ifdef _MSC_VER
-		localtime_s(&tm_local, &sd.ModificationTime);
-#else
-		localtime_r(&sd.ModificationTime, &tm_local);
-#endif
-		date = fmt::format(TRANSLATE_FS("ImGuiOverlays", DATE_TIME_FORMAT), tm_local);
-	}
+		timestamp_summary = GetSaveStateTimestampSummary(sd.ModificationTime);
 	else
-	{
-		date = TRANSLATE_STR("ImGuiOverlays", "no save yet");
-	}
+		timestamp_summary = TRANSLATE_STR("ImGuiOverlays", "no save yet");
 
 	Host::AddIconOSDMessage("ShowSlotOSDMessage", ICON_FA_MAGNIFYING_GLASS,
-		fmt::format(TRANSLATE_FS("Hotkeys", "Save slot {0} selected ({1})."), slot, date),
+		fmt::format(TRANSLATE_FS("Hotkeys", "Save slot {0} selected ({1})."), slot, timestamp_summary),
 		Host::OSD_QUICK_DURATION);
 }
 
@@ -1316,4 +1309,48 @@ void ImGuiManager::RenderOverlays()
 	DrawInputsOverlay(scale, margin, spacing);
 	if (SaveStateSelectorUI::s_open)
 		SaveStateSelectorUI::Draw();
+}
+
+std::string SaveStateSelectorUI::GetSaveStateTimestampSummary(const std::time_t& modification_time)
+{
+
+	std::tm tm_modification_local = {};
+#ifdef _MSC_VER
+	localtime_s(&tm_modification_local, &modification_time);
+#else
+	localtime_r(&modification_time, &tm_modification_local);
+#endif
+
+	const std::time_t current_time = std::time(nullptr);
+	const std::time_t time_since_save = current_time - std::mktime(&tm_modification_local);
+
+	if (time_since_save >= TWENTY_FOUR_HOURS)
+	{
+		return fmt::format(TRANSLATE_FS("ImGuiOverlays", SAVED_AGO_DAYS_TIME_DATE),
+			time_since_save / TWENTY_FOUR_HOURS, tm_modification_local);
+	}
+	else if (time_since_save >= ONE_HOUR)
+	{
+		return fmt::format(TRANSLATE_FS("ImGuiOverlays", SAVED_AGO_HOURS_MINUTES),
+			time_since_save / ONE_HOUR, (time_since_save / 60) % 60, tm_modification_local);
+	}
+	else if (time_since_save >= 60)
+	{
+		return fmt::format(TRANSLATE_FS("ImGuiOverlays", SAVED_AGO_MINUTES),
+			time_since_save / 60, tm_modification_local);
+	}
+	else if (time_since_save >= 5)
+	{
+		return fmt::format(TRANSLATE_FS("ImGuiOverlays", SAVED_AGO_SECONDS),
+			time_since_save);
+	}
+	else if (time_since_save >= 0)
+	{
+		return TRANSLATE_STR("ImGuiOverlays", SAVED_AGO_NOW);
+	}
+	else
+	{
+		return fmt::format(TRANSLATE_FS("ImGuiOverlays", SAVED_FUTURE_TIME_DATE),
+			tm_modification_local);
+	}
 }


### PR DESCRIPTION
### Description of Changes
Along the lines of #13478, changes the timestamp format shown in OSD messages and on the save state selector UI to be adaptive to information the user plausibly wants to know. Also resolves an issue where we accidentally had two periods ending the OSD message: `.).`

NOTE: Plural strings are handled by translations, so in testing this PR, you'll see "1 days", "1 hours", and "1 minutes". This is normal and expected behavior and will be resolved if/after the PR is merged.

NOTE 2: This intentionally uses integer division, so flooring is expected, normal behavior.

This is what every save state timestamp format looked like before:
<img width="380" height="42" alt="Shows saved at time on date" src="https://github.com/user-attachments/assets/fa4aa8f8-74a0-43db-a255-b44b983583fc" />

Now:
* If saved more than 24 hours ago, keep the same basic structure as before but also state the number of days ago.
  * <img width="447" height="42" alt="Shows days, time, and date" src="https://github.com/user-attachments/assets/e6730aff-6938-4841-8593-16e3b5a6adf6" />
* If saved more than one hour ago, report both the hours and minutes since plus the time it was taken at.
  * <img width="396" height="37" alt="Shows hour, minutes, and time" src="https://github.com/user-attachments/assets/3dad88fd-ef3c-4c8e-9eb1-e316fc790ffc" />
* If saved one minute ago or more, report the minutes since plus the time it was taken at.
  * <img width="347" height="38" alt="Shows minutes and time" src="https://github.com/user-attachments/assets/6941a271-21ca-4f4e-b8f8-dc823d33a77b" />
* If saved five seconds ago or more, report the number of seconds since the save state was taken.
  * <img width="313" height="49" alt="Shows seconds" src="https://github.com/user-attachments/assets/74d76a07-36a5-463b-8b00-e7b1278124bc" />
* Otherwise, they basically just saved now.
  * <img width="274" height="38" alt="Reads: Saved just now" src="https://github.com/user-attachments/assets/c286ab5a-25b9-4f56-9aa0-ba0c9e1a7feb" />


<img width="596" height="431" alt="F2 UI menu showing multiple states" src="https://github.com/user-attachments/assets/32e91f7c-9b95-4f38-872d-b76208ec3d2a" />

### Rationale behind Changes
* Uses the same function for selector UI and OSD to avoid discrepancies.
* Fixes a typo in the OSD message.
* Hopefully makes the information more relevant generally.
  * Someone who saved to the slot 38 seconds ago doesn't need to know the time, let alone the date.
  * Giving the number of days for longer times makes it more readily parsed.
    * For example, "2 days ago" versus parsing YMD and figuring out where that is relative to you.
      * But of course you still have YMD if that helps.
    * For exceptionally old states, this number of days could be large.
      * I see that as neutral at worst and positive at best.
  * If the user saved in the last 24 hours, hours, minutes, and the time are relevant.
    * But there's no reason they need a YMD string clogging up the UI.
  * "Now" to me is more appropriate than something like "3 seconds ago".
* Ideally closes #13478.

### Suggested Testing Steps
* Make sure the messages are free of typos.
* Make sure the logic described above works.

### Did you use AI to help find, test, or implement this issue or feature?
No.
