### PR TITLE
GS/Vulkan: Update ImGui when resizing the swap chain

### DIFF
--- a/pcsx2/GS/Renderers/Vulkan/VKSwapChain.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/VKSwapChain.cpp
@@ -4,6 +4,7 @@
 #include "GS/Renderers/Vulkan/GSDeviceVK.h"
 #include "GS/Renderers/Vulkan/VKBuilders.h"
 #include "GS/Renderers/Vulkan/VKSwapChain.h"
+#include "ImGui/ImGuiManager.h"
 #include "VMManager.h"
 
 #include "common/Assertions.h"
@@ -588,6 +589,8 @@ bool VKSwapChain::ResizeSwapChain(u32 new_width, u32 new_height, float new_scale
 		DestroySwapChain();
 		return false;
 	}
+
+	ImGuiManager::WindowResized();
 
 	return true;
 }


### PR DESCRIPTION
### Description of Changes
Make sure imgui resize events is triggered during a vulkan swap chain resize.
This allows for the OSD and BPM to stay in sync when resizing heavily

cc @TheLastRar for testing, whether this is implemented correctly/fixes the issue etc 

### Rationale behind Changes
Smoother resize

### Suggested Testing Steps
Resize with the BPM, the OSD or other imgui related events

### Did you use AI to help find, test, or implement this issue or feature?
No