### PR TITLE
Misc: Rewrite code for reading/writing zip files

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -34,6 +34,7 @@ target_sources(common PRIVATE
 	WAVWriter.cpp
 	WindowInfo.cpp
 	YAML.cpp
+	ZipFile.cpp
 )
 
 target_sources(common PRIVATE
@@ -81,6 +82,7 @@ target_sources(common PRIVATE
 	WindowInfo.h
 	WrappedMemCopy.h
 	YAML.h
+	ZipFile.h
 )
 
 if(_M_X86)
@@ -209,6 +211,7 @@ target_link_libraries(common PUBLIC
 	fmt::fmt
 	fast_float
 	rapidyaml::rapidyaml
+	libzip::zip
 )
 
 fixup_file_properties(common)

--- a/common/ZipFile.cpp
+++ b/common/ZipFile.cpp
@@ -1,0 +1,436 @@
+// SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "ZipFile.h"
+
+#include "common/Assertions.h"
+
+ZipArchive::ZipArchive()
+{
+}
+
+ZipArchive::~ZipArchive()
+{
+	if (m_zip)
+		DiscardChangesAndClose();
+}
+
+ZipArchive::ZipArchive(ZipArchive&& rhs)
+	: m_zip(rhs.m_zip)
+{
+	rhs.m_zip = nullptr;
+}
+
+ZipArchive& ZipArchive::operator=(ZipArchive&& rhs)
+{
+	if (m_zip)
+		DiscardChangesAndClose();
+
+	m_zip = rhs.m_zip;
+	rhs.m_zip = nullptr;
+
+	return *this;
+}
+
+bool ZipArchive::Open(const char* path, int flags, int* error_code, Error* error)
+{
+	pxAssert(!m_zip);
+
+	int err;
+	m_zip = zip_open(path, flags, &err);
+	if (!m_zip)
+	{
+		if (error_code)
+			*error_code = err;
+
+		zip_error_t open_error;
+		zip_error_init_with_code(&open_error, err);
+		Error::SetString(error, zip_error_strerror(&open_error));
+		zip_error_fini(&open_error);
+
+		return false;
+	}
+
+	return true;
+}
+
+bool ZipArchive::SaveChangesAndClose(Error* error)
+{
+	if (zip_close(m_zip) != 0)
+	{
+		Error::SetString(error, zip_strerror(m_zip));
+		return false;
+	}
+
+	m_zip = nullptr;
+	return true;
+}
+
+void ZipArchive::DiscardChangesAndClose()
+{
+	pxAssert(m_zip);
+
+	zip_discard(m_zip);
+	m_zip = nullptr;
+}
+
+bool ZipArchive::IsValid()
+{
+	return m_zip != nullptr;
+}
+
+std::optional<ZipEntryIndex> ZipArchive::LocateFile(const char* name, zip_flags_t flags, Error* error)
+{
+	pxAssert(m_zip);
+
+	s64 index = zip_name_locate(m_zip, name, flags);
+	if (index < 0)
+	{
+		Error::SetString(error, zip_strerror(m_zip));
+		return std::nullopt;
+	}
+
+	return static_cast<ZipEntryIndex>(index);
+}
+
+std::optional<zip_stat_t> ZipArchive::StatFile(ZipEntryIndex index, zip_flags_t flags, Error* error)
+{
+	pxAssert(m_zip);
+
+	zip_stat_t stat = {};
+	if (zip_stat_index(m_zip, index, flags, &stat) != 0)
+	{
+		Error::SetString(error, zip_strerror(m_zip));
+		return std::nullopt;
+	}
+
+	return stat;
+}
+
+std::optional<std::string> ZipArchive::ReadTextFile(ZipEntryIndex index, zip_flags_t flags, Error* error)
+{
+	pxAssert(m_zip);
+
+	ZipEntry file;
+	if (!file.Open(*this, index, flags, error))
+		return std::nullopt;
+
+	return file.ReadText(error);
+}
+
+std::optional<std::vector<u8>> ZipArchive::ReadBinaryFile(ZipEntryIndex index, zip_flags_t flags, Error* error)
+{
+	pxAssert(m_zip);
+
+	ZipEntry file;
+	if (!file.Open(*this, index, flags, error))
+		return std::nullopt;
+
+	return file.ReadBinary(error);
+}
+
+std::optional<ZipEntryIndex> ZipArchive::AddFileFromBuffer(
+	const char* name, void* data, u64 length, zip_flags_t flags, int freep, Error* error)
+{
+	pxAssert(m_zip);
+
+	ZipSource source;
+
+	if (!source.CreateBuffer(data, length, freep, error))
+		return false;
+
+	return AddFileFromSource(name, source, flags, error);
+}
+
+std::optional<ZipEntryIndex> ZipArchive::AddFileFromSource(
+	const char* name, ZipSource& source, zip_flags_t flags, Error* error)
+{
+	pxAssert(m_zip);
+
+	s64 index = zip_file_add(m_zip, name, source.m_source, flags);
+	if (index < 0)
+	{
+		Error::SetString(error, zip_strerror(m_zip));
+		return std::nullopt;
+	}
+
+	// Ownership of the source has been transferred.
+	source.m_source = nullptr;
+
+	return static_cast<ZipEntryIndex>(index);
+}
+
+bool ZipArchive::SetFileCompression(ZipEntryIndex index, s32 comp, u32 comp_flags, Error* error)
+{
+	pxAssert(m_zip);
+
+	if (zip_set_file_compression(m_zip, index, comp, comp_flags) != 0)
+	{
+		Error::SetString(error, zip_strerror(m_zip));
+		return false;
+	}
+
+	return true;
+}
+
+// *****************************************************************************
+
+ZipEntry::ZipEntry()
+{
+}
+
+ZipEntry::~ZipEntry()
+{
+	if (m_file)
+		Close();
+}
+
+ZipEntry::ZipEntry(ZipEntry&& rhs)
+	: m_archive(rhs.m_archive)
+	, m_index(rhs.m_index)
+	, m_file(rhs.m_file)
+{
+	rhs.m_archive = nullptr;
+	rhs.m_index = 0;
+	rhs.m_file = nullptr;
+}
+
+ZipEntry& ZipEntry::operator=(ZipEntry&& rhs)
+{
+	if (m_file)
+		Close();
+
+	m_archive = rhs.m_archive;
+	m_index = rhs.m_index;
+	m_file = rhs.m_file;
+
+	rhs.m_archive = nullptr;
+	rhs.m_index = 0;
+	rhs.m_file = nullptr;
+
+	return *this;
+}
+
+bool ZipEntry::Open(ZipArchive& archive, ZipEntryIndex index, zip_flags_t flags, Error* error)
+{
+	pxAssert(!m_file);
+	pxAssert(archive.m_zip);
+
+	m_file = zip_fopen_index(archive.m_zip, index, flags);
+	if (!m_file)
+	{
+		Error::SetString(error, zip_strerror(archive.m_zip));
+		return false;
+	}
+
+	m_archive = &archive;
+	m_index = index;
+
+	return true;
+}
+
+void ZipEntry::Close()
+{
+	pxAssert(m_file);
+
+	zip_fclose(m_file);
+
+	m_archive = nullptr;
+	m_index = 0;
+	m_file = nullptr;
+}
+
+bool ZipEntry::IsValid()
+{
+	return m_file != nullptr;
+}
+
+bool ZipEntry::Read(void* buffer, u64 nbytes, Error* error)
+{
+	pxAssert(m_file);
+
+	s64 bytes = zip_fread(m_file, buffer, nbytes);
+	if (bytes < 0)
+	{
+		Error::SetString(error, zip_file_strerror(m_file));
+		return false;
+	}
+
+	if (static_cast<u64>(bytes) != nbytes)
+	{
+		Error::SetString(error, "Tried to read past end of file");
+		return false;
+	}
+
+	return true;
+}
+
+bool ZipEntry::Seek(s64 offset, int whence, Error* error)
+{
+	pxAssert(m_file);
+
+	if (zip_fseek(m_file, offset, whence) != 0)
+	{
+		Error::SetString(error, zip_file_strerror(m_file));
+		return false;
+	}
+
+	return true;
+}
+
+std::optional<u64> ZipEntry::Tell(Error* error)
+{
+	pxAssert(m_file);
+
+	s64 offset = zip_ftell(m_file);
+	if (offset < 0)
+	{
+		Error::SetString(error, zip_file_strerror(m_file));
+		return std::nullopt;
+	}
+
+	return static_cast<u64>(offset);
+}
+
+std::optional<u64> ZipEntry::Size(Error* error)
+{
+	pxAssert(m_file);
+
+	std::optional<zip_stat_t> stat = m_archive->StatFile(m_index, ZIP_STAT_SIZE, error);
+	if (!stat.has_value())
+		return std::nullopt;
+
+	return stat->size;
+}
+
+std::optional<std::string> ZipEntry::ReadText(Error* error)
+{
+	pxAssert(m_file);
+
+	std::optional<u64> size = Size(error);
+	if (!size.has_value())
+		return std::nullopt;
+
+	std::string string(*size, '\0');
+	if (!Read(string.data(), string.size(), error))
+		return std::nullopt;
+
+	return string;
+}
+
+std::optional<std::vector<u8>> ZipEntry::ReadBinary(Error* error)
+{
+	pxAssert(m_file);
+
+	std::optional<u64> size = Size(error);
+	if (!size.has_value())
+		return std::nullopt;
+
+	std::vector<u8> binary(*size, '\0');
+	if (!Read(binary.data(), binary.size(), error))
+		return std::nullopt;
+
+	return binary;
+}
+
+// *****************************************************************************
+
+ZipSource::ZipSource()
+{
+}
+
+ZipSource::~ZipSource()
+{
+	if (m_source)
+		Free();
+}
+
+ZipSource::ZipSource(ZipSource&& rhs)
+	: m_source(rhs.m_source)
+{
+	rhs.m_source = nullptr;
+}
+
+ZipSource& ZipSource::operator=(ZipSource&& rhs)
+{
+	if (m_source)
+		Free();
+
+	m_source = rhs.m_source;
+	rhs.m_source = nullptr;
+
+	return *this;
+}
+
+bool ZipSource::CreateBuffer(void* data, u64 length, int freep, Error* error)
+{
+	pxAssert(!m_source);
+
+	zip_error_t create_error;
+	zip_error_init(&create_error);
+	m_source = zip_source_buffer_create(data, length, freep, &create_error);
+	if (!m_source)
+	{
+		Error::SetString(error, zip_error_strerror(&create_error));
+		zip_error_fini(&create_error);
+		if (freep)
+			std::free(data);
+		return false;
+	}
+
+	zip_error_fini(&create_error);
+
+	return true;
+}
+
+void ZipSource::Free()
+{
+	pxAssert(m_source);
+
+	zip_source_free(m_source);
+	m_source = nullptr;
+}
+
+bool ZipSource::IsValid()
+{
+	return m_source != nullptr;
+}
+
+bool ZipSource::BeginWrite(Error* error)
+{
+	pxAssert(m_source);
+
+	if (zip_source_begin_write(m_source) != 0)
+	{
+		Error::SetString(error, zip_error_strerror(zip_source_error(m_source)));
+		return false;
+	}
+
+	return true;
+}
+
+bool ZipSource::Write(const void* data, u64 length, Error* error)
+{
+	pxAssert(m_source);
+
+	if (zip_source_write(m_source, data, length) != 0)
+	{
+		Error::SetString(error, zip_error_strerror(zip_source_error(m_source)));
+		return false;
+	}
+
+	return true;
+}
+
+bool ZipSource::CommitWrite(Error* error)
+{
+	pxAssert(m_source);
+
+	if (zip_source_commit_write(m_source) != 0)
+	{
+		Error::SetString(error, zip_error_strerror(zip_source_error(m_source)));
+		return false;
+	}
+
+	return true;
+}

--- a/common/ZipFile.h
+++ b/common/ZipFile.h
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: 2002-2025 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#pragma once
+
+#include "Error.h"
+
+#include <zip.h>
+
+#include <optional>
+#include <vector>
+
+class ZipEntry;
+class ZipSource;
+
+/// An index of a file in the central directory of a ZIP archive.
+using ZipEntryIndex = u64;
+
+/// A ZIP archive. Thin RAII wrapper around a zip_t object from libzip.
+class ZipArchive
+{
+	friend ZipEntry;
+
+public:
+	ZipArchive();
+	~ZipArchive();
+
+	/// Don't allow copying.
+	ZipArchive(const ZipArchive& rhs) = delete;
+	ZipArchive& operator=(const ZipArchive& rhs) = delete;
+
+	/// Allow moving.
+	ZipArchive(ZipArchive&& rhs);
+	ZipArchive& operator=(ZipArchive&& rhs);
+
+	/// Open the archive using zip_open.
+	///
+	/// Valid flags:
+	///   ZIP_CHECKCONS, ZIP_CREATE, ZIP_EXCL, ZIP_TRUNCATE, ZIP_RDONLY
+	bool Open(const char* path, int flags, int* error_code, Error* error);
+
+	/// Save changes made to the archive and close it using zip_close.
+	bool SaveChangesAndClose(Error* error);
+
+	/// Discard changes made to the archive and close it using zip_discard.
+	void DiscardChangesAndClose();
+
+	/// Check if the archive is open.
+	bool IsValid();
+
+	/// Find a file inside the archive given its name using zip_name_locate.
+	///
+	/// Valid flags:
+	///   ZIP_FL_NOCASE, ZIP_FL_NODIR, ZIP_FL_ENC_GUESS,
+	///   ZIP_FL_ENC_RAW, ZIP_FL_ENC_STRICT, ZIP_FL_ENC_CP437, ZIP_FL_ENC_UTF_8
+	std::optional<ZipEntryIndex> LocateFile(const char* name, zip_flags_t flags, Error* error);
+
+	/// Retrieve file metadata using zip_stat_index. Ownership of the name
+	/// string is NOT transferred to the caller.
+	///
+	/// Valid flags:
+	///   ZIP_STAT_NAME, ZIP_STAT_INDEX, ZIP_STAT_SIZE,
+	///   ZIP_STAT_COMP_SIZE, ZIP_STAT_MTIME, ZIP_STAT_CRC,
+	///   ZIP_STAT_COMP_METHOD, ZIP_STAT_ENCRYPTION_METHOD, ZIP_STAT_FLAGS
+	std::optional<zip_stat_t> StatFile(ZipEntryIndex index, zip_flags_t flags, Error* error);
+
+	/// Read the entire contents of a file into a std::string.
+	///
+	/// Valid flags:
+	///   ZIP_FL_COMPRESSED, ZIP_FL_UNCHANGED
+	std::optional<std::string> ReadTextFile(ZipEntryIndex index, zip_flags_t flags, Error* error);
+
+	/// Read the entire contents of a file into a std::vector<u8>.
+	///
+	/// Valid flags:
+	///   ZIP_FL_COMPRESSED, ZIP_FL_UNCHANGED
+	std::optional<std::vector<u8>> ReadBinaryFile(ZipEntryIndex index, zip_flags_t flags, Error* error);
+
+	/// Add a file to the zip using zip_source_buffer_create and zip_file_add.
+	/// If freep is non-zero, ownership of the buffer will be transferred, and
+	/// will be freed if there's an error.
+	///
+	/// Valid flags:
+	///   ZIP_FL_OVERWRITE, ZIP_FL_ENC_GUESS, ZIP_FL_ENC_UTF_8, ZIP_FL_ENC_CP437
+	std::optional<ZipEntryIndex> AddFileFromBuffer(
+		const char* name, void* data, u64 length, zip_flags_t flags, int freep, Error* error);
+
+	/// Add a file to the zip using zip_file_add.
+	/// On success, ownership of the underlying source will be transferred to
+	/// the file and the source object will be made empty.
+	///
+	/// Valid flags:
+	///   ZIP_FL_OVERWRITE, ZIP_FL_ENC_GUESS, ZIP_FL_ENC_UTF_8, ZIP_FL_ENC_CP437
+	std::optional<ZipEntryIndex> AddFileFromSource(
+		const char* name, ZipSource& source, zip_flags_t flags, Error* error);
+
+	/// Set the compression method for a file using zip_set_file_compression.
+	bool SetFileCompression(ZipEntryIndex index, s32 comp, u32 comp_flags, Error* error);
+
+private:
+	zip_t* m_zip = nullptr;
+};
+
+/// An individual file inside a ZIP archive.
+/// Thin RAII wrapper around a zip_file_t object from libzip.
+class ZipEntry
+{
+public:
+	ZipEntry();
+	~ZipEntry();
+
+	/// Don't allow copying.
+	ZipEntry(const ZipEntry& rhs) = delete;
+	ZipEntry& operator=(const ZipEntry& rhs) = delete;
+
+	/// Allow moving.
+	ZipEntry(ZipEntry&& rhs);
+	ZipEntry& operator=(ZipEntry&& rhs);
+
+	/// Open the file from the given archive using zip_fopen_index.
+	///
+	/// Valid flags:
+	///   ZIP_FL_COMPRESSED, ZIP_FL_UNCHANGED
+	bool Open(ZipArchive& archive, ZipEntryIndex index, zip_flags_t flags, Error* error);
+
+	/// Close the file using zip_fclose.
+	void Close();
+
+	/// Check if the file is open.
+	bool IsValid();
+
+	/// Read nbytes bytes into buffer using zip_fread.
+	bool Read(void* buffer, u64 nbytes, Error* error);
+
+	/// Set the position indicator using zip_fseek.
+	bool Seek(s64 offset, int whence, Error* error);
+
+	/// Retrieve the position indicator using zip_ftell.
+	std::optional<u64> Tell(Error* error);
+
+	/// Retrieve the uncompressed size of the file.
+	std::optional<u64> Size(Error* error);
+
+	/// Read the entire file into a std::string.
+	std::optional<std::string> ReadText(Error* error);
+
+	/// Read the entire file into a std::vector.
+	std::optional<std::vector<u8>> ReadBinary(Error* error);
+
+	/// Read sizeof(Value) bytes into a variable of type Value and return it.
+	template <typename Value>
+	std::optional<Value> ReadValue(Error* error)
+	{
+		Value value;
+
+		if (!Read(&value, sizeof(Value), error))
+			return std::nullopt;
+
+		return value;
+	}
+
+private:
+	ZipArchive* m_archive = nullptr;
+	u64 m_index = 0;
+	zip_file_t* m_file = nullptr;
+};
+
+/// Data source for the contents of a file in a ZIP archive.
+/// Thin RAII wrapper around a zip_source_t object from libzip.
+/// Users of this class shouldn't have to worry about zip_source_t being
+/// reference counted.
+class ZipSource
+{
+	friend ZipArchive;
+
+public:
+	ZipSource();
+	~ZipSource();
+
+	/// Don't allow copying.
+	ZipSource(const ZipSource& rhs) = delete;
+	ZipSource& operator=(const ZipSource& rhs) = delete;
+
+	/// Allow moving.
+	ZipSource(ZipSource&& rhs);
+	ZipSource& operator=(ZipSource&& rhs);
+
+	/// Create an in-memory source using zip_source_buffer_create. If freep is
+	/// non-zero, ownership of the buffer will be transferred, and the buffer
+	/// be freed if there's an error.
+	bool CreateBuffer(void* data, u64 length, int freep, Error* error);
+
+	/// Free the source using zip_source_free.
+	void Free();
+
+	/// Check if the underlying source exists.
+	bool IsValid();
+
+	/// Start writing data to the source using zip_source_begin_write.
+	bool BeginWrite(Error* error);
+
+	/// Write data to the source using zip_source_write.
+	/// The source takes a copy of the data.
+	bool Write(const void* data, u64 length, Error* error);
+
+	/// Stop writing data to the source using zip_source_commit_write.
+	bool CommitWrite(Error* error);
+
+private:
+	zip_source_t* m_source = nullptr;
+};

--- a/common/common.vcxproj
+++ b/common/common.vcxproj
@@ -37,6 +37,7 @@
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SolutionDir)3rdparty\fmt\include</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SolutionDir)3rdparty\jpgd</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SolutionDir)3rdparty\rapidyaml\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SolutionDir)3rdparty\libzip\msvc;$(SolutionDir)3rdparty\libzip\lib</AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <ForcedIncludeFiles>PrecompiledHeader.h</ForcedIncludeFiles>
       <PrecompiledHeaderFile>PrecompiledHeader.h</PrecompiledHeaderFile>
@@ -74,6 +75,7 @@
     <ClCompile Include="WAVWriter.cpp" />
     <ClCompile Include="WindowInfo.cpp" />
     <ClCompile Include="YAML.cpp" />
+    <ClCompile Include="ZipFile.cpp" />
     <ClCompile Include="Perf.cpp" />
     <ClCompile Include="PrecompiledHeader.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
@@ -161,6 +163,7 @@
     <ClInclude Include="WAVWriter.h" />
     <ClInclude Include="WindowInfo.h" />
     <ClInclude Include="YAML.h" />
+    <ClInclude Include="ZipFile.h" />
     <ClInclude Include="Threading.h" />
     <ClInclude Include="emitter\implement\avx.h" />
     <ClInclude Include="emitter\implement\bmi.h" />

--- a/common/common.vcxproj.filters
+++ b/common/common.vcxproj.filters
@@ -130,6 +130,9 @@
     <ClCompile Include="YAML.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ZipFile.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AlignedMalloc.h">
@@ -339,6 +342,9 @@
     <ClInclude Include="SingleRegisterTypes.h" />
     <ClInclude Include="FPControl.h" />
     <ClInclude Include="YAML.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ZipFile.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1141,7 +1141,6 @@ target_link_libraries(PCSX2_FLAGS INTERFACE
 	imgui
 	fmt::fmt
 	libchdr
-	libzip::zip
 	cpuinfo
 	cubeb
 	rcheevos

--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -264,8 +264,9 @@ u32 Patch::LoadPatchesFromString(std::vector<PatchGroup>* patch_list, const std:
 					[](const PatchGroup& pg) { return pg.name.empty(); });
 				if (ungrouped_patch != patch_list->end())
 				{
-					Console.WriteLn(Color_Gray, fmt::format(
-						"Patch: Merging {} new patch commands into ungrouped list.", current_patch_group.patches.size()));
+					Console.WriteLnFmt(Color_Gray,
+						"Patch: Merging {} new patch commands into ungrouped list.",
+						current_patch_group.patches.size());
 
 					ungrouped_patch->patches.reserve(ungrouped_patch->patches.size() + current_patch_group.patches.size());
 					for (PatchCommand& cmd : current_patch_group.patches)
@@ -291,9 +292,9 @@ u32 Patch::LoadPatchesFromString(std::vector<PatchGroup>* patch_list, const std:
 		}
 		else
 		{
-			Console.WriteLn(Color_Gray, fmt::format(
+			Console.WriteLnFmt(Color_Gray,
 				"Patch: Skipped loading patch '{}' since a patch with a duplicate name was already loaded.",
-				current_patch_group.name));
+				current_patch_group.name);
 		}
 	};
 
@@ -309,7 +310,7 @@ u32 Patch::LoadPatchesFromString(std::vector<PatchGroup>* patch_list, const std:
 		{
 			if (line.length() < 2 || line.back() != ']')
 			{
-				Console.Error(fmt::format("Malformed patch line: {}", line.c_str()));
+				Console.ErrorFmt("Malformed patch line: {}", line.c_str());
 				continue;
 			}
 
@@ -321,7 +322,7 @@ u32 Patch::LoadPatchesFromString(std::vector<PatchGroup>* patch_list, const std:
 
 			current_patch_group.name = line.substr(1, line.length() - 2);
 			if (current_patch_group.name.empty())
-				Console.Error(fmt::format("Malformed patch name: {}", line));
+				Console.ErrorFmt("Malformed patch name: {}", line);
 
 			continue;
 		}
@@ -372,7 +373,7 @@ std::string Patch::GetPnachTemplate(const std::string_view serial, u32 crc, bool
 	if (!serial.empty())
 	{
 		if (all_crcs)
-			return fmt::format("{}_*.pnach", serial);	
+			return fmt::format("{}_*.pnach", serial);
 		else if (include_serial)
 			return fmt::format("{}_{:08X}{}.pnach", serial, crc, add_wildcard ? "*" : "");
 	}
@@ -430,7 +431,7 @@ void Patch::EnumeratePnachFiles(const std::string_view serial, u32 crc, bool che
 				if (PatchStringHasUnlabelledPatch(contents.value()))
 				{
 					unlabeled_patch_found = true;
-					Console.WriteLn(fmt::format("Patch: Disabling any bundled '{}' patches due to unlabeled patch being loaded. (To avoid conflicts)", PATCHES_ZIP_NAME));
+					Console.WriteLnFmt("Patch: Disabling any bundled '{}' patches due to unlabeled patch being loaded. (To avoid conflicts)", PATCHES_ZIP_NAME);
 				}
 
 				f(std::move(file), std::move(contents.value()));
@@ -518,7 +519,7 @@ void Patch::ExtractPatchInfo(std::vector<PatchInfo>* dst, const std::string& pna
 					}
 					else
 					{
-						Console.WriteLn(Color_Gray, fmt::format("Patch: Skipped reading patch '{}' since a patch with a duplicate name was already loaded.", current_patch.name));
+						Console.WriteLnFmt(Color_Gray, "Patch: Skipped reading patch '{}' since a patch with a duplicate name was already loaded.", current_patch.name);
 					}
 				}
 				current_patch = {};
@@ -700,8 +701,8 @@ u32 Patch::EnablePatches(const std::vector<PatchGroup>* patches, const std::vect
 		if (!p.name.empty() && std::find(enable_list.begin(), enable_list.end(), p.name) == enable_list.end())
 			continue;
 
-		Console.WriteLn(Color_Green, fmt::format("Enabled patch: {}",
-										 p.name.empty() ? std::string_view("<unknown>") : std::string_view(p.name)));
+		Console.WriteLnFmt(Color_Green, "Enabled patch: {}",
+			p.name.empty() ? std::string_view("<unknown>") : std::string_view(p.name));
 
 		for (const PatchCommand& ip : p.patches)
 		{
@@ -773,7 +774,7 @@ void Patch::ReloadPatches(const std::string& serial, u32 crc, bool reload_files,
 			{
 				const u32 patch_count = LoadPatchesFromString(&s_gamedb_patches, *patches);
 				if (patch_count > 0)
-					Console.WriteLn(Color_Green, fmt::format("Found {} game patches in GameDB.", patch_count));
+					Console.WriteLnFmt(Color_Green, "Found {} game patches in GameDB.", patch_count);
 			}
 
 			LoadDynamicPatches(game->dynaPatches);
@@ -784,7 +785,7 @@ void Patch::ReloadPatches(const std::string& serial, u32 crc, bool reload_files,
 			serial, s_patches_crc, false, false, [](const std::string& filename, const std::string& pnach_data) {
 				const u32 patch_count = LoadPatchesFromString(&s_game_patches, pnach_data);
 				if (patch_count > 0)
-					Console.WriteLn(Color_Green, fmt::format("Found {} game patches in {}.", patch_count, filename));
+					Console.WriteLnFmt(Color_Green, "Found {} game patches in {}.", patch_count, filename);
 			});
 
 		s_cheat_patches.clear();
@@ -792,7 +793,7 @@ void Patch::ReloadPatches(const std::string& serial, u32 crc, bool reload_files,
 			serial, s_patches_crc, true, false, [](const std::string& filename, const std::string& pnach_data) {
 				const u32 patch_count = LoadPatchesFromString(&s_cheat_patches, pnach_data);
 				if (patch_count > 0)
-					Console.WriteLn(Color_Green, fmt::format("Found {} cheats in {}.", patch_count, filename));
+					Console.WriteLnFmt(Color_Green, "Found {} cheats in {}.", patch_count, filename);
 			});
 	}
 
@@ -865,15 +866,15 @@ void Patch::ApplyPatchSettingOverrides()
 	{
 		EmuConfig.CurrentCustomAspectRatio = s_override_aspect_ratio.value();
 
-		Console.WriteLn(Color_Gray,
-			fmt::format("Patch: Setting aspect ratio to {} by patch request.", s_override_aspect_ratio.value()));
+		Console.WriteLn(Color_Gray, "Patch: Setting aspect ratio to {} by patch request.",
+			s_override_aspect_ratio.value());
 	}
 
 	// Disable interlacing in GS if active.
 	if (s_override_interlace_mode.has_value() && EmuConfig.GS.InterlaceMode == GSInterlaceMode::Automatic)
 	{
-		Console.WriteLn(Color_Gray, fmt::format("Patch: Setting deinterlace mode to {} by patch request.",
-										static_cast<int>(s_override_interlace_mode.value())));
+		Console.WriteLnFmt(Color_Gray, "Patch: Setting deinterlace mode to {} by patch request.",
+			static_cast<int>(s_override_interlace_mode.value()));
 		EmuConfig.GS.InterlaceMode = s_override_interlace_mode.value();
 	}
 }
@@ -886,7 +887,7 @@ bool Patch::ReloadPatchAffectingOptions()
 	const AspectRatioType current_ar = EmuConfig.GS.AspectRatio;
 	const GSInterlaceMode current_interlace = EmuConfig.GS.InterlaceMode;
 	const float custom_aspect_ratio = EmuConfig.CurrentCustomAspectRatio;
-	
+
 	// This is pretty gross, but we're not using a config layer, so...
 	AspectRatioType new_ar = Pcsx2Config::GSOptions::DEFAULT_ASPECT_RATIO;
 	const std::string ar_value = Host::GetStringSettingValue("EmuCore/GS", "AspectRatio",
@@ -928,7 +929,7 @@ void Patch::UnloadPatches()
 void Patch::PatchFunc::patch(PatchGroup* group, const std::string_view cmd, const std::string_view param)
 {
 #define PATCH_ERROR(fstring, ...) \
-	Console.Error(fmt::format("(Patch) Error Parsing: {}={}: " fstring, cmd, param, __VA_ARGS__))
+	Console.ErrorFmt("(Patch) Error Parsing: {}={}: " fstring, cmd, param, __VA_ARGS__)
 
 	// [0]=PlaceToPatch,[1]=CpuType,[2]=MemAddr,[3]=OperandSize,[4]=WriteValue
 	const std::vector<std::string_view> pieces(StringUtil::SplitString(param, ',', false));
@@ -1021,7 +1022,7 @@ void Patch::PatchFunc::gsaspectratio(PatchGroup* group, const std::string_view c
 		return;
 	}
 
-	Console.Error(fmt::format("Patch error: {} is an unknown aspect ratio.", param));
+	Console.ErrorFmt("Patch error: {} is an unknown aspect ratio.", param);
 }
 
 void Patch::PatchFunc::gsinterlacemode(PatchGroup* group, const std::string_view cmd, const std::string_view param)
@@ -1030,7 +1031,7 @@ void Patch::PatchFunc::gsinterlacemode(PatchGroup* group, const std::string_view
 	if (!interlace_mode.has_value() || interlace_mode.value() < 0 ||
 		interlace_mode.value() >= static_cast<int>(GSInterlaceMode::Count))
 	{
-		Console.Error(fmt::format("Patch error: {} is an unknown interlace mode.", param));
+		Console.ErrorFmt("Patch error: {} is an unknown interlace mode.", param);
 		return;
 	}
 
@@ -1040,7 +1041,7 @@ void Patch::PatchFunc::gsinterlacemode(PatchGroup* group, const std::string_view
 void Patch::PatchFunc::dpatch(PatchGroup* group, const std::string_view cmd, const std::string_view param)
 {
 #define PATCH_ERROR(fstring, ...) \
-	Console.Error(fmt::format("(dPatch) Error Parsing: {}={}: " fstring, cmd, param, __VA_ARGS__))
+	Console.ErrorFmt("(dPatch) Error Parsing: {}={}: " fstring, cmd, param, __VA_ARGS__)
 
 	// [0]=version/type,[1]=number of patterns,[2]=number of replacements
 	// Each pattern or replacement is [3]=offset,[4]=hex

--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -36,7 +36,7 @@
 #include "common/Path.h"
 #include "common/ScopedGuard.h"
 #include "common/StringUtil.h"
-#include "common/ZipHelpers.h"
+#include "common/ZipFile.h"
 
 #include "IconsFontAwesome6.h"
 #include "fmt/format.h"
@@ -359,9 +359,9 @@ static int SysState_MTGSFreeze(FreezeAction mode, freezeData* fP)
 static constexpr SysState_Component SPU2_{"SPU2", SPU2freeze};
 static constexpr SysState_Component GS{"GS", SysState_MTGSFreeze};
 
-static bool SysState_ComponentFreezeIn(zip_file_t* zf, SysState_Component comp)
+static bool SysState_ComponentFreezeIn(ZipEntry* ze, SysState_Component comp)
 {
-	if (!zf)
+	if (!ze)
 		return true;
 
 	freezeData fP = {0, nullptr};
@@ -376,9 +376,10 @@ static bool SysState_ComponentFreezeIn(zip_file_t* zf, SysState_Component comp)
 		data = std::make_unique<u8[]>(fP.size);
 		fP.data = data.get();
 
-		if (zip_fread(zf, data.get(), fP.size) != static_cast<zip_int64_t>(fP.size))
+		Error error;
+		if (!ze->Read(data.get(), fP.size, &error))
 		{
-			Console.ErrorFmt("* {}: Failed to decompress save data", comp.name);
+			Console.ErrorFmt("* {}: Failed to decompress save data ({})", comp.name, error.GetDescription());
 			return false;
 		}
 	}
@@ -420,13 +421,13 @@ static bool SysState_ComponentFreezeOut(SaveStateBase& writer, SysState_Componen
 	return true;
 }
 
-static bool SysState_ComponentFreezeInNew(zip_file_t* zf, const char* name, bool (*do_state_func)(StateWrapper&))
+static bool SysState_ComponentFreezeInNew(ZipEntry* ze, const char* name, bool (*do_state_func)(StateWrapper&))
 {
 	// TODO: We could decompress on the fly here for a little bit more speed.
 	std::vector<u8> data;
-	if (zf)
+	if (ze)
 	{
-		std::optional<std::vector<u8>> optdata(ReadBinaryFileInZip(zf));
+		std::optional<std::vector<u8>> optdata(ze->ReadBinary(nullptr));
 		if (optdata.has_value())
 			data = std::move(optdata.value());
 	}
@@ -468,7 +469,7 @@ public:
 	virtual ~BaseSavestateEntry() = default;
 
 	virtual const char* GetFilename() const = 0;
-	virtual bool FreezeIn(zip_file_t* zf) const = 0;
+	virtual bool FreezeIn(ZipEntry* ze) const = 0;
 	virtual bool FreezeOut(SaveStateBase& writer) const = 0;
 	virtual bool IsRequired() const = 0;
 };
@@ -480,7 +481,7 @@ protected:
 	virtual ~MemorySavestateEntry() = default;
 
 public:
-	virtual bool FreezeIn(zip_file_t* zf) const;
+	virtual bool FreezeIn(ZipEntry* ze) const;
 	virtual bool FreezeOut(SaveStateBase& writer) const;
 	virtual bool IsRequired() const { return true; }
 
@@ -489,14 +490,13 @@ protected:
 	virtual u32 GetDataSize() const = 0;
 };
 
-bool MemorySavestateEntry::FreezeIn(zip_file_t* zf) const
+bool MemorySavestateEntry::FreezeIn(ZipEntry* ze) const
 {
-	const u32 expectedSize = GetDataSize();
-	const s64 bytesRead = zip_fread(zf, GetDataPtr(), expectedSize);
-	if (bytesRead != static_cast<s64>(expectedSize))
+	Error error;
+	if (ze->Read(GetDataPtr(), GetDataSize(), &error))
 	{
-		Console.WriteLn(Color_Yellow, " '%s' is incomplete (expected 0x%x bytes, loading only 0x%x bytes)",
-			GetFilename(), expectedSize, static_cast<u32>(bytesRead));
+		Console.WriteLnFmt(Color_Yellow, "* '{}' is incomplete ({})",
+			GetFilename(), error.GetDescription());
 	}
 
 	return true;
@@ -526,9 +526,9 @@ public:
 	u8* GetDataPtr() const override { return eeMem->Main; }
 	uint GetDataSize() const override { return Ps2MemSize::ExposedRam; }
 
-	virtual bool FreezeIn(zip_file_t* zf) const override
+	virtual bool FreezeIn(ZipEntry* ze) const override
 	{
-		return MemorySavestateEntry::FreezeIn(zf);
+		return MemorySavestateEntry::FreezeIn(ze);
 	}
 };
 
@@ -618,7 +618,7 @@ public:
 	~SavestateEntry_SPU2() override = default;
 
 	const char* GetFilename() const override { return "SPU2.bin"; }
-	bool FreezeIn(zip_file_t* zf) const override { return SysState_ComponentFreezeIn(zf, SPU2_); }
+	bool FreezeIn(ZipEntry* ze) const override { return SysState_ComponentFreezeIn(ze, SPU2_); }
 	bool FreezeOut(SaveStateBase& writer) const override { return SysState_ComponentFreezeOut(writer, SPU2_); }
 	bool IsRequired() const override { return true; }
 };
@@ -629,7 +629,7 @@ public:
 	~SavestateEntry_USB() override = default;
 
 	const char* GetFilename() const override { return "USB.bin"; }
-	bool FreezeIn(zip_file_t* zf) const override { return SysState_ComponentFreezeInNew(zf, "USB", &USB::DoState); }
+	bool FreezeIn(ZipEntry* ze) const override { return SysState_ComponentFreezeInNew(ze, "USB", &USB::DoState); }
 	bool FreezeOut(SaveStateBase& writer) const override { return SysState_ComponentFreezeOutNew(writer, "USB", 16 * 1024, &USB::DoState); }
 	bool IsRequired() const override { return false; }
 };
@@ -640,7 +640,7 @@ public:
 	~SavestateEntry_PAD() override = default;
 
 	const char* GetFilename() const override { return "PAD.bin"; }
-	bool FreezeIn(zip_file_t* zf) const override { return SysState_ComponentFreezeInNew(zf, "PAD", &Pad::Freeze); }
+	bool FreezeIn(ZipEntry* ze) const override { return SysState_ComponentFreezeInNew(ze, "PAD", &Pad::Freeze); }
 	bool FreezeOut(SaveStateBase& writer) const override { return SysState_ComponentFreezeOutNew(writer, "PAD", 16 * 1024, &Pad::Freeze); }
 	bool IsRequired() const override { return true; }
 };
@@ -651,7 +651,7 @@ public:
 	~SavestateEntry_GS() = default;
 
 	const char* GetFilename() const { return "GS.bin"; }
-	bool FreezeIn(zip_file_t* zf) const { return SysState_ComponentFreezeIn(zf, GS); }
+	bool FreezeIn(ZipEntry* ze) const { return SysState_ComponentFreezeIn(ze, GS); }
 	bool FreezeOut(SaveStateBase& writer) const { return SysState_ComponentFreezeOut(writer, GS); }
 	bool IsRequired() const { return true; }
 };
@@ -661,14 +661,14 @@ class SaveStateEntry_Achievements final : public BaseSavestateEntry
 	~SaveStateEntry_Achievements() override = default;
 
 	const char* GetFilename() const override { return "Achievements.bin"; }
-	bool FreezeIn(zip_file_t* zf) const override
+	bool FreezeIn(ZipEntry* ze) const override
 	{
 		if (!Achievements::IsActive())
 			return true;
 
 		std::optional<std::vector<u8>> data;
-		if (zf)
-			data = ReadBinaryFileInZip(zf);
+		if (ze)
+			data = ze->ReadBinary(nullptr);
 
 		if (data.has_value())
 			Achievements::LoadState(data.value());
@@ -777,25 +777,23 @@ std::unique_ptr<SaveStateScreenshotData> SaveState_SaveScreenshot()
 	return data;
 }
 
-static bool SaveState_CompressScreenshot(SaveStateScreenshotData* data, zip_t* zf)
+static bool SaveState_CompressScreenshot(SaveStateScreenshotData* data, ZipArchive& archive, Error* error)
 {
-	zip_error_t ze = {};
-	zip_source_t* const zs = zip_source_buffer_create(nullptr, 0, 0, &ze);
-	if (!zs)
+	ZipSource source;
+
+	if (!source.CreateBuffer(nullptr, 0, 0, error))
 		return false;
 
-	if (zip_source_begin_write(zs) != 0)
-	{
-		zip_source_free(zs);
+	if (!source.BeginWrite(error))
 		return false;
-	}
-
-	ScopedGuard zs_free([zs]() { zip_source_free(zs); });
 
 	png_structp png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
 	png_infop info_ptr = nullptr;
 	if (!png_ptr)
+	{
+		Error::SetString(error, "png_create_write_struct failed");
 		return false;
+	}
 
 	ScopedGuard cleanup([&png_ptr, &info_ptr]() {
 		if (png_ptr)
@@ -804,15 +802,22 @@ static bool SaveState_CompressScreenshot(SaveStateScreenshotData* data, zip_t* z
 
 	info_ptr = png_create_info_struct(png_ptr);
 	if (!info_ptr)
+	{
+		Error::SetString(error, "png_create_info_struct failed");
 		return false;
+	}
 
 	if (setjmp(png_jmpbuf(png_ptr)))
 		return false;
 
 	png_set_write_fn(
-		png_ptr, zs,
+		png_ptr, &source,
 		[](png_structp png_ptr, png_bytep data_ptr, png_size_t size) {
-			zip_source_write(static_cast<zip_source_t*>(png_get_io_ptr(png_ptr)), data_ptr, size);
+			ZipSource& source = *static_cast<ZipSource*>(png_get_io_ptr(png_ptr));
+
+			Error write_error;
+			if (!source.Write(data_ptr, size, &write_error))
+				png_error(png_ptr, write_error.GetDescription().c_str());
 		},
 		[](png_structp png_ptr) {});
 	png_set_compression_level(png_ptr, 5);
@@ -832,25 +837,33 @@ static bool SaveState_CompressScreenshot(SaveStateScreenshotData* data, zip_t* z
 
 	png_write_end(png_ptr, nullptr);
 
-	if (zip_source_commit_write(zs) != 0)
+	if (!source.CommitWrite(error))
 		return false;
 
-	const s64 file_index = zip_file_add(zf, EntryFilename_Screenshot, zs, 0);
-	if (file_index < 0)
+	std::optional<ZipEntryIndex> index = archive.AddFileFromSource(
+		EntryFilename_Screenshot, source, 0, error);
+	if (!index.has_value())
+	{
 		return false;
+	}
 
 	// png is already compressed, no point doing it twice
-	zip_set_file_compression(zf, file_index, ZIP_CM_STORE, 0);
+	if (!archive.SetFileCompression(*index, ZIP_CM_STORE, 0, error))
+		return false;
 
-	// source is now owned by the zip file for later compression
-	zs_free.Cancel();
 	return true;
 }
 
-static bool SaveState_ReadScreenshot(zip_t* zf, u32* out_width, u32* out_height, std::vector<u32>* out_pixels)
+static bool SaveState_ReadScreenshot(
+	ZipArchive& archive, u32* out_width, u32* out_height, std::vector<u32>* out_pixels)
 {
-	auto zff = zip_fopen_managed(zf, EntryFilename_Screenshot, 0);
-	if (!zff)
+	ZipEntry entry;
+
+	std::optional<ZipEntryIndex> index = archive.LocateFile(EntryFilename_Screenshot, 0, nullptr);
+	if (!index.has_value())
+		return false;
+
+	if (!entry.Open(archive, *index, 0, nullptr))
 		return false;
 
 	png_structp png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
@@ -871,8 +884,12 @@ static bool SaveState_ReadScreenshot(zip_t* zf, u32* out_width, u32* out_height,
 	if (setjmp(png_jmpbuf(png_ptr)))
 		return false;
 
-	png_set_read_fn(png_ptr, zff.get(), [](png_structp png_ptr, png_bytep data_ptr, png_size_t size) {
-		zip_fread(static_cast<zip_file_t*>(png_get_io_ptr(png_ptr)), data_ptr, size);
+	png_set_read_fn(png_ptr, &entry, [](png_structp png_ptr, png_bytep data_ptr, png_size_t size) {
+		ZipEntry& entry = *static_cast<ZipEntry*>(png_get_io_ptr(png_ptr));
+
+		Error read_error;
+		if (!entry.Read(data_ptr, size, &read_error))
+			png_error(png_ptr, read_error.GetDescription().c_str());
 	});
 
 	png_read_info(png_ptr, info_ptr);
@@ -926,56 +943,92 @@ static bool SaveState_ReadScreenshot(zip_t* zf, u32* out_width, u32* out_height,
 	return true;
 }
 
-// --------------------------------------------------------------------------------------
-//  CompressThread_VmState
-// --------------------------------------------------------------------------------------
-static bool SaveState_AddToZip(zip_t* zf, ArchiveEntryList* srclist, SaveStateScreenshotData* screenshot)
+static std::tuple<u32, u32> SaveState_Get_CompressionParameters()
 {
-	u32 compression;
-	u32 compression_level;
+	u32 compression = ZIP_CM_STORE;
+	u32 compression_level = 0;
 
-	if (EmuConfig.Savestate.CompressionType == SavestateCompressionMethod::Zstandard)
+	switch (EmuConfig.Savestate.CompressionType)
 	{
-		compression = ZIP_CM_ZSTD;
+		case SavestateCompressionMethod::Uncompressed:
+		{
+			break;
+		}
+		case SavestateCompressionMethod::Deflate64:
+		{
+			compression = ZIP_CM_DEFLATE64;
 
-		if (EmuConfig.Savestate.CompressionRatio == SavestateCompressionLevel::Low)
-			compression_level = 1;
-		else if (EmuConfig.Savestate.CompressionRatio == SavestateCompressionLevel::Medium)
-			compression_level = 3;
-		else if (EmuConfig.Savestate.CompressionRatio == SavestateCompressionLevel::High)
-			compression_level = 10;
-		else if (EmuConfig.Savestate.CompressionRatio == SavestateCompressionLevel::VeryHigh)
-			compression_level = 22;
+			switch (EmuConfig.Savestate.CompressionRatio)
+			{
+				case SavestateCompressionLevel::Low:
+					compression_level = 1;
+					break;
+				case SavestateCompressionLevel::Medium:
+					compression_level = 3;
+					break;
+				case SavestateCompressionLevel::High:
+					compression_level = 7;
+					break;
+				case SavestateCompressionLevel::VeryHigh:
+					compression_level = 9;
+					break;
+			}
+
+			break;
+		}
+		case SavestateCompressionMethod::Zstandard:
+		{
+			compression = ZIP_CM_ZSTD;
+
+			switch (EmuConfig.Savestate.CompressionRatio)
+			{
+				case SavestateCompressionLevel::Low:
+					compression_level = 1;
+					break;
+				case SavestateCompressionLevel::Medium:
+					compression_level = 3;
+					break;
+				case SavestateCompressionLevel::High:
+					compression_level = 10;
+					break;
+				case SavestateCompressionLevel::VeryHigh:
+					compression_level = 22;
+					break;
+			}
+
+			break;
+		}
+		case SavestateCompressionMethod::LZMA2:
+		{
+			compression = ZIP_CM_LZMA2;
+
+			switch (EmuConfig.Savestate.CompressionRatio)
+			{
+				case SavestateCompressionLevel::Low:
+					compression_level = 1;
+					break;
+				case SavestateCompressionLevel::Medium:
+					compression_level = 3;
+					break;
+				case SavestateCompressionLevel::High:
+					compression_level = 7;
+					break;
+				case SavestateCompressionLevel::VeryHigh:
+					compression_level = 9;
+					break;
+			}
+
+			break;
+		}
 	}
-	else if (EmuConfig.Savestate.CompressionType == SavestateCompressionMethod::Deflate64)
-	{
-		compression = ZIP_CM_DEFLATE64;
-		if (EmuConfig.Savestate.CompressionRatio == SavestateCompressionLevel::Low)
-			compression_level = 1;
-		else if (EmuConfig.Savestate.CompressionRatio == SavestateCompressionLevel::Medium)
-			compression_level = 3;
-		else if (EmuConfig.Savestate.CompressionRatio == SavestateCompressionLevel::High)
-			compression_level = 7;
-		else if (EmuConfig.Savestate.CompressionRatio == SavestateCompressionLevel::VeryHigh)
-			compression_level = 9;
-	}
-	else if (EmuConfig.Savestate.CompressionType == SavestateCompressionMethod::LZMA2)
-	{
-		compression = ZIP_CM_LZMA2;
-		if (EmuConfig.Savestate.CompressionRatio == SavestateCompressionLevel::Low)
-			compression_level = 1;
-		else if (EmuConfig.Savestate.CompressionRatio == SavestateCompressionLevel::Medium)
-			compression_level = 3;
-		else if (EmuConfig.Savestate.CompressionRatio == SavestateCompressionLevel::High)
-			compression_level = 7;
-		else if (EmuConfig.Savestate.CompressionRatio == SavestateCompressionLevel::VeryHigh)
-			compression_level = 9;
-	}
-	else if (EmuConfig.Savestate.CompressionType == SavestateCompressionMethod::Uncompressed)
-	{
-		compression = ZIP_CM_STORE;
-		compression_level = 0;
-	}
+
+	return {compression, compression_level};
+}
+
+static bool SaveState_AddToZip(
+	ZipArchive& archive, ArchiveEntryList* srclist, SaveStateScreenshotData* screenshot)
+{
+	auto [compression, compression_level] = SaveState_Get_CompressionParameters();
 
 	// version indicator
 	{
@@ -996,22 +1049,23 @@ static bool SaveState_AddToZip(zip_t* zf, ArchiveEntryList* srclist, SaveStateSc
 			StringUtil::Strlcpy(vi->version, "Unknown", std::size(vi->version));
 		}
 
-		zip_source_t* const zs = zip_source_buffer(zf, vi, sizeof(*vi), 1);
-		if (!zs)
+		Error add_error;
+		std::optional<ZipEntryIndex> index = archive.AddFileFromBuffer(
+			EntryFilename_StateVersion, vi, sizeof(*vi), ZIP_FL_ENC_UTF_8, 1, &add_error);
+
+		if (!index.has_value())
 		{
-			std::free(vi);
+			Console.ErrorFmt("Failed to add version indicator to zip ({}).", add_error.GetDescription());
 			return false;
 		}
 
-		// NOTE: Source should not be freed if successful.
-		const s64 fi = zip_file_add(zf, EntryFilename_StateVersion, zs, ZIP_FL_ENC_UTF_8);
-		if (fi < 0)
+		Error compression_error;
+		if (!archive.SetFileCompression(*index, compression, compression_level, &compression_error))
 		{
-			zip_source_free(zs);
+			Console.ErrorFmt("Failed to set compression parameters ({}, {}).",
+				compression, compression_level);
 			return false;
 		}
-
-		zip_set_file_compression(zf, fi, compression, compression_level);
 	}
 
 	const uint listlen = srclist->GetLength();
@@ -1021,24 +1075,33 @@ static bool SaveState_AddToZip(zip_t* zf, ArchiveEntryList* srclist, SaveStateSc
 		if (!entry.GetDataSize())
 			continue;
 
-		zip_source_t* const zs = zip_source_buffer(zf, srclist->GetPtr(entry.GetDataIndex()), entry.GetDataSize(), 0);
-		if (!zs)
-			return false;
+		u8* ptr = srclist->GetPtr(entry.GetDataIndex());
+		uint size = entry.GetDataSize();
 
-		const s64 fi = zip_file_add(zf, entry.GetFilename().c_str(), zs, ZIP_FL_ENC_UTF_8);
-		if (fi < 0)
+		Error add_error;
+		std::optional<ZipEntryIndex> index = archive.AddFileFromBuffer(
+			EntryFilename_StateVersion, ptr, size, ZIP_FL_ENC_UTF_8, 0, &add_error);
+
+		if (!index.has_value())
 		{
-			zip_source_free(zs);
+			Console.ErrorFmt("Failed to add '{}' to zip ({}).", entry.GetFilename(), add_error.GetDescription());
 			return false;
 		}
 
-		zip_set_file_compression(zf, fi, compression, compression_level);
+		Error compression_error;
+		if (!archive.SetFileCompression(*index, compression, compression_level, &compression_error))
+		{
+			Console.ErrorFmt("Failed to set compression parameters ({}, {}).",
+				compression, compression_level);
+			return false;
+		}
 	}
 
-	if (screenshot)
+	Error screenshot_error;
+	if (screenshot && !SaveState_CompressScreenshot(screenshot, archive, &screenshot_error))
 	{
-		if (!SaveState_CompressScreenshot(screenshot, zf))
-			return false;
+		Console.ErrorFmt("Failed to compress save state screenshot ({}).", screenshot_error.GetDescription());
+		return false;
 	}
 
 	return true;
@@ -1048,35 +1111,30 @@ bool SaveState_ZipToDisk(
 	std::unique_ptr<ArchiveEntryList> srclist, std::unique_ptr<SaveStateScreenshotData> screenshot,
 	const char* filename, Error* error)
 {
-	zip_error_t ze = {};
-	zip_source_t* zs = zip_source_file_create(filename, 0, 0, &ze);
-	zip_t* zf = nullptr;
-	if (zs && !(zf = zip_open_from_source(zs, ZIP_CREATE | ZIP_TRUNCATE, &ze)))
+	ZipArchive archive;
+
+	Error open_error;
+	if (!archive.Open(filename, ZIP_CREATE | ZIP_TRUNCATE, nullptr, &open_error))
 	{
 		Error::SetStringFmt(error,
-			TRANSLATE_FS("SaveState", "Failed to open zip file '{}' for save state: {}."),
-			filename, zip_error_strerror(&ze));
-
-		// have to clean up source
-		zip_source_free(zs);
+			TRANSLATE_FS("SaveState", "Cannot open zip file '{}' ({})."),
+			filename, open_error.GetDescription());
 		return false;
 	}
 
-	// discard zip file if we fail saving something
-	if (!SaveState_AddToZip(zf, srclist.get(), screenshot.get()))
+	if (!SaveState_AddToZip(archive, srclist.get(), screenshot.get()))
 	{
 		Error::SetStringFmt(error,
 			TRANSLATE_FS("SaveState", "Failed to save state to zip file '{}'."), filename);
-		zip_discard(zf);
 		return false;
 	}
 
-	// force the zip to close, this is the expensive part with libzip.
-	if (zip_close(zf) != 0)
+	Error close_error;
+	if (archive.SaveChangesAndClose(&close_error))
 	{
 		Error::SetStringFmt(error,
-			TRANSLATE_FS("SaveState", "Failed to save state to zip file '{}': {}."), filename, zip_strerror(zf));
-		zip_discard(zf);
+			TRANSLATE_FS("SaveState", "Cannot save state to zip file '{}' ({})."),
+			filename, close_error.GetDescription());
 		return false;
 	}
 
@@ -1085,30 +1143,50 @@ bool SaveState_ZipToDisk(
 
 bool SaveState_ReadScreenshot(const std::string& filename, u32* out_width, u32* out_height, std::vector<u32>* out_pixels)
 {
-	zip_error_t ze = {};
-	auto zf = zip_open_managed(filename.c_str(), ZIP_RDONLY, &ze);
-	if (!zf)
+	ZipArchive archive;
+
+	Error open_error;
+	if (!archive.Open(filename.c_str(), ZIP_RDONLY, nullptr, &open_error))
 	{
-		Console.Error("Failed to open zip file '%s' for save state screenshot: %s", filename.c_str(), zip_error_strerror(&ze));
+		Console.ErrorFmt("Failed to open save state '{}' for save state screenshot: {}",
+			filename, open_error.GetDescription());
 		return false;
 	}
 
-	return SaveState_ReadScreenshot(zf.get(), out_width, out_height, out_pixels);
+	return SaveState_ReadScreenshot(archive, out_width, out_height, out_pixels);
 }
 
-static bool CheckVersion(const std::string& filename, zip_t* zf, Error* error)
+static bool CheckVersion(const std::string& filename, ZipArchive& archive, Error* error)
 {
 	u32 savever;
 
-	auto zff = zip_fopen_managed(zf, EntryFilename_StateVersion, 0);
-	if (!zff || zip_fread(zff.get(), &savever, sizeof(savever)) != sizeof(savever))
+	ZipEntry entry;
+
+	std::optional<ZipEntryIndex> index = archive.LocateFile(EntryFilename_StateVersion, 0, nullptr);
+	if (!index.has_value())
 	{
-		Error::SetString(error, "Savestate file does not contain version indicator.");
+		Error::SetString(error, "Save state file does not contain version indicator.");
+		return false;
+	}
+
+	Error open_error;
+	if (!entry.Open(archive, *index, 0, &open_error))
+	{
+		Error::SetStringFmt(error, "Failed to open save state version indicator entry ({}).",
+			open_error.GetDescription());
+		return false;
+	}
+
+	Error read_error;
+	if (!entry.Read(&savever, sizeof(savever), &read_error))
+	{
+		Error::SetStringFmt(error, "Save state file contains invalid version indicator ({}).",
+			read_error.GetDescription());
 		return false;
 	}
 
 	char version_string[STATE_PCSX2_VERSION_SIZE];
-	if (zip_fread(zff.get(), version_string, STATE_PCSX2_VERSION_SIZE) == STATE_PCSX2_VERSION_SIZE)
+	if (entry.Read(version_string, STATE_PCSX2_VERSION_SIZE, nullptr))
 		version_string[STATE_PCSX2_VERSION_SIZE - 1] = 0;
 	else
 		StringUtil::Strlcpy(version_string, "Unknown", std::size(version_string));
@@ -1137,39 +1215,31 @@ static bool CheckVersion(const std::string& filename, zip_t* zf, Error* error)
 	return true;
 }
 
-static zip_int64_t CheckFileExistsInState(zip_t* zf, const char* name, bool required)
+static std::optional<ZipEntryIndex> CheckFileExistsInState(ZipArchive& archive, const char* name, bool required)
 {
-	zip_int64_t index = zip_name_locate(zf, name, /*ZIP_FL_NOCASE*/ 0);
-	if (index >= 0)
+	std::optional<ZipEntryIndex> index = archive.LocateFile(name, 0, nullptr);
+	if (!index.has_value())
 	{
-		DevCon.WriteLn(Color_Green, " ... found '%s'", name);
-		return index;
+		if (required)
+			Console.WriteLnFmt(Color_Red, " ... not found '{}'!", name);
+		else
+			DevCon.WriteLnFmt(Color_Red, " ... not found '{}'!", name);
+
+		return std::nullopt;
 	}
 
-	if (required)
-		Console.WriteLn(Color_Red, " ... not found '%s'!", name);
-	else
-		DevCon.WriteLn(Color_Red, " ... not found '%s'!", name);
+	DevCon.WriteLn(Color_Green, " ... found '%s'", name);
 
 	return index;
 }
 
-static bool LoadInternalStructuresState(zip_t* zf, s64 index, Error* error)
+static bool LoadInternalStructuresState(ZipArchive& archive, ZipEntryIndex index, Error* error)
 {
-	zip_stat_t zst;
-	if (zip_stat_index(zf, index, 0, &zst) != 0 || zst.size > std::numeric_limits<int>::max())
+	std::optional<std::vector<u8>> buffer = archive.ReadBinaryFile(index, 0, error);
+	if (!buffer.has_value())
 		return false;
 
-	// Load all the internal data
-	auto zff = zip_fopen_index_managed(zf, index, 0);
-	if (!zff)
-		return false;
-
-	std::vector<u8> buffer(zst.size);
-	if (zip_fread(zff.get(), buffer.data(), buffer.size()) != static_cast<zip_int64_t>(buffer.size()))
-		return false;
-
-	memLoadingState state(buffer);
+	memLoadingState state(*buffer);
 	if (!state.FreezeBios())
 		return false;
 
@@ -1181,40 +1251,45 @@ static bool LoadInternalStructuresState(zip_t* zf, s64 index, Error* error)
 
 bool SaveState_UnzipFromDisk(const std::string& filename, Error* error)
 {
-	zip_error_t ze = {};
-	auto zf = zip_open_managed(filename.c_str(), ZIP_RDONLY, &ze);
-	if (!zf)
+	ZipArchive archive;
+
+	int err;
+	Error open_error;
+	if (!archive.Open(filename.c_str(), 0, &err, &open_error))
 	{
-		Console.Error("Failed to open zip file '%s' for save state load: %s", filename.c_str(), zip_error_strerror(&ze));
-		if (zip_error_code_zip(&ze) == ZIP_ER_NOENT)
-			Error::SetString(error, "Savestate file does not exist.");
+		Console.ErrorFmt("Failed to open zip file '{}' for save state load: {}",
+			filename, open_error.GetDescription());
+
+		if (err == ZIP_ER_NOENT)
+			Error::SetString(error, "Save state file does not exist.");
 		else
-			Error::SetStringFmt(error, "Savestate zip error: {}", zip_error_strerror(&ze));
+			Error::SetStringFmt(error, "Save state zip error: {}", open_error.GetDescription());
 
 		return false;
 	}
 
 	// look for version and screenshot information in the zip stream:
-	if (!CheckVersion(filename, zf.get(), error))
+	if (!CheckVersion(filename, archive, error))
 		return false;
 
 	// check that all parts are included
-	const s64 internal_index = CheckFileExistsInState(zf.get(), EntryFilename_InternalStructures, true);
-	s64 entryIndices[std::size(SavestateEntries)];
+	const std::optional<ZipEntryIndex> internal_index = CheckFileExistsInState(
+		archive, EntryFilename_InternalStructures, true);
+	std::optional<ZipEntryIndex> entry_indices[std::size(SavestateEntries)];
 
 	// Log any parts and pieces that are missing, and then generate an exception.
-	bool allPresent = (internal_index >= 0);
+	bool all_present = internal_index >= 0;
 	for (u32 i = 0; i < std::size(SavestateEntries); i++)
 	{
 		const bool required = SavestateEntries[i]->IsRequired();
-		entryIndices[i] = CheckFileExistsInState(zf.get(), SavestateEntries[i]->GetFilename(), required);
-		if (entryIndices[i] < 0 && required)
+		entry_indices[i] = CheckFileExistsInState(archive, SavestateEntries[i]->GetFilename(), required);
+		if (!entry_indices[i].has_value() && required)
 		{
-			allPresent = false;
+			all_present = false;
 			break;
 		}
 	}
-	if (!allPresent)
+	if (!all_present)
 	{
 		Error::SetString(error, "Some required components were not found or are incomplete.");
 		return false;
@@ -1222,7 +1297,7 @@ bool SaveState_UnzipFromDisk(const std::string& filename, Error* error)
 
 	PreLoadPrep();
 
-	if (!LoadInternalStructuresState(zf.get(), internal_index, error))
+	if (!internal_index.has_value() || !LoadInternalStructuresState(archive, *internal_index, error))
 	{
 		if (!error->IsValid())
 			Error::SetString(error, "Save state corruption in internal structures.");
@@ -1233,14 +1308,16 @@ bool SaveState_UnzipFromDisk(const std::string& filename, Error* error)
 
 	for (u32 i = 0; i < std::size(SavestateEntries); ++i)
 	{
-		if (entryIndices[i] < 0)
+		if (!entry_indices[i].has_value())
 		{
 			SavestateEntries[i]->FreezeIn(nullptr);
 			continue;
 		}
 
-		auto zff = zip_fopen_index_managed(zf.get(), entryIndices[i], 0);
-		if (!zff || !SavestateEntries[i]->FreezeIn(zff.get()))
+		ZipEntry zip_entry;
+		bool opened = zip_entry.Open(archive, *entry_indices[i], 0, error);
+
+		if (!opened || !SavestateEntries[i]->FreezeIn(&zip_entry))
 		{
 			Error::SetStringFmt(error, "Save state corruption in {}.", SavestateEntries[i]->GetFilename());
 			VMManager::Reset();


### PR DESCRIPTION
### Description of Changes
This introduces new classes for reading/writing zip files to replace the existing functions in `ZipHelpers.h`. These provide a proper RAII wrapper around libzip that integrates with our `Error` class.

### Rationale behind Changes
- There are some libzip call sites where we aren't checking for errors. I already fixed one of these in a previous PR (#13638) but there are others too.
- The `zip_open_managed` and `zip_open_buffer_managed` functions are both affected by the following issues:
  - Because `zip_close` is called from a custom `std::unique_ptr` deleter, there's no way to pass error information up the call stack, and since `zip_close` is the step that causes the original file on disk to be replaced with the new one, this error information is meaningful (for example, if there is a permissions problem).
  - The code seems to think the return value of `zip_close` is an error code, which it is not.
- There are some cases where incorrect flags are passed to libzip functions. For example, in `ReadFileInZipToContainer`, `ZIP_FL_NOCASE` is passed to functions that don't check for it.
- As for why I opted to write my own wrapper classes instead of using an existing C++ wrapper library, this way the classes can be integrated with our own `Error` class, and I haven't found an existing one that I'm confident is high quality.

### Suggested Testing Steps
Not yet ready for testing.

### Did you use AI to help find, test, or implement this issue or feature?
No.
