### PR TITLE
Patch: Show correct place value when mixing labelled/unlabelled patches

### DIFF
--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -522,11 +522,11 @@ void Patch::ExtractPatchInfo(std::vector<PatchInfo>* dst, const std::string& pna
 					}
 				}
 				current_patch = {};
-				last_place = std::nullopt;
-				unknown_place = false;
 			}
 
 			current_patch.name = line.substr(1, line.length() - 2);
+			last_place = std::nullopt;
+			unknown_place = false;
 			continue;
 		}
 


### PR DESCRIPTION
### Description of Changes
Make it so if the file contains unlabelled patches, which have a different place value to the first labelled one, the first labelled one doesn't always show up as "Applied: Unknown".

### Rationale behind Changes
It's a fairly minor bug, but I think it's still a good idea to get it fixed.

### Suggested Testing Steps
Example pnach file to test with:

```
patch=0,EE,0015ed98,word,7fffffff

[Should Be Every Frame]
author=Chaoticgd
descripton=Example
patch=1,EE,0015ed98,word,7fffffff
```

### Did you use AI to help find, test, or implement this issue or feature?
No.
