### PR TITLE
GS/DX12: Don't move to next command list until after wait

### DIFF
--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -343,12 +343,14 @@ bool GSDevice12::CreateCommandLists()
 
 void GSDevice12::MoveToNextCommandList()
 {
-	m_current_command_list = (m_current_command_list + 1) % NUM_COMMAND_LISTS;
-	m_current_fence_value++;
+	const int next_command_list = (m_current_command_list + 1) % NUM_COMMAND_LISTS;
 
 	// We may have to wait if this command list hasn't finished on the GPU.
-	CommandListResources& res = m_command_lists[m_current_command_list];
+	CommandListResources& res = m_command_lists[next_command_list];
 	WaitForFence(res.ready_fence_value, false);
+
+	m_current_command_list = next_command_list;
+	m_current_fence_value++;
 	res.ready_fence_value = m_current_fence_value;
 	res.init_command_list_used = false;
 


### PR DESCRIPTION
### Description of Changes
Don't move to next command list until after we have waited on it.

### Rationale behind Changes
In the DX12 backend, we sometimes defer freeing resources/descriptors until the associated command list is done.
This is handled in the `WaitForFence()` function, which among other locations, gets called in `MoveToNextCommandList()`

Our command lists are held in a ring buffer, with the current command list specified by ``m_current_command_list``, so `WaitForFence` will loop the command lists to for any completed lists.
It will start from checking the command list _after_ the current list, and loop until finding a list that isn't complete, or having freed all.

See simplified example for a ring buffer of 3 elements
```
m_current_command_list = 1
Start from index 2
Check m_command_lists[2], is complete, free resources
Check m_command_lists[0], is complete, free resources
Check m_command_lists[1], is not complete, exit loop
```

Now, in `MoveToNextCommandList()` we previously set `m_current_command_list` to the next list and then waited on it's fence so we could use it.
However,  because we set `m_current_command_list` before waiting, when `WaitForFence()` tries to free resources it might fail to free the resources from the old command list (instead carrying them into the new one)

See example
```
m_current_command_list set to 2 by MoveToNextCommandList()
Start from index 0 (wrapping around)
Check m_command_lists[0], is complete, free resources
Check m_command_lists[1], is not complete, exit loop
Old resource from m_command_lists[2] not freed
```

This same behaviour will also cause us to leak resources/descriptors on shutdown.

### Suggested Testing Steps
Test VRAM usage after shutting down a game using the DX12 render
Might be worth checking VRAM usage during gameplay to see if there is an impact.

### Did you use AI to help find, test, or implement this issue or feature?
No
