### PR TITLE
GS: Disallow flipped GS->GS transfer when destination overwrites source

### DIFF
--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -211,13 +211,20 @@ protected:
 	void CorrectATEAlphaMinMax(const u32 atst, const int aref);
 
 public:
+	enum EEGS_TransferType
+	{
+		EE_to_GS,
+		GS_to_GS,
+		GS_to_EE
+	};
+
 	struct GSUploadQueue
 	{
 		GIFRegBITBLTBUF blit;
 		GSVector4i rect;
 		int draw;
 		bool zero_clear;
-		bool ee_to_gs;
+		EEGS_TransferType transfer_type;
 	};
 
 	enum NoGapsType


### PR DESCRIPTION
### Description of Changes
Disallows GS Local to Local transfers to reverse the direction of copies if the destination overwrites source data.

### Rationale behind Changes
On the console the copies are page buffered, so this isn't a problem, this is exactly the same issue as #5601 fixed, but for reversed coordinates.

As far as I can understand, these directions don't do anything beyond try to guarantee a page break for upcoming draws to make sure the cache is correctly updated, it serves little purpose beyond this.

### Suggested Testing Steps
Test Armored Core 2, the pulsing light tunnel on the last level, but also the lights on top of the builds in the first level intro.
Also check Tekken 5 and Wild ARMs Alter Code F to make sure they're fine from the transfer list changes (Tekken shows less uploads, which is nice)

### Did you use AI to help find, test, or implement this issue or feature?
No

Fixes #2399 Armored Core 2 garbled textures.

GS Dump that shows it broken on master but not the PR (all original dumps are broken already)
[Armored Core 2_SLPS-25007_20260108033737.gs.zip](https://github.com/user-attachments/files/24486710/Armored.Core.2_SLPS-25007_20260108033737.gs.zip)


Master:
<img width="1414" height="1186" alt="image" src="https://github.com/user-attachments/assets/307ab91e-7df3-4cd8-afa6-6db1000338e1" />

PR:
<img width="1414" height="1186" alt="image" src="https://github.com/user-attachments/assets/05e0fedd-f03b-4f96-8b70-7d2cdbdbfcbe" />