### PR TITLE
Git/CI: Bump controller db create-pull-request to v7.0.11

### DIFF
--- a/.github/workflows/cron_update_controller_db.yml
+++ b/.github/workflows/cron_update_controller_db.yml
@@ -19,7 +19,7 @@ jobs:
           mv ./game_controller_db.txt ${{github.workspace}}/bin/resources/game_controller_db.txt
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@4320041ed380b20e97d388d56a7fb4f9b8c20e79
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676
         with:
           title: "PAD: Update to latest controller database"
           commit-message: "[ci skip] PAD: Update to latest controller database."


### PR DESCRIPTION
### Description of Changes
Bumps the tagged commit to version 7.0.11.

### Rationale behind Changes
Should fix the controller db cron also failing after updating to checkout v6.

### Suggested Testing Steps
NA

### Did you use AI to help find, test, or implement this issue or feature?
No
