### PR TITLE
GameDB: Simple 91/ All Star Fighters fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -26717,6 +26717,8 @@ SLES-54458:
 SLES-54459:
   name: "All-Star Fighters"
   region: "PAL-E"
+  gameFixes:
+    - XGKickHack # Fixes inverted or broken character textures.
 SLES-54460:
   name: "Dragon Sisters"
   region: "PAL-E"
@@ -56605,7 +56607,7 @@ SLPS-20430:
   region: "NTSC-J"
   compat: 5
   gameFixes:
-    - XGKickHack # Fixes cell shade like effect.
+    - XGKickHack # Fixes inverted or broken character textures.
 SLPS-20431:
   name: "SIMPLE2000シリーズ Vol.86 THE 免許取得シミュレーション ～改正道路交通法対応版～"
   name-sort: "しんぷる2000しりーず Vol.  86 THE めんきょしゅとくしみゅれーしょん ～かいせいどうろこうつうほうたいおうばん～"


### PR DESCRIPTION
### Description of Changes
Fixes broken or inverted character textures by adding a missing fix only present on the JP release.

### Rationale behind Changes
The game being broken is bad.

### Suggested Testing Steps
Already tested.

### Did you use AI to help find, test, or implement this issue or feature?
No
