### PR TITLE
VMManager: Fix LoadStateFromSlot error messages

### DIFF
--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -2010,25 +2010,34 @@ bool VMManager::LoadStateFromSlot(s32 slot, bool backup, Error* error)
 	const std::string filename = GetCurrentSaveStateFileName(slot, backup);
 	if (filename.empty() || !FileSystem::FileExists(filename.c_str()))
 	{
-		Host::AddIconOSDMessage("LoadStateFromSlot", ICON_FA_TRIANGLE_EXCLAMATION,
-			fmt::format(TRANSLATE_FS("VMManager", "There is no saved {} in slot {}."), backup ? TRANSLATE("VMManager", "backup state") : "state", slot),
-			Host::OSD_QUICK_DURATION);
+		if (backup)
+			Error::SetStringFmt(error,
+				TRANSLATE_FS("VMManager", "There is no save state in backup slot {}."), slot);
+		else
+			Error::SetStringFmt(error,
+				TRANSLATE_FS("VMManager", "There is no save state in slot {}."), slot);
 		return false;
 	}
 
 	if (Achievements::IsHardcoreModeActive())
 	{
-		Host::AddIconOSDMessage("LoadStateHardcoreBlocked", ICON_FA_TRIANGLE_EXCLAMATION,
-			fmt::format(TRANSLATE_FS("VMManager", "Cannot load save {} from slot {} while RetroAchievements Hardcore Mode is active."), backup ? TRANSLATE("VMManager", "backup state") : TRANSLATE("VMManager", "state"), slot),
-			Host::OSD_WARNING_DURATION);
+		if (backup)
+			Error::SetStringFmt(error,
+				TRANSLATE_FS("VMManager", "Cannot load save state from backup slot {} while RetroAchievements Hardcore Mode is active."), slot);
+		else
+			Error::SetStringFmt(error,
+				TRANSLATE_FS("VMManager", "Cannot load save state from slot {} while RetroAchievements Hardcore Mode is active."), slot);
 		return false;
 	}
 
 	if (MemcardBusy::IsBusy())
 	{
-		Host::AddIconOSDMessage("LoadStateFromSlot", ICON_FA_TRIANGLE_EXCLAMATION,
-			fmt::format(TRANSLATE_FS("VMManager", "Failed to load {} from slot {} (Memory card is busy)"), backup ? TRANSLATE("VMManager", "backup state") : TRANSLATE("VMManager", "state"), slot),
-			Host::OSD_QUICK_DURATION);
+		if (backup)
+			Error::SetStringFmt(error,
+				TRANSLATE_FS("VMManager", "Failed to load save state from backup slot {} (memory card is busy)."), slot);
+		else
+			Error::SetStringFmt(error,
+				TRANSLATE_FS("VMManager", "Failed to load save state from slot {} (memory card is busy)."), slot);
 		return false;
 	}
 


### PR DESCRIPTION
### Description of Changes
This fixes a silly regression from #13619 where the user may be prompted with an empty dialog box because the error message isn't being passed up correctly.

I've also separated the messages for backup and non-backup save states, which should make things easier for translators.

### Rationale behind Changes
Prevent the user being prompted with an empty message box.

### Suggested Testing Steps
Try to get the memory card activity warning to show up while loading a save state.

### Did you use AI to help find, test, or implement this issue or feature?
No.
