### PR TITLE
DEV9: Improve DVE Emulation

### DIFF
--- a/pcsx2/Memory.cpp
+++ b/pcsx2/Memory.cpp
@@ -341,6 +341,12 @@ void ba0W16(u32 mem, u16 value)
 		}
 		else if (s_ba[masked_mem] & 0x80) // Start executing
 		{
+			if (s_ba[0x2] == 0x44)
+			{
+				s_ba[0x6] |= 2; // seems to just set 0xBA000006 bit 1 to 2 probably not right but will be enough for now
+				s_ba_command_executing = true;
+				s_ba_error_detected = false;
+			}
 			if (s_ba[0x2] == 0x43) // Write Mode
 			{
 				int size = (s_ba[masked_mem] & 0xF);
@@ -356,7 +362,7 @@ void ba0W16(u32 mem, u16 value)
 				s_ba_command_executing = true;
 				s_ba_error_detected = false;
 			}
-			else if (s_ba[0x2] == 0x42 || s_ba[0x2] == 0x44) // Read Mode
+			else if (s_ba[0x2] == 0x42) // Read Mode
 			{
 				int size = (s_ba[masked_mem] & 0xF);
 


### PR DESCRIPTION
### Description of Changes
Adds a missing DVE syscall (0x44) that fixes crashes with certain PS2's

### Rationale behind Changes
Games crashing is bad

### Suggested Testing Steps
Test if games that use the DVE boot and work properly 

### Did you use AI to help find, test, or implement this issue or feature?
No
