### PR TITLE
GS: Add texture replacement dump/load indicators to OSD

### DIFF
--- a/pcsx2-qt/Settings/GraphicsOnScreenDisplaySettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsOnScreenDisplaySettingsTab.ui
@@ -149,6 +149,13 @@
           </property>
          </widget>
         </item>
+        <item row="6" column="2">
+         <widget class="QCheckBox" name="showTextureReplacements">
+          <property name="text">
+           <string>Show Texture Replacement Status</string>
+          </property>
+         </widget>
+        </item>
         <item row="4" column="0">
          <widget class="QCheckBox" name="showResolution">
           <property name="text">
@@ -391,6 +398,7 @@
   <tabstop>showInputs</tabstop>
   <tabstop>showVideoCapture</tabstop>
   <tabstop>showInputRec</tabstop>
+  <tabstop>showTextureReplacements</tabstop>
   <tabstop>warnAboutUnsafeSettings</tabstop>
  </tabstops>
  <resources/>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -241,6 +241,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_osd.showInputs, "EmuCore/GS", "OsdShowInputs", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_osd.showVideoCapture, "EmuCore/GS", "OsdShowVideoCapture", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_osd.showInputRec, "EmuCore/GS", "OsdShowInputRec", true);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_osd.showTextureReplacements, "EmuCore/GS", "OsdShowTextureReplacements", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_osd.warnAboutUnsafeSettings, "EmuCore", "OsdWarnAboutUnsafeSettings", true);
 
 	//////////////////////////////////////////////////////////////////////////
@@ -768,6 +769,9 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 
 		dialog()->registerWidgetHelp(m_osd.showInputRec, tr("Show Input Recording Status"), tr("Checked"),
 			tr("Shows the status of the currently active input recording in the top-right corner of the display.."));
+
+		dialog()->registerWidgetHelp(m_osd.showTextureReplacements, tr("Show Texture Replacement Status"), tr("Checked"),
+			tr("Shows the status of the number of dumped and loaded texture replacements in the top-right corner of the display."));
 
 		dialog()->registerWidgetHelp(m_osd.warnAboutUnsafeSettings, tr("Warn About Unsafe Settings"), tr("Checked"),
 			tr("Displays warnings when settings are enabled which may break games."));

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -749,6 +749,7 @@ struct Pcsx2Config
 					OsdShowInputs : 1,
 					OsdShowVideoCapture : 1,
 					OsdShowInputRec : 1,
+					OsdShowTextureReplacements : 1,
 					HWSpinGPUForReadbacks : 1,
 					HWSpinCPUForReadbacks : 1,
 					GPUPaletteConversion : 1,

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1134,6 +1134,7 @@ static void HotkeyToggleOSD()
 	GSConfig.OsdShowInputs ^= EmuConfig.GS.OsdShowInputs;
 	GSConfig.OsdShowInputRec ^= EmuConfig.GS.OsdShowInputRec;
 	GSConfig.OsdShowVideoCapture ^= EmuConfig.GS.OsdShowVideoCapture;
+	GSConfig.OsdShowTextureReplacements ^= EmuConfig.GS.OsdShowTextureReplacements;
 
 	GSConfig.OsdMessagesPos =
 		GSConfig.OsdMessagesPos == OsdOverlayPos::None ? EmuConfig.GS.OsdMessagesPos : OsdOverlayPos::None;

--- a/pcsx2/GS/Renderers/HW/GSTextureReplacements.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureReplacements.cpp
@@ -124,6 +124,7 @@ namespace GSTextureReplacements
 
 	/// Textures that have been dumped, to save stat() calls.
 	static std::unordered_set<TextureName> s_dumped_textures;
+	static std::mutex s_dumped_textures_mutex;
 
 	/// Lookup map of texture names to replacements, if they exist.
 	static std::unordered_map<TextureName, std::string> s_replacement_texture_filenames;
@@ -802,10 +803,13 @@ void GSTextureReplacements::DumpTexture(const GSTextureCache::HashCacheKey& hash
 {
 	// check if it's been dumped or replaced already
 	const TextureName name(CreateTextureName(hash, level));
-	if (s_dumped_textures.find(name) != s_dumped_textures.end() || s_replacement_texture_filenames.find(name) != s_replacement_texture_filenames.end())
-		return;
+	{
+		std::unique_lock<std::mutex> lock(s_dumped_textures_mutex);
+		if (s_dumped_textures.find(name) != s_dumped_textures.end() || s_replacement_texture_filenames.find(name) != s_replacement_texture_filenames.end())
+			return;
 
-	s_dumped_textures.insert(name);
+		s_dumped_textures.insert(name);
+	}
 
 	// already exists on disk?
 	std::string filename(GetDumpFilename(name, level));
@@ -842,7 +846,20 @@ void GSTextureReplacements::DumpTexture(const GSTextureCache::HashCacheKey& hash
 
 void GSTextureReplacements::ClearDumpedTextureList()
 {
+	std::unique_lock<std::mutex> lock(s_dumped_textures_mutex);
 	s_dumped_textures.clear();
+}
+
+u32 GSTextureReplacements::GetDumpedTextureCount()
+{
+	std::unique_lock<std::mutex> lock(s_dumped_textures_mutex);
+	return static_cast<u32>(s_dumped_textures.size());
+}
+
+u32 GSTextureReplacements::GetLoadedTextureCount()
+{
+	std::unique_lock<std::mutex> lock(s_replacement_texture_cache_mutex);
+	return static_cast<u32>(s_replacement_texture_cache.size());
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/pcsx2/GS/Renderers/HW/GSTextureReplacements.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureReplacements.h
@@ -47,6 +47,12 @@ namespace GSTextureReplacements
 		GSTextureCache::SourceRegion region, GSLocalMemory& mem, u32 level);
 	void ClearDumpedTextureList();
 
+	/// Get the number of textures that have been dumped.
+	u32 GetDumpedTextureCount();
+
+	/// Get the number of replacement textures that have been loaded/cached.
+	u32 GetLoadedTextureCount();
+
 	/// Loader will take a filename and interpret the format (e.g. DDS, PNG, etc).
 	using ReplacementTextureLoader = bool (*)(const std::string& filename, GSTextureReplacements::ReplacementTexture* tex, bool only_base_image);
 	ReplacementTextureLoader GetLoader(const std::string_view filename);

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -4254,7 +4254,6 @@ void FullscreenUI::DrawInterfaceSettingsPage()
 	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_SLIDERS, "Show Settings"),
 		FSUI_CSTR("Shows the current configuration in the bottom-right corner of the display."),
 		"EmuCore/GS", "OsdShowSettings", false);
-
 	bool show_settings = (bsi->GetBoolValue("EmuCore/GS", "OsdShowSettings", false) == false);
 	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_HAMMER, "Show Patches"),
 		FSUI_CSTR("Shows the amount of currently active patches/cheats on the bottom-right corner of the display."), "EmuCore/GS",
@@ -4268,6 +4267,9 @@ void FullscreenUI::DrawInterfaceSettingsPage()
 	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_KEYBOARD, "Show Input Recording Status"),
 		FSUI_CSTR("Shows the status of the currently active input recording."), "EmuCore/GS",
 		"OsdShowInputRec", true);
+	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_IMAGES, "Show Texture Replacement Status"),
+		FSUI_CSTR("Shows the number of dumped and loaded texture replacements on the OSD."), "EmuCore/GS",
+		"OsdShowTextureReplacements", true);
 	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_TRIANGLE_EXCLAMATION, "Warn About Unsafe Settings"),
 		FSUI_CSTR("Displays warnings when settings are enabled which may break games."), "EmuCore", "WarnAboutUnsafeSettings", true);
 

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -741,6 +741,7 @@ Pcsx2Config::GSOptions::GSOptions()
 	OsdShowInputs = false;
 	OsdShowVideoCapture = true;
 	OsdShowInputRec = true;
+	OsdShowTextureReplacements = true;
 
 	HWDownloadMode = GSHardwareDownloadMode::Enabled;
 	HWSpinGPUForReadbacks = false;
@@ -960,6 +961,7 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitBool(OsdShowHardwareInfo);
 	SettingsWrapBitBool(OsdShowVideoCapture);
 	SettingsWrapBitBool(OsdShowInputRec);
+	SettingsWrapBitBool(OsdShowTextureReplacements);
 
 	SettingsWrapBitBool(HWSpinGPUForReadbacks);
 	SettingsWrapBitBool(HWSpinCPUForReadbacks);


### PR DESCRIPTION
<img width="616" height="307" alt="image" src="https://github.com/user-attachments/assets/c11e4466-1499-48ea-a6f2-6c8e28dd626f" />

### Description of Changes
Adds visual indicators to the OSD showing the number of dumped and loaded texture replacements. The indicator appears in the performance overlay as a single line: [Icon] Dumped: X | [Icon] Replaced: X, 
### Rationale behind Changes
Fixes #12958 no one had a way to see if texture dumping/replacement was active or how many textures were processed. The existing notification only appeared once and didn't show counts.

### Suggested Testing Steps
1. Enable texture dumping:
    - Settings -> Graphics -> Texture Replacement -> Enable "Dump Textures"
2. Settings -> Graphics -> On-Screen Display -> Enable "Show Texture Replacement Status"
    - Start a game and observe the OSD showing "Dumped: X" increasing
3. Enable texture replacement:
    - Place replacement textures in the game's texture directory
    - Settings -> Graphics -> Texture Replacement -> Enable "Load Textures"
    - Start a game and observe the OSD showing "Replaced: X"
4. Test both simultaneously:
    - Enable both dumping and replacement
    - Verify the OSD shows: [Icon] Dumped: X | [Icon] Replaced: X

### Did you use AI to help find, test, or implement this issue or feature?
No.