### PR TITLE
Achievements/Qt: Show success feedback on RetroAchievements login

### DIFF
--- a/pcsx2-qt/Settings/AchievementLoginDialog.cpp
+++ b/pcsx2-qt/Settings/AchievementLoginDialog.cpp
@@ -127,7 +127,25 @@ void AchievementLoginDialog::processLoginResult(bool result, const QString& mess
 		}
 	}
 
-	done(0);
+	// Show success messagebox
+	const std::string username = Host::GetBaseStringSettingValue("Achievements", "Username");
+	QMessageBox::information(
+		this, tr("Login Successful"),
+		tr("Successfully logged in to RetroAchievements as %1.").arg(QString::fromStdString(username)));
+	
+	m_ui.status->setText(tr("Successfully logged in as %1.").arg(QString::fromStdString(username)));
+	m_ui.status->setStyleSheet("color: green; font-weight: bold;");
+	
+	disconnect(m_ui.buttonBox, &QDialogButtonBox::accepted, this, &AchievementLoginDialog::loginClicked);
+	
+	m_login->setVisible(false);
+	QPushButton* dismissButton = m_ui.buttonBox->addButton(tr("&Dismiss"), QDialogButtonBox::AcceptRole);
+	dismissButton->setDefault(true);
+	dismissButton->setFocus();
+	
+	connect(dismissButton, &QPushButton::clicked, this, [this]() { done(0); });
+	
+	enableUI(false);
 }
 
 void AchievementLoginDialog::connectUi()


### PR DESCRIPTION
### Description of Changes
Fixes #13528 this adds success feedback when the user logs in

### Rationale behind Changes
Because it was jarring when the login box just closed with zero feedback

### Suggested Testing Steps
Try logging in via the Qt UI to RetroAchievements and it should give you success or failed feedback.

### Did you use AI to help find, test, or implement this issue or feature?
No.