### PR TITLE
Debugger: Exclude end address when scanning for functions

### DIFF
--- a/pcsx2/DebugTools/MIPSAnalyst.cpp
+++ b/pcsx2/DebugTools/MIPSAnalyst.cpp
@@ -186,9 +186,7 @@ namespace MIPSAnalyst
 		bool suspectedNoReturn = false;
 
 		u32 addr;
-		for (u64 i = startAddr; i <= endAddr; i += 4) {
-			addr = static_cast<u32>(i);
-
+		for (addr = startAddr; addr < endAddr; addr += 4) {
 			// Use pre-existing symbol map info if available. May be more reliable.
 			ccc::FunctionHandle existing_symbol_handle = database.functions.first_handle_from_starting_address(addr);
 			const ccc::Function* existing_symbol = database.functions.symbol_from_handle(existing_symbol_handle);


### PR DESCRIPTION
### Description of Changes
Change the loop condition for the function scanner so it excludes the end address.

### Rationale behind Changes
A previous PR I opened fixed an infinite loop here, but I think this solution makes more sense.

### Suggested Testing Steps
Make sure scanning for functions in the debugger still works.

### Did you use AI to help find, test, or implement this issue or feature?
No.
