### PR TITLE
GS: Correct GS to GS direction check and simplify

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2528,7 +2528,7 @@ void GSState::Move()
 	if (m_env.TRXPOS.DIRX)
 	{
 		// Only allow it to reverse if the destination is behind the source.
-		if (!intersect || (sx <= dx && (sx == dx || ((!m_env.TRXPOS.DIRY && sy >= dy) || (m_env.TRXPOS.DIRY && sy < dy)))))
+		if (!intersect || sx < dx)
 		{
 			sx += w - 1;
 			dx += w - 1;
@@ -2538,7 +2538,7 @@ void GSState::Move()
 	if (m_env.TRXPOS.DIRY)
 	{
 		// Only allow it to reverse if the destination is behind the source.
-		if (!intersect || (sy <= dy && (sy == dy || ((!m_env.TRXPOS.DIRX && sx >= dx) || (m_env.TRXPOS.DIRX && sx < dx)))))
+		if (!intersect || sy < dy)
 		{
 			sy += h - 1;
 			dy += h - 1;


### PR DESCRIPTION
### Description of Changes
Fixes the check for reversed direction GS to GS transfers

### Rationale behind Changes
I overthought #13791 and tried to put all these safeguards in I didn't need, and I bugged it anyway.

### Suggested Testing Steps
Test Armored Core 2, final level, the blue ring going down the shaft after you blow up the shield generators. (Already tested)

### Did you use AI to help find, test, or implement this issue or feature?
No
