### PR TITLE
GS/VK: Don't reference old swapchain when recreating on AMD

### DIFF
--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -41,7 +41,8 @@ public:
 		bool vk_ext_rasterization_order_attachment_access : 1;
 		bool vk_ext_full_screen_exclusive : 1;
 		bool vk_ext_line_rasterization : 1;
-		bool vk_ext_swapchain_maintenance1 : 1;
+		bool vk_swapchain_maintenance1 : 1;
+		bool vk_swapchain_maintenance1_is_khr : 1;
 		bool vk_khr_driver_properties : 1;
 		bool vk_khr_shader_non_semantic_info : 1;
 		bool vk_ext_attachment_feedback_loop_layout : 1;

--- a/pcsx2/GS/Renderers/Vulkan/VKEntryPoints.inl
+++ b/pcsx2/GS/Renderers/Vulkan/VKEntryPoints.inl
@@ -241,4 +241,7 @@ VULKAN_DEVICE_ENTRY_POINT(vkCmdPushDescriptorSetKHR, false)
 // VK_EXT_swapchain_maintenance1
 VULKAN_DEVICE_ENTRY_POINT(vkReleaseSwapchainImagesEXT, false)
 
+// VK_KHR_swapchain_maintenance1
+VULKAN_DEVICE_ENTRY_POINT(vkReleaseSwapchainImagesKHR, false)
+
 #endif // VULKAN_DEVICE_ENTRY_POINT

--- a/pcsx2/GS/Renderers/Vulkan/VKSwapChain.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/VKSwapChain.cpp
@@ -369,7 +369,7 @@ bool VKSwapChain::CreateSwapChain()
 	VkSwapchainKHR old_swap_chain;
 	// RDNA4 experences a 2s delay in the following 2-3 vkAcquireNextImageKHR calls if we pass the old swapchain to the new one.
 	// Instead, pass null. This requires us to have freed the old image, which we already do with the swapchain maintenance extension.
-	if (GSDeviceVK::GetInstance()->IsDeviceAMD() && GSDeviceVK::GetInstance()->GetOptionalExtensions().vk_ext_swapchain_maintenance1)
+	if (GSDeviceVK::GetInstance()->IsDeviceAMD() && GSDeviceVK::GetInstance()->GetOptionalExtensions().vk_swapchain_maintenance1)
 	{
 		vkDestroySwapchainKHR(GSDeviceVK::GetInstance()->GetDevice(), m_swap_chain, nullptr);
 		old_swap_chain = VK_NULL_HANDLE;
@@ -559,17 +559,29 @@ void VKSwapChain::ReleaseCurrentImage()
 		return;
 
 	if ((m_image_acquire_result.value() == VK_SUCCESS || m_image_acquire_result.value() == VK_SUBOPTIMAL_KHR) &&
-		GSDeviceVK::GetInstance()->GetOptionalExtensions().vk_ext_swapchain_maintenance1)
+		GSDeviceVK::GetInstance()->GetOptionalExtensions().vk_swapchain_maintenance1)
 	{
 		GSDeviceVK::GetInstance()->WaitForGPUIdle();
 
-		const VkReleaseSwapchainImagesInfoEXT info = {.sType = VK_STRUCTURE_TYPE_RELEASE_SWAPCHAIN_IMAGES_INFO_EXT,
-			.swapchain = m_swap_chain,
-			.imageIndexCount = 1,
-			.pImageIndices = &m_current_image};
-		VkResult res = vkReleaseSwapchainImagesEXT(GSDeviceVK::GetInstance()->GetDevice(), &info);
+		VkResult res;
+		if (GSDeviceVK::GetInstance()->GetOptionalExtensions().vk_swapchain_maintenance1_is_khr)
+		{
+			const VkReleaseSwapchainImagesInfoKHR info = {.sType = VK_STRUCTURE_TYPE_RELEASE_SWAPCHAIN_IMAGES_INFO_KHR,
+				.swapchain = m_swap_chain,
+				.imageIndexCount = 1,
+				.pImageIndices = &m_current_image};
+			res = vkReleaseSwapchainImagesKHR(GSDeviceVK::GetInstance()->GetDevice(), &info);
+		}
+		else
+		{
+			const VkReleaseSwapchainImagesInfoEXT info = {.sType = VK_STRUCTURE_TYPE_RELEASE_SWAPCHAIN_IMAGES_INFO_EXT,
+				.swapchain = m_swap_chain,
+				.imageIndexCount = 1,
+				.pImageIndices = &m_current_image};
+			res = vkReleaseSwapchainImagesEXT(GSDeviceVK::GetInstance()->GetDevice(), &info);
+		}
 		if (res != VK_SUCCESS)
-			LOG_VULKAN_ERROR(res, "vkReleaseSwapchainImagesEXT() failed: ");
+			LOG_VULKAN_ERROR(res, "vkReleaseSwapchainImages() failed: ");
 	}
 
 	m_image_acquire_result.reset();


### PR DESCRIPTION
### Description of Changes
Don't reference old swapchain when recreating on AMD

### Rationale behind Changes
RDNA4 experiences a 2 second delay for the first 2-3 vkAcquireNextImageKHR() calls after swapchain recreation if the new swapchain is linked to the old one.

One should not have to wait 4s for a resize.

### Suggested Testing Steps
Resize the window using the Vulkan backend

### Did you use AI to help find, test, or implement this issue or feature?
Nay I Say!