### PR TITLE
Config: Initialize AchievementsOptions bitset to zero

### DIFF
--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1844,6 +1844,7 @@ bool Pcsx2Config::PadOptions::Port::operator!=(const PadOptions::Port& right) co
 
 Pcsx2Config::AchievementsOptions::AchievementsOptions()
 {
+	bitset = 0;
 	Enabled = false;
 	HardcoreMode = false;
 	EncoreMode = false;


### PR DESCRIPTION
### Description of Changes
Initialize `AchievementsOptions::bitset` to zero.

### Rationale behind Changes
The `Pcsx2Config::AchievementsOptions::operator==` function reads the whole bitset so it shouldn't be uninitialized.

### Suggested Testing Steps
N/A

### Did you use AI to help find, test, or implement this issue or feature?
Only valgrind.
