### PR TITLE
GS/TC: Check format matches on invalidation rect translation

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -691,7 +691,7 @@ void GSTextureCache::DirtyRectByPage(u32 sbp, u32 spsm, u32 sbw, Target* t, GSVe
 		const int src_bpp = src_info->bpp;
 		const bool column_align = !block_offset && src_r.z <= src_info->cs.x && src_r.w <= src_info->cs.y && src_info->depth == dst_info->depth;
 
-		if (block_offset)
+		if (block_offset && src_info->bpp == dst_info->bpp)
 			in_rect = in_rect.ralign<Align_Outside>(src_info->bs);
 		else if (column_align)
 			in_rect = in_rect.ralign<Align_Outside>(src_info->cs);


### PR DESCRIPTION
### Description of Changes
Modifies rect calculation for page invalidation when the formats don't match.

### Rationale behind Changes
Before it was using the block alignment of the destination, however the block ordering can be crazily different and a pain to get right since the blocks may not line up as desired, so in these cases when the format doesn't match, we should just invalidate the entire page.

### Suggested Testing Steps
Test Final Fantasy X-2, Battle Engine Aquila and Dragon Quest VIII (though this change is very minor)

### Did you use AI to help find, test, or implement this issue or feature?
No

Fixes #13645 Final Fantasy X-2 load menu
Fixes very small graphical error in Dragon Quest VIII
Fixes more glaring graphical error on the terrain in Battle Engine Aquila

Battle Engine Aquila:
Master:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/1175888f-7840-4916-851e-1e5dda5573c4" />
PR:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/3dad1196-48a8-4cd3-8d40-74e595a7aff7" />

Dragon Quest VIII (There's a very small dot of missing texture half way down the rock face):
Master:
<img width="682" height="512" alt="image" src="https://github.com/user-attachments/assets/852bb8c1-b705-4b10-b6a3-a9237b51c742" />
PR:
<img width="682" height="512" alt="image" src="https://github.com/user-attachments/assets/1ba39ad9-5edc-4720-8474-5cf99fb62477" />

Final Fantasy X-2:
Master;
<img width="554" height="416" alt="image" src="https://github.com/user-attachments/assets/bcdd7c9e-b864-455a-b485-b44bc1a92541" />
PR:
<img width="554" height="416" alt="image" src="https://github.com/user-attachments/assets/2b727648-774f-4f04-b928-3af6a4f9e230" />
