### PR TITLE
GS: Correct scaling of image when Bilinear Sharp is enabled

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -918,10 +918,15 @@ void GSDevice::Resize(int width, int height)
 	GSVector2i s = m_current->GetSize();
 	int multiplier = 1;
 
-	while (width > s.x || height > s.y)
+	if ((width > s.x || height > s.y))
 	{
-		s = m_current->GetSize() * GSVector2i(++multiplier);
+		while (width > s.x || height > s.y)
+		{
+			s = m_current->GetSize() * GSVector2i(++multiplier);
+		}
 	}
+	else
+		s = GSVector2i(width, height);
 
 	if (ResizeRenderTarget(&dTex, s.x, s.y, false, false))
 	{

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -714,6 +714,15 @@ void GSRenderer::VSync(u32 field, bool registers_written, bool idle_frame)
 		u32 screenshot_width, screenshot_height;
 		std::vector<u32> screenshot_pixels;
 
+		if (GSConfig.LinearPresent == GSPostBilinearMode::BilinearSharp)
+		{
+			const GSTexture* current = g_gs_device->GetCurrent();
+			const GSVector2i internal_res = GetInternalResolution();
+
+			if (current->GetWidth() > internal_res.x || current->GetHeight() > internal_res.y)
+				g_gs_device->Resize(internal_res.x, internal_res.y);
+		}
+
 		if (!m_dump && m_dump_frames > 0)
 		{
 			if (GSConfig.UserHacks_ReadTCOnClose)


### PR DESCRIPTION
### Description of Changes
Corrects the size of the image for screenshots when bilinear sharp is enabled

### Rationale behind Changes
Before it was making it bigger as it relies on Qt to downscale it, this will manually downscale it when dumping draws or making a screenshot.

### Suggested Testing Steps
Make a screenshot at native resolution with a big window, make sure the resulting shot is the expected size.

### Did you use AI to help find, test, or implement this issue or feature?
No

Fixes #13800
