### PR TITLE
GameListWidget: Fix header width bug

### DIFF
--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -256,8 +256,6 @@ void GameListWidget::initialize()
 
 	m_table_view = new QTableView(m_ui.stack);
 	m_table_view->setModel(m_sort_model);
-	m_table_view->setSortingEnabled(true);
-	m_table_view->horizontalHeader()->setSectionsMovable(true);
 	m_table_view->setSelectionMode(QAbstractItemView::SingleSelection);
 	m_table_view->setSelectionBehavior(QAbstractItemView::SelectRows);
 	m_table_view->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -265,8 +263,9 @@ void GameListWidget::initialize()
 	m_table_view->setMouseTracking(true);
 	m_table_view->setShowGrid(false);
 	m_table_view->setCurrentIndex(QModelIndex());
-	m_table_view->horizontalHeader()->setHighlightSections(false);
 	m_table_view->horizontalHeader()->setContextMenuPolicy(Qt::CustomContextMenu);
+	m_table_view->horizontalHeader()->setHighlightSections(false);
+	m_table_view->horizontalHeader()->setSectionsMovable(true);
 	m_table_view->verticalHeader()->hide();
 	m_table_view->setVerticalScrollMode(QAbstractItemView::ScrollMode::ScrollPerPixel);
 
@@ -738,8 +737,8 @@ void GameListWidget::resizeTableViewColumnsToFit()
 	QtUtils::ResizeColumnsForTableView(m_table_view, {
 														 DEFAULT_COLUMN_WIDTHS[GameListModel::Column_Type],
 														 DEFAULT_COLUMN_WIDTHS[GameListModel::Column_Serial],
+														 DEFAULT_COLUMN_WIDTHS[GameListModel::Column_Title],
 														 DEFAULT_COLUMN_WIDTHS[GameListModel::Column_FileTitle],
-														 DEFAULT_COLUMN_WIDTHS[GameListModel::Column_Type],
 														 DEFAULT_COLUMN_WIDTHS[GameListModel::Column_CRC],
 														 DEFAULT_COLUMN_WIDTHS[GameListModel::Column_TimePlayed],
 														 DEFAULT_COLUMN_WIDTHS[GameListModel::Column_LastPlayed],


### PR DESCRIPTION
### Description of Changes
* Fixes [this issue](https://forums.pcsx2.net/Thread-GUI-problem-since-v2-5-313) with headers introduced by #13559.
  * Just a typo. My bad.
  * Likely would've been caught with a basic code review.
  * But we can't abide by obvious, bare-minimum standards all the time.
  * The productivity lost would've easily cost us a hundred-thousandth of a barrier. :^)
* Also fixes an issue from the same PR that's harmless behaviorally but which does extra work for no reason.

Edit: I see an issue was introduced for the bug this fixes, so obligatory: "Fixes #13611".

### Suggested Testing Steps
Make sure the headers work now.

### Did you use AI to help find, test, or implement this issue or feature?
No.
