### PR TITLE
Qt: Add missing include

### DIFF
--- a/pcsx2-qt/Settings/GameCheatSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GameCheatSettingsWidget.cpp
@@ -14,6 +14,7 @@
 #include "common/HeterogeneousContainers.h"
 
 #include <QtCore/QSortFilterProxyModel>
+#include <QtGui/QMouseEvent>
 #include <QtGui/QStandardItemModel>
 
 GameCheatSettingsWidget::GameCheatSettingsWidget(SettingsWindow* settings_dialog, QWidget* parent)


### PR DESCRIPTION
### Description of Changes
Adds a missing include.

### Rationale behind Changes
[A user was reporting build errors.](https://github.com/PCSX2/pcsx2/commit/a33612cf7d0dfde45d3b96d51e65c96ee919a93a#r172956681)

### Suggested Testing Steps
N/A

### Did you use AI to help find, test, or implement this issue or feature?
No.
