### PR TITLE
Qt: Add RA Logo to Achievement Login Dialog

### DIFF
--- a/pcsx2-qt/Settings/AchievementLoginDialog.cpp
+++ b/pcsx2-qt/Settings/AchievementLoginDialog.cpp
@@ -17,7 +17,8 @@ AchievementLoginDialog::AchievementLoginDialog(QWidget* parent, Achievements::Lo
 	, m_reason(reason)
 {
 	m_ui.setupUi(this);
-	QtUtils::SetScalableIcon(m_ui.loginIcon, QIcon::fromTheme(QStringLiteral("login-box-line")), QSize(32, 32));
+	const QString base_path(QtHost::GetResourcesBasePath());
+	QtUtils::SetScalableIcon(m_ui.loginIcon, QIcon(QStringLiteral("%1/icons/ra-icon.svg").arg(base_path)), QSize(50, 50));
 	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
 	// Adjust text if needed based on reason.


### PR DESCRIPTION
<img width="449" height="228" alt="image" src="https://github.com/user-attachments/assets/5cab73a8-41c0-415c-8e5e-57312e7b2cac" />

### Description of Changes
Adds the RetroAchievements logo to the Qt login dialog.

### Rationale behind Changes
Improves visual consistency and brings the Qt login dialog in line with BPM/FSUI.

### Suggested Testing Steps
Open the login dialog and make sure that the RetroAchievements logo is displayed correctly.

### Did you use AI to help find, test, or implement this issue or feature?
No