### PR TITLE
Testing SDL patch for FFB quality

### DIFF
--- a/.github/workflows/scripts/windows/0001-DirectInput-FFB-Calculate-appropriate-update-flags.patch
+++ b/.github/workflows/scripts/windows/0001-DirectInput-FFB-Calculate-appropriate-update-flags.patch
@@ -1,0 +1,133 @@
+Subject: [PATCH] DirectInput FFB: Calculate appropriate update flags
+
+---
+ src/haptic/windows/SDL_dinputhaptic.c | 106 ++++++++++++++++++++++++--
+ 1 file changed, 98 insertions(+), 8 deletions(-)
+
+diff --git a/src/haptic/windows/SDL_dinputhaptic.c b/src/haptic/windows/SDL_dinputhaptic.c
+index 79c4b3501..68ec30526 100644
+--- a/src/haptic/windows/SDL_dinputhaptic.c
++++ b/src/haptic/windows/SDL_dinputhaptic.c
+@@ -946,6 +946,103 @@ err_effectdone:
+     return false;
+ }
+ 
++BOOL DIGetDirectionUpdateFlag(DIEFFECT* before, DIEFFECT* after)
++{
++    if (before->cAxes != after->cAxes) {
++        return true;
++    }
++    // rglDirection must be non-null for DIEP_DIRECTION to be a valid flag
++    if (after->rglDirection == NULL) {
++        return false;
++    }
++    if (before->rglDirection == NULL) {
++        return true;
++    }
++
++    return SDL_memcmp(before->rglDirection, after->rglDirection, sizeof(LONG) * before->cAxes) != 0;
++}
++
++BOOL DIGetEnvelopeUpdateFlag(DIEFFECT* before, DIEFFECT* after) {
++    if (before->lpEnvelope == NULL && after->lpEnvelope == NULL) {
++        return false;
++    }
++    // A null lpEnvelope is valid for DIEP_ENVELOPE (clears the envelope from the effect)
++    if (before->lpEnvelope == NULL || after->lpEnvelope == NULL) {
++        return true;
++    }
++    return SDL_memcmp(before->lpEnvelope, after->lpEnvelope, sizeof(DIENVELOPE)) != 0;
++}
++
++BOOL DIGetTypeSpecificParamsUpdateFlag(DIEFFECT* before, DIEFFECT* after)
++{
++    // Shouldn't happen since this implies an effect's type somehow changed, but need to check to avoid an out-of-bounds memcmp
++    if (before->cbTypeSpecificParams != after->cbTypeSpecificParams) {
++        return true;
++    }
++    // lpvTypeSpecificParams must be non-null for the DIEP_TYPESPECIFICPARAMS flag.
++    if (after->lpvTypeSpecificParams == NULL) {
++        return false;
++    }
++    if (before->lpvTypeSpecificParams == NULL) {
++        return true;
++    }
++    return SDL_memcmp(before->lpvTypeSpecificParams, after->lpvTypeSpecificParams, before->cbTypeSpecificParams) != 0;
++}
++
++/*
++    Calculate the exact flags needed when updating an existing DirectInput haptic effect.
++*/
++DWORD DICalculateUpdateFlags(DIEFFECT *before, DIEFFECT *after)
++{
++    DWORD flags = 0;
++
++    if (DIGetDirectionUpdateFlag(before, after)) {
++        flags |= DIEP_DIRECTION;
++    }
++
++    if (before->dwDuration != after->dwDuration) {
++        flags |= DIEP_DURATION;
++    }
++
++    if (DIGetEnvelopeUpdateFlag(before, after)) {
++        flags |= DIEP_ENVELOPE;
++    }
++
++    if (before->dwStartDelay != after->dwStartDelay) {
++        flags |= DIEP_STARTDELAY;
++    }
++
++    if (before->dwTriggerButton != after->dwTriggerButton) {
++        flags |= DIEP_TRIGGERBUTTON;
++    }
++
++    if (before->dwTriggerRepeatInterval != after->dwTriggerRepeatInterval) {
++        flags |= DIEP_TRIGGERREPEATINTERVAL;
++    }
++
++    if (DIGetTypeSpecificParamsUpdateFlag(before, after)) {
++        flags |= DIEP_TYPESPECIFICPARAMS;
++    }
++
++    if (flags == 0) {
++        /* Awkward: SDL_UpdateHapticEffect was called, but nothing was changed.
++         * Calling IDirectInputEffect_SetParameters with no flags is nonsense,
++         * so our options are to either send all the flags, or exit early.
++         * Sending all the flags seems like the safer option: The programmer may be trying
++         * to force an update for some reason (e.g. driver bug workaround?). Conversely,
++         * if the programmer doesn't want IDirectInputEffect_SetParameters to be called, they
++         * can just avoid calling SDL_UpdateHapticEffect when there's no changes. */
++        flags = DIEP_DIRECTION |
++                DIEP_DURATION |
++                DIEP_ENVELOPE |
++                DIEP_STARTDELAY |
++                DIEP_TRIGGERBUTTON |
++                DIEP_TRIGGERREPEATINTERVAL | DIEP_TYPESPECIFICPARAMS;
++    }
++
++    return flags;
++}
++
+ bool SDL_DINPUT_HapticUpdateEffect(SDL_Haptic *haptic, struct haptic_effect *effect, const SDL_HapticEffect *data)
+ {
+     HRESULT ret;
+@@ -958,14 +1055,7 @@ bool SDL_DINPUT_HapticUpdateEffect(SDL_Haptic *haptic, struct haptic_effect *eff
+         goto err_update;
+     }
+ 
+-    /* Set the flags.  Might be worthwhile to diff temp with loaded effect and
+-     *  only change those parameters. */
+-    flags = DIEP_DIRECTION |
+-            DIEP_DURATION |
+-            DIEP_ENVELOPE |
+-            DIEP_STARTDELAY |
+-            DIEP_TRIGGERBUTTON |
+-            DIEP_TRIGGERREPEATINTERVAL | DIEP_TYPESPECIFICPARAMS;
++    flags = DICalculateUpdateFlags(&effect->hweffect->effect, &temp);
+ 
+     // Create the actual effect.
+     ret =
+-- 
+2.41.0.windows.3
+

--- a/.github/workflows/scripts/windows/build-dependencies.bat
+++ b/.github/workflows/scripts/windows/build-dependencies.bat
@@ -185,6 +185,7 @@ echo Building SDL...
 rmdir /S /Q "%SDL%"
 %SEVENZIP% x "%SDL%.zip" || goto error
 cd "%SDL%" || goto error
+%PATCH% -p1 < "%SCRIPTDIR%\0001-DirectInput-FFB-Calculate-appropriate-update-flags.patch" || goto error
 cmake -B build -DCMAKE_BUILD_TYPE=Release %FORCEPDB% -DCMAKE_INSTALL_PREFIX="%INSTALLDIR%" -DBUILD_SHARED_LIBS=ON -DSDL_SHARED=ON -DSDL_STATIC=OFF -G Ninja || goto error
 cmake --build build --parallel || goto error
 ninja -C build install || goto error


### PR DESCRIPTION
### Description of Changes
This (should be) a patch of SDL that implements my planned fix to the library. This should address cases where redundant flags were being set to DirectInput's SetParameters method, which appears to have been causing some wheels to misbehave in a way that was best described as "worse feeling/quality/definition" with various FFB effects.

### Rationale behind Changes
This is a draft PR only so that I can get the CI bot to apply this patch to SDL. The final version should go into the SDL project itself.

### Suggested Testing Steps
If you have a wheel which feels worse ever since PCSX2 switched to SDL, try this version and compare directly to see if things feel better.

For the rest of us, you can validate whether this has fixed the (presumed) low-level problem by opening Wireshark and peeking at USBPcap: If the patch worked correctly, you should only see one PID report being sent per update, instead of two, under most circumstances (e.g. when a racing game like GT4 implements its FFB by rapidly updating a constant force).

Try a Wireshark filter string like this:

`usbhid.data && usbhid.data[0]!=0x41 && usb.dst != host`

If that sounded convoluted, it's late and my brain is cooked after work.

### Did you use AI to help find, test, or implement this issue or feature?
fuck no
