### PR TITLE
GameDB: Guitar Hero Smash Hits fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -30130,6 +30130,11 @@ SLES-55544:
   region: "PAL-M5"
   roundModes:
     vu1RoundMode: 0 # Fixes VU size spam and potential graphical issues with GH3 engine.
+  gsHWFixes:
+    cpuCLUTRender: 1 # Fixes broken rainbow rendering.
+    halfPixelOffset: 4 # Mostly aligns post-processing.
+    nativeScaling: 1 # Fixes post-processing smoothness and position.
+    autoFlush: 1 # Fixes edge garbage and shadow definition.
 SLES-55545:
   name: "WWE SmackDown! vs. Raw 2010"
   region: "PAL-M5"
@@ -74178,8 +74183,10 @@ SLUS-21866:
   roundModes:
     vu1RoundMode: 0 # Fixes VU size spam and potential graphical issues with GH3 engine.
   gsHWFixes:
+    cpuCLUTRender: 1 # Fixes broken rainbow rendering.
     halfPixelOffset: 4 # Mostly aligns post-processing.
     nativeScaling: 1 # Fixes post-processing smoothness and position.
+    autoFlush: 1 # Fixes edge garbage and shadow definition.
 SLUS-21867:
   name: "Guitar Hero - Van Halen"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Adds CPU CLUT to fix the clown vomit graphics all over the screen.

Before:
<img width="2389" height="1344" alt="Guitar Hero - Smash Hits_SLUS-21866_20251223135015" src="https://github.com/user-attachments/assets/893f99cf-061b-4ca8-bbd9-c8590ad3da4c" />

After:
<img width="2389" height="1344" alt="Guitar Hero - Smash Hits_SLUS-21866_20251223135039" src="https://github.com/user-attachments/assets/f48a9b97-d24c-4059-ac5b-d23ac4a6e634" />

### Rationale behind Changes
Broken game bad.

### Suggested Testing Steps
N/A

### Did you use AI to help find, test, or implement this issue or feature?
No
