### PR TITLE
Qt: Prevent entering/exiting fullscreen while the VM is locked

### DIFF
--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -69,6 +69,7 @@ public:
 		friend MainWindow;
 
 		QWidget* m_dialog_parent;
+		bool m_has_lock;
 		bool m_was_paused;
 		bool m_was_fullscreen;
 	};

--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -290,4 +290,10 @@ namespace QtHost
 
 	/// Compare strings in the locale of the current UI language
 	int LocaleSensitiveCompare(QStringView lhs, QStringView rhs);
+
+	/// Determines whether or not requests to enter/exit fullscreen mode should
+	/// be ignored. This is a hack so that we don't destroy a dialog box while
+	/// inside its exec function, which would cause a crash.
+	void LockVMWithDialog();
+	void UnlockVMWithDialog();
 } // namespace QtHost


### PR DESCRIPTION
### Description of Changes
Add an atomic counter storing the number of VMLock objects in existence, and refuse to enter/exit fullscreen if the counter is greater than zero.

### Rationale behind Changes

Don't destroy people's memory cards when the hotkey to enter/exit fullscreen is pressed while the memory card busy dialog is shown.

This papers over #13450 with a hack fix. To fix this properly I think we'd need to make these dialogs asynchronous, which would volve a rewrite of a lot of the UI code, and I'm not sure if we want to do that so close to a feature freeze (or maybe we can find another solution...). In addition, this gives us more time to think about what to do with #13512 (currently the hardcore mode prompt uses a synchronous dialog).

There are definitely cases this isn't addressing, but I don't want to play whack-a-mole. So we should leave the issue open for now, and just fix the one that's likely to cause harm.

### Suggested Testing Steps
- Make sure any memory cards you care about are removed.
- Insert a sacrificial memory card.
- Bind a hotkey to enter/exit fullscreen mode with a controller input.
- Launch a game.
- Try to save the game.
- While saving, try to shutdown the VM.
- While the memory card busy prompt is shown, trigger the hotkey you just bound.
- On master, PCSX2 will crash. With this PR, nothing will happen.
- Remember to remove the hotkey again, just in case you're testing a build without this fix, and run into this yourself (right-click on the button for it).

### Did you use AI to help find, test, or implement this issue or feature?
No.
