### PR TITLE
GSRunner: Use correct config name to disable shader cache.

### DIFF
--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -726,7 +726,7 @@ bool GSRunner::ParseCommandLineArgs(int argc, char* argv[], VMBootParameters& pa
 			else if (CHECK_ARG("-noshadercache"))
 			{
 				Console.WriteLn("Disabling shader cache");
-				s_settings_interface.SetBoolValue("EmuCore/GS", "disable_shader_cache", true);
+				s_settings_interface.SetBoolValue("EmuCore/GS", "DisableShaderCache", true);
 				continue;
 			}
 			else if (CHECK_ARG("-window"))


### PR DESCRIPTION
### Description of Changes
Change the name of the the setting to disable the shader cache in the GS runner.

### Rationale behind Changes
Allow disabling the shader cache from the GS runner command line.

### Suggested Testing Steps
Check Config.h for the correct spelling of the DisableShaderCache setting.

### Did you use AI to help find, test, or implement this issue or feature?
No.
