### PR TITLE
GS/TC: Don't use bilinear when upscaling RT target

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2770,7 +2770,7 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVe
 				g_gs_device->FilteredDownsampleTexture(dst->m_texture, tex, downsample_factor, clamp_min, dRect);
 			}
 			else
-				g_gs_device->StretchRect(dst->m_texture, sRect, tex, dRect, (type == RenderTarget) ? ShaderConvert::COPY : ShaderConvert::DEPTH_COPY, dst->m_scale < scale);
+				g_gs_device->StretchRect(dst->m_texture, sRect, tex, dRect, (type == RenderTarget) ? ShaderConvert::COPY : ShaderConvert::DEPTH_COPY, false);
 
 			g_perfmon.Put(GSPerfMon::TextureCopies, 1);
 			m_target_memory_usage = (m_target_memory_usage - dst->m_texture->GetMemUsage()) + tex->GetMemUsage();


### PR DESCRIPTION
### Description of Changes
Disables bilinear filtering when upscaling an RT target.

### Rationale behind Changes
I originally set this for native scaling, but it turned out to be pointless and it looks like it makes the picture less agreeable than without it, so let's not.

### Suggested Testing Steps
Test Steambot (mainly the ingame menus), and random games which use native scaling.

### Did you use AI to help find, test, or implement this issue or feature?
No

Steambot Chronicles:

Master:
<img width="1438" height="1274" alt="image" src="https://github.com/user-attachments/assets/9e1bd7e0-7210-42eb-9c3e-134ff1c82503" />

PR:
<img width="1438" height="1274" alt="image" src="https://github.com/user-attachments/assets/87bc7658-81c4-4288-ade5-6be036502834" />
