### PR TITLE
GS/HW: Optimize source sizes when using CLAMP_CLAMP

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -445,7 +445,7 @@ protected:
 	std::unique_ptr<GSDownloadTexture> m_uint16_download_texture;
 	std::unique_ptr<GSDownloadTexture> m_uint32_download_texture;
 
-	Source* CreateSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, Target* t, int x_offset, int y_offset, const GSVector2i* lod, const GSVector4i* src_range, GSTexture* gpu_clut, SourceRegion region, bool force_temporary = false);
+	Source* CreateSource(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA, const GIFRegCLAMP& CLAMP, Target* t, int x_offset, int y_offset, const GSVector2i* lod, const GSVector4i* src_range, GSTexture* gpu_clut, SourceRegion region, bool force_temporary = false);
 
 	bool PreloadTarget(GIFRegTEX0 TEX0, const GSVector2i& size, const GSVector2i& valid_size, bool is_frame,
 		bool preload, bool preserve_target, const GSVector4i draw_rect, Target* dst, GSTextureCache::Source* src = nullptr);


### PR DESCRIPTION
### Description of Changes
Optimises source sizes when using CLAMP_CLAMP. Improves performance by a bit in D.C.I.F Da Capo Innocent Finale during a screen transition.

Fixes #13705 

<img width="678" height="213" alt="image" src="https://github.com/user-attachments/assets/bb52eb96-25e1-4e11-bdb4-d7456cbecc6b" />


### Rationale behind Changes
10 fps is unacceptable for a simple screen transition may also speed up other games.

### Suggested Testing Steps
Test any games that use the hash cache heavily or that use paltex or estimate texture region and make sure they don't regress visually or performance wise.

### Did you use AI to help find, test, or implement this issue or feature?
No
