### PR TITLE
GS/GL: Only issue barriers for framebuffer optimizations if needed.

### DIFF
--- a/pcsx2/GS/Renderers/OpenGL/GLState.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GLState.cpp
@@ -36,6 +36,10 @@ namespace GLState
 
 	GSTextureOGL* rt = nullptr;
 	GSTextureOGL* ds = nullptr;
+
+	bool rt_written;
+	bool ds_written;
+
 	GLuint tex_unit[8];
 	GLuint64 tex_handle[8];
 
@@ -67,6 +71,10 @@ namespace GLState
 
 		rt = nullptr;
 		ds = nullptr;
+
+		rt_written = false;
+		ds_written = false;
+
 		std::fill(std::begin(tex_unit), std::end(tex_unit), 0);
 		std::fill(std::begin(tex_handle), std::end(tex_handle), 0);
 	}

--- a/pcsx2/GS/Renderers/OpenGL/GLState.h
+++ b/pcsx2/GS/Renderers/OpenGL/GLState.h
@@ -40,6 +40,10 @@ namespace GLState
 
 	extern GSTextureOGL* rt; // render target
 	extern GSTextureOGL* ds; // Depth-Stencil
+
+	extern bool rt_written; // Render Target written
+	extern bool ds_written; // Depth Stencil written
+
 	extern GLuint tex_unit[8]; // shader input texture
 	extern GLuint64 tex_handle[8]; // shader input texture
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/GL: Only issue barriers for framebuffer optimizations if needed.

Check if the state changed previous draw/pass and if not then we need to issue a barrier or render pass then to ensure writes.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Big speed gains for gl, optimizations.

Needs https://github.com/PCSX2/pcsx2/pull/13595 merged first then this rebased/updated.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Nothing broken, many games see barrier reductions but I will only list significant ones above 900.

Test the games listed in the log, also test Time Crisis 2 if it's broken or not.
Benchmark the mentioned games with high barrier reductions mentioned below:

```
Ace_Combat_04_-_Shattered_Skies_SLUS-20152_20230214003004
Barriers: -1302 [1306=>4]

Avatar_-_The_Last_Airbender_SLUS-21395_20240428221833
Barriers: -999 [17716=>16717]

EA_Sports_Rugby_2004_SLES-51732_20220817213743
Barriers: -980 [1960=>980]

EoN slowdown
Barriers: -1340 [2664=>1324]

Final Fantasy XII preload frame data texture isses
Barriers: -1144 [2291=>1147]

The Getaway _PAL-M5__SCES-51159
Barriers: -1001 [2002=>1001]

Happy! Happy!! Boarders in Hokkaidou Rusutsu Resort - SHADOWS
Barriers: -911 [1823=>912]

Keroro Gunsou - Mero Mero Battle Royale_SLPS-25399_20230724102648
Barriers: -1530 [3071=>1541]

Need for Speed - Carbon_SLUS-21493_20220727201009
Barriers: -2073 [3769=>1696]

Need_for_Speed_-_Most_Wanted_Black_Edition_SLES-53857_20230808153118
Barriers: -2125 [4250=>2125]

Need for Speed - ProStreet_SLES-55002_Menu
Barriers: -1376 [2119=>743]

Need for Speed - Undercover_SLUS-21801_20230404102430
Barriers: -1064 [1957=>893]

socom slow
Barriers: -1746 [3493=>1747]

Stuntman_SLUS-20250_20230326220301
Barriers: -2026 [4053=>2027]

Transformers_Special_Edition_SLES-52388_20240618185125
Barriers: -2160 [4320=>2160]

WRC_4_SCES-52389_20230329024724
Barriers: -6603 [13473=>6870]
```

Log with all barrier reductions:
[log.txt](https://github.com/user-attachments/files/23665921/log.txt)


### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.
