### PR TITLE
Debugger: Rewrite menu bar layout logic

### DIFF
--- a/pcsx2-qt/Debugger/Docking/DockMenuBar.h
+++ b/pcsx2-qt/Debugger/Docking/DockMenuBar.h
@@ -9,6 +9,7 @@
 #include <QtWidgets/QProxyStyle>
 #include <QtWidgets/QPushButton>
 #include <QtWidgets/QTabBar>
+#include <QtWidgets/QBoxLayout>
 #include <QtWidgets/QWidget>
 
 class DockMenuBarStyle;
@@ -36,8 +37,6 @@ public:
 	void updateBlink();
 	void stopBlink();
 
-	int innerHeight() const;
-
 Q_SIGNALS:
 	void currentLayoutChanged(DockLayout::Index layout_index);
 	void newButtonClicked();
@@ -54,6 +53,7 @@ private:
 
 	QWidget* m_original_menu_bar;
 
+	QVBoxLayout* m_layout_switcher_layout;
 	QTabBar* m_layout_switcher;
 	QMetaObject::Connection m_tab_connection;
 	int m_plus_tab_index = -1;
@@ -70,8 +70,7 @@ private:
 	DockMenuBarStyle* m_style = nullptr;
 };
 
-// Fixes some theming issues relating to the menu bar, the layout switcher and
-// the layout locked/unlocked toggle button.
+// Fixes some theming issues relating to the menu bar and the layout switcher.
 class DockMenuBarStyle : public QProxyStyle
 {
 	Q_OBJECT
@@ -83,11 +82,11 @@ public:
 		ControlElement element,
 		const QStyleOption* option,
 		QPainter* painter,
-		const QWidget* widget = nullptr) const override;
+		const QWidget* widget) const override;
 
 	QSize sizeFromContents(
 		QStyle::ContentsType type,
 		const QStyleOption* option,
 		const QSize& contents_size,
-		const QWidget* widget = nullptr) const override;
+		const QWidget* widget) const override;
 };


### PR DESCRIPTION
### Description of Changes
Rewrites the layout logic for the menu bar in the debugger, removes most layout hacks.

### Rationale behind Changes
This is how I should have done it originally. Fixes #13523, which was a regression from #13494.

### Suggested Testing Steps
- Test with global menus enabled in your OS.
- Test with different themes, including the Windows and macOS platform themes.

I can't test on macOS so it would nice if someone could show me how it looks with the native theme.

### Did you use AI to help find, test, or implement this issue or feature?
No.
