### PR TITLE
GS/HW: Allow baking shaders into executable.

### DIFF
--- a/cmake/ShaderToCpp.cmake
+++ b/cmake/ShaderToCpp.cmake
@@ -1,0 +1,31 @@
+function(shader_to_cpp SHADER_FILES_OUT SHADER_FILES_CPP_OUT CPP_OUTPUT_DIR_OUT)
+	set(SHADER_FILES "")
+	set(SHADER_FILES_CPP "")
+	set(CPP_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/shaders_cpp")
+	file(MAKE_DIRECTORY ${CPP_OUTPUT_DIR})
+	file(GLOB_RECURSE DIR_FILES "${CMAKE_CURRENT_SOURCE_DIR}/../bin/resources/shaders/*")
+	foreach(path IN LISTS DIR_FILES)
+		if(NOT ("${path}" MATCHES ".*\.glsl$" OR "${path}" MATCHES ".*\.fx$"))
+			continue()
+		endif()
+		if (NOT WIN32 AND "${path}" MATCHES "/dx11/") # Don't include unneccessary stuff
+			continue()
+		endif()
+		get_filename_component(DIR ${path} DIRECTORY)
+		get_filename_component(API ${DIR} NAME)
+		get_filename_component(BASE ${path} NAME_WE)
+		set(cpp_path "${CPP_OUTPUT_DIR}/${API}_${BASE}.cpp")
+		add_custom_command(
+			OUTPUT ${cpp_path}
+			COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/../tools/shader_to_cpp.py ${path} ${cpp_path} "${API}_${BASE}"
+			DEPENDS ${path} ${CMAKE_CURRENT_SOURCE_DIR}/../tools/shader_to_cpp.py
+			COMMENT "Shader to CPP: ${path} -> ${cpp_path}"
+			VERBATIM
+		)
+		list(APPEND SHADER_FILES ${path})
+		list(APPEND SHADER_FILES_CPP ${cpp_path})
+	endforeach()
+	set(${SHADER_FILES_OUT} ${SHADER_FILES} PARENT_SCOPE)
+	set(${SHADER_FILES_CPP_OUT} ${SHADER_FILES_CPP} PARENT_SCOPE)
+	set(${CPP_OUTPUT_DIR_OUT} ${CPP_OUTPUT_DIR} PARENT_SCOPE)
+endfunction()

--- a/common/vsprops/ShaderToCpp.props
+++ b/common/vsprops/ShaderToCpp.props
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="UserMacros">
+    <BakeShadersInCpp>true</BakeShadersInCpp>
+    <ShaderCppDir>$(OutDir)shaders_cpp\</ShaderCppDir>
+  </PropertyGroup>
+  <ItemGroup>
+    <BuildMacro Include="BakeShadersInCpp">
+      <Value>$(BakeShadersInCpp)</Value>
+    </BuildMacro>
+  </ItemGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions Condition="'$(BakeShadersInCpp)'=='true'">BAKE_SHADERS_IN_CPP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories Condition="'$(BakeShadersInCpp)'=='true'">%(AdditionalIncludeDirectories);$(ShaderCppDir)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Target Name="ShaderToCpp" BeforeTargets="ClCompile" Condition="'@(ShaderToCpp)'!='' And '$(BakeShadersInCpp)'=='true'">
+    <!--Ensure output directory exists-->
+    <MakeDir Directories="$(ShaderCppDir)" Condition="!Exists('$(ShaderCppDir)')" />
+    <!--Setup metadata for following tasks-->
+    <ItemGroup>
+      <ShaderToCpp>
+        <Command>
+          "python" "$(SolutionDir)\tools\shader_to_cpp.py" "%(Identity)" "$(ShaderCppDir)%(VarName).cpp" "%(VarName)"
+        </Command>
+        <Outputs>$(ShaderCppDir)%(VarName).cpp</Outputs>
+      </ShaderToCpp>
+    </ItemGroup>
+    <!--Helper for dealing with tlogs-->
+    <!--https://learn.microsoft.com/en-us/visualstudio/msbuild/getoutofdateitems-task?view=vs-2022-->
+    <GetOutOfDateItems Sources="@(ShaderToCpp)" OutputsMetadataName="Outputs" CommandMetadataName="Command" TLogDirectory="$(TLogLocation)" TLogNamePrefix="ShaderToCpp">
+      <Output TaskParameter="OutOfDateSources" ItemName="OutOfDateShaderToCpp" />
+    </GetOutOfDateItems>
+    <CustomBuild Condition="'@(OutOfDateShaderToCpp)'!=''" Sources="@(OutOfDateShaderToCpp)" />
+    <Message Text="Shader to CPP: '%(OutOfDateShaderToCpp.Identity)' -&gt; '$(ShaderCppDir)%(OutOfDateShaderToCpp.VarName).cpp'" Importance="high" Condition="'@(OutOfDateShaderToCpp)'!=''" />
+  </Target>
+  <Target Name="ShaderToCppClean">
+    <Delete Files="@(ShaderToCpp->'$(ShaderCppDir)%(VarName).cpp')" />
+  </Target>
+</Project>

--- a/common/vsprops/ShaderToCpp.targets
+++ b/common/vsprops/ShaderToCpp.targets
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <CleanDependsOn>ShaderToCppClean;$(CleanDependsOn)</CleanDependsOn>
+  </PropertyGroup>
+</Project>

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -51,6 +51,16 @@ if(WIN32)
 	)
 endif(WIN32)
 
+option(BAKE_SHADERS_IN_CPP "Bake shaders into C++ source files" OFF)
+if(BAKE_SHADERS_IN_CPP)
+	include(ShaderToCpp)
+	shader_to_cpp(SHADER_FILES SHADER_FILES_CPP CPP_OUTPUT_DIR)
+	add_custom_target(GeneratedShaders DEPENDS ${SHADER_FILES} ${SHADER_FILES_CPP})
+	add_dependencies(PCSX2 GeneratedShaders)
+	target_compile_definitions(PCSX2_FLAGS INTERFACE BAKE_SHADERS_IN_CPP=1)
+	target_include_directories(PCSX2_FLAGS INTERFACE ${CPP_OUTPUT_DIR})
+endif()
+
 # Main pcsx2 source
 set(pcsx2Sources
 	Achievements.cpp

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -340,8 +340,69 @@ GSVector4i GSDevice::ProcessCopyArea(const GSVector4i& rtsize, const GSVector4i&
 	return snapped_drawarea;
 }
 
+#ifdef BAKE_SHADERS_IN_CPP
+#include "common_fxaa.cpp"
+#include "vulkan_convert.cpp"
+#include "vulkan_imgui.cpp"
+#include "vulkan_interlace.cpp"
+#include "vulkan_merge.cpp"
+#include "vulkan_present.cpp"
+#include "vulkan_shadeboost.cpp"
+#include "vulkan_tfx.cpp"
+#include "opengl_convert.cpp"
+#include "opengl_imgui.cpp"
+#include "opengl_interlace.cpp"
+#include "opengl_merge.cpp"
+#include "opengl_present.cpp"
+#include "opengl_shadeboost.cpp"
+#include "opengl_tfx_fs.cpp"
+#include "opengl_tfx_vgs.cpp"
+#ifdef _WIN32
+#include "dx11_convert.cpp"
+#include "dx11_imgui.cpp"
+#include "dx11_interlace.cpp"
+#include "dx11_merge.cpp"
+#include "dx11_present.cpp"
+#include "dx11_shadeboost.cpp"
+#include "dx11_tfx.cpp"
+#endif
+
+static const std::map<std::string, const unsigned char*> baked_shaders = {
+	{ "shaders/common/fxaa.fx"         , common_fxaa},
+	{ "shaders/vulkan/convert.glsl"    , vulkan_convert},
+	{ "shaders/vulkan/imgui.glsl"      , vulkan_imgui},
+	{ "shaders/vulkan/interlace.glsl"  , vulkan_interlace},
+	{ "shaders/vulkan/merge.glsl"      , vulkan_merge },
+	{ "shaders/vulkan/present.glsl"    , vulkan_present },
+	{ "shaders/vulkan/shadeboost.glsl" , vulkan_shadeboost },
+	{ "shaders/vulkan/tfx.glsl"        , vulkan_tfx },
+	{ "shaders/opengl/convert.glsl"    , opengl_convert },
+	{ "shaders/opengl/imgui.glsl"      , opengl_imgui },
+	{ "shaders/opengl/interlace.glsl"  , opengl_interlace },
+	{ "shaders/opengl/merge.glsl"      , opengl_merge },
+	{ "shaders/opengl/present.glsl"    , opengl_present },
+	{ "shaders/opengl/shadeboost.glsl" , opengl_shadeboost },
+	{ "shaders/opengl/tfx_fs.glsl"     , opengl_tfx_fs },
+	{ "shaders/opengl/tfx_vgs.glsl"    , opengl_tfx_vgs },
+#ifdef _WIN32
+	{ "shaders/direct3d/convert.fx"    , dx11_convert },
+	{ "shaders/direct3d/imgui.fx"      , dx11_imgui },
+	{ "shaders/direct3d/interlace.fx"  , dx11_interlace },
+	{ "shaders/direct3d/merge.fx"      , dx11_merge },
+	{ "shaders/direct3d/present.fx"    , dx11_present },
+	{ "shaders/direct3d/shadeboost.fx" , dx11_shadeboost },
+	{ "shaders/direct3d/tfx.fx"        , dx11_tfx },
+#endif
+};
+#endif
+
 std::optional<std::string> GSDevice::ReadShaderSource(const char* filename)
 {
+#ifdef BAKE_SHADERS_IN_CPP
+	const auto it = baked_shaders.find(filename);
+	if (it != baked_shaders.end())
+		return reinterpret_cast<const char*>(it->second);
+#endif
 	return FileSystem::ReadFileToString(Path::Combine(EmuFolders::Resources, filename).c_str());
 }
 

--- a/pcsx2/pcsx2.vcxproj
+++ b/pcsx2/pcsx2.vcxproj
@@ -24,6 +24,7 @@
     <Import Condition="$(Configuration.Contains(Devel))" Project="$(SolutionDir)common\vsprops\CodeGen_Devel.props" />
     <Import Condition="$(Configuration.Contains(Release))" Project="$(SolutionDir)common\vsprops\CodeGen_Release.props" />
     <Import Condition="!$(Configuration.Contains(Release))" Project="$(SolutionDir)common\vsprops\IncrementalLinking.props" />
+    <Import Project="$(SolutionDir)common\vsprops\ShaderToCpp.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
@@ -70,8 +71,86 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ShaderToCpp Include="..\bin\resources\shaders\vulkan\convert.glsl">
+      <VarName>vulkan_convert</VarName>
+    </ShaderToCpp>
+    <ShaderToCpp Include="..\bin\resources\shaders\vulkan\imgui.glsl">
+      <VarName>vulkan_imgui</VarName>
+    </ShaderToCpp>
+    <ShaderToCpp Include="..\bin\resources\shaders\vulkan\interlace.glsl">
+      <VarName>vulkan_interlace</VarName>
+    </ShaderToCpp>
+    <ShaderToCpp Include="..\bin\resources\shaders\vulkan\merge.glsl">
+      <VarName>vulkan_merge</VarName>
+    </ShaderToCpp>
+    <ShaderToCpp Include="..\bin\resources\shaders\vulkan\present.glsl">
+      <VarName>vulkan_present</VarName>
+    </ShaderToCpp>
+    <ShaderToCpp Include="..\bin\resources\shaders\vulkan\shadeboost.glsl">
+      <VarName>vulkan_shadeboost</VarName>
+    </ShaderToCpp>
+    <ShaderToCpp Include="..\bin\resources\shaders\vulkan\tfx.glsl">
+      <VarName>vulkan_tfx</VarName>
+    </ShaderToCpp>
+    <ShaderToCpp Include="..\bin\resources\shaders\opengl\convert.glsl">
+      <VarName>opengl_convert</VarName>
+    </ShaderToCpp>
+    <ShaderToCpp Include="..\bin\resources\shaders\opengl\imgui.glsl">
+      <VarName>opengl_imgui</VarName>
+    </ShaderToCpp>
+    <ShaderToCpp Include="..\bin\resources\shaders\opengl\interlace.glsl">
+      <VarName>opengl_interlace</VarName>
+    </ShaderToCpp>
+    <ShaderToCpp Include="..\bin\resources\shaders\opengl\merge.glsl">
+      <VarName>opengl_merge</VarName>
+    </ShaderToCpp>
+    <ShaderToCpp Include="..\bin\resources\shaders\opengl\shadeboost.glsl">
+      <VarName>opengl_shadeboost</VarName>
+    </ShaderToCpp>
+    <ShaderToCpp Include="..\bin\resources\shaders\opengl\tfx_fs.glsl">
+      <VarName>opengl_tfx_fs</VarName>
+    </ShaderToCpp>
+    <ShaderToCpp Include="..\bin\resources\shaders\opengl\tfx_vgs.glsl">
+      <VarName>opengl_tfx_vgs</VarName>
+    </ShaderToCpp>
+    <ShaderToCpp Include="..\bin\resources\shaders\opengl\present.glsl">
+      <VarName>opengl_present</VarName>
+    </ShaderToCpp>
+    <ShaderToCpp Include="..\bin\resources\shaders\dx11\convert.fx">
+      <VarName>dx11_convert</VarName>
+    </ShaderToCpp>
+    <ShaderToCpp Include="..\bin\resources\shaders\dx11\interlace.fx">
+      <VarName>dx11_interlace</VarName>
+    </ShaderToCpp>
+    <ShaderToCpp Include="..\bin\resources\shaders\dx11\merge.fx">
+      <VarName>dx11_merge</VarName>
+    </ShaderToCpp>
+    <ShaderToCpp Include="..\bin\resources\shaders\dx11\shadeboost.fx">
+      <VarName>dx11_shadeboost</VarName>
+    </ShaderToCpp>
+    <ShaderToCpp Include="..\bin\resources\shaders\dx11\tfx.fx">
+      <VarName>dx11_tfx</VarName>
+    </ShaderToCpp>
+    <ShaderToCpp Include="..\bin\resources\shaders\dx11\imgui.fx">
+      <VarName>dx11_imgui</VarName>
+    </ShaderToCpp>
+    <ShaderToCpp Include="..\bin\resources\shaders\dx11\present.fx">
+      <VarName>dx11_present</VarName>
+    </ShaderToCpp>
+    <ShaderToCpp Include="..\bin\resources\shaders\common\fxaa.fx">
+      <VarName>common_fxaa</VarName>
+    </ShaderToCpp>
+    <None Include="..\bin\resources\shaders\common\fxaa.fx" />
+    <None Include="..\bin\resources\shaders\opengl\cas.glsl" />
+    <None Include="..\bin\resources\shaders\opengl\convert.glsl" />
     <None Include="..\bin\resources\shaders\opengl\imgui.glsl" />
+    <None Include="..\bin\resources\shaders\opengl\interlace.glsl" />
+    <None Include="..\bin\resources\shaders\opengl\merge.glsl" />
     <None Include="..\bin\resources\shaders\opengl\present.glsl" />
+    <None Include="..\bin\resources\shaders\opengl\shadeboost.glsl" />
+    <None Include="..\bin\resources\shaders\opengl\tfx_fs.glsl" />
+    <None Include="..\bin\resources\shaders\opengl\tfx_vgs.glsl" />
+    <None Include="..\bin\resources\shaders\vulkan\cas.glsl" />
     <None Include="..\bin\resources\shaders\vulkan\convert.glsl" />
     <None Include="..\bin\resources\shaders\vulkan\imgui.glsl" />
     <None Include="..\bin\resources\shaders\vulkan\interlace.glsl" />
@@ -79,20 +158,14 @@
     <None Include="..\bin\resources\shaders\vulkan\present.glsl" />
     <None Include="..\bin\resources\shaders\vulkan\shadeboost.glsl" />
     <None Include="..\bin\resources\shaders\vulkan\tfx.glsl" />
-    <None Include="..\bin\resources\shaders\opengl\convert.glsl" />
-    <None Include="..\bin\resources\shaders\opengl\interlace.glsl" />
-    <None Include="..\bin\resources\shaders\opengl\merge.glsl" />
-    <None Include="..\bin\resources\shaders\opengl\shadeboost.glsl" />
-    <None Include="..\bin\resources\shaders\opengl\tfx_fs.glsl" />
-    <None Include="..\bin\resources\shaders\opengl\tfx_vgs.glsl" />
     <None Include="..\bin\resources\shaders\dx11\convert.fx" />
-    <None Include="..\bin\resources\shaders\common\fxaa.fx" />
+    <None Include="..\bin\resources\shaders\dx11\imgui.fx" />
     <None Include="..\bin\resources\shaders\dx11\interlace.fx" />
     <None Include="..\bin\resources\shaders\dx11\merge.fx" />
+    <None Include="..\bin\resources\shaders\dx11\present.fx" />
     <None Include="..\bin\resources\shaders\dx11\shadeboost.fx" />
     <None Include="..\bin\resources\shaders\dx11\tfx.fx" />
-    <None Include="..\bin\resources\shaders\dx11\imgui.fx" />
-    <None Include="..\bin\resources\shaders\dx11\present.fx" />
+    <None Include="..\bin\resources\shaders\dx11\cas.hlsl" />
     <None Include="GS\Renderers\Vulkan\VKEntryPoints.inl">
       <ExcludedFromBuild Condition="'$(Platform)'=='ARM64'">true</ExcludedFromBuild>
     </None>
@@ -1033,5 +1106,6 @@
   </ItemGroup>
   <Import Condition="$(Configuration.Contains(Debug)) Or $(Configuration.Contains(Devel))" Project="$(SolutionDir)3rdparty\winpixeventruntime\WinPixEventRuntime.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="$(SolutionDir)common\vsprops\ShaderToCpp.targets" />
   <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/pcsx2/pcsx2.vcxproj.filters
+++ b/pcsx2/pcsx2.vcxproj.filters
@@ -336,10 +336,19 @@
     <None Include="x86\microVU_Upper.inl">
       <Filter>System\Ps2\EmotionEngine\VU\Dynarec\microVU</Filter>
     </None>
+    <None Include="GS\Renderers\Vulkan\VKEntryPoints.inl">
+      <Filter>System\Ps2\GS\Renderers\Vulkan</Filter>
+    </None>
     <None Include="..\bin\resources\shaders\common\fxaa.fx">
       <Filter>System\Ps2\GS\Shaders\Common</Filter>
     </None>
+    <None Include="..\bin\resources\shaders\opengl\cas.glsl">
+      <Filter>System\Ps2\GS\Shaders\OpenGL</Filter>
+    </None>
     <None Include="..\bin\resources\shaders\opengl\convert.glsl">
+      <Filter>System\Ps2\GS\Shaders\OpenGL</Filter>
+    </None>
+    <None Include="..\bin\resources\shaders\opengl\imgui.glsl">
       <Filter>System\Ps2\GS\Shaders\OpenGL</Filter>
     </None>
     <None Include="..\bin\resources\shaders\opengl\interlace.glsl">
@@ -348,53 +357,41 @@
     <None Include="..\bin\resources\shaders\opengl\merge.glsl">
       <Filter>System\Ps2\GS\Shaders\OpenGL</Filter>
     </None>
-    <None Include="..\bin\resources\shaders\opengl\tfx_vgs.glsl">
-      <Filter>System\Ps2\GS\Shaders\OpenGL</Filter>
-    </None>
-    <None Include="..\bin\resources\shaders\opengl\tfx_fs.glsl">
+    <None Include="..\bin\resources\shaders\opengl\present.glsl">
       <Filter>System\Ps2\GS\Shaders\OpenGL</Filter>
     </None>
     <None Include="..\bin\resources\shaders\opengl\shadeboost.glsl">
       <Filter>System\Ps2\GS\Shaders\OpenGL</Filter>
     </None>
-    <None Include="..\bin\resources\shaders\opengl\imgui.glsl">
+    <None Include="..\bin\resources\shaders\opengl\tfx_fs.glsl">
       <Filter>System\Ps2\GS\Shaders\OpenGL</Filter>
     </None>
-    <None Include="..\bin\resources\shaders\opengl\present.glsl">
+    <None Include="..\bin\resources\shaders\opengl\tfx_vgs.glsl">
       <Filter>System\Ps2\GS\Shaders\OpenGL</Filter>
     </None>
-    <None Include="..\bin\resources\shaders\vulkan\interlace.glsl">
+    <None Include="..\bin\resources\shaders\vulkan\cas.glsl">
       <Filter>System\Ps2\GS\Shaders\Vulkan</Filter>
     </None>
     <None Include="..\bin\resources\shaders\vulkan\convert.glsl">
       <Filter>System\Ps2\GS\Shaders\Vulkan</Filter>
     </None>
-    <None Include="..\bin\resources\shaders\vulkan\merge.glsl">
+    <None Include="..\bin\resources\shaders\vulkan\imgui.glsl">
       <Filter>System\Ps2\GS\Shaders\Vulkan</Filter>
     </None>
-    <None Include="..\bin\resources\shaders\vulkan\tfx.glsl">
+    <None Include="..\bin\resources\shaders\vulkan\interlace.glsl">
+      <Filter>System\Ps2\GS\Shaders\Vulkan</Filter>
+    </None>
+    <None Include="..\bin\resources\shaders\vulkan\merge.glsl">
       <Filter>System\Ps2\GS\Shaders\Vulkan</Filter>
     </None>
     <None Include="..\bin\resources\shaders\vulkan\present.glsl">
       <Filter>System\Ps2\GS\Shaders\Vulkan</Filter>
     </None>
-    <None Include="..\bin\resources\shaders\vulkan\imgui.glsl">
-      <Filter>System\Ps2\GS\Shaders\Vulkan</Filter>
-    </None>
     <None Include="..\bin\resources\shaders\vulkan\shadeboost.glsl">
       <Filter>System\Ps2\GS\Shaders\Vulkan</Filter>
     </None>
-    <None Include="..\bin\resources\shaders\dx11\tfx.fx">
-      <Filter>System\Ps2\GS\Shaders\Direct3D</Filter>
-    </None>
-    <None Include="..\bin\resources\shaders\dx11\shadeboost.fx">
-      <Filter>System\Ps2\GS\Shaders\Direct3D</Filter>
-    </None>
-    <None Include="..\bin\resources\shaders\dx11\merge.fx">
-      <Filter>System\Ps2\GS\Shaders\Direct3D</Filter>
-    </None>
-    <None Include="..\bin\resources\shaders\dx11\interlace.fx">
-      <Filter>System\Ps2\GS\Shaders\Direct3D</Filter>
+    <None Include="..\bin\resources\shaders\vulkan\tfx.glsl">
+      <Filter>System\Ps2\GS\Shaders\Vulkan</Filter>
     </None>
     <None Include="..\bin\resources\shaders\dx11\convert.fx">
       <Filter>System\Ps2\GS\Shaders\Direct3D</Filter>
@@ -402,11 +399,23 @@
     <None Include="..\bin\resources\shaders\dx11\imgui.fx">
       <Filter>System\Ps2\GS\Shaders\Direct3D</Filter>
     </None>
+    <None Include="..\bin\resources\shaders\dx11\interlace.fx">
+      <Filter>System\Ps2\GS\Shaders\Direct3D</Filter>
+    </None>
+    <None Include="..\bin\resources\shaders\dx11\merge.fx">
+      <Filter>System\Ps2\GS\Shaders\Direct3D</Filter>
+    </None>
     <None Include="..\bin\resources\shaders\dx11\present.fx">
       <Filter>System\Ps2\GS\Shaders\Direct3D</Filter>
     </None>
-    <None Include="GS\Renderers\Vulkan\VKEntryPoints.inl">
-      <Filter>System\Ps2\GS\Renderers\Vulkan</Filter>
+    <None Include="..\bin\resources\shaders\dx11\shadeboost.fx">
+      <Filter>System\Ps2\GS\Shaders\Direct3D</Filter>
+    </None>
+    <None Include="..\bin\resources\shaders\dx11\tfx.fx">
+      <Filter>System\Ps2\GS\Shaders\Direct3D</Filter>
+    </None>
+    <None Include="..\bin\resources\shaders\dx11\cas.hlsl">
+      <Filter>System\Ps2\GS\Shaders\Direct3D</Filter>
     </None>
   </ItemGroup>
   <ItemGroup>

--- a/tools/shader_to_cpp.py
+++ b/tools/shader_to_cpp.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+import os
+import sys
+
+def generate_cpp(input_file, output_file, var_name):
+    with open(input_file, "rb") as f:
+        data = f.read()
+
+    ascii_codes = ", ".join(str(b) for b in data)
+
+    cpp = f"""// Auto-generated with {__file__}
+
+static constexpr unsigned char {var_name}[{len(data) + 1}] = {{
+    {ascii_codes}, 0
+}};
+"""
+
+    with open(output_file, "w", newline="\n") as f:
+        f.write(cpp)
+
+def main():
+    if len(sys.argv) != 4:
+        print(f"Usage: {sys.argv[0]} <input-file> <output-file> <variable-name>")
+        sys.exit(1)
+
+    input_file = sys.argv[1]
+    output_file = sys.argv[2]
+    var_name = sys.argv[3]
+    if not os.path.isfile(input_file):
+        print(f"Error: '{input_file}' does not exist or is not a file.")
+        sys.exit(1)
+
+    generate_cpp(input_file, output_file, var_name)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Description of Changes
Adds a Python script and build settings to allow baking some GS shaders into the PCSX2 executable.

Affects the following shaders:
```
bin/resources/shaders/common/fxaa.cpp
bin/resources/shaders/vulkan/convert.cpp
bin/resources/shaders/vulkan/imgui.cpp
bin/resources/shaders/vulkan/interlace.cpp
bin/resources/shaders/vulkan/merge.cpp
bin/resources/shaders/vulkan/present.cpp
bin/resources/shaders/vulkan/shadeboost.cpp
bin/resources/shaders/vulkan/tfx.cpp
bin/resources/shaders/opengl/convert.cpp
bin/resources/shaders/opengl/imgui.cpp
bin/resources/shaders/opengl/interlace.cpp
bin/resources/shaders/opengl/merge.cpp
bin/resources/shaders/opengl/present.cpp
bin/resources/shaders/opengl/shadeboost.cpp
bin/resources/shaders/opengl/tfx_fs.cpp
bin/resources/shaders/opengl/tfx_vgs.cpp
bin/resources/shaders/dx11/convert.cpp
bin/resources/shaders/dx11/imgui.cpp
bin/resources/shaders/dx11/interlace.cpp
bin/resources/shaders/dx11/merge.cpp
bin/resources/shaders/dx11/present.cpp
bin/resources/shaders/dx11/shadeboost.cpp
bin/resources/shaders/dx11/tfx.cpp
```

### Rationale behind Changes
This allows different shaders to be more easily tested. For example, we can test multiple executables with different shaders without having to make sure the shaders on disk don't change.

### Suggested Testing Steps
VS (manual): In the file `common/vsprops/ShaderToCpp.props`, change the line `<BakeShadersInCpp>false</BakeShadersInCpp>` to  `<BakeShadersInCpp>true</BakeShadersInCpp>`.

VS (UI): In `Property Manger` window go under the `pcsx2` project, select any configuration (e.g., `Debug | x64`), double click on `ShaderToCpp`. In the `Common Properties > User Macros` section, change the value of `BakeShadersInCpp` to `true`.

CMake: Build with the config variable `BAKE_SHADERS_IN_CPP=true`.

When building, you should see messages in the build log that indicate that the shaders are being converted to CPP files. The resulting executable should have the shaders baked at compile time so any changes made to the files in `bin/resources/shaders` should have no effect.

### Did you use AI to help find, test, or implement this issue or feature?
I used AI to generate the Python files for converting text -> CPP. Also, to get help with the build file setup.
