### PR TITLE
Qt: Handle display surface Drag & Drop events

### DIFF
--- a/pcsx2-qt/DisplayWidget.cpp
+++ b/pcsx2-qt/DisplayWidget.cpp
@@ -365,6 +365,16 @@ bool DisplaySurface::event(QEvent* event)
 			return true;
 		}
 
+		case QEvent::DragEnter:
+			QWindow::event(event);
+			emit dragEnterEvent(static_cast<QDragEnterEvent*>(event));
+			return event->isAccepted();
+
+		case QEvent::Drop:
+			QWindow::event(event);
+			emit dropEvent(static_cast<QDropEvent*>(event));
+			return event->isAccepted();
+
 		case QEvent::Move:
 		{
 			updateCenterPos();

--- a/pcsx2-qt/DisplayWidget.h
+++ b/pcsx2-qt/DisplayWidget.h
@@ -3,6 +3,7 @@
 
 #pragma once
 #include "common/WindowInfo.h"
+#include <QtGui/QDragMoveEvent>
 #include <QtGui/QWindow>
 #include <optional>
 #include <vector>
@@ -31,6 +32,9 @@ public:
 Q_SIGNALS:
 	void windowResizedEvent(int width, int height, float scale);
 	void windowRestoredEvent();
+
+	void dragEnterEvent(QDragEnterEvent* event);
+	void dropEvent(QDropEvent* event);
 
 protected:
 	void handleCloseEvent(QCloseEvent* event);

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -2441,6 +2441,10 @@ void MainWindow::createDisplayWidget(bool fullscreen, bool render_to_main)
 		m_ui.mainContainer->setCurrentIndex(1);
 	}
 
+	// Attatch drag and drop signals
+	connect(m_display_surface, &DisplaySurface::dragEnterEvent, this, &MainWindow::dragEnterEvent);
+	connect(m_display_surface, &DisplaySurface::dropEvent, this, &MainWindow::dropEvent);
+
 	updateDisplayRelatedActions(true, render_to_main, fullscreen);
 
 	// We need the surface visible.


### PR DESCRIPTION
### Description of Changes
Add handling of Drag & drop events in DisplaySurface

### Rationale behind Changes
The QWindowContainer forwards drag events regardless of if the child window supports them
Supporting them also allows you to drag onto the render to separate window.

### Suggested Testing Steps
Test https://github.com/PCSX2/pcsx2/pull/13466#issuecomment-3540469196

### Did you use AI to help find, test, or implement this issue or feature?
No
