### PR TITLE
Debugger: Fix some infinite loops

### DIFF
--- a/pcsx2-qt/Debugger/DisassemblyView.cpp
+++ b/pcsx2-qt/Debugger/DisassemblyView.cpp
@@ -424,7 +424,7 @@ void DisassemblyView::paintEvent(QPaintEvent* event)
 	bool alternate = m_visibleStart % 8;
 
 	// Draw visible disassembly rows
-	for (u32 i = 0; i <= m_visibleRows; i++)
+	for (u32 i = 0; i < m_visibleRows + 1; i++)
 	{
 		// Address of instruction being displayed on row
 		const u32 rowAddress = (i * 4) + m_visibleStart;
@@ -977,18 +977,18 @@ QColor DisassemblyView::GetAddressFunctionColor(u32 address)
 QString DisassemblyView::FetchSelectionInfo(SelectionInfo selInfo)
 {
 	QString infoBlock;
-	for (u32 i = m_selectedAddressStart; i <= m_selectedAddressEnd; i += 4)
+	for (u64 i = m_selectedAddressStart; i <= m_selectedAddressEnd; i += 4)
 	{
 		if (i != m_selectedAddressStart)
 			infoBlock += '\n';
 		if (selInfo == SelectionInfo::ADDRESS)
 		{
-			infoBlock += FilledQStringFromValue(i, 16);
+			infoBlock += FilledQStringFromValue(static_cast<u32>(i), 16);
 		}
 		else if (selInfo == SelectionInfo::INSTRUCTIONTEXT)
 		{
 			DisassemblyLineInfo line;
-			m_disassemblyManager.getLine(i, true, line);
+			m_disassemblyManager.getLine(static_cast<u32>(i), true, line);
 			infoBlock += QString("%1 %2").arg(line.name.c_str()).arg(line.params.c_str());
 		}
 		else // INSTRUCTIONHEX
@@ -1075,9 +1075,9 @@ void DisassemblyView::setInstructions(u32 start, u32 end, u32 value)
 
 bool DisassemblyView::AddressCanRestore(u32 start, u32 end)
 {
-	for (u32 i = start; i <= end; i += 4)
+	for (u64 i = start; i <= end; i += 4)
 	{
-		if (this->m_nopedInstructions.find(i) != this->m_nopedInstructions.end())
+		if (this->m_nopedInstructions.find(static_cast<u32>(i)) != this->m_nopedInstructions.end())
 		{
 			return true;
 		}

--- a/pcsx2/DebugTools/MIPSAnalyst.cpp
+++ b/pcsx2/DebugTools/MIPSAnalyst.cpp
@@ -186,7 +186,9 @@ namespace MIPSAnalyst
 		bool suspectedNoReturn = false;
 
 		u32 addr;
-		for (addr = startAddr; addr <= endAddr; addr += 4) {
+		for (u64 i = startAddr; i <= endAddr; i += 4) {
+			addr = static_cast<u32>(i);
+
 			// Use pre-existing symbol map info if available. May be more reliable.
 			ccc::FunctionHandle existing_symbol_handle = database.functions.first_handle_from_starting_address(addr);
 			const ccc::Function* existing_symbol = database.functions.symbol_from_handle(existing_symbol_handle);


### PR DESCRIPTION
### Description of Changes
Fix some infinite loops.

### Rationale behind Changes
The infinite loops are an unintended consequence of a phenomenon known as integer overflow.

### Suggested Testing Steps
- Launch a game.
- Open the debugger.
- In the disassembler, goto address 0xfffffffc with the G key.
- Select the line for address 0xfffffffc.
- Try to open the context menu.
- On master, PCSX2 will freeze. With the PR, no freeze.

### Did you use AI to help find, test, or implement this issue or feature?
No.
