### PR TITLE
QT: Focus the main window when the DisplayWidget is focused to get its toolbar

### DIFF
--- a/pcsx2-qt/DisplayWidget.cpp
+++ b/pcsx2-qt/DisplayWidget.cpp
@@ -477,6 +477,13 @@ bool DisplaySurface::eventFilter(QObject* object, QEvent* event)
 			}
 			return false;
 
+		case QEvent::FocusIn:
+			// macOS: When we (the display window) get focus from another window with a toolbar we update to the MainWindow toolbar.
+			// This is because we are a different native window from our MainWindow. So, whenever we get focus, focus our MainWindow.
+			// That way macOS will show the MainWindow toolbar when you click from the debugger / log window to the game.
+			if (auto* w = qobject_cast<QWidget*>(object))
+				w->window()->activateWindow();
+			return false;
 		default:
 			return false;
 	}


### PR DESCRIPTION
### Description of Changes
Whenever the game rendering surface is focused, focus the main window.

### Rationale behind Changes
Since #13466, we render to a new native window. This is fine on Linux and Window, but on macOS this new window doesn't have the MainWindow toolbar. Clicking from the debugger, on to the game would have macOS show the debugger toolbar still.

Fixes #13852

### Suggested Testing Steps
I think this might break USB HID keyboard input or controller buttons bound to the keyboard?
There were some event filters passing these events back to the core, and I'm not sure if the MainWindow does the same if it's focused.

- Open and focus the debugger or log window.
- Click back on to the game.
- Try to use the HID keyboard or a controller button mapped to your keyboard
- Tell me if it works or if it's broken.

### Did you use AI to help find, test, or implement this issue or feature?
I tried to see if you could have a window inherit a toolbar, but it says no.
