### PR TITLE
GS SW: Use implicit GSVector4i int32x4_t conversion

### DIFF
--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -374,7 +374,7 @@ void GSRendererSW::RewriteVerticesIfSTOverflow()
 					const GSVector4 q = (primclass == GS_SPRITE_CLASS) ? stcq[1].wwww() : stcq[j].wwww();
 					stcq[j] = stcq[j].blend32(uv_new * q, GSVector4::cast(rewrite));
 
-					vertex_copy[i + j].m[0] = GSVector4i::cast(stcq[j]).m;
+					vertex_copy[i + j].m[0] = GSVector4i::cast(stcq[j]);
 					vertex_copy[i + j].m[1] = vertex[index[i + j]].m[1];
 					index[i + j] = i + j;
 				}


### PR DESCRIPTION
### Description of Changes
Removes the usage of `GSVector4i::m` since it's not required, and doesn't exist on ARM

### Rationale behind Changes
This broke ARM builds.

### Suggested Testing Steps
Test the SW renderer with overflowing ST.

### Did you use AI to help find, test, or implement this issue or feature?
No
