### PR TITLE
cmake: only require Qt modules when Qt UI is enabled

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -109,14 +109,14 @@ disable_compiler_warnings_for_target(speex)
 # Find the Qt components that we need.
 if(ENABLE_QT_UI)
 	find_package(Qt6 6.10.0 COMPONENTS CoreTools Core GuiTools Gui WidgetsTools Widgets LinguistTools REQUIRED)
-endif()
 
-if (Qt6_VERSION VERSION_GREATER_EQUAL 6.10.0)
-	find_package(Qt6 COMPONENTS CorePrivate GuiPrivate WidgetsPrivate REQUIRED)
-endif()
+	if (Qt6_VERSION VERSION_GREATER_EQUAL 6.10.0)
+		find_package(Qt6 COMPONENTS CorePrivate GuiPrivate WidgetsPrivate REQUIRED)
+	endif()
 
-# The docking system for the debugger.
+	# The docking system for the debugger.
 	find_package(KDDockWidgets-qt6 2.3.0 REQUIRED)
+endif()
 
 if(WIN32)
 	add_subdirectory(3rdparty/rainterface EXCLUDE_FROM_ALL)


### PR DESCRIPTION
### Description of Changes
The Qt6 CorePrivate/GuiPrivate/WidgetsPrivate components are only needed for the Qt UI build. Move their find_package() call under ENABLE_QT_UI to avoid requiring private Qt modules when building without the UI.

### Rationale behind Changes
Building without Qt fails if Qt libs aren't installed.

### Suggested Testing Steps
Build without Qt enabled & no Qt libs installed on machine,

### Did you use AI to help find, test, or implement this issue or feature?
no. Just my own brain,
