### PR TITLE
FullscreenUI: Update auto mapping to include device names with display names

### DIFF
--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -3458,8 +3458,8 @@ void FullscreenUI::StartAutomaticBinding(u32 port)
 			names.reserve(devices.size());
 			for (auto& [name, display_name] : devices)
 			{
+				options.emplace_back(fmt::format("{} ({})", name, display_name), false);
 				names.push_back(std::move(name));
-				options.emplace_back(std::move(display_name), false);
 			}
 			OpenChoiceDialog(FSUI_CSTR("Select Device"), false, std::move(options),
 				[port, names = std::move(names)](s32 index, const std::string& title, bool checked) {


### PR DESCRIPTION
Before:
<img width="577" height="495" alt="image" src="https://github.com/user-attachments/assets/d5e07b67-0cc2-4c9c-a6ed-f3eb426bf101" />

After:
<img width="577" height="495" alt="image" src="https://github.com/user-attachments/assets/29a6bd09-bf1d-437f-bcbb-47c973a143cb" />
Fixes #13774
### Description of Changes
Fixes an issue with FSUI Auto Mapping where devices with identical names would conflict or be indistinguishable. This change updates the device selection dialog to include the input source ID (for example `SDL-0`) along with the device name, this also brings more parity with Qt as the auto mapping is the same now.

### Rationale behind Changes
Users with multiple controllers of the same type (for example two PS4 controllers) previously saw duplicate entries like "PS4 Controller" in the selection list, which caused imgui popups to conflict and not be able to click either of the options. Adding the source ID clarifies this (for example "SDL-0 (PS4 Controller)" vs "SDL-1 (PS4 Controller)").

### Suggested Testing Steps
1. Connect multiple controllers, ideally two of the same type.
2. Enter Big Picture Mode.
3. Navigate to Settings > Controller.
4. Select a port and choose Automatic Binding.
5. Verify that the "Select Device" list now formats entries as SourceID (Device Name) (for example SDL-0 (PS4 Controller)).

### Did you use AI to help find, test, or implement this issue or feature?
No.