### PR TITLE
EyeToy: Check for calloc success before using data

### DIFF
--- a/pcsx2/GS/GSLzma.cpp
+++ b/pcsx2/GS/GSLzma.cpp
@@ -106,8 +106,7 @@ bool GSDumpFile::ReadFile(Error* error)
 				return false;
 			}
 
-			if (header.serial_size > 0)
-				m_serial.assign(reinterpret_cast<const char*>(m_state_data.data()) + header.serial_offset, header.serial_size);
+			m_serial.assign(reinterpret_cast<const char*>(m_state_data.data()) + header.serial_offset, header.serial_size);
 		}
 
 		// Read the real state data


### PR DESCRIPTION
### Description of Changes
* In `cam-windows.cpp`, checks three calls to `calloc` to make sure they were successful.
* Makes the `calloc` size a `const size_t` instead of an `int`.
* Adds a prefix before error messages so we immediately know where they came from.
* Also removes a redundant nested conditional check in `GSLzma.cpp`.

I feel personally compelled to, at some point, revisit this file. It's kind of a mess.

### Rationale behind Changes
I :heart: memory safety. :crab: 

### Suggested Testing Steps
I can't think of a way to artificially induce a `calloc` failure, so, uhh...

### Did you use AI to help find, test, or implement this issue or feature?
No. Used Cppcheck to find unsafe `calloc` usage and `GSLzma.cpp` redundancy.