### PR TITLE
GS/HW: Optimize Z floor usage and use conservative depth.

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -112,7 +112,7 @@ struct VS_OUTPUT
 
 struct PS_INPUT
 {
-	float4 p : SV_Position;
+	noperspective centroid float4 p : SV_Position;
 	float4 t : TEXCOORD0;
 	float4 ti : TEXCOORD2;
 #if VS_IIP != 0 || GS_IIP != 0 || PS_IIP != 0
@@ -140,7 +140,7 @@ struct PS_OUTPUT
 #endif
 #endif
 #if PS_ZCLAMP || PS_ZFLOOR
-	float depth : SV_Depth;
+	float depth : SV_DepthLessEqual;
 #endif
 };
 

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -113,6 +113,10 @@ layout(binding = 3) uniform sampler2D img_prim_min;
 //layout(pixel_center_integer) in vec4 gl_FragCoord;
 #endif
 
+#if (PS_ZFLOOR || PS_ZCLAMP) && HAS_CONSERVATIVE_DEPTH
+layout(depth_less) out float gl_FragDepth;
+#endif
+
 vec4 sample_from_rt()
 {
 #if !NEEDS_RT

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -361,6 +361,10 @@ layout(set = 1, binding = 1) uniform texture2D Palette;
 layout(set = 1, binding = 3) uniform texture2D PrimMinTexture;
 #endif
 
+#if PS_ZFLOOR || PS_ZCLAMP
+layout(depth_less) out float gl_FragDepth;
+#endif
+
 #if NEEDS_TEX
 
 vec4 sample_c(vec2 uv)

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5168,7 +5168,9 @@ void GSRendererHW::EmulateZbuffer(const GSTextureCache::Target* ds)
 	m_conf.cb_vs.max_depth = GSVector2i(0xFFFFFFFF);
 	//ps_cb.MaxDepth = GSVector4(0.0f, 0.0f, 0.0f, 1.0f);
 	m_conf.ps.zclamp = 0;
-	m_conf.ps.zfloor = !m_cached_ctx.ZBUF.ZMSK;
+	m_conf.ps.zfloor = !m_vt.m_eq.z &&
+		(m_vt.m_primclass == GS_TRIANGLE_CLASS || m_vt.m_primclass == GS_LINE_CLASS) &&
+		(m_cached_ctx.DepthWrite() || (m_cached_ctx.DepthRead() && m_cached_ctx.TEST.ZTST == ZTST_GREATER));
 
 	if (clamp_z)
 	{

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -770,6 +770,11 @@ bool GSDeviceOGL::CheckFeatures()
 		m_features.line_expand ? "hardware" : (m_features.vs_expand ? "vertex expanding" : "UNSUPPORTED"),
 		m_features.vs_expand ? "vertex expanding" : "CPU");
 
+	if (!GLAD_GL_ARB_conservative_depth)
+	{
+		Console.Warning("GLAD_GL_ARB_conservative_depth is not supported. This will reduce performance.");
+	}
+
 	return true;
 }
 
@@ -1292,6 +1297,16 @@ std::string GSDeviceOGL::GenGlslHeader(const std::string_view entry, GLenum type
 		header += "#define HAS_FRAMEBUFFER_FETCH 1\n";
 	else
 		header += "#define HAS_FRAMEBUFFER_FETCH 0\n";
+
+	if (GLAD_GL_ARB_conservative_depth)
+	{
+		header += "#extension GL_ARB_conservative_depth : enable\n";
+		header += "#define HAS_CONSERVATIVE_DEPTH 1\n";
+	}
+	else
+	{
+		header += "#define HAS_CONSERVATIVE_DEPTH 0\n";
+	}
 
 	// Allow to puts several shader in 1 files
 	switch (type)

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 80;
+static constexpr u32 SHADER_CACHE_VERSION = 81;


### PR DESCRIPTION
### Description of Changes
- Enable Z floor only in cases where there is interpolation and depth test/write needs it.
- Use conservative depth in shaders to preserve some early Z optimizations. This only affects GL, DX12, DX11, VK. The equivalent functionality is already in Metal.

### Rationale behind Changes
Improve performance and make sure depth test with zfloor is correct.

Case where we need Z floor while depth testing (uses ZTST_GREATER):
Soukou_Kihei_Votoms_SLPS-25827_20240405201525.gs.xz

Master VK
<img width="512" height="480" alt="00550_f00003_fr1_01c00_C_32" src="https://github.com/user-attachments/assets/2e13b843-08c6-49b7-8e6f-3e22f8a8f1ba" />

Master SW
<img width="512" height="446" alt="00550_f00003_fr1_01c00_C_32" src="https://github.com/user-attachments/assets/8500383f-4f1d-43c0-aa7b-2cf727a07618" />

PR VK
<img width="512" height="480" alt="00550_f00003_fr1_01c00_C_32" src="https://github.com/user-attachments/assets/24929778-b2f5-4872-88f8-56ff488aadac" />

### Suggested Testing Steps
Testing games with the HW renderer.

### Did you use AI to help find, test, or implement this issue or feature?
Yes, to learn about conservative depth test.