### PR TITLE
GS/HW: Re check if RT is written after we know the source alpha.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -7662,6 +7662,21 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 	if ((!IsOpaque() || m_context->ALPHA.IsBlack()) && rt && ((m_conf.colormask.wrgba & 0x7) || (m_texture_shuffle && !m_copy_16bit_to_target_shuffle && !m_same_group_texture_shuffle)))
 	{
 		EmulateBlending(blend_alpha_min, blend_alpha_max, DATE, DATE_PRIMID, DATE_BARRIER, rt, can_scale_rt_alpha, new_scale_rt_alpha);
+
+		// Similar to IsRTWritten(), check if the rt will change.
+		const bool no_rt = (!DATE && !m_conf.colormask.wrgba && !m_channel_shuffle);
+		const bool no_ds = !m_conf.ds ||
+			// Depth will be written through the RT.
+			(!no_rt && m_cached_ctx.FRAME.FBP == m_cached_ctx.ZBUF.ZBP && !PRIM->TME && m_cached_ctx.ZBUF.ZMSK == 0 &&
+				(m_cached_ctx.FRAME.FBMSK & GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].fmsk) == 0 && m_cached_ctx.TEST.ZTE) ||
+			// No color or Z being written.
+			(no_rt && m_cached_ctx.ZBUF.ZMSK != 0);
+
+		if (no_rt && no_ds)
+		{
+			GL_INS("HW: Late draw cancel EmulateBlending().");
+			return;
+		}
 	}
 	else
 	{


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/HW: Re check if RT is written after we know the source alpha.
Re check whenever RT is written after updating the alpha source, this will allow the draw to be better handled where we need to check if rt is present resulting in more accurate behavior. The draw calls reduction is just a bonus from the result.

GS/HW: Also check if blend will update the rt. 
If it doesn't and there is no depth buffer we can abort the draw(s) safely.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Accuracy, optimization, speed.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Some notable differences worth benchmarking:
nfscarbon ['Draw Calls: -1684 [7290=>5606]']
Need for Speed - Most Wanted Black Edition_SLUS-21351_20230424015330 ['Draw Calls: -1222 [5413=>4191]']
Need_for_Speed_-_Undercover_SLUS-21801_20231222095536 ['Draw Calls: -1158 [5265=>4107]']
Need for Speed - ProStreet_SLES-55002_Menu Draw Calls: -1493 [5667=>4174]
Log with list of games with draw reduction:
[vk no rt w.txt](https://github.com/user-attachments/files/23538052/vk.no.rt.w.txt)


Test/benchmark the above games/dumps, check other games.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.
