### PR TITLE
EE: Correct addresses for counter event test

### DIFF
--- a/pcsx2/R5900OpcodeImpl.cpp
+++ b/pcsx2/R5900OpcodeImpl.cpp
@@ -526,7 +526,7 @@ void LB()
 	cpuRegs.GPR.r[_Rt_].SD[0] = temp;
 
 	// Force event test on EE counter read to improve read + interrupt syncing. Namely ESPN Games.
-	if ((addr & 0xFFFFE0000) == 0x10000000)
+	if ((addr & 0xFFFFE000) == 0x10000000)
 	{
 		intUpdateCPUCycles();
 		intEventTest();
@@ -542,7 +542,7 @@ void LBU()
 	cpuRegs.GPR.r[_Rt_].UD[0] = temp;
 
 	// Force event test on EE counter read to improve read + interrupt syncing. Namely ESPN Games.
-	if ((addr & 0xFFFFE0000) == 0x10000000)
+	if ((addr & 0xFFFFE000) == 0x10000000)
 	{
 		intUpdateCPUCycles();
 		intEventTest();
@@ -562,7 +562,7 @@ void LH()
 	cpuRegs.GPR.r[_Rt_].SD[0] = temp;
 
 	// Force event test on EE counter read to improve read + interrupt syncing. Namely ESPN Games.
-	if ((addr & 0xFFFFE0000) == 0x10000000)
+	if ((addr & 0xFFFFE000) == 0x10000000)
 	{
 		intUpdateCPUCycles();
 		intEventTest();
@@ -582,7 +582,7 @@ void LHU()
 	cpuRegs.GPR.r[_Rt_].UD[0] = temp;
 
 	// Force event test on EE counter read to improve read + interrupt syncing. Namely ESPN Games.
-	if ((addr & 0xFFFFE0000) == 0x10000000)
+	if ((addr & 0xFFFFE000) == 0x10000000)
 	{
 		intUpdateCPUCycles();
 		intEventTest();
@@ -602,7 +602,7 @@ void LW()
 	cpuRegs.GPR.r[_Rt_].SD[0] = (s32)temp;
 
 	// Force event test on EE counter read to improve read + interrupt syncing. Namely ESPN Games.
-	if ((addr & 0xFFFFE0000) == 0x10000000)
+	if ((addr & 0xFFFFE000) == 0x10000000)
 	{
 		intUpdateCPUCycles();
 		intEventTest();

--- a/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
+++ b/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
@@ -113,7 +113,7 @@ static void recLoad(u32 bits, bool sign)
 		const u32 srcadr = g_cpuConstRegs[_Rs_].UL[0] + _Imm_;
 
 		// Force event test on EE counter read to improve read + interrupt syncing. Namely ESPN Games.
-		if (bits <= 32 && (srcadr & 0xFFFFE0000) == 0x10000000)
+		if (bits <= 32 && (srcadr & 0xFFFFE000) == 0x10000000)
 			needs_flush = true;
 
 		x86reg = vtlb_DynGenReadNonQuad_Const(bits, sign, false, srcadr, alloc_cb);


### PR DESCRIPTION
### Description of Changes
Fixes the addresses for checking for EE timer reads in order to make an event test.

### Rationale behind Changes
Fingers were fat and put too many zero's, making it false positive on a lot of EE register addresses.

### Suggested Testing Steps
Test some ESPN games and GT3 (make sure it no longer delays before the language select)

### Did you use AI to help find, test, or implement this issue or feature?
No, maybe it would have caught this.. lol
