### PR TITLE
GS: Fix copy/paste typo in TextureMinMax calculation, clean up code

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -5073,22 +5073,17 @@ GSState::TextureMinMaxResult GSState::GetTextureMinMax(GIFRegTEX0 TEX0, GIFRegCL
 				const GSVertex* vert_third = &m_vertex.buff[m_index.buff[2]];
 
 				GSVector4 new_st = st;
-				bool u_forward_check = false;
-				bool x_forward_check = false;
+				bool u_forward_check = PRIM->FST ? (vert_first->U < vert_second->U) : ((vert_first->ST.S / vert_first->RGBAQ.Q) < (vert_second->ST.S / vert_first->RGBAQ.Q));
+				bool x_forward_check = vert_first->XYZ.X < vert_second->XYZ.X;
+
 				if (m_vt.m_primclass == GS_TRIANGLE_CLASS)
 				{
-					u_forward_check = PRIM->FST ? ((vert_first->U < vert_second->U) || (vert_first->U < vert_third->U)) : (((vert_first->ST.S / vert_first->RGBAQ.Q) < (vert_second->ST.S / vert_second->RGBAQ.Q)) || ((vert_first->ST.S / vert_first->RGBAQ.Q) < (vert_third->ST.S / vert_third->RGBAQ.Q)));
-					x_forward_check = (vert_first->XYZ.X < vert_second->XYZ.X) || (vert_first->XYZ.X < vert_third->XYZ.X);
+					u_forward_check |= PRIM->FST ? (vert_first->U < vert_third->U) : ((vert_first->ST.S / vert_first->RGBAQ.Q) < (vert_third->ST.S / vert_third->RGBAQ.Q));
+					x_forward_check |= vert_first->XYZ.X < vert_third->XYZ.X;
 				}
-				else
-				{
-					u_forward_check = PRIM->FST ? (vert_first->U < vert_second->U) : ((vert_first->ST.T / vert_first->RGBAQ.Q) < (vert_second->ST.T / vert_first->RGBAQ.Q));
-					x_forward_check = vert_first->XYZ.Y < vert_second->XYZ.Y;
-				}
+
 				// Check if the UV coords are going in a different direction to the verts, if they match direction, no need to swap
-				const bool u_forward = u_forward_check;
-				const bool x_forward = x_forward_check;
-				const bool swap_x = u_forward != x_forward;
+				const bool swap_x = u_forward_check != x_forward_check;
 
 				if (int_rc.left < scissored_rc.left)
 				{
@@ -5110,21 +5105,16 @@ GSState::TextureMinMaxResult GSState::GetTextureMinMax(GIFRegTEX0 TEX0, GIFRegCL
 					st.x = new_st.x;
 					st.z = new_st.z;
 				}
-				bool v_forward_check = false;
-				bool y_forward_check = false;
+				bool v_forward_check = PRIM->FST ? (vert_first->V < vert_second->V) : ((vert_first->ST.T / vert_first->RGBAQ.Q) < (vert_second->ST.T / vert_first->RGBAQ.Q));
+				bool y_forward_check = vert_first->XYZ.Y < vert_second->XYZ.Y;
+
 				if (m_vt.m_primclass == GS_TRIANGLE_CLASS)
 				{
-					v_forward_check = PRIM->FST ? ((vert_first->V < vert_second->V) || (vert_first->V < vert_third->V)) : (((vert_first->ST.T / vert_first->RGBAQ.Q) < (vert_second->ST.T / vert_second->RGBAQ.Q)) || ((vert_first->ST.T / vert_first->RGBAQ.Q) < (vert_third->ST.T / vert_third->RGBAQ.Q)));
-					y_forward_check = (vert_first->XYZ.Y < vert_second->XYZ.Y) || (vert_first->XYZ.Y < vert_third->XYZ.Y);
+					v_forward_check |= PRIM->FST ? (vert_first->V < vert_third->V) : ((vert_first->ST.T / vert_first->RGBAQ.Q) < (vert_third->ST.T / vert_third->RGBAQ.Q));
+					y_forward_check |= vert_first->XYZ.Y < vert_third->XYZ.Y;
 				}
-				else
-				{
-					v_forward_check = PRIM->FST ? (vert_first->V < vert_second->V) : ((vert_first->ST.T / vert_first->RGBAQ.Q) < (vert_second->ST.T / vert_first->RGBAQ.Q));
-					y_forward_check = vert_first->XYZ.Y < vert_second->XYZ.Y;
-				}
-				const bool v_forward = v_forward_check;
-				const bool y_forward = y_forward_check;
-				const bool swap_y = v_forward != y_forward;
+
+				const bool swap_y = v_forward_check != y_forward_check;
 
 				if (int_rc.top < scissored_rc.top)
 				{


### PR DESCRIPTION
### Description of Changes
Corrects a copy paste typo in the TextureMinMax optimization and tidies the related code a little.

### Rationale behind Changes
It was using the Y values to calculate if X was flipped, causing texture clipping (mainly in software) to errornously clip the wrong side.

### Suggested Testing Steps
Test games in software mainly, smoke test HW, but nothing showed as changed there.

### Did you use AI to help find, test, or implement this issue or feature?
No

## All screenshots are from software mode


Black (shadow under the scaffolding type thing on the left):
Master:
<img width="597" height="448" alt="image" src="https://github.com/user-attachments/assets/72d34c35-a247-46be-bf8b-97e18b2075ff" />
PR:
<img width="597" height="448" alt="image" src="https://github.com/user-attachments/assets/7a8f0068-1512-41c1-b762-7e3e67897a14" />

Crazy Taxi (Fare meter):
Master:
<img width="682" height="512" alt="image" src="https://github.com/user-attachments/assets/b6957dd2-e801-41a1-a379-9379fcea7d4e" />
PR:
<img width="682" height="512" alt="image" src="https://github.com/user-attachments/assets/f0bdc585-e820-443e-bde4-79394c620bac" />

Dr. Muto:
Master:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/2a919116-d701-43d5-8df8-08491c40be6f" />
PR:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/74f8afc1-71f1-4937-8980-24047ddc9018" />

Eternal Poison:
Master:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/9bbc4a5b-8c54-403f-8e61-927ad03d44d7" />
PR:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/ba1e52dd-c460-41a7-af07-7dbb641965bd" />

Mega Man X8 (lighting):
Master:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/6c11de59-d7b3-4f03-88fb-8584f5e691ad" />
PR:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/4173073d-5bad-45d0-ace4-552df827aa4f" />

MLB 11 The Show (bottom right):
Master:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/0023bdf9-7995-4cb0-bff0-671d26f460a6" />
PR:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/92f55b74-a4a7-40d1-a32d-3d27f8bbf767" />

Playstation demo disc 57 demo I don't remember the name of:
Master:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/72ea71cd-169a-4717-8a49-4c71c6c159d2" />
PR:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/b3d5f495-a105-4d7b-ab73-29fea7719f5f" />

Rocky Legends (UI on the left):
Master:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/0e50dae3-3f78-4c37-abaa-074773c64304" />
PR:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/158cebd6-3b51-472c-8d44-c21243edab92" />

King of Fighters XI (Top left character portrait):
Master:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/d84cc72c-a26b-4d17-983c-d78a8d9c28c8" />
PR:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/a5c367d3-0576-4179-b34c-96e3c9e09160" />
