### PR TITLE
Achievements: Support a custom host

### DIFF
--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -484,6 +484,13 @@ bool Achievements::CreateClient(rc_client_t** client, std::unique_ptr<HTTPDownlo
 
 	rc_client_set_userdata(new_client, http->get());
 
+	const std::string custom_host = Host::GetBaseStringSettingValue("Achievements", "Host", "");
+	if (!custom_host.empty())
+	{
+		Console.WriteLn("Achievements: Using custom host %s", custom_host.c_str());
+		rc_client_set_host(new_client, custom_host.c_str());
+	}
+
 	*client = new_client;
 	return true;
 }


### PR DESCRIPTION
### Description of Changes
This PR adds support for a `Host` INI setting in the `Achievements` scope, eg:
```
[Achievements]
Host = http://localhost:64000
```
When a value for `Host` is given, `rc_client_set_host()` is called during achievement client creation.

### Rationale behind Changes
I am an admin and engineer over at RetroAchievements. I am trying to test some changes we made in rcheevos v12 on my local server instance.

### Suggested Testing Steps
When no `Host` value is given, you should see the normal behavior (hitting prod @ https://retroachievements.org).
Setting `Host = https://stage.retroachievements.org` should hit our staging environment.

### Did you use AI to help find, test, or implement this issue or feature?
No.