### PR TITLE
GS/HW: Detect offset shuffle on TexIsFB

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -7085,7 +7085,10 @@ bool GSRendererHW::CanUseTexIsFB(const GSTextureCache::Target* rt, const GSTextu
 	if (m_texture_shuffle)
 	{
 		// We can't do tex is FB if the source and destination aren't pointing to the same bit of texture.
-		if (m_texture_shuffle && (floor(abs(m_vt.m_min.t.y) + tex->m_region.GetMinY()) != floor(abs(m_vt.m_min.p.y))))
+		if (floor(abs(m_vt.m_min.t.y) + tex->m_region.GetMinY()) != floor(abs(m_vt.m_min.p.y)))
+			return false;
+
+		if (abs(floor(abs(m_vt.m_min.t.x) + tex->m_region.GetMinX()) - floor(abs(m_vt.m_min.p.x))) > 16)
 			return false;
 
 		GL_CACHE("HW: Enabling tex-is-fb for texture shuffle.");


### PR DESCRIPTION
### Description of Changes
Updates TexIsFB to check for horizontally offset shuffle

### Rationale behind Changes
Didn't check before, causing a shuffle in Timesplitters 2 to copy the wrong data.

### Suggested Testing Steps
Test Timesplitters 2, not sure anything else is affected.

### Did you use AI to help find, test, or implement this issue or feature?
No

Fixes Timesplitters 2 hologram thingy.