### PR TITLE
GS/HW: Add Limit 24 Bit Depth Hack

### DIFF
--- a/pcsx2-qt/Settings/GraphicsHardwareFixesSettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsHardwareFixesSettingsTab.ui
@@ -14,8 +14,31 @@
    <string/>
   </property>
   <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
-   <item row="3" column="1">
-    <widget class="QComboBox" name="hwAutoFlush">
+   <item row="8" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="skipDrawLabel">
+     <property name="text">
+      <string>Skip Draw Range:</string>
+     </property>
+     <property name="buddy">
+      <cstring>skipDrawStart</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QComboBox" name="textureInsideRt">
      <item>
       <property name="text">
        <string>Disabled (Default)</string>
@@ -23,12 +46,12 @@
      </item>
      <item>
       <property name="text">
-       <string>Enabled (Sprites Only)</string>
+       <string>Inside Target</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string>Enabled (All Primitives)</string>
+       <string>Merge Targets</string>
       </property>
      </item>
     </widget>
@@ -41,41 +64,6 @@
      <property name="buddy">
       <cstring>textureInsideRt</cstring>
      </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="skipDrawLabel">
-     <property name="text">
-      <string>Skip Draw Range:</string>
-     </property>
-     <property name="buddy">
-      <cstring>skipDrawStart</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QComboBox" name="cpuCLUTRender">
-     <property name="currentText">
-      <string extracomment="0 (Disabled)">0 (Disabled)</string>
-     </property>
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <item>
-      <property name="text">
-       <string>0 (Disabled)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>1 (Normal)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>2 (Aggressive)</string>
-      </property>
-     </item>
     </widget>
    </item>
    <item row="0" column="1">
@@ -160,8 +148,36 @@
      </item>
     </layout>
    </item>
-   <item row="4" column="1">
-    <widget class="QComboBox" name="textureInsideRt">
+   <item row="3" column="0">
+    <widget class="QLabel" name="hwAutoFlushLabel">
+     <property name="text">
+      <string>Auto Flush:</string>
+     </property>
+     <property name="buddy">
+      <cstring>hwAutoFlush</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1">
+    <layout class="QHBoxLayout" name="skipDrawLayout">
+     <item>
+      <widget class="QSpinBox" name="skipDrawStart">
+       <property name="maximum">
+        <number>10000</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="skipDrawEnd">
+       <property name="maximum">
+        <number>10000</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="1">
+    <widget class="QComboBox" name="gpuTargetCLUTMode">
      <item>
       <property name="text">
        <string>Disabled (Default)</string>
@@ -169,12 +185,57 @@
      </item>
      <item>
       <property name="text">
-       <string>Inside Target</string>
+       <string>Enabled (Exact Match)</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string>Merge Targets</string>
+       <string>Enabled (Check Inside Target)</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="cpuCLUTRenderLabel">
+     <property name="text">
+      <string>CPU Sprite Render Size:</string>
+     </property>
+     <property name="buddy">
+      <cstring>cpuSpriteRenderBW</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="gpuTargetCLUTLabel">
+     <property name="text">
+      <string extracomment="CLUT: Color Look Up Table, often referred to as a palette in non-PS2 things.  GPU Target CLUT: GPU handling of when a game uses data from a render target as a CLUT.">GPU Target CLUT:</string>
+     </property>
+     <property name="buddy">
+      <cstring>gpuTargetCLUTMode</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="cpuCLUTRender">
+     <property name="currentText">
+      <string extracomment="0 (Disabled)">0 (Disabled)</string>
+     </property>
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <item>
+      <property name="text">
+       <string>0 (Disabled)</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>1 (Normal)</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>2 (Aggressive)</string>
       </property>
      </item>
     </widget>
@@ -189,7 +250,26 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="2">
+   <item row="3" column="1">
+    <widget class="QComboBox" name="hwAutoFlush">
+     <item>
+      <property name="text">
+       <string>Disabled (Default)</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Enabled (Sprites Only)</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Enabled (All Primitives)</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="2">
     <layout class="QGridLayout" name="hwFixesLayout">
      <item row="4" column="0">
       <widget class="QCheckBox" name="estimateTextureRegion">
@@ -256,28 +336,8 @@
      </item>
     </layout>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="hwAutoFlushLabel">
-     <property name="text">
-      <string>Auto Flush:</string>
-     </property>
-     <property name="buddy">
-      <cstring>hwAutoFlush</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="gpuTargetCLUTLabel">
-     <property name="text">
-      <string extracomment="CLUT: Color Look Up Table, often referred to as a palette in non-PS2 things.  GPU Target CLUT: GPU handling of when a game uses data from a render target as a CLUT.">GPU Target CLUT:</string>
-     </property>
-     <property name="buddy">
-      <cstring>gpuTargetCLUTMode</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QComboBox" name="gpuTargetCLUTMode">
+   <item row="5" column="1">
+    <widget class="QComboBox" name="limit24BitDepth">
      <item>
       <property name="text">
        <string>Disabled (Default)</string>
@@ -285,56 +345,22 @@
      </item>
      <item>
       <property name="text">
-       <string>Enabled (Exact Match)</string>
+       <string>Prioritize Upper</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string>Enabled (Check Inside Target)</string>
+       <string>Prioritize Lower</string>
       </property>
      </item>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="cpuCLUTRenderLabel">
+   <item row="5" column="0">
+    <widget class="QLabel" name="limitDepthLabel">
      <property name="text">
-      <string>CPU Sprite Render Size:</string>
-     </property>
-     <property name="buddy">
-      <cstring>cpuSpriteRenderBW</cstring>
+      <string>Limit 24 Bit Depth</string>
      </property>
     </widget>
-   </item>
-   <item row="5" column="1">
-    <layout class="QHBoxLayout" name="skipDrawLayout">
-     <item>
-      <widget class="QSpinBox" name="skipDrawStart">
-       <property name="maximum">
-        <number>10000</number>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QSpinBox" name="skipDrawEnd">
-       <property name="maximum">
-        <number>10000</number>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="7" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Orientation::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>0</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -147,6 +147,8 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 		sif, m_fixes.disablePartialInvalidation, "EmuCore/GS", "UserHacks_DisablePartialInvalidation", false);
 	SettingWidgetBinder::BindWidgetToIntSetting(
 		sif, m_fixes.textureInsideRt, "EmuCore/GS", "UserHacks_TextureInsideRt", static_cast<int>(GSTextureInRtMode::Disabled));
+	SettingWidgetBinder::BindWidgetToIntSetting(
+		sif, m_fixes.limit24BitDepth, "EmuCore/GS", "UserHacks_Limit24BitDepth", static_cast<int>(GSLimit24BitDepth::Disabled));
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_fixes.readTCOnClose, "EmuCore/GS", "UserHacks_ReadTCOnClose", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_fixes.estimateTextureRegion, "EmuCore/GS", "UserHacks_EstimateTextureRegion", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_fixes.gpuPaletteConversion, "EmuCore/GS", "paltex", false);
@@ -623,6 +625,9 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 
 		dialog()->registerWidgetHelp(m_fixes.textureInsideRt, tr("Texture Inside RT"), tr("Disabled"),
 			tr("Allows the texture cache to reuse as an input texture the inner portion of a previous framebuffer."));
+
+		dialog()->registerWidgetHelp(m_fixes.limit24BitDepth, tr("Limit 24 Bit Depth"), tr("Disabled"),
+			tr("Eats your cheese."));
 
 		dialog()->registerWidgetHelp(m_fixes.readTCOnClose, tr("Read Targets When Closing"), tr("Unchecked"),
 			tr("Flushes all targets in the texture cache back to local memory when shutting down. Can prevent lost visuals when saving "

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -432,6 +432,13 @@ enum class GSTextureInRtMode : u8
 	MergeTargets,
 };
 
+enum class GSLimit24BitDepth : u8
+{
+	Disabled,
+	PrioritizeUpper,
+	PrioritizeLower,
+};
+
 enum class GSBilinearDirtyMode : u8
 {
 	Automatic,
@@ -844,6 +851,7 @@ struct Pcsx2Config
 		u8 UserHacks_CPUCLUTRender = 0;
 		GSGPUTargetCLUTMode UserHacks_GPUTargetCLUTMode = GSGPUTargetCLUTMode::Disabled;
 		GSTextureInRtMode UserHacks_TextureInsideRt = GSTextureInRtMode::Disabled;
+		GSLimit24BitDepth UserHacks_Limit24BitDepth = GSLimit24BitDepth::Disabled;
 		GSBilinearDirtyMode UserHacks_BilinearHack = GSBilinearDirtyMode::Automatic;
 		TriFiltering TriFilter = TriFiltering::Automatic;
 		s8 OverrideTextureBarriers = -1;

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -4657,6 +4657,14 @@ __forceinline void GSState::VertexKick(u32 skip)
 	u32 next = m_vertex.next;
 	u32 xy_tail = m_vertex.xy_tail;
 
+	if (GSIsHardwareRenderer() && GSLocalMemory::m_psm[m_context->ZBUF.PSM].bpp == 32)
+	{
+		if (GSConfig.UserHacks_Limit24BitDepth == GSLimit24BitDepth::PrioritizeUpper)
+			m_v.XYZ.Z = ((m_v.XYZ.Z >> 8) & ~0xFF) | (m_v.XYZ.Z & 0xFF);
+		else if (GSConfig.UserHacks_Limit24BitDepth == GSLimit24BitDepth::PrioritizeLower)
+			m_v.XYZ.Z &= 0x00FFFFFF;
+	}
+
 	// callers should write XYZUVF to m_v.m[1] in one piece to have this load store-forwarded, either by the cpu or the compiler when this function is inlined
 
 	const GSVector4i new_v0(m_v.m[0]);

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -619,6 +619,8 @@ __ri void ImGuiManager::DrawSettingsOverlay(float scale, float margin, float spa
 			APPEND("SD={}/{} ", GSConfig.SkipDrawStart, GSConfig.SkipDrawEnd);
 		if (GSConfig.UserHacks_TextureInsideRt != GSTextureInRtMode::Disabled)
 			APPEND("TexRT={} ", static_cast<unsigned>(GSConfig.UserHacks_TextureInsideRt));
+		if (GSConfig.UserHacks_Limit24BitDepth != GSLimit24BitDepth::Disabled)
+			APPEND("TDR={} ", static_cast<unsigned>(GSConfig.UserHacks_Limit24BitDepth));
 		if (GSConfig.UserHacks_BilinearHack != GSBilinearDirtyMode::Automatic)
 			APPEND("BLU={} ", static_cast<unsigned>(GSConfig.UserHacks_BilinearHack));
 		if (GSConfig.UserHacks_ForceEvenSpritePosition)

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -755,6 +755,7 @@ Pcsx2Config::GSOptions::GSOptions()
 	ManualUserHacks = false;
 	UserHacks_AlignSpriteX = false;
 	UserHacks_AutoFlush = GSHWAutoFlushLevel::Disabled;
+	UserHacks_Limit24BitDepth = GSLimit24BitDepth::Disabled;
 	UserHacks_CPUFBConversion = false;
 	UserHacks_ReadTCOnClose = false;
 	UserHacks_DisableDepthSupport = false;
@@ -847,6 +848,7 @@ bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 		OpEqu(UserHacks_CPUCLUTRender) &&
 		OpEqu(UserHacks_GPUTargetCLUTMode) &&
 		OpEqu(UserHacks_TextureInsideRt) &&
+		OpEqu(UserHacks_Limit24BitDepth) &&
 		OpEqu(UserHacks_BilinearHack) &&
 		OpEqu(OverrideTextureBarriers) &&
 
@@ -983,6 +985,7 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapIntEnumEx(UserHacks_BilinearHack, "UserHacks_BilinearHack");
 	SettingsWrapBitBoolEx(UserHacks_NativePaletteDraw, "UserHacks_NativePaletteDraw");
 	SettingsWrapIntEnumEx(UserHacks_TextureInsideRt, "UserHacks_TextureInsideRt");
+	SettingsWrapIntEnumEx(UserHacks_Limit24BitDepth, "UserHacks_Limit24BitDepth");
 	SettingsWrapBitBoolEx(UserHacks_EstimateTextureRegion, "UserHacks_EstimateTextureRegion");
 	SettingsWrapBitBoolEx(FXAA, "fxaa");
 	SettingsWrapBitBool(ShadeBoost);
@@ -1111,6 +1114,7 @@ void Pcsx2Config::GSOptions::MaskUserHacks()
 	UserHacks_CPUFBConversion = false;
 	UserHacks_ReadTCOnClose = false;
 	UserHacks_TextureInsideRt = GSTextureInRtMode::Disabled;
+	UserHacks_Limit24BitDepth = GSLimit24BitDepth::Disabled;
 	UserHacks_EstimateTextureRegion = false;
 	UserHacks_TCOffsetX = 0;
 	UserHacks_TCOffsetY = 0;


### PR DESCRIPTION
### Description of Changes
Adds a new hardware hack to prioritise the upper or lower of depth.

Worms Forts Under Siege

Before:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f51991cd-902d-4359-a84e-1c98878a11af" />

After using prioritize lower:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/38158ba6-3ae4-4323-849a-9902725bd008" />

Flower sun and rain

Before:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/075b3433-1995-459b-8aec-19767555ad1e" />

After with prioritize upper:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/414bbd52-a7b3-4c78-8154-5adb38b04dcb" />

Disaster Report

Before:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ac01b2ef-b86d-4ac5-9384-4284891ad639" />

After prioritize lower:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a66a235d-6590-4426-9978-eca161b3b8db" />

The king of fighters 2002

Before:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5c00ec40-0fa0-4f6a-a443-0d79d7e50fbb" />

After prioritize lower:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/95e3de22-dd37-43ae-aa87-8e87c5537bd3" />

### Rationale behind Changes
This may fix some of the worst z fighting in games such as the Worms series.

### Suggested Testing Steps
Test any games with z fighting using the new option to see if it helps and if it doesn't end up breaking them worse than before.

### Did you use AI to help find, test, or implement this issue or feature?
No
