### PR TITLE
SPU: Deduplicate DMA counter code

### DIFF
--- a/pcsx2/SPU2/Dma.cpp
+++ b/pcsx2/SPU2/Dma.cpp
@@ -345,16 +345,7 @@ void V_Core::FinishDMAwrite()
 
 	DMAICounter = (DMAICounter - ReadSize) * 4;
 
-	if (((psxCounters[6].startCycle + psxCounters[6].deltaCycles) - psxRegs.cycle) > (u32)DMAICounter)
-	{
-		psxCounters[6].startCycle = psxRegs.cycle;
-		psxCounters[6].deltaCycles = DMAICounter;
-
-		psxNextDeltaCounter -= (psxRegs.cycle - psxNextStartCounter);
-		psxNextStartCounter = psxRegs.cycle;
-		if (psxCounters[6].deltaCycles < psxNextDeltaCounter)
-			psxNextDeltaCounter = psxCounters[6].deltaCycles;
-	}
+	CounterUpdate(DMAICounter);
 
 	ActiveTSA = TDA;
 	ActiveTSA &= 0xfffff;
@@ -439,16 +430,7 @@ void V_Core::FinishDMAread()
 	else
 		DMAICounter = 4;
 
-	if (((psxCounters[6].startCycle + psxCounters[6].deltaCycles) - psxRegs.cycle) > (u32)DMAICounter)
-	{
-		psxCounters[6].startCycle = psxRegs.cycle;
-		psxCounters[6].deltaCycles = DMAICounter;
-
-		psxNextDeltaCounter -= (psxRegs.cycle - psxNextStartCounter);
-		psxNextStartCounter = psxRegs.cycle;
-		if (psxCounters[6].deltaCycles < psxNextDeltaCounter)
-			psxNextDeltaCounter = psxCounters[6].deltaCycles;
-	}
+	CounterUpdate(DMAICounter);
 
 	ActiveTSA = TDA;
 	ActiveTSA &= 0xfffff;
@@ -470,16 +452,7 @@ void V_Core::DoDMAread(u16* pMem, u32 size)
 	//Regs.ATTR |= 0x30;
 	TADR = MADR + (size << 1);
 
-	if (((psxCounters[6].startCycle + psxCounters[6].deltaCycles) - psxRegs.cycle) > (u32)DMAICounter)
-	{
-		psxCounters[6].startCycle = psxRegs.cycle;
-		psxCounters[6].deltaCycles = DMAICounter;
-
-		psxNextDeltaCounter -= (psxRegs.cycle - psxNextStartCounter);
-		psxNextStartCounter = psxRegs.cycle;
-		if (psxCounters[6].deltaCycles < psxNextDeltaCounter)
-			psxNextDeltaCounter = psxCounters[6].deltaCycles;
-	}
+	CounterUpdate(DMAICounter);
 
 	if (SPU2::MsgDMA())
 	{

--- a/pcsx2/SPU2/spu2.h
+++ b/pcsx2/SPU2/spu2.h
@@ -80,6 +80,7 @@ void SPU2writeDMA7Mem(u16* pMem, u32 size);
 
 extern u32 lClocks;
 
+extern void CounterUpdate(u32 DMAICounter);
 extern void TimeUpdate(u32 cClocks);
 extern void SPU2_FastWrite(u32 rmem, u16 value);
 


### PR DESCRIPTION
### Description of Changes
The SPU has a bunch of copy pasted code for updating the counter it uses for tracking DMA progress. This combines it all into two functions.

### Rationale behind Changes
It was bugging me :)

### Suggested Testing Steps
There should be no functional change, so I don't have any specific testing suggestions. Just smoke test whatever you feel like.

### Did you use AI to help find, test, or implement this issue or feature?
No
