### PR TITLE
flatpak: allow gamescope socket

### DIFF
--- a/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
+++ b/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
@@ -22,7 +22,8 @@
     "--socket=wayland",
     "--socket=fallback-x11",
     "--socket=pulseaudio",
-    "--talk-name=org.freedesktop.ScreenSaver"
+    "--talk-name=org.freedesktop.ScreenSaver",
+    "--filesystem=xdg-run/gamescope-0:ro"
   ],
   "modules": [
     "modules/10-libpcap.json",


### PR DESCRIPTION
### Description of Changes
We get the same error as https://github.com/flathub/org.DolphinEmu.dolphin-emu/pull/178 , so let's just allow the gamescope socket by default.

### Rationale behind Changes
Do not show errors to users

### Suggested Testing Steps
run pcsx2 on steam deck, make sure there is no error messages
cc @JordanTheToaster for reference

### Did you use AI to help find, test, or implement this issue or feature?
0x90
