### PR TITLE
Qt: Fix status bar widgets being cut off with longer translations

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -221,15 +221,21 @@ void MainWindow::setupAdditionalUi()
 	m_status_resolution_widget->hide();
 
 	m_status_fps_widget = new QLabel(m_ui.statusBar);
-	m_status_fps_widget->setFixedSize(60, 16);
+	m_status_fps_widget->setFixedHeight(16);
+	m_status_fps_widget->setMinimumWidth(60);
+	m_status_fps_widget->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 	m_status_fps_widget->hide();
 
 	m_status_vps_widget = new QLabel(m_ui.statusBar);
-	m_status_vps_widget->setFixedSize(60, 16);
+	m_status_vps_widget->setFixedHeight(16);
+	m_status_vps_widget->setMinimumWidth(60);
+	m_status_vps_widget->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 	m_status_vps_widget->hide();
 
 	m_status_speed_widget = new QLabel(m_ui.statusBar);
-	m_status_speed_widget->setFixedSize(90, 16);
+	m_status_speed_widget->setFixedHeight(16);
+	m_status_speed_widget->setMinimumWidth(130);
+	m_status_speed_widget->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 	m_status_speed_widget->hide();
 
 	m_settings_toolbar_menu = new QMenu(m_ui.toolBar);


### PR DESCRIPTION
### Description of Changes
Fixes #13452 this fixes the status bar so with longer translations it shouldn't be cut off anymore

### Rationale behind Changes
They were made so people can see their speed without it being cut off in the status bar

### Suggested Testing Steps
Go to German boot to bios and see if you can see the full speed % 

### Did you use AI to help find, test, or implement this issue or feature?
No.
