### PR TITLE
Misc: use std::lock_guard

### DIFF
--- a/pcsx2-qt/Debugger/DebuggerSettingsManager.cpp
+++ b/pcsx2-qt/Debugger/DebuggerSettingsManager.cpp
@@ -153,7 +153,7 @@ void DebuggerSettingsManager::saveGameSettings(QAbstractTableModel* abstractTabl
 	if (path.empty())
 		return;
 
-	const std::lock_guard<std::mutex> lock(writeLock);
+	std::lock_guard<std::mutex> lock(writeLock);
 	QJsonObject loadedSettings = loadGameSettingsJSON();
 	QJsonArray rowsArray;
 	QStringList keys;

--- a/pcsx2/Host.cpp
+++ b/pcsx2/Host.cpp
@@ -71,7 +71,7 @@ std::pair<const char*, u32> Host::LookupTranslationString(const std::string_view
 
 add_string:
 	s_translation_string_mutex.unlock_shared();
-	s_translation_string_mutex.lock();
+	std::lock_guard lock(s_translation_string_mutex);
 
 	if (s_translation_string_cache.empty()) [[unlikely]]
 	{
@@ -110,7 +110,6 @@ add_string:
 
 	ret.first = &s_translation_string_cache[insert_pos];
 	ret.second = static_cast<u32>(len);
-	s_translation_string_mutex.unlock();
 	return ret;
 }
 
@@ -132,10 +131,9 @@ std::string Host::TranslateToString(const std::string_view context, const std::s
 
 void Host::ClearTranslationCache()
 {
-	s_translation_string_mutex.lock();
+	std::lock_guard lock(s_translation_string_mutex);
 	s_translation_string_map.clear();
 	s_translation_string_cache_pos = 0;
-	s_translation_string_mutex.unlock();
 }
 
 void Host::ReportFormattedInfoAsync(const std::string_view title, const char* format, ...)

--- a/pcsx2/USB/usb-eyetoy/cam-linux.cpp
+++ b/pcsx2/USB/usb-eyetoy/cam-linux.cpp
@@ -56,11 +56,10 @@ namespace usb_eyetoy
 
 		static void store_mpeg_frame(const unsigned char* data, const unsigned int len)
 		{
-			mpeg_mutex.lock();
+			std::lock_guard lock(mpeg_mutex);
 			if (len > 0)
 				memcpy(mpeg_buffer.start, data, len);
 			mpeg_buffer.length = len;
-			mpeg_mutex.unlock();
 		}
 
 		static void process_image(const unsigned char* data, int size)
@@ -642,13 +641,12 @@ namespace usb_eyetoy
 
 		int V4L2::GetImage(uint8_t* buf, size_t len)
 		{
-			mpeg_mutex.lock();
+			std::lock_guard lock(mpeg_mutex);
 			int len2 = mpeg_buffer.length;
 			if (len < mpeg_buffer.length)
 				len2 = len;
 			memcpy(buf, mpeg_buffer.start, len2);
 			mpeg_buffer.length = 0;
-			mpeg_mutex.unlock();
 			return len2;
 		};
 

--- a/pcsx2/USB/usb-eyetoy/cam-windows.cpp
+++ b/pcsx2/USB/usb-eyetoy/cam-windows.cpp
@@ -374,11 +374,10 @@ namespace usb_eyetoy
 
 		void store_mpeg_frame(const unsigned char* data, const unsigned int len)
 		{
-			mpeg_mutex.lock();
+			std::lock_guard lock(mpeg_mutex);
 			if (len > 0)
 				memcpy(mpeg_buffer.start, data, len);
 			mpeg_buffer.length = len;
-			mpeg_mutex.unlock();
 		}
 
 		void dshow_callback(unsigned char* data, int len, int bitsperpixel)
@@ -593,13 +592,12 @@ namespace usb_eyetoy
 
 		int DirectShow::GetImage(uint8_t* buf, size_t len)
 		{
-			mpeg_mutex.lock();
+			std::lock_guard lock(mpeg_mutex);
 			int len2 = mpeg_buffer.length;
 			if (static_cast<size_t>(len) < mpeg_buffer.length)
 				len2 = len;
 			memcpy(buf, mpeg_buffer.start, len2);
 			mpeg_buffer.length = 0;
-			mpeg_mutex.unlock();
 			return len2;
 		};
 


### PR DESCRIPTION
### Description of Changes
Use `std::lock_guard` instead of `lock` and `unlock`.

### Rationale behind Changes
Refactoring to improve code quality.

### Suggested Testing Steps
Should not be necessary.

### Did you use AI to help find, test, or implement this issue or feature?
No.
