### PR TITLE
Memcard: Purge automatic save management

### DIFF
--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
@@ -40,7 +40,6 @@ MemoryCardSettingsWidget::MemoryCardSettingsWidget(SettingsWindow* settings_dial
 
 	SettingWidgetBinder::BindWidgetToFolderSetting(sif, m_ui.directory, m_ui.browse, m_ui.open, m_ui.reset, "Folders",
 		"MemoryCards", Path::Combine(EmuFolders::DataRoot, "memcards"));
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.automaticManagement, "EmuCore", "McdFolderAutoManage", true);
 
 	setupAdditionalUi();
 
@@ -58,11 +57,6 @@ MemoryCardSettingsWidget::MemoryCardSettingsWidget(SettingsWindow* settings_dial
 	connect(m_ui.deleteCard, &QPushButton::clicked, this, &MemoryCardSettingsWidget::deleteCard);
 
 	refresh();
-
-	dialog()->registerWidgetHelp(m_ui.automaticManagement, tr("Automatically manage saves based on running game"),
-		tr("Checked"),
-		tr("(Folder type only / Card size: Auto) Loads only the relevant booted game saves, ignoring others. Avoids "
-		   "running out of space for saves."));
 }
 
 MemoryCardSettingsWidget::~MemoryCardSettingsWidget() = default;

--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.h
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.h
@@ -9,6 +9,7 @@
 #include <QtWidgets/QTreeWidget>
 #include <QtWidgets/QToolButton>
 #include <QtWidgets/QListWidget>
+#include <QtWidgets/QCheckBox>
 
 #include <array>
 #include <optional>

--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.ui
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.ui
@@ -175,22 +175,6 @@
      </layout>
     </widget>
    </item>
-   <item>
-    <widget class="QGroupBox" name="settingsGroupBox">
-     <property name="title">
-      <string>Settings</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="automaticManagement">
-        <property name="text">
-         <string>Automatically manage saves based on running game</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -211,7 +195,6 @@
   <tabstop>renameCard</tabstop>
   <tabstop>convertCard</tabstop>
   <tabstop>deleteCard</tabstop>
-  <tabstop>automaticManagement</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1326,7 +1326,6 @@ struct Pcsx2Config
 		UseSavestateSelector : 1,
 		InhibitScreensaver : 1,
 		BackupSavestate : 1,
-		McdFolderAutoManage : 1,
 		ManuallySetRealTimeClock : 1, // passes user-set real-time clock information to cdvd at startup
 		UseSystemLocaleFormat : 1, // presents OS time format instead of yyyy-MM-dd HH:mm:ss for manual RTC
 

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1923,7 +1923,6 @@ Pcsx2Config::Pcsx2Config()
 {
 	bitset = 0;
 	// Set defaults for fresh installs / reset settings
-	McdFolderAutoManage = true;
 	EnablePatches = true;
 	EnableFastBoot = true;
 	EnableRecordingTools = true;
@@ -1979,7 +1978,6 @@ void Pcsx2Config::LoadSaveCore(SettingsWrapper& wrap)
 	SettingsWrapBitBool(HostFs);
 
 	SettingsWrapBitBool(BackupSavestate);
-	SettingsWrapBitBool(McdFolderAutoManage);
 
 	SettingsWrapBitBool(WarnAboutUnsafeSettings);
 

--- a/pcsx2/SIO/Memcard/MemoryCardFile.cpp
+++ b/pcsx2/SIO/Memcard/MemoryCardFile.cpp
@@ -611,7 +611,7 @@ void FileMcd_EmuOpen()
 
 
 	Mcd::impl.Open();
-	Mcd::implFolder.SetFiltering(EmuConfig.McdFolderAutoManage);
+	Mcd::implFolder.SetFiltering(true);
 	Mcd::implFolder.Open();
 }
 
@@ -823,7 +823,7 @@ int FileMcd_ReIndex(uint port, uint slot, const std::string& filter)
 		//	return Mcd::impl.ReIndex( combinedSlot, filter );
 		//	break;
 		case MemoryCardType::Folder:
-			if (!Mcd::implFolder.ReIndex(combinedSlot, EmuConfig.McdFolderAutoManage, filter))
+			if (!Mcd::implFolder.ReIndex(combinedSlot, true, filter))
 				return -1;
 			break;
 		default:
@@ -930,7 +930,7 @@ std::vector<AvailableMcdInfo> FileMcd_GetAvailableCards(bool include_in_use_card
 			Pcsx2Config::McdOptions config;
 			config.Enabled = true;
 			config.Type = MemoryCardType::Folder;
-			sourceFolderMemoryCard.Open(fd.FileName, config, (8 * 1024 * 1024) / FolderMemoryCard::ClusterSize, EmuConfig.McdFolderAutoManage, "");
+			sourceFolderMemoryCard.Open(fd.FileName, config, (8 * 1024 * 1024) / FolderMemoryCard::ClusterSize, true, "");
 
 			mcds.push_back({std::move(basename), std::move(fd.FileName), fd.ModificationTime,
 				MemoryCardType::Folder, MemoryCardFileType::Unknown, 0u, sourceFolderMemoryCard.IsFormatted()});

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -2993,8 +2993,6 @@ void VMManager::CheckForMemoryCardConfigChanges(const Pcsx2Config& old_config)
 		}
 	}
 
-	changed |= (EmuConfig.McdFolderAutoManage != old_config.McdFolderAutoManage);
-
 	if (!changed)
 		return;
 


### PR DESCRIPTION
### Description of Changes
Removes the option to disable automatic management of folder memory cards.

### Rationale behind Changes
There's a fairly refined suspicion that disabling this will inevitably nuke peoples folder memory cards and if you need this functionally you should just be using standard memory cards regardless.

### Suggested Testing Steps
Make a backup or a dummy folder memory card and make sure nothing goes kaboom.

### Did you use AI to help find, test, or implement this issue or feature?
No
