### PR TITLE
Debugger: Allow removing conditions from the breakpoint dialog

### DIFF
--- a/pcsx2-qt/Debugger/Breakpoints/BreakpointDialog.cpp
+++ b/pcsx2-qt/Debugger/Breakpoints/BreakpointDialog.cpp
@@ -123,6 +123,11 @@ void BreakpointDialog::accept()
 			bp->cond.expression = expr;
 			bp->cond.expressionString = m_ui.txtCondition->text().toStdString();
 		}
+		else
+		{
+			bp->hasCond = false;
+			bp->cond = {};
+		}
 	}
 	if (auto* mc = std::get_if<MemCheck>(&m_bp_mc))
 	{
@@ -158,6 +163,11 @@ void BreakpointDialog::accept()
 
 			mc->cond.expression = expr;
 			mc->cond.expressionString = m_ui.txtCondition->text().toStdString();
+		}
+		else
+		{
+			mc->hasCond = false;
+			mc->cond = {};
 		}
 
 		int condition = 0;


### PR DESCRIPTION
### Description of Changes
Make it so if you clear the condition field in the breakpoint dialog it will actually remove the condition.

### Rationale behind Changes
You could already remove the condition using the delegates, but this was causing user confusion so I still think it's a good idea to fix this.

### Suggested Testing Steps
Try creating a breakpoint with a condition, then removing it using the breakpoint editor dialog.

### Did you use AI to help find, test, or implement this issue or feature?
No.
