### PR TITLE
GS/VK: Fixes to queue creation

### DIFF
--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -481,7 +481,7 @@ bool GSDeviceVK::CreateDevice(VkSurfaceKHR surface, bool enable_validation_layer
 	vkGetPhysicalDeviceQueueFamilyProperties(m_physical_device, &queue_family_count, queue_family_properties.data());
 	DevCon.WriteLn("%u vulkan queue families", queue_family_count);
 
-	std::vector<int> queue_family_users(queue_family_count, 0);
+	std::vector<uint32_t> queue_family_users(queue_family_count, 0);
 
 	m_graphics_queue_family_index = queue_family_count;
 	m_present_queue_family_index = queue_family_count;
@@ -528,7 +528,7 @@ bool GSDeviceVK::CreateDevice(VkSurfaceKHR surface, bool enable_validation_layer
 	else
 	{
 		// No spare queue? Try the graphics queue.
-		if ((queue_family_properties[m_graphics_queue_family_index].queueCount & VK_QUEUE_COMPUTE_BIT) &&
+		if ((queue_family_properties[m_graphics_queue_family_index].queueFlags & VK_QUEUE_COMPUTE_BIT) &&
 			(queue_family_properties[m_graphics_queue_family_index].timestampValidBits != 0))
 		{
 			m_spin_queue_family_index = m_graphics_queue_family_index;
@@ -647,7 +647,7 @@ bool GSDeviceVK::CreateDevice(VkSurfaceKHR surface, bool enable_validation_layer
 		if (spin_queue_index == 1)
 			queue_infos[1].pQueuePriorities = queue_priorities + 1;
 	}
-	else
+	else if (m_spin_queue_family_index != queue_family_count)
 	{
 		VkDeviceQueueCreateInfo& spin_queue_info = queue_infos[device_info.queueCreateInfoCount++];
 		spin_queue_info.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;


### PR DESCRIPTION
### Description of Changes
Fix check for compute capability of graphics queue.
Add additional check if we fail to find a queue for spin.

### Rationale behind Changes
On hardware with a limited number of queues (such as 1) we where failing to use the graphics queue for spin wait.
Additionally, if we failed to find queue for spinning, we would request an out of bounds queue.

One of those issues was causing the emulator to freeze when entering fullscreen.

### Suggested Testing Steps
Test entering fullscreen on older or weaker Vulkan capable hardware.

### Did you use AI to help find, test, or implement this issue or feature?
No
