### PR TITLE
Achievements: Enable hardcore mode by default

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -813,9 +813,6 @@ void MainWindow::onAchievementsHardcoreModeChanged(bool enabled)
 	// disable debugger while hardcore mode is active
 	m_ui.actionDebugger->setDisabled(enabled);
 
-	// refresh emulation actions to show/hide load state buttons based on hardcore mode
-	updateEmulationActions(s_vm_valid, s_vm_valid, false);
-
 	if (enabled)
 	{
 		// If PauseOnEntry is enabled, we prompt the user to disable Hardcore Mode
@@ -911,7 +908,7 @@ void MainWindow::updateEmulationActions(bool starting, bool running, bool stoppi
 	m_ui.actionPause->setEnabled(running);
 	m_ui.actionScreenshot->setEnabled(running);
 	m_ui.menuChangeDisc->setEnabled(running);
-	m_ui.menuLoadState->setEnabled(running && !Achievements::IsHardcoreModeActive());
+	m_ui.menuLoadState->setEnabled(running);
 	m_ui.menuSaveState->setEnabled(running);
 	m_ui.actionSaveGSDump->setEnabled(running);
 
@@ -920,7 +917,7 @@ void MainWindow::updateEmulationActions(bool starting, bool running, bool stoppi
 	m_ui.actionToolbarPause->setEnabled(running);
 	m_ui.actionToolbarScreenshot->setEnabled(running);
 	m_ui.actionToolbarChangeDisc->setEnabled(running);
-	m_ui.actionToolbarLoadState->setEnabled(running && !Achievements::IsHardcoreModeActive());
+	m_ui.actionToolbarLoadState->setEnabled(running);
 	m_ui.actionToolbarSaveState->setEnabled(running);
 
 	m_ui.actionViewGameProperties->setEnabled(running);

--- a/pcsx2-qt/Settings/AchievementSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AchievementSettingsWidget.cpp
@@ -27,7 +27,7 @@ AchievementSettingsWidget::AchievementSettingsWidget(SettingsWindow* settings_di
 	setupTab(m_ui);
 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.enable, "Achievements", "Enabled", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.hardcoreMode, "Achievements", "ChallengeMode", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.hardcoreMode, "Achievements", "ChallengeMode", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.achievementNotifications, "Achievements", "Notifications", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.leaderboardNotifications, "Achievements", "LeaderboardNotifications", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.soundEffects, "Achievements", "SoundEffects", true);
@@ -49,7 +49,7 @@ AchievementSettingsWidget::AchievementSettingsWidget(SettingsWindow* settings_di
 	SettingWidgetBinder::BindWidgetToFileSetting(sif, m_ui.lbSoundPath, m_ui.lbSoundBrowse, m_ui.lbSoundOpen, m_ui.lbSoundReset, "Achievements", "LBSubmitSoundName", Path::Combine(EmuFolders::Resources, EmuConfig.Achievements.DEFAULT_LBSUBMIT_SOUND_NAME), AUDIO_FILE_FILTER, true, false);
 
 	dialog()->registerWidgetHelp(m_ui.enable, tr("Enable Achievements"), tr("Unchecked"), tr("When enabled and logged in, PCSX2 will scan for achievements on startup."));
-	dialog()->registerWidgetHelp(m_ui.hardcoreMode, tr("Enable Hardcore Mode"), tr("Unchecked"), tr("\"Challenge\" mode for achievements, including leaderboard tracking. Disables save state, cheats, and slowdown functions."));
+	dialog()->registerWidgetHelp(m_ui.hardcoreMode, tr("Enable Hardcore Mode"), tr("Checked"), tr("\"Challenge\" mode for achievements, including leaderboard tracking. Disables save state, cheats, and slowdown functions."));
 	dialog()->registerWidgetHelp(m_ui.achievementNotifications, tr("Show Achievement Notifications"), tr("Checked"), tr("Displays popup messages on events such as achievement unlocks and game completion."));
 	dialog()->registerWidgetHelp(m_ui.leaderboardNotifications, tr("Show Leaderboard Notifications"), tr("Checked"), tr("Displays popup messages when starting, submitting, or failing a leaderboard challenge."));
 	dialog()->registerWidgetHelp(m_ui.soundEffects, tr("Enable Sound Effects"), tr("Checked"), tr("Plays sound effects for events such as achievement unlocks and leaderboard submissions."));
@@ -169,7 +169,7 @@ void AchievementSettingsWidget::onHardcoreModeStateChanged()
 		return;
 
 	const bool enabled = dialog()->getEffectiveBoolValue("Achievements", "Enabled", false);
-	const bool challenge = dialog()->getEffectiveBoolValue("Achievements", "ChallengeMode", false);
+	const bool challenge = dialog()->getEffectiveBoolValue("Achievements", "ChallengeMode", true);
 	if (!enabled || !challenge)
 		return;
 
@@ -250,7 +250,7 @@ void AchievementSettingsWidget::onLoginLogoutPressed()
 		m_ui.enable->setChecked(true);
 		updateEnableState();
 	}
-	if (!m_ui.hardcoreMode->isChecked() && Host::GetBaseBoolSettingValue("Achievements", "ChallengeMode", false))
+	if (!m_ui.hardcoreMode->isChecked() && Host::GetBaseBoolSettingValue("Achievements", "ChallengeMode", true))
 	{
 		QSignalBlocker sb(m_ui.hardcoreMode);
 		m_ui.hardcoreMode->setChecked(true);

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -6948,8 +6948,7 @@ void FullscreenUI::DrawPauseMenu(MainWindowType type)
 			case PauseSubMenu::None:
 			{
 				// NOTE: Menu close must come first, because otherwise VM destruction options will race.
-				const bool can_load_state = s_current_disc_crc != 0 && !Achievements::IsHardcoreModeActive();
-				const bool can_save_state = s_current_disc_crc != 0;
+				const bool can_load_or_save_state = s_current_disc_crc != 0;
 
 				if (just_focused)
 					ImGui::SetFocusID(ImGui::GetID(FSUI_ICONSTR(ICON_FA_PLAY, "Resume Game")), ImGui::GetCurrentWindow());
@@ -6963,19 +6962,19 @@ void FullscreenUI::DrawPauseMenu(MainWindowType type)
 					DoToggleFrameLimit();
 				}
 
-				if (ActiveButton(FSUI_ICONSTR(ICON_FA_ARROW_ROTATE_LEFT, "Load State"), false, can_load_state))
+				if (ActiveButton(FSUI_ICONSTR(ICON_FA_ARROW_ROTATE_LEFT, "Load State"), false, can_load_or_save_state))
 				{
 					if (OpenSaveStateSelector(true))
 						s_current_main_window = MainWindowType::None;
 				}
 
-				if (ActiveButton(FSUI_ICONSTR(ICON_FA_DOWNLOAD, "Save State"), false, can_save_state))
+				if (ActiveButton(FSUI_ICONSTR(ICON_FA_DOWNLOAD, "Save State"), false, can_load_or_save_state))
 				{
 					if (OpenSaveStateSelector(false))
 						s_current_main_window = MainWindowType::None;
 				}
 
-				if (ActiveButton(FSUI_ICONSTR(ICON_FA_WRENCH, "Game Properties"), false, can_save_state))
+				if (ActiveButton(FSUI_ICONSTR(ICON_FA_WRENCH, "Game Properties"), false, can_load_or_save_state))
 				{
 					SwitchToGameSettings();
 				}
@@ -7015,7 +7014,7 @@ void FullscreenUI::DrawPauseMenu(MainWindowType type)
 				if (ActiveButton(FSUI_ICONSTR(ICON_FA_POWER_OFF, "Close Game"), false))
 				{
 					// skip submenu when we can't save anyway
-					if (!can_save_state)
+					if (!can_load_or_save_state)
 						RequestShutdown(false);
 					else
 						OpenPauseSubMenu(PauseSubMenu::Exit);
@@ -7340,7 +7339,7 @@ void FullscreenUI::DrawSaveStateSelector(bool is_loading)
 
 					if (ActiveButton(
 							is_loading ? FSUI_ICONSTR(ICON_FA_FOLDER_OPEN, "Load State") : FSUI_ICONSTR(ICON_FA_FOLDER_OPEN, "Save State"),
-							false, is_loading ? !Achievements::IsHardcoreModeActive() : true, LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY))
+							false, true, LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY))
 					{
 						if (is_loading)
 							DoLoadState(std::move(entry.path));

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -8816,7 +8816,7 @@ void FullscreenUI::DrawAchievementsLoginWindow()
 							});
 					}
 
-					if (!Host::GetBaseBoolSettingValue("Achievements", "ChallengeMode", false))
+					if (!Host::GetBaseBoolSettingValue("Achievements", "ChallengeMode", true))
 					{
 						OpenConfirmMessageDialog(FSUI_STR("Enable Hardcore Mode"),
 							FSUI_STR("Hardcore mode is not currently enabled. Enabling hardcore mode allows you to set times, scores, and "
@@ -8988,7 +8988,7 @@ void FullscreenUI::DrawAchievementsSettingsPage(std::unique_lock<std::mutex>& se
 	check_challenge_state |= DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_PF_DUMBELL, "Hardcore Mode"),
 		FSUI_CSTR(
 			"\"Challenge\" mode for achievements, including leaderboard tracking. Disables save state, cheats, and slowdown functions."),
-		"Achievements", "ChallengeMode", false, enabled);
+		"Achievements", "ChallengeMode", true, enabled);
 	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_BELL, "Achievement Notifications"),
 		FSUI_CSTR("Displays popup messages on events such as achievement unlocks and leaderboard submissions."), "Achievements",
 		"Notifications", true, enabled);
@@ -9044,7 +9044,7 @@ void FullscreenUI::DrawAchievementsSettingsPage(std::unique_lock<std::mutex>& se
 		"Achievements", "UnofficialTestMode", false, enabled);
 
 	// Check for challenge mode just being enabled.
-	if (check_challenge_state && enabled && bsi->GetBoolValue("Achievements", "ChallengeMode", false) && VMManager::HasValidVM())
+	if (check_challenge_state && enabled && bsi->GetBoolValue("Achievements", "ChallengeMode", true) && VMManager::HasValidVM())
 	{
 		// don't bother prompting if the game doesn't have achievements
 		auto lock = Achievements::GetLock();

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1848,7 +1848,7 @@ Pcsx2Config::AchievementsOptions::AchievementsOptions()
 {
 	bitset = 0;
 	Enabled = false;
-	HardcoreMode = false;
+	HardcoreMode = true;
 	EncoreMode = false;
 	SpectatorMode = false;
 	UnofficialTestMode = false;


### PR DESCRIPTION
### Description of Changes
This enables hardcore mode by default. As a necessary prerequisite for this, I've changed the save state UI so that it gives you an error message when trying to load a state with hardcore mode enabled, instead of just greying out the option.

The UI for input recording is currently somewhat broken with hardcore mode. The UI behaves as if it's active, even though it's inactive. I'll have to work on that.

### Rationale behind Changes
This is [explicitly recommended by the RetroAchievements documentation](https://github.com/RetroAchievements/rcheevos/wiki/rc_client-integration#enabling-hardcore):

```
NOTE: Hardcore should be on by default. Players who opt-in to hardcore are usually already
mostly abiding by hardcore restrictions, and are disappointed when they find out they have 
to replay everything again to get the hardcore unlocks. Whereas if we opt-in for them, 
they'll find the functionality restricted (usually with a warning to disable hardcore) and 
can naturally make the decision themselves.
```

On its own, this change would introduce a fairly major usability problem because currently on master the options to load save states are greyed out when hardcore mode is enabled. This is a bad idea for two reasons:
- Users receive zero feedback as to why they can't load a state. Enabling hardcore mode by default makes this much more severe, since users might not even know that hardcore mode exists in the first place. They'd just see that the option to load a save state is greyed out and wouldn't know why.
- If any hardcore mode compliance issues crop up in the core, since as it stands the UI papers over them, they would likely go unnoticed. Therefore I'd argue greying out these options actually makes the security of hardcore mode worse.

### Suggested Testing Steps
Test hardcore mode compliance while loading a save state.

### Did you use AI to help find, test, or implement this issue or feature?
No.
