### PR TITLE
FullscreenUI: Fix save state loading

### DIFF
--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -318,7 +318,9 @@ void EmuThread::loadState(const QString& filename)
 	if (!VMManager::HasValidVM())
 		return;
 
-	VMManager::LoadState(filename.toUtf8().constData());
+	Error error;
+	if (!VMManager::LoadState(filename.toUtf8().constData(), &error))
+		Host::ReportErrorAsync(TRANSLATE_SV("QtHost", "Failed to Load State"), error.GetDescription());
 }
 
 void EmuThread::loadStateFromSlot(qint32 slot, bool load_backup)
@@ -332,7 +334,9 @@ void EmuThread::loadStateFromSlot(qint32 slot, bool load_backup)
 	if (!VMManager::HasValidVM())
 		return;
 
-	VMManager::LoadStateFromSlot(slot, load_backup);
+	Error error;
+	if (!VMManager::LoadStateFromSlot(slot, load_backup, &error))
+		Host::ReportErrorAsync(TRANSLATE_SV("QtHost", "Failed to Load State"), error.GetDescription());
 }
 
 void EmuThread::saveState(const QString& filename)

--- a/pcsx2/Hotkeys.cpp
+++ b/pcsx2/Hotkeys.cpp
@@ -14,6 +14,7 @@
 #include "SIO/Memcard/MemoryCardFile.h"
 
 #include "common/Assertions.h"
+#include "common/Error.h"
 #include "common/FileSystem.h"
 #include "common/Path.h"
 #include "common/Timer.h"
@@ -103,7 +104,10 @@ static void HotkeyLoadStateSlot(s32 slot)
 			return;
 		}
 
-		VMManager::LoadStateFromSlot(slot);
+		Error error;
+		if (!VMManager::LoadStateFromSlot(slot, false, &error))
+			Host::AddIconOSDMessage("LoadStateFromSlot", ICON_FA_TRIANGLE_EXCLAMATION,
+				error.GetDescription(), Host::OSD_INFO_DURATION);
 	});
 }
 

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -7602,65 +7602,17 @@ void FullscreenUI::DrawResumeStateSelector()
 
 void FullscreenUI::DoLoadState(std::string path)
 {
-	// Check for hardcore mode before loading state
-	if (Achievements::IsHardcoreModeActive())
-	{
-		Achievements::ConfirmHardcoreModeDisableAsync(TRANSLATE("VMManager", "Loading state"),
-			[path = std::move(path)](bool approved) {
-				if (approved)
-					DoLoadState(std::move(path));
-			});
-		return;
-	}
-
-	const std::string filename = std::string(Path::GetFileName(path));
-	s32 slot = -1;
-	bool is_backup = false;
-
-	std::string base_filename = filename;
-	if (filename.length() > 7 && filename.substr(filename.length() - 7) == ".backup")
-	{
-		is_backup = true;
-		base_filename = filename.substr(0, filename.length() - 7);
-	}
-
-	// Get slot number from filename (format: serial.crc.slot.p2s)
-	const size_t last_dot = base_filename.rfind('.');
-	const size_t second_last_dot = base_filename.rfind('.', last_dot - 1);
-	if (last_dot != std::string::npos && second_last_dot != std::string::npos)
-	{
-		const std::string slot_str = base_filename.substr(second_last_dot + 1, last_dot - second_last_dot - 1);
-		if (!slot_str.empty())
-			slot = std::atoi(slot_str.c_str());
-	}
-
-	const std::string message = (slot >= 0) ?
-		fmt::format(TRANSLATE_FS("VMManager", "Loading {} from slot {}..."), is_backup ? TRANSLATE("VMManager", "backup state") : TRANSLATE("VMManager", "state"), slot) :
-		TRANSLATE_STR("VMManager", "Loading save state...");
-
-	Host::AddIconOSDMessage("LoadStateFromSlot", ICON_FA_FOLDER_OPEN, message, Host::OSD_QUICK_DURATION);
-
-	Host::RunOnCPUThread([path = std::move(path)]()
-	{
-		const std::string boot_path = s_save_state_selector_game_path;
+	Host::RunOnCPUThread([boot_path = s_save_state_selector_game_path, path = std::move(path)]() {
 		if (VMManager::HasValidVM())
 		{
 			Error error;
-			if (!SaveState_UnzipFromDisk(path, &error))
+			if (!VMManager::LoadState(path.c_str(), &error))
 			{
-				if (error.GetDescription().find("outdated") != std::string::npos)
-				{
-					Host::RunOnCPUThread([error_desc = error.GetDescription()]()
-					{
-						ImGuiFullscreen::OpenInfoMessageDialog(
-							FSUI_ICONSTR(ICON_FA_TRIANGLE_EXCLAMATION, "Incompatible Save State"),
-							error_desc);
-					});
-				}
-				else
-				{
-					Host::ReportErrorAsync(TRANSLATE_SV("VMManager", "Failed to load save state"), error.GetDescription());
-				}
+				MTGS::RunOnGSThread([error = std::move(error)]() {
+					ImGuiFullscreen::OpenInfoMessageDialog(
+						FSUI_ICONSTR(ICON_FA_TRIANGLE_EXCLAMATION, "Failed to Load State"),
+						error.GetDescription());
+				});
 				return;
 			}
 

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -28,6 +28,7 @@
 #include "VMManager.h"
 
 #include "common/BitUtils.h"
+#include "common/Error.h"
 #include "common/FileSystem.h"
 #include "common/Path.h"
 #include "common/StringUtil.h"
@@ -1325,7 +1326,10 @@ s32 SaveStateSelectorUI::GetCurrentSlot()
 void SaveStateSelectorUI::LoadCurrentSlot()
 {
 	Host::RunOnCPUThread([slot = GetCurrentSlot()]() {
-		VMManager::LoadStateFromSlot(slot);
+		Error error;
+		if (!VMManager::LoadStateFromSlot(slot, false, &error))
+			Host::AddIconOSDMessage("LoadStateFromSlot", ICON_FA_TRIANGLE_EXCLAMATION,
+				error.GetDescription(), Host::OSD_INFO_DURATION);
 	});
 	Close();
 }
@@ -1333,7 +1337,10 @@ void SaveStateSelectorUI::LoadCurrentSlot()
 void SaveStateSelectorUI::LoadCurrentBackupSlot()
 {
 	Host::RunOnCPUThread([slot = GetCurrentSlot()]() {
-		VMManager::LoadStateFromSlot(slot, true);
+		Error error;
+		if (!VMManager::LoadStateFromSlot(slot, true, &error))
+			Host::AddIconOSDMessage("LoadStateFromSlot", ICON_FA_TRIANGLE_EXCLAMATION,
+				error.GetDescription(), Host::OSD_INFO_DURATION);
 	});
 	Close();
 }

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -127,10 +127,10 @@ namespace VMManager
 	bool HasSaveStateInSlot(const char* game_serial, u32 game_crc, s32 slot);
 
 	/// Loads state from the specified file.
-	bool LoadState(const char* filename);
+	bool LoadState(const char* filename, Error* error = nullptr);
 
 	/// Loads state from the specified slot.
-	bool LoadStateFromSlot(s32 slot, bool backup = false);
+	bool LoadStateFromSlot(s32 slot, bool backup = false, Error* error = nullptr);
 
 	/// Saves state to the specified filename.
 	bool SaveState(const char* filename, bool zip_on_thread = true, bool backup_old_state = false);


### PR DESCRIPTION
### Description of Changes
- Rewrite the FullscreenUI::DoLoadState function.
- Add an error handling out parameter to VMManager::LoadState, VMManager::LoadStateFromSlot and VMManager::DoLoadState.

Since this seems more important than #13512 we can merge this one first, then I'll rebase the hardcore one.

### Rationale behind Changes
This fixes the following issues:
- A race condition that I was consistently experiencing, and confirmed using GDB, that would cause loading a save state from big picture mode to fail because s_save_state_selector_game_path was written on the GS thread but read on the CPU thread. By the time s_save_state_selector_game_path was read on the CPU thread it would be empty (or even worse, it could be half-written leading to a crash).

  The typical symptom of this is the game crashing after a few seconds, and "PS2 BIOS" showing as the title of the main window because VMManager::AutoDetectSource sees an empty string for the filename, so assumes no disc is inserted.
- This reintroduces the MemcardBusy::IsBusy() check when loading save states in big picture, which was previously missing.
- This removes some broken logic related to outdated save states. Previously, it would check if the error string contained the word "outdated" to decide whether to use an FSUI dialog or a Qt dialog to display the error.
  
  I don't think this behaviour really makes sense, but even if it did, it's broken for languages other than English (and if the error message contained a file path containing the text "outdated").

### Suggested Testing Steps

Test all different types of save state loading errors (incompatible version, memory card check, etc) with both the Qt UI and big picture.

Make sure that hardcore mode compliance is still holding up.

You may or may not be able to reproduce save state loading not working, since it's a race condition, but you will be able to reproduce the memory card activity check being broken:
- Make sure all memory cards you care about are removed.
- Insert a sacrificial memory card.
- Launch a game and save it, pausing the game before it is finished saving.
- Try closing the main window to make sure the Qt memory card check happens (but hit No when prompted).
- Press Esc to bring up the big picture pause menu, and try loading a state.
- On master, there is no memory card check. With the PR, the load be blocked.

### Did you use AI to help find, test, or implement this issue or feature?
No.
