### PR TITLE
USB: Fix missing Train Mascon case warning

### DIFF
--- a/pcsx2/USB/usb-pad/usb-train.cpp
+++ b/pcsx2/USB/usb-pad/usb-train.cpp
@@ -209,6 +209,8 @@ namespace usb_pad
 				s->power_notches = USB::GetConfigInt(si, s->port, TypeName(), "power_notches", 5);
 				s->brake_notches = USB::GetConfigInt(si, s->port, TypeName(), "brake_notches", 8);
 				break;
+			default:
+				break;
 		}
 	}
 


### PR DESCRIPTION
### Description of Changes
Adds a default case to `TrainDevice::UpdateSettings()`

### Rationale behind Changes
Fixes compiler warning.
Use of default case matches `TrainDevice::Settings()`.

### Suggested Testing Steps
Look for compile errors

### Did you use AI to help find, test, or implement this issue or feature?
No
