### PR TITLE
GameListWidget: Overhaul serialization of table header state

### DIFF
--- a/pcsx2-qt/GameList/GameListWidget.h
+++ b/pcsx2-qt/GameList/GameListWidget.h
@@ -84,6 +84,7 @@ private Q_SLOTS:
 	void onListViewItemActivated(const QModelIndex& index);
 	void onListViewContextMenuRequested(const QPoint& point);
 	void onCoverScaleChanged();
+	void onTableHeaderStateChanged();
 
 public Q_SLOTS:
 	void showGameList();
@@ -101,11 +102,10 @@ protected:
 	bool event(QEvent* event) override;
 
 private:
-	void loadTableViewColumnVisibilitySettings();
-	void saveTableViewColumnVisibilitySettings();
-	void saveTableViewColumnVisibilitySettings(int column);
-	void loadTableViewColumnSortSettings();
-	void saveTableViewColumnSortSettings(const int sort_column, const Qt::SortOrder sort_order);
+	void loadTableHeaderState();
+	void applyTableHeaderDefaults();
+	void resetTableHeaderToDefault();
+	void saveSortSettings(int column, Qt::SortOrder sort_order);
 	void listZoom(float delta);
 	void updateToolbar();
 


### PR DESCRIPTION
### Description of Changes
* Uses Qt's `saveState()` function for serializing the game list header state.
  * Header state is how Qt tracks things like column visbility, sort icon (not sort itself), position, and width.
  * Previously, we just had our own settings.
    * This was not extensible at all and would've been spaghetti to add to what we already had.
    * This is much neater.
    * This is marginally more efficient than reading and writing a bunch of position and size settings one at a time.
      * We're also not applying settings each time for no reason.
    * There's no good reason a user needs to go in and change this information manually.
      * And if you're worried about troubleshooting, the spaghetti well offset whatever benefit that conferred.
* Adds support for moving column positions.
  * This new ordering is reflected in the checkbox you get by right-clicking the header.
* Adds support for descending sort for your sorted column when reopening PCSX2.
  * Previously, your column was always sorted in ascending when you reopened PCSX2.
  * That was a bug, as we tracked that information in a setting.
  * This is great for Time Played, Last Played, and Compatibility.
    * An overwhelming majority. of users sorting those would want descending.
* As a byproduct, eliminates an insignificant bug where our keys would have spaces in them (e.g. for "File Title").
* Creates a function to restore the header settings to default.
  * Planned to go on the minibar at some point.
  * Felt like this was enough for right now, as that functionality isn't vital to the PR working well.

Should resolve #13281.

### Suggested Testing Steps
* Make sure the game list still works.
* Make sure the game list saves your state (except width) and restores it next session.
* Make sure that the typical defaults are there the first time you boot it, like File Title and CRC being hidden.
* Make sure that you can change the orders of columns.
* Make sure you can't scroll to the right and see the biblically accurate game grid in the imaginary 11th column.

### What this PR does not fix
Column widths are resizable and are *typically* serialized into the save state. However, our current column headers are a hardcoded trainwreck, and to salvage them would be an entirely separate feat. For some reason, the widths simply aren't reloaded on boot – or they are and are being immediately overwritten by `ResizeColumnsForTableView()`. I can at least tell you that it isn't the `-1` causing these problems. We're also ostensibly using the Interactive header widths.

Either way, I didn't care to troubleshoot this because it's the product of our abject broken handling of column widths, and that's a rabbit hole of its own that I wanted this PR to stay as far away from as possible.

### Screenshots
<img width="1920" height="294" alt="A screenshot of the game list sorted by time played in descending order." src="https://github.com/user-attachments/assets/78646034-3464-4e8c-8d58-fd89b84a2ed8" />
<img width="152" height="289" alt="A screenshot of the right-click menu that lets you hide and show columns; they're arranged according to the previous screenshot" src="https://github.com/user-attachments/assets/440ce308-8767-44c0-815b-e6e53e602f55" />

### Did you use AI to help find, test, or implement this issue or feature?
No, but I think I'm going to need alcoholic inebriation by the time I start touching the column widths.