### PR TITLE
Qt: Don't use wildcard disconnection for media capture and audio settings combo boxes

### DIFF
--- a/pcsx2-qt/Settings/AudioSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.cpp
@@ -180,7 +180,7 @@ void AudioSettingsWidget::updateDriverNames()
 	const AudioBackend backend = getEffectiveBackend();
 	const std::vector<std::pair<std::string, std::string>> names = AudioStream::GetDriverNames(backend);
 
-	m_ui.driver->disconnect();
+	QObject::disconnect(m_ui.driver, &QComboBox::currentIndexChanged, nullptr, nullptr);
 	m_ui.driver->clear();
 	if (names.empty())
 	{
@@ -208,7 +208,7 @@ void AudioSettingsWidget::updateDeviceNames()
 	const std::string current_device = dialog()->getEffectiveStringValue("SPU2/Output", "DeviceName", "");
 	const std::vector<AudioStream::DeviceInfo> devices = AudioStream::GetOutputDevices(backend, driver_name.c_str());
 
-	m_ui.outputDevice->disconnect();
+	QObject::disconnect(m_ui.outputDevice, &QComboBox::currentIndexChanged, nullptr, nullptr);
 	m_ui.outputDevice->clear();
 	m_output_device_latency = 0;
 

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -981,7 +981,7 @@ void GraphicsSettingsWidget::onCaptureContainerChanged()
 	const std::string container(
 		dialog()->getEffectiveStringValue("EmuCore/GS", "CaptureContainer", Pcsx2Config::GSOptions::DEFAULT_CAPTURE_CONTAINER));
 
-	m_capture.videoCaptureCodec->disconnect();
+	QObject::disconnect(m_capture.videoCaptureCodec, &QComboBox::currentIndexChanged, nullptr, nullptr);
 	m_capture.videoCaptureCodec->clear();
 	//: This string refers to a default codec, whether it's an audio codec or a video codec.
 	m_capture.videoCaptureCodec->addItem(tr("Default"), QString());
@@ -996,7 +996,7 @@ void GraphicsSettingsWidget::onCaptureContainerChanged()
 		dialog()->getSettingsInterface(), m_capture.videoCaptureCodec, "EmuCore/GS", "VideoCaptureCodec");
 	connect(m_capture.videoCaptureCodec, &QComboBox::currentIndexChanged, this, &GraphicsSettingsWidget::onCaptureCodecChanged);
 
-	m_capture.audioCaptureCodec->disconnect();
+	QObject::disconnect(m_capture.audioCaptureCodec, &QComboBox::currentIndexChanged, nullptr, nullptr);
 	m_capture.audioCaptureCodec->clear();
 	m_capture.audioCaptureCodec->addItem(tr("Default"), QString());
 	for (const auto& [format, name] : GSCapture::GetAudioCodecList(container.c_str()))
@@ -1012,7 +1012,7 @@ void GraphicsSettingsWidget::onCaptureContainerChanged()
 
 void GraphicsSettingsWidget::GraphicsSettingsWidget::onCaptureCodecChanged()
 {
-	m_capture.videoCaptureFormat->disconnect();
+	QObject::disconnect(m_capture.videoCaptureFormat, &QComboBox::currentIndexChanged, nullptr, nullptr);
 	m_capture.videoCaptureFormat->clear();
 	//: This string refers to a default pixel format
 	m_capture.videoCaptureFormat->addItem(tr("Default"), "");


### PR DESCRIPTION
### Description of Changes
Disconnect only the QComboBox::currentIndexChanged signal for some combo boxes instead of doing a wildcard disconnect.

Thanks to Pesa for coming up with this simpler solution, the one I thought of initially was more complicated.

### Rationale behind Changes
[Silences the following warnings:](https://github.com/qt/qtbase/blob/90b845d15ffb97693dba527385db83510ebd121a/src/corelib/kernel/qobject.cpp#L3776)

```
QObject::disconnect: wildcard call disconnects from destroyed signal of QComboBox::videoCaptureCodec
QObject::disconnect: wildcard call disconnects from destroyed signal of QComboBox::audioCaptureCodec
QObject::disconnect: wildcard call disconnects from destroyed signal of QComboBox::videoCaptureFormat
QObject::disconnect: wildcard call disconnects from destroyed signal of QComboBox::driver
QObject::disconnect: wildcard call disconnects from destroyed signal of QComboBox::outputDevice
```

According to the documentation [Qt uses the destroyed signal for some internal cleanup, and so doing a wildcard disconnect interferes with that](https://doc.qt.io/qt-6/qobject.html#disconnect-1).

### Suggested Testing Steps
Make sure that the media capture and audio settings still work.

### Did you use AI to help find, test, or implement this issue or feature?
No.
