### PR TITLE
DiscordRPC: Simplify Game Icon Retrieval

### DIFF
--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -1043,20 +1043,10 @@ void Achievements::ClientLoadGameCallback(int result, const char* error_message,
 	s_has_leaderboards = has_leaderboards;
 	s_has_rich_presence = rc_client_has_rich_presence(client);
 	s_game_icon = {};
-	s_game_icon_url = {};
+	s_game_icon_url = info->badge_url;
 
 	// ensure fullscreen UI is ready for notifications
 	MTGS::RunOnGSThread(&ImGuiManager::InitializeFullscreenUI);
-
-	char url_buffer[URL_BUFFER_SIZE];
-	if (int err = rc_client_game_get_image_url(info, url_buffer, std::size(url_buffer)); err == RC_OK)
-	{
-		s_game_icon_url = url_buffer;
-	}
-	else
-	{
-		ReportRCError(err, "rc_client_game_get_image_url() failed: ");
-	}
 
 	if (const std::string_view badge_name = info->badge_name; !badge_name.empty())
 	{

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -3725,15 +3725,16 @@ void VMManager::UpdateDiscordPresence(bool update_session_time)
 
 	auto lock = Achievements::GetLock();
 
-	if (Achievements::HasRichPresence())
+	if (Achievements::HasActiveGame() && Achievements::HasAchievementsOrLeaderboards())
 	{
-		rp.state = (state_string = StringUtil::Ellipsise(Achievements::GetRichPresenceString(), 128)).c_str();
-
 		if (const std::string& icon_url = Achievements::GetGameIconURL(); !icon_url.empty())
 		{
 			rp.largeImageKey = icon_url.c_str();
 			rp.largeImageText = s_title.c_str();
 		}
+
+		if (Achievements::HasRichPresence())
+			rp.state = (state_string = StringUtil::Ellipsise(Achievements::GetRichPresenceString(), 128)).c_str();
 	}
 
 	Discord_UpdatePresence(&rp);


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

Simplify how we retrieve the rcheevos set image. Previously we have to get the URL manually by using `rc_client_game_get_image_url` since `rc_client_get_game_info` does not provide the URL by default.

#12940 rcheevos v12.0.0 added `badge_url` entry to `rc_client_get_game_info` which means we can use it instead of having to grab the URL on our own manually.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

Simplification

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

Just run a game which has an achievement set + rich presence support and see if the icon shows up properly.

I've already tested locally and they still work.

<img width="476" height="282" alt="image" src="https://github.com/user-attachments/assets/4b710241-5081-45ca-a89e-ab1ae30fd6bf" />

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->

Gak