### PR TITLE
Debugger: Properly reset the breakpoint skip first when skipped

### DIFF
--- a/pcsx2/DebugTools/Breakpoints.h
+++ b/pcsx2/DebugTools/Breakpoints.h
@@ -135,7 +135,8 @@ public:
 
 	static void SetSkipFirst(BreakPointCpu cpu, u32 pc);
 	static u32 CheckSkipFirst(BreakPointCpu cpu, u32 pc);
-	static void ClearSkipFirst();
+	static void ClearSkipFirst(BreakPointCpu cpu = BREAKPOINT_IOP_AND_EE);
+	static void CommitClearSkipFirst(BreakPointCpu cpu);
 
 	// Includes uncached addresses.
 	static const std::vector<MemCheck> GetMemCheckRanges();
@@ -169,9 +170,9 @@ private:
 
 	static std::vector<BreakPoint> breakPoints_;
 	static u32 breakSkipFirstAtEE_;
-	static u64 breakSkipFirstTicksEE_;
+	static bool pendingClearSkipFirstAtEE_;
 	static u32 breakSkipFirstAtIop_;
-	static u64 breakSkipFirstTicksIop_;
+	static bool pendingClearSkipFirstAtIop_;
 
 	static bool breakpointTriggered_;
 	static BreakPointCpu breakpointTriggeredCpu_;

--- a/pcsx2/Interpreter.cpp
+++ b/pcsx2/Interpreter.cpp
@@ -67,7 +67,10 @@ void intBreakpoint(bool memcheck)
 {
 	const u32 pc = cpuRegs.pc;
  	if (CBreakPoints::CheckSkipFirst(BREAKPOINT_EE, pc) != 0)
+	{
+		CBreakPoints::ClearSkipFirst(BREAKPOINT_EE);
 		return;
+	}
 
 	if (!memcheck)
 	{
@@ -161,6 +164,8 @@ static void execI()
 		intBreakpoint(false);
 
 	intCheckMemcheck();
+
+	CBreakPoints::CommitClearSkipFirst(BREAKPOINT_EE);
 #endif
 
 	const u32 pc = cpuRegs.pc;

--- a/pcsx2/R3000AInterpreter.cpp
+++ b/pcsx2/R3000AInterpreter.cpp
@@ -120,7 +120,10 @@ void psxBreakpoint(bool memcheck)
 {
 	u32 pc = psxRegs.pc;
 	if (CBreakPoints::CheckSkipFirst(BREAKPOINT_IOP, pc) != 0)
+	{
+		CBreakPoints::ClearSkipFirst(BREAKPOINT_IOP);
 		return;
+	}
 
 	if (!memcheck)
 	{
@@ -208,6 +211,8 @@ static __fi void execI()
 		psxBreakpoint(false);
 
 	psxCheckMemcheck();
+	
+	CBreakPoints::CommitClearSkipFirst(BREAKPOINT_IOP);
 #endif
 
 	// Inject IRX hack


### PR DESCRIPTION
### Description of Changes
The breakpoint skip first wasn't resetting after it skipped, so you couldn't properly run an iteration once and break on the same instruction.

### Rationale behind Changes
The behaviour in #13766 is broken, this fixes it. 

### Suggested Testing Steps
Test breakpoints on the recompiler and interpreters.

### Did you use AI to help find, test, or implement this issue or feature?
No
