### PR TITLE
Debugger: Fix crash in getEEThreads

### DIFF
--- a/pcsx2-qt/Debugger/ThreadModel.cpp
+++ b/pcsx2-qt/Debugger/ThreadModel.cpp
@@ -13,7 +13,7 @@ ThreadModel::ThreadModel(DebugInterface& cpu, QObject* parent)
 
 int ThreadModel::rowCount(const QModelIndex&) const
 {
-	return m_cpu.GetThreadList().size();
+	return static_cast<int>(m_threads.size());
 }
 
 int ThreadModel::columnCount(const QModelIndex&) const


### PR DESCRIPTION
### Description of Changes
- Add a null pointer check in the getEEThreads function. Also check for a valid VM.
- Make ThreadModel::rowCount return the cached size instead of re-reading the thread list every time.
- Neaten up the code a bit.

### Rationale behind Changes
Fix a crash.

### Suggested Testing Steps
- Set the update interval for the debugger to 10ms (the minimum).
- Reset the game a whole bunch.
- On master, eventually get a crash from dereferencing a null pointer.

### Did you use AI to help find, test, or implement this issue or feature?
No.
