### PR TITLE
VMManager: Fix access of variable after std::move()

### DIFF
--- a/pcsx2/GS/GSLzma.cpp
+++ b/pcsx2/GS/GSLzma.cpp
@@ -106,8 +106,7 @@ bool GSDumpFile::ReadFile(Error* error)
 				return false;
 			}
 
-			if (header.serial_size > 0)
-				m_serial.assign(reinterpret_cast<const char*>(m_state_data.data()) + header.serial_offset, header.serial_size);
+			m_serial.assign(reinterpret_cast<const char*>(m_state_data.data()) + header.serial_offset, header.serial_size);
 		}
 
 		// Read the real state data

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1763,14 +1763,14 @@ bool SaveStateBase::vmFreeze()
 		{
 			if (s_elf_path.empty())
 			{
-				// Shouldn't have executed a non-existant ELF.. unless you load state created from a deleted ELF override I guess.
+				// Shouldn't have executed a non-existent ELF... unless you load state created from a deleted ELF override I guess.
 				if (s_elf_executed)
-					Console.Error("Somehow executed a non-existant ELF");
+					Console.Error("Somehow executed a non-existent ELF");
 				VMManager::ClearELFInfo();
 			}
 			else
 			{
-				VMManager::UpdateELFInfo(std::move(s_elf_path));
+				VMManager::UpdateELFInfo(s_elf_path);
 			}
 		}
 


### PR DESCRIPTION
### Description of Changes
* Fixes a comparison of a string's value (`s_elf_path != prev_elf`) after we've already moved it.
  * Simply removes the move operation.
* Also removes a redundant nested conditional check in `GSLzma.cpp`.

### Rationale behind Changes
* The value of a variable after a `std::move()` and before reassignment is considered unspecified and should not be used.
* The check is nested inside of an identical conditional.
  * The value never changes, nor can it change since it's scoped inside the conditional `if (m_crc == 0xFFFFFFFFu)`.

### Suggested Testing Steps
I honestly don't know.

### Did you use AI to help find, test, or implement this issue or feature?
No. Used Cppcheck to find access after move and the redundant conditional.