### PR TITLE
GSRunner: Disable framerate limit in runner and dump frame timing stats.

### DIFF
--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -31,6 +31,7 @@
 #include "pcsx2/Achievements.h"
 #include "pcsx2/CDVD/CDVD.h"
 #include "pcsx2/GS.h"
+#include "pcsx2/GS/Renderers/Common/GSDevice.h"
 #include "pcsx2/GS/GSPerfMon.h"
 #include "pcsx2/GSDumpReplayer.h"
 #include "pcsx2/GameList.h"
@@ -99,6 +100,17 @@ static u64 s_total_uploads = 0;
 static u64 s_total_readbacks = 0;
 static u32 s_total_frames = 0;
 static u32 s_total_drawn_frames = 0;
+
+static bool s_perf_enable = false;
+static float s_perf_updates = 0.0f;
+static float s_perf_sum_fps = 0.0f;
+static float s_perf_sum_internal_fps = 0.0f;
+static float s_perf_sum_cpu_thread_usage = 0.0f;
+static float s_perf_sum_cpu_thread_time = 0.0f;
+static float s_perf_sum_gs_thread_usage = 0.0f;
+static float s_perf_sum_gs_thread_time = 0.0f;
+static float s_perf_sum_gpu_time = 0.0f;
+static float s_perf_sum_gpu_usage = 0.0f;
 
 bool GSRunner::InitializeConfig()
 {
@@ -318,6 +330,18 @@ void Host::OnGameChanged(const std::string& title, const std::string& elf_overri
 
 void Host::OnPerformanceMetricsUpdated()
 {
+	if (s_perf_enable)
+	{
+		s_perf_updates += 1.0f;
+		s_perf_sum_fps += PerformanceMetrics::GetFPS();
+		s_perf_sum_internal_fps += PerformanceMetrics::GetInternalFPS();
+		s_perf_sum_cpu_thread_usage += PerformanceMetrics::GetCPUThreadUsage();
+		s_perf_sum_cpu_thread_time += PerformanceMetrics::GetCPUThreadAverageTime();
+		s_perf_sum_gs_thread_usage += PerformanceMetrics::GetGSThreadUsage();
+		s_perf_sum_gs_thread_time += PerformanceMetrics::GetGSThreadAverageTime();
+		s_perf_sum_gpu_time += PerformanceMetrics::GetGPUAverageTime();
+		s_perf_sum_gpu_usage += PerformanceMetrics::GetGPUUsage();
+	}
 }
 
 void Host::OnSaveStateLoading(const std::string_view filename)
@@ -482,6 +506,7 @@ static void PrintCommandLineHelp(const char* progname)
 	std::fprintf(stderr, "  -surfaceless: Disables showing a window.\n");
 	std::fprintf(stderr, "  -logfile <filename>: Writes emu log to filename.\n");
 	std::fprintf(stderr, "  -noshadercache: Disables the shader cache (useful for parallel runs).\n");
+	std::fprintf(stderr, "  -perf: Enable frame timing performance stats.\n");
 	std::fprintf(stderr, "  --: Signals that no more arguments will follow and the remaining\n"
 						 "    parameters make up the filename. Use when the filename contains\n"
 						 "    spaces or starts with a dash.\n");
@@ -768,6 +793,12 @@ bool GSRunner::ParseCommandLineArgs(int argc, char* argv[], VMBootParameters& pa
 				s_use_window = false;
 				continue;
 			}
+			else if (CHECK_ARG("-perf"))
+			{
+				Console.WriteLn("Enable performance stats");
+				s_perf_enable = true;
+				continue;
+			}
 			else if (CHECK_ARG("--"))
 			{
 				no_more_args = true;
@@ -876,6 +907,18 @@ void GSRunner::DumpStats()
 	Console.WriteLn(fmt::format("@HWSTAT@ Copies: {} (avg {})", s_total_copies, static_cast<u64>(std::ceil(s_total_copies / static_cast<double>(s_total_drawn_frames)))));
 	Console.WriteLn(fmt::format("@HWSTAT@ Uploads: {} (avg {})", s_total_uploads, static_cast<u64>(std::ceil(s_total_uploads / static_cast<double>(s_total_drawn_frames)))));
 	Console.WriteLn(fmt::format("@HWSTAT@ Readbacks: {} (avg {})", s_total_readbacks, static_cast<u64>(std::ceil(s_total_readbacks / static_cast<double>(s_total_drawn_frames)))));
+	if (s_perf_enable)
+	{
+		Console.WriteLn(fmt::format("@HWSTAT@ Minimum Frame Time: {:.3f} ms ({:.3f} FPS)", PerformanceMetrics::GetMinimumFrameTime(), 1000.0f / PerformanceMetrics::GetMinimumFrameTime()));
+		Console.WriteLn(fmt::format("@HWSTAT@ Average Frame Time: {:.3f} ms ({:.3f} FPS)", PerformanceMetrics::GetAverageFrameTime(), 1000.0f / PerformanceMetrics::GetAverageFrameTime()));
+		Console.WriteLn(fmt::format("@HWSTAT@ Maximum Frame Time: {:.3f} ms ({:.3f} FPS)", PerformanceMetrics::GetMaximumFrameTime(), 1000.0f / PerformanceMetrics::GetMaximumFrameTime()));
+		Console.WriteLn(fmt::format("@HWSTAT@ CPU Thread Usage: {:.3f} %", s_perf_sum_cpu_thread_usage / s_perf_updates));
+		Console.WriteLn(fmt::format("@HWSTAT@ GS Thread Usage: {:.3f} %", s_perf_sum_gs_thread_usage / s_perf_updates));
+		Console.WriteLn(fmt::format("@HWSTAT@ GPU Usage: {:.3f} %", s_perf_sum_gpu_usage / s_perf_updates));
+		Console.WriteLn(fmt::format("@HWSTAT@ Average CPU Thread Time: {:.3f} ms", s_perf_sum_cpu_thread_time / s_perf_updates));
+		Console.WriteLn(fmt::format("@HWSTAT@ Average GS Thread Time: {:.3f} ms", s_perf_sum_gs_thread_time / s_perf_updates));
+		Console.WriteLn(fmt::format("@HWSTAT@ Average GPU Time: {:.3f} ms", s_perf_sum_gpu_time / s_perf_updates));
+	}
 	Console.WriteLn("============================================");
 }
 
@@ -899,6 +942,11 @@ static void CPUThreadMain(VMBootParameters* params, std::atomic<int>* ret)
 			// run until end
 			GSDumpReplayer::SetLoopCount(s_loop_count);
 			VMManager::SetState(VMState::Running);
+			if (s_perf_enable)
+			{
+				VMManager::SetLimiterMode(LimiterModeType::Unlimited);
+				g_gs_device->SetGPUTimingEnabled(true);
+			}
 			while (VMManager::GetState() == VMState::Running)
 				VMManager::Execute();
 			VMManager::Shutdown(false);

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -692,7 +692,7 @@ void GSRenderer::VSync(u32 field, bool registers_written, bool idle_frame)
 
 			EndPresentFrame();
 
-			if (GSConfig.OsdShowGPU)
+			if (GSConfig.OsdShowGPU || GSDumpReplayer::IsReplayingDump())
 				PerformanceMetrics::OnGPUPresent(g_gs_device->GetAndResetAccumulatedGPUTime());
 		}
 


### PR DESCRIPTION
### Description of Changes
1. Set the frame limit mode to unlimited in the GS runner.
2. Add a switch (-perf) to GS runner to allow dumping the frame timing stats.

### Rationale behind Changes
Allows benchmarking in the GS runner. Might make dump runs go a bit faster.

### Suggested Testing Steps
1. Run the GS runner on dumps and check if the frame rate goes about 30 or 60 fps depending on the type of game.
2. The output when using the -perf switch should look like this (new content from Minimum Frame Time):
    ```
    [    9.1993] ======= HW STATISTICS FOR 16 (16) FRAMES ========
    [    9.1995] @HWSTAT@ Draw Calls: 92141 (avg 5759)
    [    9.1996] @HWSTAT@ Render Passes: 702 (avg 44)
    [    9.1998] @HWSTAT@ Barriers: 70032 (avg 4377)
    [    9.1999] @HWSTAT@ Copies: 128 (avg 8)
    [    9.1999] @HWSTAT@ Uploads: 186 (avg 12)
    [    9.2000] @HWSTAT@ Readbacks: 16 (avg 1)
    [    9.2001] @HWSTAT@ Minimum Frame Time: 224.168 ms (4.461 FPS)
    [    9.2002] @HWSTAT@ Average Frame Time: 238.668 ms (4.190 FPS)
    [    9.2004] @HWSTAT@ Maximum Frame Time: 252.306 ms (3.963 FPS)
    [    9.2005] @HWSTAT@ CPU Thread Usage: 0.974 %
    [    9.2007] @HWSTAT@ GS Thread Usage: 91.021 %
    [    9.2008] @HWSTAT@ GPU Usage: 7.278 %
    [    9.2009] @HWSTAT@ Average CPU Thread Time: 2.522 ms
    [    9.2011] @HWSTAT@ Average GS Thread Time: 289.631 ms
    [    9.2013] @HWSTAT@ Average GPU Time: 16.549 ms
    [    9.2014] ============================================
    ```

### Did you use AI to help find, test, or implement this issue or feature?
No.
