### PR TITLE
GS/D3D: Default to DX12 on older GCN amd cards.

### DIFF
--- a/pcsx2/GS/Renderers/DX11/D3D.cpp
+++ b/pcsx2/GS/Renderers/DX11/D3D.cpp
@@ -439,7 +439,9 @@ GSRendererType D3D::GetPreferredRenderer()
 			if (!feature_level.has_value())
 				return GSRendererType::DX11;
 			else if (feature_level == D3D_FEATURE_LEVEL_12_0)
-				return check_vulkan_supported() ? GSRendererType::VK : GSRendererType::DX11;
+				return check_vulkan_supported() ? GSRendererType::VK : GSRendererType::DX12;
+			else if (feature_level == D3D_FEATURE_LEVEL_11_1)
+				return GSRendererType::DX12;
 			else
 				return GSRendererType::DX11;
 		}


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/D3D: Default to DX12 on older GCN amd cards.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Older gcn cards support dx12 at feature level 11.1 and up, we can use that as the default, will be faster than dx11 and opengl since they use the old pre re written gl drivers, I don't think older Vulkan driver works either.
Note: Terascale 3 and lower cap at feature level 11.0.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Someone with a gcn1 card test if it defaults to dx12.
A good dump to test if dx12 works properly is this below
[superman_shadow_of_apokolips.gs.zip](https://github.com/user-attachments/files/24321654/superman_shadow_of_apokolips.gs.zip)

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.
