### PR TITLE
GS/HW: Small improvement to texture shuffle heuristics

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3056,8 +3056,10 @@ void GSRendererHW::Draw()
 						const int second_u = (PRIM->FST ? v[i + 1].U : static_cast<int>(v[i + 1].ST.S / v[i + 1].RGBAQ.Q)) >> 4;
 						const int vector_width = std::abs(v[i + 1].XYZ.X - v[i].XYZ.X) / 16;
 						const int tex_width = std::abs(second_u - first_u);
+						const int first_vector = (static_cast<int>(v[i].XYZ.X + 8) - static_cast<int>(m_context->XYOFFSET.OFX)) / 16;
 						// & 7 just a quicker way of doing % 8
-						if ((vector_width & 7) != 0 || (tex_width & 7) != 0 || tex_width != vector_width)
+						// If the first vector is the same position as the first_u, then it's not shuffling, it's just copying.
+						if ((vector_width & 7) != 0 || (tex_width & 7) != 0 || tex_width != vector_width || first_vector == first_u)
 						{
 							shuffle_channel_reads = false;
 							break;


### PR DESCRIPTION
### Description of Changes
Improves one section of the heuristics for texture shuffles

### Rationale behind Changes
There was a pretty bad misdetection for the the FMV's on Shox, where it was a 16bit copy, but it thought it could be a shuffle, so this checks if the X values don't match, they should be offset between the draw and texture coordinates in order to actually shuffle anything.
Fixes https://github.com/PCSX2/pcsx2/issues/13727

### Suggested Testing Steps
Test Shox, maybe some random games. Nothing else was fixed/broken by the dump run.

### Did you use AI to help find, test, or implement this issue or feature?
No

Shox:
Master:
<img width="597" height="448" alt="image" src="https://github.com/user-attachments/assets/307d41f1-7ee3-4646-9769-9ebed4c84368" />
PR:
<img width="597" height="448" alt="image" src="https://github.com/user-attachments/assets/499003cd-6064-4c4f-a512-9f97f580ad02" />
