### PR TITLE
Git/CI: Bump translations create-pull-request to v7.0.11

### DIFF
--- a/.github/workflows/cron_update_base_translation.yml
+++ b/.github/workflows/cron_update_base_translation.yml
@@ -17,7 +17,7 @@ jobs:
         run: ./.github/workflows/scripts/common/update_base_translation.sh
       
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@4320041ed380b20e97d388d56a7fb4f9b8c20e79
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676
         with:
           title: "Qt: Update Base Translation"
           commit-message: "[ci skip] Qt: Update Base Translation."


### PR DESCRIPTION
### Description of Changes
Bumps the tagged commit to version 7.0.11.

### Rationale behind Changes
Should fix the translations cron failing after updating to checkout v6.

### Suggested Testing Steps
NA

### Did you use AI to help find, test, or implement this issue or feature?
No
