### PR TITLE
DEV9: Make socket auto adapter name translatable

### DIFF
--- a/pcsx2/DEV9/sockets.cpp
+++ b/pcsx2/DEV9/sockets.cpp
@@ -6,6 +6,7 @@
 #include "common/ScopedGuard.h"
 
 #ifdef _WIN32
+#include "common/RedtapeWindows.h"
 #include <winsock2.h>
 #include <iphlpapi.h>
 #elif defined(__POSIX__)


### PR DESCRIPTION
### Description of Changes
Allow the Auto adapter's name to be translatable

### Rationale behind Changes
Probably should be translatable

Also, I'm not sure what to name the translation context, so went with `DEV9`

### Suggested Testing Steps
Make a translation string and see if it shows up

### Did you use AI to help find, test, or implement this issue or feature?
No
