### PR TITLE
GSCapture: add volume slider and scale recorded audio

### DIFF
--- a/pcsx2-qt/Settings/GraphicsMediaCaptureSettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsMediaCaptureSettingsTab.ui
@@ -191,14 +191,63 @@
              </property>
             </widget>
            </item>
-           <item row="2" column="0" colspan="2">
+           <item row="2" column="0">
+            <widget class="QLabel" name="audioCaptureVolumeLabel">
+             <property name="text">
+              <string>Volume:</string>
+             </property>
+             <property name="buddy">
+              <cstring>audioCaptureVolume</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <layout class="QHBoxLayout" name="audioCaptureVolumeLayout" stretch="1,0">
+             <item>
+              <widget class="QSlider" name="audioCaptureVolume">
+               <property name="orientation">
+                <enum>Qt::Orientation::Horizontal</enum>
+               </property>
+               <property name="minimum">
+                <number>0</number>
+               </property>
+               <property name="maximum">
+                <number>100</number>
+               </property>
+               <property name="value">
+                <number>100</number>
+               </property>
+               <property name="tickPosition">
+                <enum>QSlider::TickPosition::TicksBelow</enum>
+               </property>
+               <property name="tickInterval">
+                <number>25</number>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="audioCaptureVolumeValue">
+               <property name="text">
+                <string>100%</string>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>40</width>
+                 <height>0</height>
+                </size>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item row="3" column="0" colspan="2">
             <widget class="QCheckBox" name="enableAudioCaptureArguments">
              <property name="text">
               <string>Extra Arguments</string>
              </property>
             </widget>
            </item>
-           <item row="3" column="0" colspan="2">
+           <item row="4" column="0" colspan="2">
             <widget class="QLineEdit" name="audioCaptureArguments"/>
            </item>
           </layout>
@@ -401,6 +450,7 @@
   <tabstop>enableAudioCapture</tabstop>
   <tabstop>audioCaptureCodec</tabstop>
   <tabstop>audioCaptureBitrate</tabstop>
+  <tabstop>audioCaptureVolume</tabstop>
   <tabstop>enableAudioCaptureArguments</tabstop>
   <tabstop>audioCaptureArguments</tabstop>
  </tabstops>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -417,6 +417,8 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 		SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_capture.enableAudioCapture, "EmuCore/GS", "EnableAudioCapture", true);
 		SettingWidgetBinder::BindWidgetToIntSetting(
 			sif, m_capture.audioCaptureBitrate, "EmuCore/GS", "AudioCaptureBitrate", Pcsx2Config::GSOptions::DEFAULT_AUDIO_CAPTURE_BITRATE);
+		SettingWidgetBinder::BindWidgetAndLabelToIntSetting(
+			sif, m_capture.audioCaptureVolume, m_capture.audioCaptureVolumeValue, "%", "EmuCore/GS", "AudioCaptureVolume", Pcsx2Config::GSOptions::DEFAULT_AUDIO_CAPTURE_VOLUME);
 		SettingWidgetBinder::BindWidgetToBoolSetting(
 			sif, m_capture.enableAudioCaptureArguments, "EmuCore/GS", "EnableAudioCaptureParameters", false);
 		SettingWidgetBinder::BindWidgetToStringSetting(sif, m_capture.audioCaptureArguments, "EmuCore/GS", "AudioCaptureParameters");
@@ -817,6 +819,10 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 			   "<b>If unsure, leave it on default.<b>"));
 
 		dialog()->registerWidgetHelp(m_capture.audioCaptureBitrate, tr("Audio Bitrate"), tr("192 kbps"), tr("Sets the audio bitrate to be used."));
+
+		dialog()->registerWidgetHelp(
+			m_capture.audioCaptureVolume, tr("Audio Volume"), QStringLiteral("100%"),
+			tr("Sets the volume level for recorded audio. 100% is full volume, lower values reduce the volume."));
 
 		dialog()->registerWidgetHelp(m_capture.enableAudioCaptureArguments, tr("Enable Extra Audio Arguments"), tr("Unchecked"), tr("Allows you to pass arguments to the selected audio codec."));
 

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -711,6 +711,7 @@ struct Pcsx2Config
 		static constexpr int DEFAULT_VIDEO_CAPTURE_WIDTH = 640;
 		static constexpr int DEFAULT_VIDEO_CAPTURE_HEIGHT = 480;
 		static constexpr int DEFAULT_AUDIO_CAPTURE_BITRATE = 192;
+		static constexpr int DEFAULT_AUDIO_CAPTURE_VOLUME = 100;
 		static const char* DEFAULT_CAPTURE_CONTAINER;
 
 		static constexpr int DEFAULT_SHADEBOOST_BRIGHTNESS = 50;
@@ -889,6 +890,7 @@ struct Pcsx2Config
 		int VideoCaptureWidth = DEFAULT_VIDEO_CAPTURE_WIDTH;
 		int VideoCaptureHeight = DEFAULT_VIDEO_CAPTURE_HEIGHT;
 		int AudioCaptureBitrate = DEFAULT_AUDIO_CAPTURE_BITRATE;
+		int AudioCaptureVolume = DEFAULT_AUDIO_CAPTURE_VOLUME;
 
 		std::string Adapter;
 		std::string HWDumpDirectory;

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1076,6 +1076,7 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitfieldEx(VideoCaptureWidth, "VideoCaptureWidth");
 	SettingsWrapBitfieldEx(VideoCaptureHeight, "VideoCaptureHeight");
 	SettingsWrapBitfieldEx(AudioCaptureBitrate, "AudioCaptureBitrate");
+	SettingsWrapBitfieldEx(AudioCaptureVolume, "AudioCaptureVolume");
 
 	SettingsWrapEntry(Adapter);
 	SettingsWrapEntry(HWDumpDirectory);


### PR DESCRIPTION
### Description of Changes
Fixes #12700
- Added an audio capture volume slider
- Made a new AudioCaptureVolume setting stored in GS config, defaulting to 80%.
- Applied the volume multiplier when feeding samples to the FFmpeg encoder

Originally I was going to add `libavfilter` but I couldn't justify adding that library for one feature so that's why I did this the way I did. 
### Rationale behind Changes
Giving users a volume control makes built-in recording behave more like standard capture tools where mic/system levels can be balanced before hitting "Record."

### Suggested Testing Steps
- Start a capture with default settings, then inspect the resulting video to confirm the recorded audio is quieter than before.
- Change the slider to e.g. 50% and 100%, capture again, and confirm the output volume scales accordingly for the video capture

### Did you use AI to help find, test, or implement this issue or feature?
No.