### PR TITLE
GS/HW: Enable barrier date on alpha masked blend case.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5760,8 +5760,7 @@ void GSRendererHW::EmulateBlending(int rt_alpha_min, int rt_alpha_max, const boo
 	// Replace Ad with As, blend flags will be used from As since we are chaging the blend_index value.
 	// Must be done before index calculation, after blending equation optimizations
 	const bool blend_ad = m_conf.ps.blend_c == 1;
-	const bool alpha_mask = (m_cached_ctx.FRAME.FBMSK & 0xFF000000) == 0xFF000000;
-	bool blend_ad_alpha_masked = blend_ad && alpha_mask;
+	bool blend_ad_alpha_masked = blend_ad && !m_conf.colormask.wa;
 	const bool is_basic_blend = GSConfig.AccurateBlendingUnit != AccBlendLevel::Minimum;
 	if (blend_ad_alpha_masked && (((is_basic_blend || (COLCLAMP.CLAMP == 0)) && (features.texture_barrier || features.multidraw_fb_copy))
 		|| ((GSConfig.AccurateBlendingUnit >= AccBlendLevel::Medium) || m_conf.require_one_barrier)))
@@ -5770,6 +5769,9 @@ void GSRendererHW::EmulateBlending(int rt_alpha_min, int rt_alpha_max, const boo
 		m_conf.ps.a_masked = 1;
 		m_conf.ps.blend_c = 0;
 		m_conf.require_one_barrier |= true;
+
+		// Alpha write is masked, by default this is enabled on vk/gl but not on dx11/12 as copies are slow so we can enable it now since rt alpha is read.
+		DATE_BARRIER = DATE;
 	}
 	else
 		blend_ad_alpha_masked = false;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/HW: Enable barrier date on alpha masked blend case.
If alpha write is masked and barrier/copy enabled then we can switch to DATE_BARRIER since it uses the destination alpha for testing anyway.
By default this is enabled on vk/gl but not on dx11/12 as copies are slow so we can enable it now since rt alpha is read anyway.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Optimization, speed.
Less draw calls and render passes on dx11/12.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
List of affected games with reduced draw calls and render passes:
[log.txt](https://github.com/user-attachments/files/23570053/log.txt)

Some notable reductions on DX11/12:
Enthusia Professional Racing_SLUS-20967_SW
Draw Calls: -198 [816=>618]
Render Passes: -396 [417=>21]

Need_for_Speed_-_Underground_SLES-51967_20240617051110
Draw Calls: -61 [2359=>2298]
Render Passes: -122 [270=>148]

Wild Arms 3 Depth Clamp (21)
Draw Calls: -49 [1055=>1006]
Render Passes: -99 [399=>300]

Dumps to benchmark:
[Dumps_datebr_dx11.zip](https://github.com/user-attachments/files/23570075/Dumps_datebr_dx11.zip)

Test other games listed in the log to make sure nothing broke on dx11/dx12.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.