### PR TITLE
pcsx2-qt: delay resize events using a timer

### DIFF
--- a/pcsx2-qt/DisplayWidget.h
+++ b/pcsx2-qt/DisplayWidget.h
@@ -3,6 +3,7 @@
 
 #pragma once
 #include "common/WindowInfo.h"
+#include <QtCore/QTimer>
 #include <QtGui/QDragMoveEvent>
 #include <QtGui/QWindow>
 #include <optional>
@@ -42,6 +43,9 @@ protected:
 	bool event(QEvent* event) override;
 	bool eventFilter(QObject* object, QEvent* event) override;
 
+private Q_SLOTS:
+	void onResizeDebounceTimer();
+
 private:
 	bool isActuallyFullscreen() const;
 	void updateCenterPos();
@@ -59,6 +63,11 @@ private:
 	u32 m_last_window_width = 0;
 	u32 m_last_window_height = 0;
 	float m_last_window_scale = 1.0f;
+
+	QTimer* m_resize_debounce_timer = nullptr;
+	u32 m_pending_window_width = 0;
+	u32 m_pending_window_height = 0;
+	float m_pending_window_scale = 1.0f;
 
 	QWidget* m_container = nullptr;
 };


### PR DESCRIPTION

### Description of Changes
for some godforsaken reason qt fired up up to multiple resize events per ms. This is, needless to say, unwanted when a single resize event can take up to 30ms. Additionally, when said resize events stops, all queued events are resumed and done at once, which leads to noticeable lag as pcsx2 tries to catch up.

This fixes #13613


@JordanTheToaster add before after.
Also I'm waiting for my check, you know my billing rates.

### Rationale behind Changes
Have an UI that does not have a stroke

### Suggested Testing Steps
resize. a lot.

### Did you use AI to help find, test, or implement this issue or feature?
Added about 50 profiling timers with AI that I then removed once I saw the issue, saved me ~1h of my time. Probably the first time it's been useful to me to that degree.
