### PR TITLE
GS/DX11: Do Stencil date one in a single pass if there's a barrier.

### DIFF
--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -3831,8 +3831,12 @@ GSTexture12* GSDevice12::SetupPrimitiveTrackingDATE(GSHWDrawConfig& config, Pipe
 void GSDevice12::RenderHW(GSHWDrawConfig& config)
 {
 	// Destination Alpha Setup
-	const bool stencil_DATE = (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::Stencil ||
-							   config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::StencilOne);
+	const bool stencil_DATE_One = config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::StencilOne;
+	const bool stencil_DATE = (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::Stencil || stencil_DATE_One);
+
+	// TODO: Backport from vk.
+	if (stencil_DATE_One)
+		config.ps.date = 0;
 
 	GSTexture12* colclip_rt = static_cast<GSTexture12*>(g_gs_device->GetColorClipTexture());
 	GSTexture12* draw_rt = static_cast<GSTexture12*>(config.rt);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -7939,7 +7939,8 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 	}
 	else if (DATE_one)
 	{
-		if (features.texture_barrier)
+		const bool multidraw_fb_copy = features.multidraw_fb_copy && (m_conf.require_one_barrier || m_conf.require_full_barrier);
+		if (features.texture_barrier || multidraw_fb_copy)
 		{
 			m_conf.require_one_barrier = true;
 			m_conf.ps.date = 5 + m_cached_ctx.TEST.DATM;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/DX11: Do Stencil date_one in a single pass if there's a barrier.
We currently have a barrier so let's do date_one in a single pass, plus this avoids any issues with copies and stencil issues.
On dx copies are slower so we can only use the optimization if we have barriers already present.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Accuracy, speed, optimizations, less draw calls and renderer passes.

To do1: Make it work on dx12.
To do2: Can be made to work on all renderers with barriers/multidrawfb copy disabled.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Some notable improvements on basic blending:
Overvolume shadows in Dead or Alive 2 Hardcore (NTSC-J)
Draw Calls: -15 [444=>429]
Steambot_Chronicles_SLUS-21344_20230511114115
Draw Calls: -10 [2455=>2445]
Render Passes: -19 [912=>893]
StrawberryShortcake_[SLUS-21497]_d3d11_brokenshadows
Draw Calls: -30 [291=>261]

Note: Increasing the blend level will allow more games to trigger the path (example persona 3)

Smoke test games on dx11 the mentioned games above, smoke test dx12 just in case on max blend.
Smoke test persona 3/4 shadows on max blend as that also hits the path.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.
