### PR TITLE
GS: Improve PCRTC offset wrapping and simplify some deinterlacing

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -27834,8 +27834,6 @@ SLES-54812:
 SLES-54813:
   name: "NASCAR 08"
   region: "PAL-A-E"
-  gsHWFixes:
-    deinterlace: 8 # Game requires AdaptiveTFF de-interlacing when auto.
 SLES-54814:
   name: "Dead Eye Jim"
   region: "PAL-E"
@@ -29188,8 +29186,6 @@ SLES-55199:
   name: "NASCAR 09"
   region: "PAL-M5"
   compat: 5
-  gsHWFixes:
-    deinterlace: 8 # Game requires AdaptiveTFF de-interlacing when auto.
 SLES-55200:
   name: "Guitar Hero - Aerosmith"
   region: "PAL-M4"
@@ -66465,7 +66461,6 @@ SLUS-20535:
   compat: 5
   gsHWFixes:
     roundSprite: 1 # Fix horizontal and vertical lines when racing.
-    deinterlace: 8 # Fixes misdetection of game deinterlace.
 SLUS-20536:
   name: "NBA Live 2003"
   region: "NTSC-U"
@@ -67665,7 +67660,6 @@ SLUS-20754:
   region: "NTSC-U"
   gsHWFixes:
     roundSprite: 1 # Fix horizontal and vertical lines when racing.
-    deinterlace: 8 # Fixes misdetection of game deinterlace.
   memcardFilters:
     - "PSCD10088" # Enables EA Sports BIO.
     - "SLUS-20754"
@@ -68030,7 +68024,6 @@ SLUS-20824:
   region: "NTSC-U"
   gsHWFixes:
     roundSprite: 1 # Fix horizontal and vertical lines when racing.
-    deinterlace: 8 # Fixes misdetection of game deinterlace.
   memcardFilters:
     - "PSCD10088" # Enables EA Sports BIO.
     - "SLUS-20824"
@@ -73078,8 +73071,6 @@ SLUS-21639:
   name: "NASCAR 08"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    deinterlace: 8 # Game requires AdaptiveTFF de-interlacing when auto.
 SLUS-21640:
   name: "Rugby 08"
   region: "NTSC-U"
@@ -73647,8 +73638,6 @@ SLUS-21744:
   name: "NASCAR 09"
   region: "NTSC-U"
   compat: 5
-  gsHWFixes:
-    deinterlace: 8 # Game requires AdaptiveTFF de-interlacing when auto.
   patches:
     1B6C22B9:
       content: |-

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -442,7 +442,7 @@ void GSvsync(u32 field, bool registers_written)
 	g_gs_renderer->PCRTCDisplays.SetRects(0, g_gs_renderer->m_regs->DISP[0].DISPLAY, g_gs_renderer->m_regs->DISP[0].DISPFB);
 	g_gs_renderer->PCRTCDisplays.SetRects(1, g_gs_renderer->m_regs->DISP[1].DISPLAY, g_gs_renderer->m_regs->DISP[1].DISPFB);
 	g_gs_renderer->PCRTCDisplays.CalculateDisplayOffset(g_gs_renderer->m_scanmask_used);
-	g_gs_renderer->PCRTCDisplays.CalculateFramebufferOffset(g_gs_renderer->m_scanmask_used);
+	g_gs_renderer->PCRTCDisplays.CalculateFramebufferOffset(g_gs_renderer->m_scanmask_used, g_gs_renderer->m_regs->DISP[0].DISPFB, g_gs_renderer->m_regs->DISP[1].DISPFB);
 
 	// Do not move the flush into the VSync() method. It's here because EE transfers
 	// get cleared in HW VSync, and may be needed for a buffered draw (FFX FMVs).

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -5971,44 +5971,36 @@ void GSState::GSPCRTCRegs::SetRects(int display, GSRegDISPLAY displayReg, GSRegD
 
 // Calculate framebuffer read offsets, should be considered if only one circuit is enabled, or difference is more than 1 line.
 // Only considered if "Anti-blur" is enabled.
-void GSState::GSPCRTCRegs::CalculateFramebufferOffset(bool scanmask)
+void GSState::GSPCRTCRegs::CalculateFramebufferOffset(bool scanmask, GSRegDISPFB framebuffer0Reg, GSRegDISPFB framebuffer1Reg)
 {
+	GSVector2i fb0 = GSVector2i(PCRTCDisplays[0].framebufferOffsets.x, PCRTCDisplays[0].framebufferOffsets.y);
+	GSVector2i fb1 = GSVector2i(PCRTCDisplays[1].framebufferOffsets.x, PCRTCDisplays[1].framebufferOffsets.y);
+
+	if (fb0.x + PCRTCDisplays[0].displayRect.z > 2048)
+	{
+		fb0.x -= 2048;
+		PCRTCDisplays[0].framebufferOffsets.x = fb0.x;
+	}
+	if (fb0.y + PCRTCDisplays[0].displayRect.w > 2048)
+	{
+		fb0.y -= 2048;
+		PCRTCDisplays[0].framebufferOffsets.y = fb0.y;
+	}
+	if (fb1.x + PCRTCDisplays[1].displayRect.z > 2048)
+	{
+		fb1.x -= 2048;
+		PCRTCDisplays[1].framebufferOffsets.x = fb1.x;
+	}
+	if (fb1.y + PCRTCDisplays[1].displayRect.w > 2048)
+	{
+		fb1.y -= 2048;
+		PCRTCDisplays[1].framebufferOffsets.y = fb1.y;
+	}
+
 	if (GSConfig.PCRTCAntiBlur && PCRTCSameSrc && !scanmask)
 	{
-		GSVector2i fb0 = GSVector2i(PCRTCDisplays[0].framebufferOffsets.x, PCRTCDisplays[0].framebufferOffsets.y);
-		GSVector2i fb1 = GSVector2i(PCRTCDisplays[1].framebufferOffsets.x, PCRTCDisplays[1].framebufferOffsets.y);
-
-		if (fb0.x + PCRTCDisplays[0].displayRect.z > 2048)
-		{
-			fb0.x -= 2048;
-			fb0.x = abs(fb0.x);
-		}
-		if (fb0.y + PCRTCDisplays[0].displayRect.w > 2048)
-		{
-			fb0.y -= 2048;
-			fb0.y = abs(fb0.y);
-		}
-		if (fb1.x + PCRTCDisplays[1].displayRect.z > 2048)
-		{
-			fb1.x -= 2048;
-			fb1.x = abs(fb1.x);
-		}
-		if (fb1.y + PCRTCDisplays[1].displayRect.w > 2048)
-		{
-			fb1.y -= 2048;
-			fb1.y = abs(fb1.y);
-		}
-
-		if (abs(fb1.y - fb0.y) == 1
-			&& PCRTCDisplays[0].displayRect.y == PCRTCDisplays[1].displayRect.y)
-		{
-			if (fb1.y < fb0.y)
-				PCRTCDisplays[0].framebufferOffsets.y = fb1.y;
-			else
-				PCRTCDisplays[1].framebufferOffsets.y = fb0.y;
-		}
-		if (abs(fb1.x - fb0.x) == 1
-			&& PCRTCDisplays[0].displayRect.x == PCRTCDisplays[1].displayRect.x)
+		
+		if (abs(fb1.x - fb0.x) == 1 && PCRTCDisplays[0].displayRect.x == PCRTCDisplays[1].displayRect.x)
 		{
 			if (fb1.x < fb0.x)
 				PCRTCDisplays[0].framebufferOffsets.x = fb1.x;
@@ -6025,6 +6017,20 @@ void GSState::GSPCRTCRegs::CalculateFramebufferOffset(bool scanmask)
 	PCRTCDisplays[1].framebufferRect.z += PCRTCDisplays[1].framebufferOffsets.x;
 	PCRTCDisplays[1].framebufferRect.y += PCRTCDisplays[1].framebufferOffsets.y;
 	PCRTCDisplays[1].framebufferRect.w += PCRTCDisplays[1].framebufferOffsets.y;
+
+	if (GSConfig.PCRTCAntiBlur && PCRTCSameSrc && !scanmask && abs(fb1.y - fb0.y) <= 1)
+	{
+		if (framebuffer0Reg.DBY != PCRTCDisplays[0].prevFramebufferReg.DBY)
+		{
+			PCRTCDisplays[0].framebufferRect.y = PCRTCDisplays[1].framebufferRect.y;
+			PCRTCDisplays[0].framebufferRect.w = PCRTCDisplays[1].framebufferRect.w;
+		}
+		else
+		{
+			PCRTCDisplays[1].framebufferRect.y = PCRTCDisplays[0].framebufferRect.y;
+			PCRTCDisplays[1].framebufferRect.w = PCRTCDisplays[0].framebufferRect.w;
+		}
+	}
 }
 
 // Used in software mode to align the buffer when reading. Offset is accounted for (block aligned) by GetOutput.

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -408,7 +408,7 @@ public:
 
 		// Calculate framebuffer read offsets, should be considered if only one circuit is enabled, or difference is more than 1 line.
 		// Only considered if "Anti-blur" is enabled.
-		void CalculateFramebufferOffset(bool scanmask);
+		void CalculateFramebufferOffset(bool scanmask, GSRegDISPFB framebuffer0Reg, GSRegDISPFB framebuffer1Reg);
 
 		// Used in software mode to align the buffer when reading. Offset is accounted for (block aligned) by GetOutput.
 		void RemoveFramebufferOffset(int display);


### PR DESCRIPTION
### Description of Changes
Fixes up offsets, mainly when they wrap around 2048 and also fix up some Anti-blur stuff.  Also corrected some behaviour with game deinterlacing detection to make sure it doesn't try to skip deinterlacing when has to do it.

### Rationale behind Changes
the NASCAR games were still shaking, and it was driving me nuts, so I decided to make a better fix and make the code make a bit more sense while I was there.

### Suggested Testing Steps
Test the NASCAR games, random games that do deinterlacing with FRAME or FIELD mode.

### Did you use AI to help find, test, or implement this issue or feature?
No

NASCAR games no longer require deinterlacing forced in the DB.
