### PR TITLE
SaveState: Swap two OSD error messages that were the wrong way round

### DIFF
--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -1252,10 +1252,10 @@ void SaveState_ReportLoadErrorOSD(const std::string& message, std::optional<s32>
 	{
 		if (backup)
 			full_message = fmt::format(
-				TRANSLATE_FS("SaveState", "Failed to load state from slot {}: {}"), *slot, message);
+				TRANSLATE_FS("SaveState", "Failed to load state from backup slot {}: {}"), *slot, message);
 		else
 			full_message = fmt::format(
-				TRANSLATE_FS("SaveState", "Failed to load state from backup slot {}: {}"), *slot, message);
+				TRANSLATE_FS("SaveState", "Failed to load state from slot {}: {}"), *slot, message);
 	}
 	else
 	{


### PR DESCRIPTION
### Description of Changes
Make the error messages you get for backup/non-backup save states the right way round.

### Rationale behind Changes
Regression from #13638.

### Suggested Testing Steps
N/A

### Did you use AI to help find, test, or implement this issue or feature?
No.
