### PR TITLE
Qt: Don't detach surface from container when deleting the surface

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -2498,9 +2498,6 @@ void MainWindow::destroyDisplayWidget(bool show_game_list)
 	if (!isRenderingFullscreen() && !isRenderingToMain())
 		saveDisplayWindowGeometryToConfig();
 
-	// Detatch display surface from container.
-	m_display_surface->setParent(nullptr);
-
 	if (isRenderingToMain())
 	{
 		pxAssertRel(m_ui.mainContainer->indexOf(m_display_container) == 1, "Display widget in stack");
@@ -2512,17 +2509,12 @@ void MainWindow::destroyDisplayWidget(bool show_game_list)
 		}
 	}
 
-	if (m_display_surface)
-	{
-		m_display_surface->destroy();
-		m_display_surface = nullptr;
-	}
-
-	if (m_display_container)
-	{
-		m_display_container->deleteLater();
-		m_display_container = nullptr;
-	}
+	// displau surface is always in a container
+	pxAssert(m_display_container != nullptr);
+	m_display_container->deleteLater();
+	m_display_container = nullptr;
+	// m_display_surface will be destroyed by the container's dtor
+	m_display_surface = nullptr;
 
 	updateDisplayRelatedActions(false, false, false);
 }


### PR DESCRIPTION
### Description of Changes
Don't detatch the child window when disposing of both.
Instead, as the container takes ownership of the child window, let the container's destructor handle the display surface.

### Rationale behind Changes
Fixes the issue of an empty window being shown on the taskbar (This might have been a Windows only issue)

### Suggested Testing Steps
Enter and exit full-screen and see if that still works (all platforms)
Shutdown the emulator and see if any extra windows are shown on the taskbar

Exit emulation while full-screened _**without**_ using the pause menu and check that pcsx2 does exit (that is, all windows close & pcsx2 does not appear in task manager (or equivalent)).

### Did you use AI to help find, test, or implement this issue or feature?
No
