### PR TITLE
GS/HW: Support for integer depth.

### DIFF
--- a/bin/resources/shaders/dx11/convert.fx
+++ b/bin/resources/shaders/dx11/convert.fx
@@ -47,23 +47,28 @@ static const float3x3 rgb2yuv =
 	{-0.419, -0.081, 0.500}
 };
 
-Texture2D Texture;
 SamplerState TextureSampler;
 
 #if HAS_FLOAT32_INPUT
-
+Texture2D Texture;
 float sample_c(float2 uv)
 {
 	return Texture.Sample(TextureSampler, uv).r;
 }
-
+#elif HAS_INTEGER_INPUT
+Texture2D<uint> Texture;
+uint sample_c(float2 uv)
+{
+	uint w, h;
+	Texture.GetDimensions(w, h);
+	return Texture.Load(int3(w * uv.x, h * uv.y, 0));
+}
 #else
-
+Texture2D Texture;
 float4 sample_c(float2 uv)
 {
 	return Texture.Sample(TextureSampler, uv);
 }
-
 #endif
 
 struct PS_INPUT
@@ -72,6 +77,22 @@ struct PS_INPUT
 	float2 t : TEXCOORD0;
 	float4 c : COLOR;
 };
+
+#if HAS_INTEGER_INPUT
+	#define DEPTH_INPUT_TYPE uint
+	#define DEPTH_INPUT_SCALE 1
+#else
+	#define DEPTH_INPUT_TYPE float
+	#define DEPTH_INPUT_SCALE exp2(32.0f)
+#endif
+
+#if HAS_INTEGER_OUTPUT
+	#define DEPTH_OUTPUT_TYPE uint
+	#define DEPTH_OUTPUT_SCALE 1
+#else
+	#define DEPTH_OUTPUT_TYPE float
+	#define DEPTH_OUTPUT_SCALE exp2(-32.0f)
+#endif
 
 #if HAS_INTEGER_OUTPUT
 	#define OUTPUT_TYPE uint
@@ -104,9 +125,9 @@ uint rgb5a1_to_uint(float4 c)
 	return (i.r >> 3) | (i.g << 2) | (i.b << 7) | (i.a << 8);
 }
 
-uint depth_to_uint(float d)
+uint depth_to_uint(DEPTH_INPUT_TYPE d)
 {
-	return uint(d * exp2(32.0f));
+	return uint(d * DEPTH_INPUT_SCALE);
 }
 
 float4 uint_to_rgba8(uint i)
@@ -119,52 +140,52 @@ float4 uint_to_rgb5a1(uint i)
 	return float4(uint4(i << 3, i >> 2, i >> 7, i >> 8) & uint4(0xF8u, 0xF8u, 0xF8u, 0x80u)) / 255.0f;
 }
 
-float uint_to_depth32(uint i)
+DEPTH_OUTPUT_TYPE uint_to_depth32(uint i)
 {
-	return float(i) * exp2(-32.0f);
+	return DEPTH_OUTPUT_TYPE(i) * DEPTH_OUTPUT_SCALE;
 }
 
-float uint_to_depth24(uint i)
+DEPTH_OUTPUT_TYPE uint_to_depth24(uint i)
 {
-	return float(i & 0xFFFFFFu) * exp2(-32.0f);
+	return DEPTH_OUTPUT_TYPE(i & 0xFFFFFFu) * DEPTH_OUTPUT_SCALE;
 }
 
-float uint_to_depth16(uint i)
+DEPTH_OUTPUT_TYPE uint_to_depth16(uint i)
 {
-	return float(i & 0xFFFFu) * exp2(-32.0f);
+	return DEPTH_OUTPUT_TYPE(i & 0xFFFFu) * DEPTH_OUTPUT_SCALE;
 }
 
-float rgba8_to_depth32(float4 val)
+DEPTH_OUTPUT_TYPE rgba8_to_depth32(float4 val)
 {
 	return uint_to_depth32(rgba8_to_uint(val));
 }
 
-float rgba8_to_depth24(float4 val)
+DEPTH_OUTPUT_TYPE rgba8_to_depth24(float4 val)
 {
 	return uint_to_depth24(rgba8_to_uint(val));
 }
 
-float rgba8_to_depth16(float4 val)
+DEPTH_OUTPUT_TYPE rgba8_to_depth16(float4 val)
 {
 	return uint_to_depth16(rgba8_to_uint(val));
 }
 
-float rgb5a1_to_depth16(float4 val)
+DEPTH_OUTPUT_TYPE rgb5a1_to_depth16(float4 val)
 {
 	return uint_to_depth16(rgb5a1_to_uint(val));
 }
 
-float4 depth32_to_rgba8(float d)
+float4 depth32_to_rgba8(DEPTH_INPUT_TYPE d)
 {
 	return uint_to_rgba8(depth_to_uint(d));
 }
 
-float4 depth16_to_rgb5a1(float d)
+float4 depth16_to_rgb5a1(DEPTH_INPUT_TYPE d)
 {
 	return uint_to_rgb5a1(depth_to_uint(d));
 }
 
-float depth32_to_depth24(float d)
+DEPTH_OUTPUT_TYPE depth32_to_depth24(DEPTH_INPUT_TYPE d)
 {
 	return uint_to_depth24(depth_to_uint(d));
 }
@@ -179,7 +200,7 @@ OUTPUT_TYPE ps_copy(PS_INPUT input) : OUTPUT_SV
 #if defined(__ps_depth_copy__)
 OUTPUT_TYPE ps_depth_copy(PS_INPUT input) : OUTPUT_SV
 {
-	return sample_c(input.t);
+	return uint_to_depth32(depth_to_uint(sample_c(input.t)));
 }
 #endif
 
@@ -323,6 +344,20 @@ OUTPUT_TYPE ps_convert_depth32_depth24(PS_INPUT input) : OUTPUT_SV
 }
 #endif
 
+#if HAS_INTEGER_OUTPUT
+uint lerp_depth(uint a, uint b, float c)
+{
+  uint absdiff = a > b ? a - b : b - a;
+  uint adjust = min(uint(round(float(absdiff) * c)), absdiff);
+  return a > b ? a - adjust : a + adjust;
+}
+#else
+float lerp_depth(float a, float b, float c)
+{
+  return lerp(a, b, c);
+}
+#endif
+
 #define SAMPLE_RGBA_DEPTH_BILN(CONVERT_FN) \
 	uint width, height; \
 	Texture.GetDimensions(width, height); \
@@ -334,7 +369,7 @@ OUTPUT_TYPE ps_convert_depth32_depth24(PS_INPUT input) : OUTPUT_SV
 	float depthTR = CONVERT_FN(Texture.Load(int3(coords.zy, 0))); \
 	float depthBL = CONVERT_FN(Texture.Load(int3(coords.xw, 0))); \
 	float depthBR = CONVERT_FN(Texture.Load(int3(coords.zw, 0))); \
-	return lerp(lerp(depthTL, depthTR, mix_vals.x), lerp(depthBL, depthBR, mix_vals.x), mix_vals.y);
+	return lerp_depth(lerp_depth(depthTL, depthTR, mix_vals.x), lerp_depth(depthBL, depthBR, mix_vals.x), mix_vals.y);
 
 #if defined(__ps_convert_rgba8_depth32__)
 OUTPUT_TYPE ps_convert_rgba8_depth32(PS_INPUT input) : OUTPUT_SV

--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -56,6 +56,12 @@
 #define PS_ROV_DEPTH_READ_ONLY 2
 #endif
 
+#ifndef PS_Z_INTEGER_NONE
+#define PS_Z_INTEGER_NONE 0
+#define PS_Z_INTEGER_READ_WRITE 1
+#define PS_Z_INTEGER_READ_ONLY 2
+#endif
+
 #ifndef PS_FST
 #define PS_IIP 0
 #define PS_FST 0
@@ -119,6 +125,9 @@
 #define PS_ABE 0
 #define PS_ROV_COLOR 0
 #define PS_ROV_DEPTH 0
+#define PS_Z_RT_SLOT 0
+#define PS_Z_INTEGER 0
+#define PS_TEX_INTEGER 0
 #endif
 
 #ifndef VS_EXPAND_NONE
@@ -128,6 +137,9 @@
 #define VS_EXPAND_SPRITE 3
 #define VS_EXPAND_LINE_AA1 4
 #define VS_EXPAND_TRIANGLE_AA1 5
+#define VS_EXPAND_POINT_Z_INTEGER 6
+#define VS_EXPAND_LINE_Z_INTEGER 7
+#define VS_EXPAND_TRIANGLE_Z_INTEGER 8
 #endif
 
 #define SW_BLEND (PS_BLEND_A || PS_BLEND_B || PS_BLEND_D)
@@ -137,14 +149,29 @@
 #define NEEDS_DEPTH_FOR_AFAIL (PS_AFAIL == AFAIL_FB_ONLY || PS_AFAIL == AFAIL_RGB_ONLY_SW_Z)
 #define NEEDS_DEPTH_FOR_ZTST (PS_ZTST == ZTST_GEQUAL || PS_ZTST == ZTST_GREATER)
 #define NEEDS_DEPTH_FOR_AA1 (PS_AA1 == PS_AA1_TRIANGLE_SW_Z)
-#define SW_DEPTH (NEEDS_DEPTH_FOR_AFAIL || NEEDS_DEPTH_FOR_ZTST || NEEDS_DEPTH_FOR_AA1)
-#define ZWRITE (PS_ZFLOOR || PS_ZCLAMP || SW_DEPTH)
+#define NEEDS_DEPTH_FOR_ZINT (PS_Z_INTEGER != PS_Z_INTEGER_NONE)
+#define ZWRITE_FOR_ZINT (PS_Z_INTEGER == PS_Z_INTEGER_READ_WRITE)
+
+#define SW_DEPTH (NEEDS_DEPTH_FOR_AFAIL || NEEDS_DEPTH_FOR_ZTST || NEEDS_DEPTH_FOR_AA1 || NEEDS_DEPTH_FOR_ZINT)
+#define ZWRITE (PS_ZFLOOR || PS_ZCLAMP || AFAIL_NEEDS_DEPTH || ZTST_NEEDS_DEPTH || AA1_NEEDS_DEPTH || ZWRITE_FOR_ZINT)
 
 #define PS_RETURN_COLOR_ROV (!PS_NO_COLOR && PS_ROV_COLOR)
 #define PS_RETURN_COLOR (!PS_NO_COLOR && !PS_ROV_COLOR)
 #define PS_RETURN_DEPTH_ROV (PS_ROV_DEPTH == PS_ROV_DEPTH_READ_WRITE)
 #define PS_RETURN_DEPTH (ZWRITE && !PS_ROV_DEPTH)
 #define PS_ROV_EARLYDEPTHSTENCIL (PS_ROV_COLOR && !PS_ROV_DEPTH && !ZWRITE)
+
+#if PS_Z_INTEGER
+	#define DEPTH_TYPE uint
+#else
+	#define DEPTH_TYPE float
+#endif
+
+#if PS_Z_RT_SLOT
+	#define Z_RT_SLOT SV_Target1
+#else
+	#define Z_RT_SLOT SV_Target0
+#endif
 
 struct VS_INPUT
 {
@@ -171,6 +198,10 @@ struct VS_OUTPUT
 
 	float inv_cov : COLOR1; // We use the inverse to make it simpler to interpolate.
 	nointerpolation uint interior : COLOR2; // 1 for triangle interior; 0 for edge;
+
+#if VS_Z_INTEGER
+	nointerpolation uint z_base : COLOR3;
+#endif
 };
 
 struct PS_INPUT
@@ -178,6 +209,7 @@ struct PS_INPUT
 	noperspective centroid float4 p : SV_Position;
 	float4 t : TEXCOORD0;
 	float4 ti : TEXCOORD2;
+
 #if VS_IIP != 0 || GS_IIP != 0 || PS_IIP != 0
 	float4 c : COLOR0;
 #else
@@ -185,6 +217,11 @@ struct PS_INPUT
 #endif
 	float inv_cov : COLOR1; // We use the inverse to make it simpler to interpolate.
 	nointerpolation uint interior : COLOR2; // 1 for triangle interior; 0 for edge;
+
+#if PS_Z_INTEGER
+	nointerpolation uint z_base : COLOR3;
+#endif
+
 #if (PS_DATE >= 1 && PS_DATE <= 3) || GS_FORWARD_PRIMID
 	uint primid : SV_PrimitiveID;
 #endif
@@ -194,51 +231,51 @@ struct PS_INPUT
 
 struct PS_OUTPUT
 {
-#define NUM_RTS 0
-
 #if PS_RETURN_COLOR
 	#if PS_DATE == 1 || PS_DATE == 2
 		float c0 : SV_Target;
 	#else
-		
 		float4 c0 : SV_Target0;
-
-		#undef NUM_RTS
-		#define NUM_RTS 1
-		
 		#if !PS_NO_COLOR1
 			float4 c1 : SV_Target1;
 		#endif
 	#endif
 #endif
-
 #if PS_RETURN_DEPTH
-	// In DX12 we do depth feedback loops with a color copy.
-	#if SW_DEPTH && PS_NO_COLOR1 && PS_DEPTH_FEEDBACK_SUPPORT == 2
-		#if NUM_RTS > 0
-			float depth_color : SV_Target1;
+	#if PS_Z_INTEGER
+		#if ZWRITE_FOR_ZINT
+			uint depth : Z_RT_SLOT;
+		#endif
+	#else
+		// In DX12 we do depth feedback loops with a color copy.
+		#if SW_DEPTH && PS_NO_COLOR1 && PS_DEPTH_FEEDBACK_SUPPORT == 2
+			#if PS_Z_RT_SLOT
+				float depth_color : SV_Target1;
+			#else
+				float depth_color : SV_Target0;
+			#endif
+		#endif
+		#if PS_HAS_CONSERVATIVE_DEPTH && !SW_DEPTH
+			float depth : SV_DepthLessEqual;
 		#else
-			float depth_color : SV_Target0;
+			float depth : SV_Depth;
 		#endif
 	#endif
-	#if PS_HAS_CONSERVATIVE_DEPTH && !SW_DEPTH
-		float depth : SV_DepthLessEqual;
-	#else
-		float depth : SV_Depth;
-	#endif
 #endif
-
-#undef NUM_RTS
 };
 
+#if PS_TEX_INTEGER
+Texture2D<uint> Texture : register(t0);
+#else
 Texture2D<float4> Texture : register(t0);
+#endif
 Texture2D<float4> Palette : register(t1);
 #if !PS_ROV_COLOR
 Texture2D<float4> RtTexture : register(t2);
 #endif
 Texture2D<float> PrimMinTexture : register(t3);
 #if !PS_ROV_DEPTH
-Texture2D<float> DepthTexture : register(t4);
+Texture2D<DEPTH_TYPE> DepthTexture : register(t4);
 #endif
 SamplerState TextureSampler : register(s0);
 
@@ -248,8 +285,8 @@ static float4 rov_rt_value;
 #endif
 
 #if PS_ROV_DEPTH
-RasterizerOrderedTexture2D<float> DepthTextureRov : register(u1);
-static float rov_depth_value;
+RasterizerOrderedTexture2D<DEPTH_TYPE> DepthTextureRov : register(u1);
+static DEPTH_TYPE rov_depth_value;
 #endif
 
 #ifdef DX12
@@ -262,7 +299,7 @@ cbuffer cb1
 	float AREF;
 	float4 WH;
 	float2 TA;
-	float MaxDepthPS;
+	DEPTH_TYPE MaxDepthPS;
 	float Af;
 	uint4 FbMask;
 	float4 HalfTexel;
@@ -293,7 +330,7 @@ float4 RtLoad(int2 xy)
 #endif
 }
 
-float DepthLoad(int2 xy)
+DEPTH_TYPE DepthLoad(int2 xy)
 {
 #if PS_ROV_DEPTH
 	return rov_depth_value;
@@ -309,7 +346,7 @@ void RtWrite(int2 xy, float4 c)
 #endif
 }
 
-void DepthWrite(int2 xy, float d)
+void DepthWrite(int2 xy, DEPTH_TYPE d)
 {
 #if PS_ROV_DEPTH
 	DepthTextureRov[xy] = d;
@@ -479,6 +516,9 @@ float4 sample_c(float2 uv, float uv_w, int2 xy)
 {
 #if PS_TEX_IS_FB == 1
 	return RtLoad(xy);
+#elif PS_TEX_INTEGER == 1
+	// integer texture only applies to depth
+	return float4(0.0f, 0.0f, 0.0f, 0.0f);
 #elif PS_REGION_RECT == 1
 	return Texture.Load(int3(int2(uv), 0));
 #else
@@ -672,18 +712,25 @@ float4x4 sample_4p(uint4 u)
 
 uint fetch_raw_depth(int2 xy)
 {
+#if PS_TEX_INTEGER
+	return Texture.Load(int3(xy, 0));
+#else
 #if PS_TEX_IS_FB == 1
 	float4 col = RtLoad(xy);
 #else
 	float4 col = Texture.Load(int3(xy, 0));
 #endif
 	return (uint)(col.r * exp2(32.0f));
+#endif
 }
 
 float4 fetch_raw_color(int2 xy)
 {
 #if PS_TEX_IS_FB == 1
 	return RtLoad(xy);
+#elif PS_TEX_INTEGER
+	// integer texture only applies to depth
+	return float4(0.0f, 0.0f, 0.0f, 0.0f);
 #else
 	return Texture.Load(int3(xy, 0));
 #endif
@@ -693,6 +740,9 @@ float4 fetch_c(int2 uv)
 {
 #if PS_TEX_IS_FB == 1
 	return RtLoad(uv);
+#elif PS_TEX_INTEGER
+	// integer texture only applies to depth
+	return float4(0.0f, 0.0f, 0.0f, 0.0f);
 #else
 	return Texture.Load(int3(uv, 0));
 #endif
@@ -755,7 +805,7 @@ float4 sample_depth(float2 st, float2 pos)
 		uint depth = fetch_raw_depth(pos);
 
 		// Convert msb based on the palette
-		t = Palette.Load(int3((depth >> 8u) & 0xFFu, 0, 0)) * 255.0f;
+		t = Palette.Load(uint3((depth >> 8u) & 0xFFu, 0, 0)) * 255.0f;
 	}
 	else if (PS_URBAN_CHAOS_HLE == 1)
 	{
@@ -780,8 +830,12 @@ float4 sample_depth(float2 st, float2 pos)
 	{
 		// Based on ps_convert_depth32_rgba8 of convert
 
-		// Convert a FLOAT32 depth texture into a RGBA color texture
+		// Convert a FLOAT32 or UINT32 depth texture into a RGBA color texture
+#if PS_TEX_INTEGER
+		uint d = fetch_raw_depth(uv);
+#else
 		uint d = uint(fetch_c(uv).r * exp2(32.0f));
+#endif
 		t = float4(uint4((d & 0xFFu), ((d >> 8) & 0xFFu), ((d >> 16) & 0xFFu), (d >> 24)));
 	}
 	else if (PS_DEPTH_FMT == 2)
@@ -789,7 +843,11 @@ float4 sample_depth(float2 st, float2 pos)
 		// Based on ps_convert_depth16_rgb5a1 of convert
 
 		// Convert a FLOAT32 (only 16 lsb) depth into a RGB5A1 color texture
+#if PS_TEX_INTEGER
+		uint d = fetch_raw_depth(uv);
+#else
 		uint d = uint(fetch_c(uv).r * exp2(32.0f));
+#endif
 		t = float4(uint4((d & 0x1Fu), ((d >> 5) & 0x1Fu), ((d >> 10) & 0x1Fu), (d >> 15) & 0x01u)) * float4(8.0f, 8.0f, 8.0f, 128.0f);
 	}
 	else if (PS_DEPTH_FMT == 3)
@@ -1311,6 +1369,8 @@ void ps_blend(inout float4 Color, inout float4 As_rgba, float2 pos_xy)
 [earlydepthstencil]
 #endif
 
+// Use ROV discard macro for since we cannot do
+// conditional discard based on value read from ROV.
 #if PS_ROV_COLOR || PS_ROV_DEPTH
 	#define DISCARD { rov_discard_color = true; rov_discard_depth = true; }
 	#define DISCARD_COLOR rov_discard_color = true
@@ -1318,7 +1378,7 @@ void ps_blend(inout float4 Color, inout float4 As_rgba, float2 pos_xy)
 #else
 	#define DISCARD discard
 	#define DISCARD_COLOR o_col0 = RtLoad(input.p.xy)
-	#define DISCARD_DEPTH input.p.z = DepthLoad(input.p.xy)
+	#define DISCARD_DEPTH input_z = DepthLoad(input.p.xy)
 #endif
 
 #if (PS_RETURN_COLOR || PS_RETURN_DEPTH)
@@ -1327,11 +1387,6 @@ PS_OUTPUT ps_main(PS_INPUT input)
 void ps_main(PS_INPUT input)
 #endif
 {
-	// Must floor before depth testing.
-#if PS_ZFLOOR
-	input.p.z = floor(input.p.z * exp2(32.0f)) * exp2(-32.0f);
-#endif
-
 #if PS_ROV_COLOR
 	rov_rt_value = RtTextureRov[input.p.xy];
 #endif
@@ -1345,13 +1400,30 @@ void ps_main(PS_INPUT input)
 	bool rov_discard_depth = false;
 #endif
 
-	// Use ROV discard macro for since we cannot do
-	// conditional discard based on value read from ROV.
+#if PS_Z_INTEGER
+	// Add base plus interpolated offset.
+	uint input_z = input.z_base + uint(exp2(32.0f) * input.p.z);
+#else
+	float input_z = input.p.z;
+#endif
+
+#if !PS_Z_INTEGER && PS_ZFLOOR
+	// Must floor before depth testing.
+	input_z = floor(input_z * exp2(32.0f)) * exp2(-32.0f);
+#endif
+
+#if SW_DEPTH
+	DEPTH_TYPE curr_z = DepthLoad(input.p.xy);
+	#if PS_Z_INTEGER
+		input_z |= (curr_z & ~MaxDepthPS); // Add unused upper bits
+	#endif
+#endif
+
 #if PS_ZTST == ZTST_GEQUAL
-	if (input.p.z < DepthLoad(input.p.xy))
+	if (input_z < curr_z)
 		DISCARD;
 #elif PS_ZTST == ZTST_GREATER
-	if (input.p.z <= DepthLoad(input.p.xy))
+	if (input_z <= curr_z)
 		DISCARD;
 #endif
 
@@ -1575,7 +1647,7 @@ if (bad)
 #endif // PS_DATE != 1/2
 
 #if PS_ZCLAMP
-	input.p.z = min(input.p.z, MaxDepthPS);
+	input_z = min(input_z, MaxDepthPS);
 #endif
 
 #if PS_AA1 == PS_AA1_TRIANGLE_SW_Z
@@ -1587,7 +1659,6 @@ if (bad)
 	PS_OUTPUT output;
 #endif
 
-	// Color write back
 #if PS_RETURN_COLOR
 	output.c0 = o_col0;
 	#if !PS_NO_COLOR1
@@ -1599,16 +1670,22 @@ if (bad)
 		RtWrite(input.p.xy, o_col0);
 #endif
 
-	// Depth write back
 #if PS_RETURN_DEPTH
-	output.depth = input.p.z;
-	#if SW_DEPTH && PS_NO_COLOR1 && PS_DEPTH_FEEDBACK_SUPPORT == 2
-		// Output color clone for feedback.
-		output.depth_color = input.p.z;
+	// Non-ROV depth write
+	#if PS_Z_INTEGER
+		#if ZWRITE_FOR_ZINT
+			output.depth = input_z;
+		#endif
+	#else
+		output.depth = input_z;
+		#if SW_DEPTH && PS_NO_COLOR1 && PS_DEPTH_FEEDBACK_SUPPORT == 2
+			// Output color clone for feedback.
+			output.depth_color = input_z;
+		#endif
 	#endif
 #elif PS_RETURN_DEPTH_ROV
 	if (!rov_discard_depth)
-		DepthWrite(input.p.xy, input.p.z);
+		DepthWrite(input.p.xy, input_z);
 #endif
 
 #if (PS_RETURN_COLOR || PS_RETURN_DEPTH)
@@ -1668,7 +1745,7 @@ VS_OUTPUT vs_main(VS_INPUT input)
 	output.p.xy = output.p.xy * float2(VertexScale.x, -VertexScale.y) - float2(VertexOffset.x, -VertexOffset.y);
 	output.p.z *= exp2(-32.0f);		// integer->float depth
 
-	if(VS_TME)
+	if (VS_TME)
 	{
 		float2 uv = input.uv - TextureOffset;
 		float2 st = input.st - TextureOffset;
@@ -1703,6 +1780,11 @@ VS_OUTPUT vs_main(VS_INPUT input)
 	// Silence compiler warnings; should be optimized out when not needed.
 	output.inv_cov = 0.0f;
 	output.interior = 0;
+	
+	#if VS_Z_INTEGER
+		output.z_base = input.z;
+		output.p.z = 0.0f; // Flat Z by default
+	#endif
 
 	return output;
 }
@@ -1743,6 +1825,7 @@ VS_INPUT load_vertex(uint index)
 	vert.z = raw.Z;
 	vert.uv = uint2(raw.UV & 0xFFFFu, raw.UV >> 16);
 	vert.f = float4(float(raw.FOG & 0xFFu), float((raw.FOG >> 8) & 0xFFu), float((raw.FOG >> 16) & 0xFFu), float(raw.FOG >> 24)) / 255.0f;
+
 	return vert;
 }
 
@@ -1891,6 +1974,12 @@ VS_OUTPUT vs_main_expand(uint vid : SV_VertexID)
 	vtx.inv_cov = is_right ? 1.0f : -1.0f;
 #endif
 
+#if VS_Z_INTEGER
+	uint z_base = min(vtx.z_base, other.z_base);
+	vtx.p.z = exp2(-32.0f) * float(vtx.z_base - z_base);
+	vtx.z_base = z_base;
+#endif
+
 	// Lines will be run as (0 1 2) (1 2 3)
 	// This means that both triangles will have a point based off the top line point as their first point
 	// So we don't have to do anything for !IIP
@@ -1942,6 +2031,17 @@ VS_OUTPUT vs_main_expand(uint vid : SV_VertexID)
 		vtx = vs_main(load_vertex(load_index(3 * prim_id + prim_offset)));
 		vtx.inv_cov = 0.0f; // Full coverage
 		vtx.interior = 1;
+
+		#if VS_Z_INTEGER
+			uint i1 = (prim_offset >= 2) ? prim_offset - 2 : prim_offset + 1;
+			uint i2 = (prim_offset >= 1) ? prim_offset - 1 : prim_offset + 2;
+			VS_OUTPUT other = vs_main(load_vertex(load_index(3 * prim_id + i1)));
+			VS_OUTPUT opposite = vs_main(load_vertex(load_index(3 * prim_id + i2)));
+
+			uint z_base = min(vtx.z_base, min(other.z_base, opposite.z_base));
+			vtx.p.z = exp2(-32.0f) * float(vtx.z_base - z_base);
+			vtx.z_base = z_base;
+		#endif
 	}
 	else if (edge)
 	{
@@ -2014,10 +2114,48 @@ VS_OUTPUT vs_main_expand(uint vid : SV_VertexID)
 		vtx.inv_cov = is_near_corner ? 0.0f : 1.0f; // Full coverage at near corner, otherwise none.
 	
 		vtx.interior = 0;
+
+		#if VS_Z_INTEGER
+			uint z_base = min(vtx.z_base, min(other.z_base, opposite.z_base));
+			vtx.p.z = exp2(-32.0f) * float(vtx.z_base - z_base);
+			vtx.z_base = z_base;
+		#endif
 	}
 
 	return vtx;
 
+#elif VS_Z_INTEGER && (VS_EXPAND == VS_EXPAND_TRIANGLE_Z_INTEGER)
+
+	uint vid_base = 3 * (vid / 3);
+	uint i0 = vid - vid_base;
+	uint i1 = (i0 >= 2) ? i0 - 2 : i0 + 1;
+	uint i2 = (i0 >= 1) ? i0 - 1 : i0 + 2;
+	
+	VS_OUTPUT vtx = vs_main(load_vertex(load_index(vid_base + i0)));
+	VS_OUTPUT other = vs_main(load_vertex(load_index(vid_base + i1)));
+	VS_OUTPUT opposite = vs_main(load_vertex(load_index(vid_base + i2)));
+
+	uint z_base = min(vtx.z_base, min(other.z_base, opposite.z_base));
+	vtx.p.z = exp2(-32.0f) * float(vtx.z_base - z_base);
+	vtx.z_base = z_base;
+
+	return vtx;
+
+#elif VS_Z_INTEGER && (VS_EXPAND == VS_EXPAND_LINE_Z_INTEGER)
+
+	VS_OUTPUT vtx = vs_main(load_vertex(load_index(vid)));
+	VS_OUTPUT other = vs_main(load_vertex(load_index(vid ^ 1)));
+
+	uint z_base = min(vtx.z_base, other.z_base);
+	vtx.p.z = exp2(-32.0f) * float(vtx.z_base - z_base);
+	vtx.z_base = z_base;
+
+	return vtx;
+
+#elif VS_Z_INTEGER && (VS_EXPAND == VS_EXPAND_POINT_Z_INTEGER)
+
+	return vs_main(load_vertex(vid));
+	
 #endif
 }
 

--- a/bin/resources/shaders/opengl/convert.glsl
+++ b/bin/resources/shaders/opengl/convert.glsl
@@ -29,7 +29,41 @@ in vec4 PSin_p;
 in vec2 PSin_t;
 in vec4 PSin_c;
 
+#if HAS_INTEGER_INPUT
+layout(binding = 0) uniform usampler2D TextureSampler;
+uint sample_c()
+{
+	return texture(TextureSampler, PSin_t).r;
+}
+#elif HAS_FLOAT32_INPUT
 layout(binding = 0) uniform sampler2D TextureSampler;
+float sample_c()
+{
+	return texture(TextureSampler, PSin_t).r;
+}
+#else
+layout(binding = 0) uniform sampler2D TextureSampler;
+vec4 sample_c()
+{
+	return texture(TextureSampler, PSin_t);
+}
+#endif
+
+#if HAS_INTEGER_INPUT
+	#define DEPTH_INPUT_TYPE uint
+	#define DEPTH_INPUT_SCALE 1
+#else
+	#define DEPTH_INPUT_TYPE float
+	#define DEPTH_INPUT_SCALE exp2(32.0f)
+#endif
+
+#if HAS_INTEGER_OUTPUT
+	#define DEPTH_OUTPUT_TYPE uint
+	#define DEPTH_OUTPUT_SCALE 1
+#else
+	#define DEPTH_OUTPUT_TYPE float
+	#define DEPTH_OUTPUT_SCALE exp2(-32.0f)
+#endif
 
 #if HAS_INTEGER_OUTPUT
 	layout(location = 0) out uint o_col0;
@@ -46,22 +80,6 @@ layout(binding = 0) uniform sampler2D TextureSampler;
 	#define OUTPUT o_col0
 #endif
 
-#if HAS_FLOAT32_INPUT
-
-float sample_c()
-{
-	return texture(TextureSampler, PSin_t).r;
-}
-
-#else
-
-vec4 sample_c()
-{
-	return texture(TextureSampler, PSin_t);
-}
-
-#endif
-
 uint rgba8_to_uint(vec4 c)
 {
 	uvec4 i = uvec4(c * 255.5f) & 0xFFu;
@@ -74,9 +92,9 @@ uint rgb5a1_to_uint(vec4 c)
 	return (i.r >> 3) | (i.g << 2) | (i.b << 7) | (i.a << 8);
 }
 
-uint depth_to_uint(float d)
+uint depth_to_uint(DEPTH_INPUT_TYPE d)
 {
-	return uint(d * exp2(32.0f));
+	return uint(d * DEPTH_INPUT_SCALE);
 }
 
 vec4 uint_to_rgba8(uint i)
@@ -89,52 +107,52 @@ vec4 uint_to_rgb5a1(uint i)
 	return vec4(uvec4(i << 3, i >> 2, i >> 7, i >> 8) & uvec4(0xF8u, 0xF8u, 0xF8u, 0x80u)) / 255.0f;
 }
 
-float uint_to_depth32(uint i)
+DEPTH_OUTPUT_TYPE uint_to_depth32(uint i)
 {
-	return float(i) * exp2(-32.0f);
+	return DEPTH_OUTPUT_TYPE(i) * DEPTH_OUTPUT_SCALE;
 }
 
-float uint_to_depth24(uint i)
+DEPTH_OUTPUT_TYPE uint_to_depth24(uint i)
 {
-	return float(i & 0xFFFFFFu) * exp2(-32.0f);
+	return DEPTH_OUTPUT_TYPE(i & 0xFFFFFFu) * DEPTH_OUTPUT_SCALE;
 }
 
-float uint_to_depth16(uint i)
+DEPTH_OUTPUT_TYPE uint_to_depth16(uint i)
 {
-	return float(i & 0xFFFFu) * exp2(-32.0f);
+	return DEPTH_OUTPUT_TYPE(i & 0xFFFFu) * DEPTH_OUTPUT_SCALE;
 }
 
-float rgba8_to_depth32(vec4 val)
+DEPTH_OUTPUT_TYPE rgba8_to_depth32(vec4 val)
 {
 	return uint_to_depth32(rgba8_to_uint(val));
 }
 
-float rgba8_to_depth24(vec4 val)
+DEPTH_OUTPUT_TYPE rgba8_to_depth24(vec4 val)
 {
 	return uint_to_depth24(rgba8_to_uint(val));
 }
 
-float rgba8_to_depth16(vec4 val)
+DEPTH_OUTPUT_TYPE rgba8_to_depth16(vec4 val)
 {
 	return uint_to_depth16(rgba8_to_uint(val));
 }
 
-float rgb5a1_to_depth16(vec4 val)
+DEPTH_OUTPUT_TYPE rgb5a1_to_depth16(vec4 val)
 {
 	return uint_to_depth16(rgb5a1_to_uint(val));
 }
 
-vec4 depth32_to_rgba8(float d)
+vec4 depth32_to_rgba8(DEPTH_INPUT_TYPE d)
 {
 	return uint_to_rgba8(depth_to_uint(d));
 }
 
-vec4 depth16_to_rgb5a1(float d)
+vec4 depth16_to_rgb5a1(DEPTH_INPUT_TYPE d)
 {
 	return uint_to_rgb5a1(depth_to_uint(d));
 }
 
-float depth32_to_depth24(float d)
+DEPTH_OUTPUT_TYPE depth32_to_depth24(DEPTH_INPUT_TYPE d)
 {
 	return uint_to_depth24(depth_to_uint(d));
 }
@@ -149,7 +167,7 @@ void ps_copy()
 #ifdef ps_depth_copy
 void ps_depth_copy()
 {
-	OUTPUT = sample_c();
+	OUTPUT = uint_to_depth32(depth_to_uint(sample_c()));
 }
 #endif
 
@@ -212,17 +230,67 @@ void ps_convert_depth32_depth24()
 }
 #endif
 
+#ifdef ps_convert_rgba8_uint32
+void ps_convert_rgba8_uint32()
+{
+	// Convert an RGBA texture into a 32 bit UINT texture
+	o_col0 = rgba8_to_uint32(sample_c());
+}
+#endif
+
+#ifdef ps_convert_rgba8_uint24
+void ps_convert_rgba8_uint24()
+{
+	// Same as above but without the alpha channel (24 bits Z)
+
+	// Convert an RGBA texture into a 32 bit UINT texture
+	o_col0 = rgba8_to_uint24(sample_c());
+}
+#endif
+
+#ifdef ps_convert_rgba8_uint16
+void ps_convert_rgba8_uint16()
+{
+	// Same as above but without the A/B channels (16 bits Z)
+
+	// Convert an RGBA texture into a 32 bit UINT texture
+	o_col0 = rgba8_to_uint16(sample_c());
+}
+#endif
+
+#ifdef ps_convert_rgb5a1_uint16
+void ps_convert_rgb5a1_uint16()
+{
+	// Convert an RGB5A1 (saved as RGBA8) color to a 16 bit UINT
+	o_col0 = rgb5a1_to_uint16(sample_c());
+}
+#endif
+
+#if HAS_INTEGER_OUTPUT
+uint lerp_depth(uint a, uint b, float c)
+{
+  uint absdiff = a > b ? a - b : b - a;
+  uint adjust = min(uint(round(float(absdiff) * c)), absdiff);
+  return a > b ? a - adjust : a + adjust;
+}
+#else
+float lerp_depth(float a, float b, float c)
+{
+  return mix(a, b, c);
+}
+#endif
+
 #define SAMPLE_RGBA_DEPTH_BILN(CONVERT_FN) \
 	ivec2 dims = textureSize(TextureSampler, 0); \
 	vec2 top_left_f = PSin_t * vec2(dims) - 0.5f; \
 	ivec2 top_left = ivec2(floor(top_left_f)); \
 	ivec4 coords = clamp(ivec4(top_left, top_left + 1), ivec4(0), dims.xyxy - 1); \
 	vec2 mix_vals = fract(top_left_f); \
-	float depthTL = CONVERT_FN(texelFetch(TextureSampler, coords.xy, 0)); \
-	float depthTR = CONVERT_FN(texelFetch(TextureSampler, coords.zy, 0)); \
-	float depthBL = CONVERT_FN(texelFetch(TextureSampler, coords.xw, 0)); \
-	float depthBR = CONVERT_FN(texelFetch(TextureSampler, coords.zw, 0)); \
-	OUTPUT = mix(mix(depthTL, depthTR, mix_vals.x), mix(depthBL, depthBR, mix_vals.x), mix_vals.y);
+	DEPTH_OUTPUT_TYPE depthTL = CONVERT_FN(texelFetch(TextureSampler, coords.xy, 0)); \
+	DEPTH_OUTPUT_TYPE depthTR = CONVERT_FN(texelFetch(TextureSampler, coords.zy, 0)); \
+	DEPTH_OUTPUT_TYPE depthBL = CONVERT_FN(texelFetch(TextureSampler, coords.xw, 0)); \
+	DEPTH_OUTPUT_TYPE depthBR = CONVERT_FN(texelFetch(TextureSampler, coords.zw, 0)); \
+	OUTPUT = lerp_depth(lerp_depth(depthTL, depthTR, mix_vals.x), lerp_depth(depthBL, depthBR, mix_vals.x), mix_vals.y);
 
 #ifdef ps_convert_rgba8_depth32
 void ps_convert_rgba8_depth32()

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -40,6 +40,12 @@
 #define PS_AA1_TRIANGLE_SW_Z 3
 #endif
 
+#ifndef PS_Z_INTEGER_NONE
+#define PS_Z_INTEGER_NONE 0
+#define PS_Z_INTEGER_READ_WRITE 1
+#define PS_Z_INTEGER_READ_ONLY 2
+#endif
+
 // TEX_COORD_DEBUG output the uv coordinate as color. It is useful
 // to detect bad sampling due to upscaling
 //#define TEX_COORD_DEBUG
@@ -58,11 +64,25 @@
 #define NEEDS_DEPTH_FOR_AFAIL (PS_AFAIL == AFAIL_FB_ONLY || PS_AFAIL == AFAIL_RGB_ONLY_SW_Z)
 #define NEEDS_DEPTH_FOR_ZTST (PS_ZTST == ZTST_GEQUAL || PS_ZTST == ZTST_GREATER)
 #define NEEDS_DEPTH_FOR_AA1 (PS_AA1 == PS_AA1_TRIANGLE_SW_Z)
+#define NEEDS_DEPTH_FOR_ZINT (PS_Z_INTEGER != PS_Z_INTEGER_NONE)
+#define ZWRITE_FOR_ZINT (PS_Z_INTEGER == PS_Z_INTEGER_READ_WRITE)
 
 #define NEEDS_RT (NEEDS_RT_EARLY || NEEDS_RT_FOR_AFAIL || (!PS_PRIMID_INIT && (PS_FBMASK || SW_BLEND_NEEDS_RT || SW_AD_TO_HW)))
 #define NEEDS_TEX (PS_TFX != 4)
-#define SW_DEPTH (NEEDS_DEPTH_FOR_AFAIL || NEEDS_DEPTH_FOR_ZTST || NEEDS_DEPTH_FOR_AA1)
-#define ZWRITE (SW_DEPTH || PS_ZCLAMP || PS_ZFLOOR)
+#define SW_DEPTH (NEEDS_DEPTH_FOR_AFAIL || NEEDS_DEPTH_FOR_ZTST || NEEDS_DEPTH_FOR_AA1 || NEEDS_DEPTH_FOR_ZINT)
+#define ZWRITE (PS_ZCLAMP || PS_ZFLOOR || NEEDS_DEPTH_FOR_AFAIL || NEEDS_DEPTH_FOR_ZTST || NEEDS_DEPTH_FOR_AA1 || ZWRITE_FOR_ZINT)
+
+#if PS_Z_INTEGER
+	#define DEPTH_TYPE uint
+	#define DEPTH_VEC4 uvec4
+	#define DEPTH_TEXTURE utexture2D
+	#define DEPTH_SAMPLER usampler2D
+#else
+	#define DEPTH_TYPE float
+	#define DEPTH_VEC4 vec4
+	#define DEPTH_TEXTURE texture2D
+	#define DEPTH_SAMPLER sampler2D
+#endif
 
 layout(std140, binding = 0) uniform cb21
 {
@@ -72,7 +92,7 @@ layout(std140, binding = 0) uniform cb21
 	vec4 WH;
 
 	vec2 TA;
-	float MaxDepthPS;
+	DEPTH_TYPE MaxDepthPS;
 	float Af;
 
 	uvec4 FbMask;
@@ -115,6 +135,10 @@ in SHADER
 
 	float inv_cov; // We use the inverse to make it simpler to interpolate.
 	flat uint interior; // 1 for triangle interior; 0 for edge;
+
+	#if PS_Z_INTEGER
+		flat uint z_base;
+	#endif
 } PSin;
 
 #define TARGET_0_QUALIFIER out
@@ -146,14 +170,24 @@ in SHADER
 // Use FB fetch for the feedback if it's available.
 #if SW_DEPTH && PS_NO_COLOR1 && (DEPTH_FEEDBACK_SUPPORT == 2)
 	#if HAS_FRAMEBUFFER_FETCH
-		layout(location = 1) inout float o_col1;
+		layout(location = 1) inout DEPTH_TYPE o_col1;
 	#else
-		layout(location = 1) out float o_col1;
+		#if PS_Z_INTEGER
+			#if ZWRITE_FOR_ZINT
+				layout(location = 1) out DEPTH_TYPE o_col1;
+			#endif
+		#else
+			layout(location = 1) out DEPTH_TYPE o_col1;
+		#endif
 	#endif
 #endif
 
 #if NEEDS_TEX
-layout(binding = 0) uniform sampler2D TextureSampler;
+	#if PS_TEX_INTEGER
+		layout(binding = 0) uniform usampler2D TextureSampler;
+	#else
+		layout(binding = 0) uniform sampler2D TextureSampler;
+	#endif
 layout(binding = 1) uniform sampler2D PaletteSampler;
 #endif
 
@@ -168,8 +202,9 @@ layout(binding = 3) uniform sampler2D img_prim_min;
 // Depth feedback mode 1 binds depth buffer directly as a texture.
 // Depth feedback mode 2 (depth as color) can use FB fetch for the feedback,
 // in which case we don't need to explicitly bind depth as a texture.
-#if (DEPTH_FEEDBACK_SUPPORT == 1 || (DEPTH_FEEDBACK_SUPPORT == 2 && !HAS_FRAMEBUFFER_FETCH)) && SW_DEPTH
-layout(binding = 4) uniform sampler2D DepthSampler;
+// Depth integer without FB fetch must also bind the texture explicitly.
+#if (DEPTH_FEEDBACK_SUPPORT == 1 || (DEPTH_FEEDBACK_SUPPORT == 2 && !HAS_FRAMEBUFFER_FETCH) || (PS_Z_INTEGER && !HAS_FRAMEBUFFER_FETCH)) && SW_DEPTH
+layout(binding = 4) uniform DEPTH_SAMPLER DepthSampler;
 #endif
 
 #if ZWRITE && PS_HAS_CONSERVATIVE_DEPTH && !SW_DEPTH
@@ -187,10 +222,10 @@ vec4 sample_from_rt()
 #endif
 }
 
-float sample_from_depth()
+DEPTH_TYPE sample_from_depth()
 {
 #if !SW_DEPTH
-	return 0.0f;
+	return DEPTH_TYPE(0);
 #elif HAS_FRAMEBUFFER_FETCH && (DEPTH_FEEDBACK_SUPPORT == 2)
 	return o_col1;
 #else
@@ -1190,18 +1225,30 @@ float As = As_rgba.a;
 
 void ps_main()
 {
+#if PS_Z_INTEGER
+	// Add base plus interpolated offset.
+	uint input_z = PSin.z_base + uint(exp2(32.0f) * gl_FragCoord.z);
+#else
 	float input_z = gl_FragCoord.z;
+#endif
 
+#if !PS_Z_INTEGER && PS_ZFLOOR
 	// Must floor before depth testing.
-#if PS_ZFLOOR
 	input_z = floor(input_z * exp2(32.0f)) * exp2(-32.0f);
 #endif
 
+#if SW_DEPTH
+	DEPTH_TYPE curr_z = sample_from_depth();
+	#if PS_Z_INTEGER
+		input_z |= (curr_z & ~MaxDepthPS); // Add unused upper bits
+	#endif
+#endif
+
 #if PS_ZTST == ZTST_GEQUAL
-	if (input_z < sample_from_depth())
+	if (input_z < curr_z)
 		discard;
 #elif PS_ZTST == ZTST_GREATER
-	if (input_z <= sample_from_depth())
+	if (input_z <= curr_z)
 		discard;
 #endif
 
@@ -1382,7 +1429,7 @@ void ps_main()
 	// Alpha test with feedback
 	#if PS_AFAIL == AFAIL_FB_ONLY
 		if (!atst_pass)
-			input_z = sample_from_depth();
+			input_z = curr_z;
 	#elif PS_AFAIL == AFAIL_ZB_ONLY
 		if (!atst_pass)
 			C = sample_from_rt();
@@ -1391,7 +1438,7 @@ void ps_main()
 		{
 			C.a = sample_from_rt().a;
 		#if PS_AFAIL == AFAIL_RGB_ONLY_SW_Z
-			input_z = sample_from_depth();
+			input_z = curr_z;
 		#endif
 		}
 	#endif
@@ -1410,20 +1457,28 @@ void ps_main()
 #endif
 
 #if PS_AA1 == PS_AA1_TRIANGLE_SW_Z
-	if (!bool(PSin.interior))
-		input_z = sample_from_depth(); // No depth update for triangle edges.
+	input_z = bool(PSin.interior) ? input_z : curr_z; // No depth update for triangle edges.
+#endif
+
+#if PS_ZCLAMP && PS_Z_INTEGER
+	input_z |= (curr_z & ~MaxDepthPS); // Mask based on depth format
 #endif
 
 // Writing back depth
 #if ZWRITE
-	#if SW_DEPTH && PS_NO_COLOR1 && (DEPTH_FEEDBACK_SUPPORT == 2)
+	#if PS_Z_INTEGER
+		#if ZWRITE_FOR_ZINT
+			o_col1 = input_z;
+		#endif
+	#else
+		gl_FragDepth = input_z;
+	#endif
+	#if SW_DEPTH && PS_NO_COLOR1 && (DEPTH_FEEDBACK_SUPPORT == 2) && !PS_Z_INTEGER
 		// Depth as color write. For depth as color feedback we write to both
 		// color copy and real depth to avoid having to copy back to real depth.
 		// Warning: do not write o_col1 until the end since the value might
 		// be needed for FB fetch in sample_from_depth().
 		o_col1 = input_z;
 	#endif
-	// Standard depth write.
-	gl_FragDepth = input_z;
 #endif
 }

--- a/bin/resources/shaders/opengl/tfx_vgs.glsl
+++ b/bin/resources/shaders/opengl/tfx_vgs.glsl
@@ -26,6 +26,9 @@ layout(std140, binding = 1) uniform cb20
 #define VS_EXPAND_SPRITE 3
 #define VS_EXPAND_LINE_AA1 4
 #define VS_EXPAND_TRIANGLE_AA1 5
+#define VS_EXPAND_POINT_Z_INTEGER 6
+#define VS_EXPAND_LINE_Z_INTEGER 7
+#define VS_EXPAND_TRIANGLE_Z_INTEGER 8
 #endif
 
 out SHADER
@@ -39,6 +42,9 @@ out SHADER
 	#endif
 	float inv_cov; // We use the inverse to make it simpler to interpolate.
 	flat uint interior; // 1 for triangle interior; 0 for edge.
+	#if VS_Z_INTEGER
+		flat uint z_base;
+	#endif
 } VSout;
 
 const float exp_min32 = exp2(-32.0f);
@@ -101,6 +107,11 @@ void vs_main()
 	#if VS_POINT_SIZE
 		gl_PointSize = PointSize.x;
 	#endif
+
+	#if VS_Z_INTEGER
+		VSout.z_base = i_z;
+		gl_Position.z = 0.0f; // Flat Z by default
+	#endif
 }
 
 #else // VS_EXPAND
@@ -139,6 +150,7 @@ struct ProcessedVertex
 	vec4 t_float;
 	vec4 t_int;
 	vec4 c;
+	uint z;
 };
 
 uint load_index(uint _i)
@@ -191,6 +203,12 @@ ProcessedVertex load_vertex(uint index)
 
 	vtx.c = i_c;
 	vtx.t_float.z = i_f.x;
+
+#if VS_Z_INTEGER
+	vtx.z = i_z;
+#else
+	vtx.z = 0;
+#endif
 
 	return vtx;
 }
@@ -312,6 +330,11 @@ void main()
 	vtx.p.x += ((vid & 1u) != 0u) ? PointSize.x : 0.0f;
 	vtx.p.y += ((vid & 2u) != 0u) ? PointSize.y : 0.0f;
 
+#if VS_Z_INTEGER
+	VSout.z_base = vtx.z;
+	vtx.p.z = 0.0f; // Flat Z
+#endif
+
 #elif (VS_EXPAND == VS_EXPAND_LINE) || (VS_EXPAND == VS_EXPAND_LINE_AA1)
 
 	uint vid_base = vid >> 2;
@@ -334,6 +357,11 @@ void main()
 
 #if VS_EXPAND == VS_EXPAND_LINE_AA1
 	VSout.inv_cov = is_right ? 1.0f : -1.0f;
+#endif
+
+#if VS_Z_INTEGER
+	VSout.z_base = min(other.z, vtx.z);
+	vtx.p.z = exp2(-32.0f) * float(vtx.z - VSout.z_base);
 #endif
 
 	// Lines will be run as (0 1 2) (1 2 3)
@@ -361,6 +389,11 @@ void main()
 	vtx.t_float.y = is_bottom ? lt.t_float.y : vtx.t_float.y;
 	vtx.t_int.yw = is_bottom ? lt.t_int.yw : vtx.t_int.yw;
 
+#if VS_Z_INTEGER
+	VSout.z_base = vtx.z;
+	vtx.p.z = 0.0f; // Flat Z
+#endif
+
 #elif VS_EXPAND == VS_EXPAND_TRIANGLE_AA1
 
 	// Triangles with AA1 are expanded as follows:
@@ -382,6 +415,15 @@ void main()
 		vtx = load_vertex(load_index(3 * prim_id + prim_offset));
 		VSout.inv_cov = 0.0f; // Full coverage
 		VSout.interior = 1;
+
+		#if VS_Z_INTEGER
+			uint i1 = (prim_offset >= 2) ? prim_offset - 2 : prim_offset + 1;
+			uint i2 = (prim_offset >= 1) ? prim_offset - 1 : prim_offset + 2;
+			ProcessedVertex other = load_vertex(load_index(3 * prim_id + i1));
+			ProcessedVertex opposite = load_vertex(load_index(3 * prim_id + i2));
+			VSout.z_base = min(vtx.z, min(other.z, opposite.z));
+			vtx.p.z = exp2(-32.0f) * float(vtx.z - VSout.z_base);
+		#endif
 	}
 	else if (edge)
 	{
@@ -455,8 +497,39 @@ void main()
 		VSout.inv_cov = is_near_corner ? 0.0f : 1.0f; // Full coverage at near corner, otherwise none.
 	
 		VSout.interior = 0;
+
+		#if VS_Z_INTEGER
+			VSout.z_base = min(vtx.z, min(other.z, opposite.z));
+			vtx.p.z = exp2(-32.0f) * float(vtx.z - VSout.z_base);
+		#endif
 	}
 
+#elif VS_Z_INTEGER && (VS_EXPAND == VS_EXPAND_TRIANGLE_Z_INTEGER)
+
+	uint vid_base = 3 * (vid / 3);
+	uint i0 = vid - vid_base;
+	uint i1 = (i0 >= 2) ? i0 - 2 : i0 + 1;
+	uint i2 = (i0 >= 1) ? i0 - 1 : i0 + 2;
+	vtx = load_vertex(load_index(vid_base + i0));
+	ProcessedVertex other = load_vertex(load_index(vid_base + i1));
+	ProcessedVertex opposite = load_vertex(load_index(vid_base + i2));
+
+	VSout.z_base = min(vtx.z, min(other.z, opposite.z));
+	vtx.p.z = exp2(-32.0f) * float(vtx.z - VSout.z_base);
+
+#elif VS_Z_INTEGER && (VS_EXPAND == VS_EXPAND_LINE_Z_INTEGER)
+
+	vtx = load_vertex(load_index(vid));
+
+	ProcessedVertex other = load_vertex(load_index(vid ^ 1));
+
+	VSout.z_base = min(vtx.z, other.z);
+	vtx.p.z = exp2(-32.0f) * float(vtx.z - VSout.z_base);
+
+#elif VS_Z_INTEGER && (VS_EXPAND == VS_EXPAND_POINT_Z_INTEGER)
+	vtx = load_vertex(vid);
+	VSout.z_base = vtx.z;
+	vtx.p.z = 0.0f; // Flat Z
 #endif
 
 	gl_Position = vtx.p;

--- a/bin/resources/shaders/vulkan/convert.glsl
+++ b/bin/resources/shaders/vulkan/convert.glsl
@@ -20,6 +20,22 @@ void main()
 
 layout(location = 0) in vec2 v_tex;
 
+#if HAS_INTEGER_INPUT
+	#define DEPTH_INPUT_TYPE uint
+	#define DEPTH_INPUT_SCALE 1
+#else
+	#define DEPTH_INPUT_TYPE float
+	#define DEPTH_INPUT_SCALE exp2(32.0f)
+#endif
+
+#if HAS_INTEGER_OUTPUT
+	#define DEPTH_OUTPUT_TYPE uint
+	#define DEPTH_OUTPUT_SCALE 1
+#else
+	#define DEPTH_OUTPUT_TYPE float
+	#define DEPTH_OUTPUT_SCALE exp2(-32.0f)
+#endif
+
 #if HAS_INTEGER_OUTPUT
 	layout(location = 0) out uint o_col0;
 	#define OUTPUT o_col0
@@ -35,22 +51,24 @@ layout(location = 0) in vec2 v_tex;
 	#define OUTPUT o_col0
 #endif
 
+#if HAS_INTEGER_INPUT
+layout(set = 0, binding = 0) uniform usampler2D samp0;
+uint sample_c(vec2 uv)
+{
+	return texture(samp0, uv).r;
+}
+#elif HAS_FLOAT32_INPUT
 layout(set = 0, binding = 0) uniform sampler2D samp0;
-
-#if HAS_FLOAT32_INPUT
-
 float sample_c(vec2 uv)
 {
 	return texture(samp0, uv).r;
 }
-
 #else
-
+layout(set = 0, binding = 0) uniform sampler2D samp0;
 vec4 sample_c(vec2 uv)
 {
 	return texture(samp0, uv);
 }
-
 #endif
 
 uint rgba8_to_uint(vec4 c)
@@ -65,9 +83,9 @@ uint rgb5a1_to_uint(vec4 c)
 	return (i.r >> 3) | (i.g << 2) | (i.b << 7) | (i.a << 8);
 }
 
-uint depth_to_uint(float d)
+uint depth_to_uint(DEPTH_INPUT_TYPE d)
 {
-	return uint(d * exp2(32.0f));
+	return uint(d * DEPTH_INPUT_SCALE);
 }
 
 vec4 uint_to_rgba8(uint i)
@@ -80,52 +98,52 @@ vec4 uint_to_rgb5a1(uint i)
 	return vec4(uvec4(i << 3, i >> 2, i >> 7, i >> 8) & uvec4(0xF8u, 0xF8u, 0xF8u, 0x80u)) / 255.0f;
 }
 
-float uint_to_depth32(uint i)
+DEPTH_OUTPUT_TYPE uint_to_depth32(uint i)
 {
-	return float(i) * exp2(-32.0f);
+	return DEPTH_OUTPUT_TYPE(i) * DEPTH_OUTPUT_SCALE;
 }
 
-float uint_to_depth24(uint i)
+DEPTH_OUTPUT_TYPE uint_to_depth24(uint i)
 {
-	return float(i & 0xFFFFFFu) * exp2(-32.0f);
+	return DEPTH_OUTPUT_TYPE(i & 0xFFFFFFu) * DEPTH_OUTPUT_SCALE;
 }
 
-float uint_to_depth16(uint i)
+DEPTH_OUTPUT_TYPE uint_to_depth16(uint i)
 {
-	return float(i & 0xFFFFu) * exp2(-32.0f);
+	return DEPTH_OUTPUT_TYPE(i & 0xFFFFu) * DEPTH_OUTPUT_SCALE;
 }
 
-float rgba8_to_depth32(vec4 val)
+DEPTH_OUTPUT_TYPE rgba8_to_depth32(vec4 val)
 {
 	return uint_to_depth32(rgba8_to_uint(val));
 }
 
-float rgba8_to_depth24(vec4 val)
+DEPTH_OUTPUT_TYPE rgba8_to_depth24(vec4 val)
 {
 	return uint_to_depth24(rgba8_to_uint(val));
 }
 
-float rgba8_to_depth16(vec4 val)
+DEPTH_OUTPUT_TYPE rgba8_to_depth16(vec4 val)
 {
 	return uint_to_depth16(rgba8_to_uint(val));
 }
 
-float rgb5a1_to_depth16(vec4 val)
+DEPTH_OUTPUT_TYPE rgb5a1_to_depth16(vec4 val)
 {
 	return uint_to_depth16(rgb5a1_to_uint(val));
 }
 
-vec4 depth32_to_rgba8(float d)
+vec4 depth32_to_rgba8(DEPTH_INPUT_TYPE d)
 {
 	return uint_to_rgba8(depth_to_uint(d));
 }
 
-vec4 depth16_to_rgb5a1(float d)
+vec4 depth16_to_rgb5a1(DEPTH_INPUT_TYPE d)
 {
 	return uint_to_rgb5a1(depth_to_uint(d));
 }
 
-float depth32_to_depth24(float d)
+DEPTH_OUTPUT_TYPE depth32_to_depth24(DEPTH_INPUT_TYPE d)
 {
 	return uint_to_depth24(depth_to_uint(d));
 }
@@ -140,7 +158,7 @@ void ps_copy()
 #ifdef ps_depth_copy
 void ps_depth_copy()
 {
-	OUTPUT = sample_c(v_tex);
+	OUTPUT = uint_to_depth32(depth_to_uint(sample_c(v_tex)));
 }
 #endif
 
@@ -281,17 +299,65 @@ void ps_convert_depth32_depth24()
 }
 #endif
 
+#ifdef ps_convert_rgba8_uint32
+void ps_convert_rgba8_uint32()
+{
+	// Convert an RGBA texture into a 32 bit UINT texture
+	o_col0 = rgba8_to_uint32(sample_c(v_tex));
+}
+#endif
+
+#ifdef ps_convert_rgba8_uint24
+void ps_convert_rgba8_uint24()
+{
+	// Same as above but without the alpha channel (24 bits Z)
+	// Convert an RGBA texture into a 32 bit UINT texture
+	o_col0 = rgba8_to_uint24(sample_c(v_tex));
+}
+#endif
+
+#ifdef ps_convert_rgba8_uint16
+void ps_convert_rgba8_uint16()
+{
+	// Same as above but without the A/B channels (16 bits Z)
+	// Convert an RGBA texture into a 32 bit UINT texture
+	o_col0 = rgba8_to_uint16(sample_c(v_tex));
+}
+#endif
+
+#ifdef ps_convert_rgb5a1_uint16
+void ps_convert_rgb5a1_uint16()
+{
+	// Convert an RGB5A1 (saved as RGBA8) color to a 16 bit UINT
+	o_col0 = rgb5a1_to_uint16(sample_c(v_tex));
+}
+#endif
+
+#if HAS_INTEGER_OUTPUT
+uint lerp_depth(uint a, uint b, float c)
+{
+  uint absdiff = a > b ? a - b : b - a;
+  uint adjust = min(uint(round(float(absdiff) * c)), absdiff);
+  return a > b ? a - adjust : a + adjust;
+}
+#else
+float lerp_depth(float a, float b, float c)
+{
+  return mix(a, b, c);
+}
+#endif
+
 #define SAMPLE_RGBA_DEPTH_BILN(CONVERT_FN) \
 	ivec2 dims = textureSize(samp0, 0); \
 	vec2 top_left_f = v_tex * vec2(dims) - 0.5f; \
 	ivec2 top_left = ivec2(floor(top_left_f)); \
 	ivec4 coords = clamp(ivec4(top_left, top_left + 1), ivec4(0), dims.xyxy - 1); \
 	vec2 mix_vals = fract(top_left_f); \
-	float depthTL = CONVERT_FN(texelFetch(samp0, coords.xy, 0)); \
-	float depthTR = CONVERT_FN(texelFetch(samp0, coords.zy, 0)); \
-	float depthBL = CONVERT_FN(texelFetch(samp0, coords.xw, 0)); \
-	float depthBR = CONVERT_FN(texelFetch(samp0, coords.zw, 0)); \
-	OUTPUT = mix(mix(depthTL, depthTR, mix_vals.x), mix(depthBL, depthBR, mix_vals.x), mix_vals.y);
+	DEPTH_OUTPUT_TYPE depthTL = CONVERT_FN(texelFetch(samp0, coords.xy, 0)); \
+	DEPTH_OUTPUT_TYPE depthTR = CONVERT_FN(texelFetch(samp0, coords.zy, 0)); \
+	DEPTH_OUTPUT_TYPE depthBL = CONVERT_FN(texelFetch(samp0, coords.xw, 0)); \
+	DEPTH_OUTPUT_TYPE depthBR = CONVERT_FN(texelFetch(samp0, coords.zw, 0)); \
+	OUTPUT = lerp_depth(lerp_depth(depthTL, depthTR, mix_vals.x), lerp_depth(depthBL, depthBR, mix_vals.x), mix_vals.y);
 
 #ifdef ps_convert_rgba8_depth32
 void ps_convert_rgba8_depth32()

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -14,6 +14,9 @@
 #define VS_EXPAND_SPRITE 3
 #define VS_EXPAND_LINE_AA1 4
 #define VS_EXPAND_TRIANGLE_AA1 5
+#define VS_EXPAND_POINT_Z_INTEGER 6
+#define VS_EXPAND_LINE_Z_INTEGER 7
+#define VS_EXPAND_TRIANGLE_Z_INTEGER 8
 #endif
 
 layout(std140, set = 0, binding = 0) uniform cb0
@@ -40,6 +43,10 @@ layout(location = 0) out VSOutput
 
 	float inv_cov; // We use the inverse to make it simpler to interpolate.
 	flat uint interior; // 1 for triangle interior; 0 for edge;
+
+	#if VS_Z_INTEGER
+		flat uint z_base;
+	#endif
 } vsOut;
 
 #if VS_EXPAND == VS_EXPAND_NONE
@@ -94,6 +101,11 @@ void main()
 		gl_PointSize = PointSize.x;
 	#endif
 
+	#if VS_Z_INTEGER
+		vsOut.z_base = a_z;
+		gl_Position.z = 0.0f; // Flat Z by default
+	#endif
+
 	vsOut.c = vec4(a_c);
 	vsOut.t.z = a_f.r;
 }
@@ -134,6 +146,7 @@ struct ProcessedVertex
 	vec4 t;
 	vec4 ti;
 	vec4 c;
+	uint z;
 };
 
 uint load_index(uint _i)
@@ -185,6 +198,12 @@ ProcessedVertex load_vertex(uint index)
 
 	vtx.c = a_c;
 	vtx.t.z = a_f.r;
+
+	#if VS_Z_INTEGER
+		vtx.z = a_z;
+	#else
+		vtx.z = 0;
+	#endif
 
 	return vtx;
 }
@@ -305,6 +324,11 @@ void main()
 	vtx.p.x += ((vid & 1u) != 0u) ? PointSize.x : 0.0f;
 	vtx.p.y += ((vid & 2u) != 0u) ? PointSize.y : 0.0f;
 
+#if VS_Z_INTEGER
+	vsOut.z_base = vtx.z;
+	vtx.p.z = 0.0f; // Flat Z
+#endif
+
 #elif (VS_EXPAND == VS_EXPAND_LINE) || (VS_EXPAND == VS_EXPAND_LINE_AA1)
 
 	uint vid_base = vid >> 2;
@@ -329,6 +353,11 @@ void main()
 
 #if VS_EXPAND == VS_EXPAND_LINE_AA1
 	vsOut.inv_cov = is_right ? 1.0f : -1.0f;
+#endif
+
+#if VS_Z_INTEGER
+	vsOut.z_base = min(other.z, vtx.z);
+	vtx.p.z = exp2(-32.0f) * float(vtx.z - vsOut.z_base);
 #endif
 
 	// Lines will be run as (0 1 2) (1 2 3)
@@ -356,6 +385,11 @@ void main()
 	vtx.t.y = is_bottom ? lt.t.y : vtx.t.y;
 	vtx.ti.yw = is_bottom ? lt.ti.yw : vtx.ti.yw;
 
+#if VS_Z_INTEGER
+	vsOut.z_base = vtx.z;
+	vtx.p.z = 0.0f; // Flat Z
+#endif
+
 #elif VS_EXPAND == VS_EXPAND_TRIANGLE_AA1
 
 	// Triangles with AA1 are expanded as follows:
@@ -377,6 +411,15 @@ void main()
 		vtx = load_vertex(load_index(3 * prim_id + prim_offset));
 		vsOut.inv_cov = 0.0f; // Full coverage
 		vsOut.interior = 1;
+
+		#if VS_Z_INTEGER
+			uint i1 = (prim_offset >= 2) ? prim_offset - 2 : prim_offset + 1;
+			uint i2 = (prim_offset >= 1) ? prim_offset - 1 : prim_offset + 2;
+			ProcessedVertex other = load_vertex(load_index(3 * prim_id + i1));
+			ProcessedVertex opposite = load_vertex(load_index(3 * prim_id + i2));
+			vsOut.z_base = min(vtx.z, min(other.z, opposite.z));
+			vtx.p.z = exp2(-32.0f) * float(vtx.z - vsOut.z_base);
+		#endif
 	}
 	else if (edge)
 	{
@@ -450,8 +493,39 @@ void main()
 		vsOut.inv_cov = is_near_corner ? 0.0f : 1.0f; // Full coverage at near corner, otherwise none.
 	
 		vsOut.interior = 0;
+
+		#if VS_Z_INTEGER
+			vsOut.z_base = min(vtx.z, min(other.z, opposite.z));
+			vtx.p.z = exp2(-32.0f) * float(vtx.z - vsOut.z_base);
+		#endif
 	}
 
+#elif VS_Z_INTEGER && (VS_EXPAND == VS_EXPAND_TRIANGLE_Z_INTEGER)
+
+	uint vid_base = 3 * (vid / 3);
+	uint i0 = vid - vid_base;
+	uint i1 = (i0 >= 2) ? i0 - 2 : i0 + 1;
+	uint i2 = (i0 >= 1) ? i0 - 1 : i0 + 2;
+	vtx = load_vertex(load_index(vid_base + i0));
+	ProcessedVertex other = load_vertex(load_index(vid_base + i1));
+	ProcessedVertex opposite = load_vertex(load_index(vid_base + i2));
+
+	vsOut.z_base = min(vtx.z, min(other.z, opposite.z));
+	vtx.p.z = exp2(-32.0f) * float(vtx.z - vsOut.z_base);
+
+#elif VS_Z_INTEGER && (VS_EXPAND == VS_EXPAND_LINE_Z_INTEGER)
+
+	vtx = load_vertex(load_index(vid));
+
+	ProcessedVertex other = load_vertex(load_index(vid ^ 1));
+
+	vsOut.z_base = min(vtx.z, other.z);
+	vtx.p.z = exp2(-32.0f) * float(vtx.z - vsOut.z_base);
+
+#elif VS_Z_INTEGER && (VS_EXPAND == VS_EXPAND_POINT_Z_INTEGER)
+	vtx = load_vertex(vid);
+	vsOut.z_base = vtx.z;
+	vtx.p.z = 0.0f; // Flat Z
 #endif
 
 	gl_Position = vtx.p;
@@ -521,6 +595,12 @@ void main()
 #define PS_ROV_DEPTH_READ_ONLY 2
 #endif
 
+#ifndef PS_Z_INTEGER_NONE
+#define PS_Z_INTEGER_NONE 0
+#define PS_Z_INTEGER_READ_WRITE 1
+#define PS_Z_INTEGER_READ_ONLY 2
+#endif
+
 #ifndef PS_FST
 #define PS_FST 0
 #define PS_WMS 0
@@ -575,6 +655,9 @@ void main()
 #define PS_TEX_IS_FB 0
 #define PS_ROV_COLOR 0
 #define PS_ROV_DEPTH 0
+#define PS_Z_RT_SLOT 0
+#define PS_Z_INTEGER 0
+#define PS_TEX_INTEGER 0
 #endif
 
 #define SW_BLEND (PS_BLEND_A || PS_BLEND_B || PS_BLEND_D)
@@ -584,10 +667,12 @@ void main()
 #define AFAIL_NEEDS_DEPTH (PS_AFAIL == AFAIL_FB_ONLY || PS_AFAIL == AFAIL_RGB_ONLY_SW_Z)
 #define ZTST_NEEDS_DEPTH (PS_ZTST == ZTST_GEQUAL || PS_ZTST == ZTST_GREATER)
 #define AA1_NEEDS_DEPTH (PS_AA1 == PS_AA1_TRIANGLE_SW_Z)
+#define ZINT_NEEDS_DEPTH (PS_Z_INTEGER != PS_Z_INTEGER_NONE)
+#define ZINT_WRITES_DEPTH (PS_Z_INTEGER == PS_Z_INTEGER_READ_WRITE)
 
 #define PS_FEEDBACK_LOOP_IS_NEEDED_RT (PS_TEX_IS_FB == 1 || AFAIL_NEEDS_RT || PS_FBMASK || SW_BLEND_NEEDS_RT || SW_AD_TO_HW || (PS_DATE >= 5))
-#define PS_FEEDBACK_LOOP_IS_NEEDED_DEPTH (AFAIL_NEEDS_DEPTH || ZTST_NEEDS_DEPTH || AA1_NEEDS_DEPTH)
-#define ZWRITE (PS_ZCLAMP || PS_ZFLOOR || PS_FEEDBACK_LOOP_IS_NEEDED_DEPTH)
+#define PS_FEEDBACK_LOOP_IS_NEEDED_DEPTH (AFAIL_NEEDS_DEPTH || ZTST_NEEDS_DEPTH || AA1_NEEDS_DEPTH || ZINT_NEEDS_DEPTH)
+#define ZWRITE (PS_ZCLAMP || PS_ZFLOOR || PS_FEEDBACK_LOOP_IS_NEEDED_DEPTH || ZINT_WRITES_DEPTH)
 
 #define PS_RETURN_COLOR_ROV (!PS_NO_COLOR && PS_ROV_COLOR)
 #define PS_RETURN_COLOR (!PS_NO_COLOR && !PS_ROV_COLOR)
@@ -597,13 +682,35 @@ void main()
 
 #define NEEDS_TEX (PS_TFX != 4)
 
+#if PS_Z_INTEGER
+	#define DEPTH_TYPE uint
+	#define DEPTH_VEC4 uvec4
+	#define DEPTH_TEXTURE utexture2D
+	#define DEPTH_SAMPLER usampler2D
+	#define DEPTH_SUBPASS_INPUT usubpassInput
+	#define DEPTH_LAYOUT r32ui
+	#define DEPTH_IMAGE uimage2D
+#else
+	#define DEPTH_TYPE float
+	#define DEPTH_VEC4 vec4
+	#define DEPTH_TEXTURE texture2D
+	#define DEPTH_SAMPLER sampler2D
+	#define DEPTH_SUBPASS_INPUT subpassInput
+	#define DEPTH_LAYOUT r32f
+	#define DEPTH_IMAGE image2D
+#endif
+
 layout(std140, set = 0, binding = 1) uniform cb1
 {
 	vec3 FogColor;
 	float AREF;
 	vec4 WH;
 	vec2 TA;
+#if PS_Z_INTEGER
+	uint MaxDepthPS;
+#else
 	float MaxDepthPS;
+#endif
 	float Af;
 	uvec4 FbMask;
 	vec4 HalfTexel;
@@ -636,6 +743,9 @@ layout(location = 0) in VSOutput
 	#endif
 	float inv_cov; // We use the inverse to make it simpler to interpolate.
 	flat uint interior; // 1 for triangle interior; 0 for edge;
+	#if PS_Z_INTEGER
+		flat uint z_base;
+	#endif
 } vsIn;
 
 #if PS_RETURN_COLOR
@@ -653,17 +763,33 @@ layout(location = 0) in VSOutput
 	layout(set = 1, binding = 5, rgba8) uniform restrict coherent image2D RtImageRov;
 	vec4 rov_rt_value;
 	vec4 sample_from_rt() { return rov_rt_value; }
+	void RtWrite(ivec2 xy, vec4 c)
+	{
+		imageStore(RtImageRov, xy, c);
+	}
 #endif
 
 #if PS_ROV_DEPTH
-	layout(set = 1, binding = 6, r32f) uniform restrict coherent image2D DepthImageRov;
-	float rov_depth_value;
-	float sample_from_depth() { return rov_depth_value; }
+	layout(set = 1, binding = 6, DEPTH_LAYOUT) uniform restrict coherent DEPTH_IMAGE DepthImageRov;
+	DEPTH_TYPE rov_depth_value;
+	DEPTH_TYPE sample_from_depth() { return rov_depth_value; }
+	void DepthWrite(ivec2 xy, DEPTH_TYPE d)
+	{
+		imageStore(DepthImageRov, xy, DEPTH_VEC4(d, 0, 0, 0));
+	}
+#endif
+
+#if ZINT_WRITES_DEPTH && !PS_ROV_DEPTH
+	layout(location = PS_Z_RT_SLOT) out uint o_depth;
 #endif
 
 #if NEEDS_TEX
-layout(set = 1, binding = 0) uniform sampler2D Texture;
-layout(set = 1, binding = 1) uniform texture2D Palette;
+	#if PS_TEX_INTEGER
+		layout(set = 1, binding = 0) uniform usampler2D Texture;
+	#else
+		layout(set = 1, binding = 0) uniform sampler2D Texture;
+	#endif
+	layout(set = 1, binding = 1) uniform texture2D Palette;
 #endif
 
 #if PS_FEEDBACK_LOOP_IS_NEEDED_RT || PS_FEEDBACK_LOOP_IS_NEEDED_DEPTH
@@ -673,22 +799,22 @@ layout(set = 1, binding = 1) uniform texture2D Palette;
 			vec4 sample_from_rt() { return texelFetch(RtSampler, ivec2(gl_FragCoord.xy), 0); }
 		#endif
 		#if (PS_FEEDBACK_LOOP_IS_NEEDED_DEPTH && !PS_ROV_DEPTH)
-			layout(set = 1, binding = 4) uniform texture2D DepthSampler;
-			float sample_from_depth() { return texelFetch(DepthSampler, ivec2(gl_FragCoord.xy), 0).r; }
+			layout(set = 1, binding = 4) uniform DEPTH_TEXTURE DepthSampler;
+			DEPTH_TYPE sample_from_depth() { return texelFetch(DepthSampler, ivec2(gl_FragCoord.xy), 0).r; }
 		#endif
 	#else
 		// Must consider each case separately since the input attachment indices must be consecutive.
 		#if (PS_FEEDBACK_LOOP_IS_NEEDED_RT && !PS_ROV_COLOR) && (PS_FEEDBACK_LOOP_IS_NEEDED_DEPTH && !PS_ROV_DEPTH)
 			layout(input_attachment_index = 0, set = 1, binding = 2) uniform subpassInput RtSampler;
-			layout(input_attachment_index = 1, set = 1, binding = 4) uniform subpassInput DepthSampler;
+			layout(input_attachment_index = 1, set = 1, binding = 4) uniform DEPTH_SUBPASS_INPUT DepthSampler;
 			vec4 sample_from_rt() { return subpassLoad(RtSampler); }
-			float sample_from_depth() { return subpassLoad(DepthSampler).r; }
+			DEPTH_TYPE sample_from_depth() { return subpassLoad(DepthSampler).r; }
 		#elif (PS_FEEDBACK_LOOP_IS_NEEDED_RT && !PS_ROV_COLOR)
 			layout(input_attachment_index = 0, set = 1, binding = 2) uniform subpassInput RtSampler;
 			vec4 sample_from_rt() { return subpassLoad(RtSampler); }
 		#elif (PS_FEEDBACK_LOOP_IS_NEEDED_DEPTH && !PS_ROV_DEPTH)
-			layout(input_attachment_index = 0, set = 1, binding = 4) uniform subpassInput DepthSampler;
-			float sample_from_depth() { return subpassLoad(DepthSampler).r; }
+			layout(input_attachment_index = 0, set = 1, binding = 4) uniform DEPTH_SUBPASS_INPUT DepthSampler;
+			DEPTH_TYPE sample_from_depth() { return subpassLoad(DepthSampler).r; }
 		#endif
 	#endif
 #endif
@@ -697,7 +823,7 @@ layout(set = 1, binding = 1) uniform texture2D Palette;
 layout(set = 1, binding = 3) uniform texture2D PrimMinTexture;
 #endif
 
-#if ZWRITE && !PS_FEEDBACK_LOOP_IS_NEEDED_DEPTH
+#if ZWRITE && !PS_FEEDBACK_LOOP_IS_NEEDED_DEPTH && !PS_Z_INTEGER && !PS_ROV_DEPTH
 layout(depth_less) out float gl_FragDepth;
 #endif
 
@@ -854,6 +980,8 @@ vec4 sample_c(vec2 uv)
 {
 #if PS_TEX_IS_FB
 	return sample_from_rt();
+#elif PS_TEX_INTEGER
+	return vec4(0.0, 0.0, 0.0, 0.0);
 #elif PS_REGION_RECT
 	return texelFetch(Texture, ivec2(uv), 0);
 #else
@@ -1032,18 +1160,24 @@ mat4 sample_4p(uvec4 u)
 
 uint fetch_raw_depth(ivec2 xy)
 {
+#if PS_TEX_INTEGER
+	return texelFetch(Texture, xy, 0).r;
+#else
 #if PS_TEX_IS_FB
 	vec4 col = sample_from_rt();
 #else
 	vec4 col = texelFetch(Texture, xy, 0);
 #endif
 	return uint(col.r * exp2(32.0f));
+#endif
 }
 
 vec4 fetch_raw_color(ivec2 xy)
 {
 #if PS_TEX_IS_FB
 	return sample_from_rt();
+#elif PS_TEX_INTEGER
+	return vec4(0.0, 0.0, 0.0, 0.0);
 #else
 	return texelFetch(Texture, xy, 0);
 #endif
@@ -1053,6 +1187,8 @@ vec4 fetch_c(ivec2 uv)
 {
 #if PS_TEX_IS_FB
 	return sample_from_rt();
+#elif PS_TEX_INTEGER
+	return vec4(0.0, 0.0, 0.0, 0.0);
 #else
 	return texelFetch(Texture, uv, 0);
 #endif
@@ -1144,16 +1280,24 @@ vec4 sample_depth(vec2 st, ivec2 pos)
 	{
 		// Based on ps_convert_depth32_rgba8 of convert
 
-		// Convert a vec32 depth texture into a RGBA color texture
+		// Convert a float32 or uint32 depth texture into a RGBA color texture
+#if PS_TEX_INTEGER
+		uint d = fetch_raw_depth(uv);
+#else
 		uint d = uint(fetch_c(uv).r * exp2(32.0f));
+#endif
 		t = vec4(uvec4((d & 0xFFu), ((d >> 8) & 0xFFu), ((d >> 16) & 0xFFu), (d >> 24)));
 	}
 	#elif (PS_DEPTH_FMT == 2)
 	{
 		// Based on ps_convert_depth16_rgb5a1 of convert
 
-		// Convert a vec32 (only 16 lsb) depth into a RGB5A1 color texture
+		// Convert a float32 or uint32 (only 16 lsb) depth into a RGB5A1 color texture
+#if PS_TEX_INTEGER
+		uint d = fetch_raw_depth(uv);
+#else
 		uint d = uint(fetch_c(uv).r * exp2(32.0f));
+#endif
 		t = vec4(uvec4((d & 0x1Fu), ((d >> 5) & 0x1Fu), ((d >> 10) & 0x1Fu), (d >> 15) & 0x01u)) * vec4(8.0f, 8.0f, 8.0f, 128.0f);
 	}
 	#elif (PS_DEPTH_FMT == 3)
@@ -1726,10 +1870,15 @@ layout(early_fragment_tests) in;
 
 void main()
 {
+#if PS_Z_INTEGER
+	// Add base plus interpolated offset.
+	uint input_z = vsIn.z_base + uint(exp2(32.0f) * gl_FragCoord.z);
+#else
 	float input_z = gl_FragCoord.z;
+#endif
 
+#if PS_ZFLOOR && !PS_Z_INTEGER
 	// Must floor before depth testing.
-#if PS_ZFLOOR
 	input_z = floor(input_z * exp2(32.0f)) * exp2(-32.0f);
 #endif
 
@@ -1750,11 +1899,18 @@ void main()
 	bool rov_discard_depth = gl_HelperInvocation;
 #endif
 
+#if PS_FEEDBACK_LOOP_IS_NEEDED_DEPTH
+	DEPTH_TYPE curr_z = sample_from_depth();
+	#if PS_Z_INTEGER
+		input_z |= (curr_z & ~MaxDepthPS); // Add unused upper bits
+	#endif
+#endif
+
 #if PS_ZTST == ZTST_GEQUAL
-	if (input_z < sample_from_depth())
+	if (input_z < curr_z)
 		DISCARD;
 #elif PS_ZTST == ZTST_GREATER
-	if (input_z <= sample_from_depth())
+	if (input_z <= curr_z)
 		DISCARD;
 #endif
 
@@ -1763,6 +1919,7 @@ void main()
 	if ((int(gl_FragCoord.y) & 1) == (PS_SCANMSK & 1))
 		DISCARD;
 #endif
+
 #if PS_DATE >= 5
 
 #if PS_WRITE_RG == 1
@@ -1963,21 +2120,30 @@ void main()
 		if (!bool(vsIn.interior))
 			DISCARD_DEPTH; // No depth update for triangle edges.
 	#endif
+
+	#if PS_ZCLAMP && PS_Z_INTEGER
+		input_z |= (curr_z & ~MaxDepthPS); // Mask based on depth format
+	#endif
 	
-	// Writing back color (result already written to o_col0 for non-ROV)
 	#if PS_RETURN_COLOR_ROV
 		o_col0 = mix(o_col0, sample_from_rt(), equal(FbMask, uvec4(0xFFu))); // channel masking
 
 		if (!rov_discard_color)
-			imageStore(RtImageRov, ivec2(gl_FragCoord.xy), o_col0);
+			RtWrite(ivec2(gl_FragCoord.xy), o_col0);
 	#endif
 	
 	// Writing back depth
 	#if PS_RETURN_DEPTH
-		gl_FragDepth = input_z;
+		#if PS_Z_INTEGER
+			#if ZINT_WRITES_DEPTH
+				o_depth = input_z;
+			#endif
+		#else
+			gl_FragDepth = input_z;
+		#endif
 	#elif PS_RETURN_DEPTH_ROV
 		if (!rov_discard_depth)
-			imageStore(DepthImageRov, ivec2(gl_FragCoord.xy), vec4(input_z, 0, 0, 1.0f));
+			DepthWrite(ivec2(gl_FragCoord.xy), input_z);
 	#endif
 
 	#if PS_ROV_COLOR || PS_ROV_DEPTH

--- a/pcsx2-qt/Settings/GraphicsHardwareRenderingSettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsHardwareRenderingSettingsTab.ui
@@ -48,7 +48,7 @@
      </item>
     </widget>
    </item>
-   <item row="6" column="0" colspan="2">
+   <item row="7" column="0" colspan="2">
     <layout class="QGridLayout" name="hardwareRenderingOptionsLayout">
      <item row="0" column="1">
       <widget class="QCheckBox" name="accurateAlphaTest">
@@ -181,6 +181,25 @@
      </item>
     </widget>
    </item>
+   <item row="6" column="1">
+    <widget class="QComboBox" name="intDepth">
+     <item>
+      <property name="text">
+       <string>Disabled</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Enabled</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Always On (Debug)</string>
+      </property>
+     </item>
+    </widget>
+   </item>
    <item row="2" column="1">
     <widget class="QComboBox" name="trilinearFiltering">
      <item>
@@ -215,6 +234,16 @@
      </property>
     </widget>
    </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="intDepthLabel">
+     <property name="text">
+      <string>Integer Depth:</string>
+     </property>
+     <property name="buddy">
+      <cstring>intDepth</cstring>
+     </property>
+    </widget>
+   </item>
    <item row="2" column="0">
     <widget class="QLabel" name="trilinearFilterLabel">
      <property name="text">
@@ -225,7 +254,7 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="0">
+   <item row="8" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Orientation::Vertical</enum>
@@ -247,6 +276,7 @@
   <tabstop>anisotropicFiltering</tabstop>
   <tabstop>dithering</tabstop>
   <tabstop>blending</tabstop>
+  <tabstop>intDepth</tabstop>
   <tabstop>mipmapping</tabstop>
   <tabstop>accurateAlphaTest</tabstop>
   <tabstop>hwAA1</tabstop>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -116,6 +116,8 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_hw.rov, "EmuCore/GS", "HWROV", false);
 	SettingWidgetBinder::BindWidgetToIntSetting(
 		sif, m_hw.blending, "EmuCore/GS", "accurate_blending_unit", static_cast<int>(AccBlendLevel::Basic));
+	SettingWidgetBinder::BindWidgetToIntSetting(
+		sif, m_hw.intDepth, "EmuCore/GS", "HWZIntegerMode", static_cast<int>(GSHardwareZIntegerMode::Disabled));
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_hw.enableHWFixes, "EmuCore/GS", "UserHacks", false);
 	connect(m_hw.upscaleMultiplier, &QComboBox::currentIndexChanged, this,
 		&GraphicsSettingsWidget::onUpscaleMultiplierChanged);
@@ -529,6 +531,10 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 		dialog()->registerWidgetHelp(m_hw.blending, tr("Blending Accuracy"), tr("Basic (Recommended)"),
 			tr("Control the accuracy level of the GS blending unit emulation.<br> "
 			   "The higher the setting, the more blending is emulated in the shader accurately, and the higher the speed penalty will be."));
+
+		dialog()->registerWidgetHelp(m_hw.intDepth, tr("Integer Depth"), tr("Disabled"),
+			tr("Emulate depth using 32 bit integers like the GS.<br> "
+			   "May result in a significant performance penalty and is recommended only with ROV or framebuffer fetch."));
 
 		dialog()->registerWidgetHelp(m_advanced.texturePreloading, tr("Texture Preloading"), tr("Full (Hash Cache)"),
 			tr("Uploads entire textures at once instead of in small pieces, avoiding redundant uploads when possible. "

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -405,6 +405,13 @@ enum class GSHardwareDownloadMode : u8
 	Disabled
 };
 
+enum class GSHardwareZIntegerMode : u8
+{
+	Disabled,
+	Enabled,
+	Always
+};
+
 enum class GSCASMode : u8
 {
 	Disabled,
@@ -870,6 +877,7 @@ struct Pcsx2Config
 		GSDumpCompressionMethod GSDumpCompression = GSDumpCompressionMethod::Zstandard;
 		GSHardwareDownloadMode HWDownloadMode = GSHardwareDownloadMode::Enabled;
 		GSCASMode CASMode = DEFAULT_CAS_MODE;
+		GSHardwareZIntegerMode HWZIntegerMode = GSHardwareZIntegerMode::Disabled;
 		u8 Dithering = 2;
 		u8 MaxAnisotropy = 0;
 		u8 TVShader = 0;

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -800,6 +800,7 @@ void GSState::ResetPCRTC()
 void GSState::UpdateSettings(const Pcsx2Config::GSOptions& old_config)
 {
 	m_mipmap = GSConfig.Mipmap;
+	UpdateZIntegerEnabled();
 
 	if (
 		GSConfig.AutoFlushSW != old_config.AutoFlushSW ||
@@ -6087,7 +6088,9 @@ __forceinline void GSState::VertexKick(u32 skip)
 	temp_draw_rect = temp_draw_rect.rintersect(m_context->scissor.in);
 
 	constexpr u32 max_vertices = MaxVerticesForPrim(prim);
-	if (max_vertices != 0 && vtx_buff.tail >= max_vertices)
+	// Z integer vertices get expanded to have unique indices so we need to check the index count instead.
+	const u32 check_size = static_cast<u32>(m_z_integer_enabled ? idx_buff.tail : vtx_buff.tail);
+	if (max_vertices != 0 && check_size >= max_vertices)
 		Flush(VERTEXCOUNT);
 }
 

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -303,6 +303,7 @@ public:
 	bool m_temp_z_full_copy = false;
 	bool m_in_target_draw = false;
 	bool m_channel_shuffle_finish = false;
+	bool m_z_integer_enabled = false;
 
 	u32 m_target_offset = 0;
 	u8 m_scanmask_used = 0;
@@ -540,6 +541,12 @@ public:
 	bool SpriteDrawWithoutGaps();
 	void CalculatePrimitiveCoversWithoutGaps();
 	GIFRegTEX0 GetTex0Layer(u32 lod);
+
+	__fi void UpdateZIntegerEnabled()
+	{
+		m_z_integer_enabled = GSIsHardwareRenderer() && g_gs_device->Features().depth_integer &&
+			GSConfig.HWZIntegerMode >= GSHardwareZIntegerMode::Enabled;
+	}
 };
 
 // We put this in the header because of Multi-ISA.

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -38,7 +38,7 @@ const char* ShaderEntryPoint(ShaderConvert value)
 		case ShaderConvert::RTA_CORRECTION:         return "ps_rta_correction";
 		case ShaderConvert::RTA_DECORRECTION:       return "ps_rta_decorrection";
 		case ShaderConvert::TRANSPARENCY_FILTER:    return "ps_filter_transparency";
-		case ShaderConvert::DEPTH32_TO_16_BITS:     return "ps_convert_depth32_32bits";
+		case ShaderConvert::DEPTH16_TO_16_BITS:     return "ps_convert_depth32_32bits";
 		case ShaderConvert::DEPTH32_TO_32_BITS:     return "ps_convert_depth32_32bits";
 		case ShaderConvert::DEPTH32_TO_RGBA8:       return "ps_convert_depth32_rgba8";
 		case ShaderConvert::DEPTH32_TO_RGB8:        return "ps_convert_depth32_rgba8";
@@ -99,7 +99,7 @@ const char* ShaderConvertName(ShaderConvert shader)
 		ENTRY(RTA_CORRECTION);
 		ENTRY(RTA_DECORRECTION);
 		ENTRY(TRANSPARENCY_FILTER);
-		ENTRY(DEPTH32_TO_16_BITS);
+		ENTRY(DEPTH16_TO_16_BITS);
 		ENTRY(DEPTH32_TO_32_BITS);
 		ENTRY(DEPTH32_TO_RGBA8);
 		ENTRY(DEPTH32_TO_RGB8);
@@ -441,14 +441,10 @@ void GSDevice::ThrottlePresentation()
 	Threading::SleepUntil(m_last_frame_displayed_time);
 }
 
-void GSDevice::ClearRenderTarget(GSTexture* t, u32 c)
+void GSDevice::ClearRenderTarget(GSTexture* t, u32 value)
 {
-	t->SetClearColor(c);
-}
-
-void GSDevice::ClearDepth(GSTexture* t, float d)
-{
-	t->SetClearDepth(d);
+	pxAssert(t->IsRenderTargetOrDepthStencil());
+	t->SetClearValue(value);
 }
 
 bool GSDevice::ProcessClearsBeforeCopy(GSTexture* sTex, GSTexture* dTex, const bool full_copy)
@@ -458,10 +454,7 @@ bool GSDevice::ProcessClearsBeforeCopy(GSTexture* sTex, GSTexture* dTex, const b
 	// Pass it forward if we're clearing the whole thing.
 	if (full_copy)
 	{
-		if (dTex->IsDepthStencil())
-			dTex->SetClearDepth(sTex->GetClearDepth());
-		else
-			dTex->SetClearColor(sTex->GetClearColor());
+		dTex->SetClearValue(sTex->GetClearValue());
 
 		dTex->SetState(GSTexture::State::Cleared);
 
@@ -471,16 +464,8 @@ bool GSDevice::ProcessClearsBeforeCopy(GSTexture* sTex, GSTexture* dTex, const b
 	// Destination is cleared, if it's the same colour and rect, we can just avoid this entirely.
 	if (dTex->GetState() == GSTexture::State::Cleared)
 	{
-		if (dTex->IsDepthStencil())
-		{
-			if (dTex->GetClearDepth() == sTex->GetClearDepth())
-				return true;
-		}
-		else
-		{
-			if (dTex->GetClearColor() == sTex->GetClearColor())
-				return true;
-		}
+		if (dTex->GetClearValue() == sTex->GetClearValue())
+			return true;
 	}
 
 	return false;
@@ -671,17 +656,10 @@ GSTexture* GSDevice::FetchSurface(GSTexture::Usage usage, int width, int height,
 		}
 	}
 
-	if (t->IsRenderTarget())
+	if (t->IsRenderTarget() || t->IsDepthStencil())
 	{
 		if (clear)
 			ClearRenderTarget(t, 0);
-		else
-			InvalidateRenderTarget(t);
-	}
-	else if (t->IsDepthStencil())
-	{
-		if (clear)
-			ClearDepth(t, 0.0f);
 		else
 			InvalidateRenderTarget(t);
 	}
@@ -836,9 +814,11 @@ GSTexture* GSDevice::CreateCompatible(GSTexture* tex, int w, int h, bool clear, 
 void GSDevice::DoStretchRectWithAssertions(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex,
 	const GSVector4& dRect, ShaderConvertSelector shader, Filter filter)
 {
-	pxAssert((dTex && dTex->IsDepthLike()) == shader.Float32Output());
+	pxAssert((dTex && dTex->IsFloat32Like()) == shader.Float32Output());
+	pxAssert((dTex && dTex->IsIntegerFormat()) == shader.IntegerOutput());
+	pxAssert((sTex && sTex->IsIntegerFormat()) == shader.IntegerInput());
 	pxAssert(!(filter == Biln && shader.SupportsBilinear())); // Don't allow HW bilinear if SW bilinear is required.
-	GL_INS("StretchRect(%s) {%d,%d} %dx%d -> {%d,%d) %dx%d", ShaderConvertName(shader.Shader()),
+	GL_INS("StretchRect(%s) {%d,%d} %dx%d -> {%d,%d) %dx%d", shader.Name(),
 		int(sRect.left), int(sRect.top),
 		int(sRect.right - sRect.left), int(sRect.bottom - sRect.top), int(dRect.left), int(dRect.top),
 		int(dRect.right - dRect.left), int(dRect.bottom - dRect.top));
@@ -1272,12 +1252,15 @@ static const char* GetVSExpandName(GSHWDrawConfig::VSExpand vsexpand)
 {
 	switch (vsexpand)
 	{
-		case GSHWDrawConfig::VSExpand::None:        return "None";
-		case GSHWDrawConfig::VSExpand::Point:       return "Point";
-		case GSHWDrawConfig::VSExpand::Line:        return "Line";
-		case GSHWDrawConfig::VSExpand::Sprite:      return "Sprite";
-		case GSHWDrawConfig::VSExpand::LineAA1:     return "LineAA1";
-		case GSHWDrawConfig::VSExpand::TriangleAA1: return "TriangleAA1";
+		case GSHWDrawConfig::VSExpand::None:             return "None";
+		case GSHWDrawConfig::VSExpand::Point:            return "Point";
+		case GSHWDrawConfig::VSExpand::Line:             return "Line";
+		case GSHWDrawConfig::VSExpand::Sprite:           return "Sprite";
+		case GSHWDrawConfig::VSExpand::LineAA1:          return "LineAA1";
+		case GSHWDrawConfig::VSExpand::TriangleAA1:      return "TriangleAA1";
+		case GSHWDrawConfig::VSExpand::PointZInteger:    return "PointZInteger";
+		case GSHWDrawConfig::VSExpand::LineZInteger:     return "LineZInteger";
+		case GSHWDrawConfig::VSExpand::TriangleZInteger: return "TriangleZInteger";
 	}
 	return "Unknown";
 }
@@ -1815,24 +1798,34 @@ void GSHWDrawConfig::DumpConfig(const std::string& path, const GSHWDrawConfig& c
 	}
 }
 
-static constexpr u32 NUM_REMAP_INPUTS = static_cast<u32>(ShaderConvert::Count) * 4;
+static constexpr u32 NUM_REMAP_INPUTS = static_cast<u32>(ShaderConvert::Count) * 16;
 
 static constexpr ShaderConvertSelector GetRemappedShader(u32 idx)
 {
-	ShaderConvert convert = static_cast<ShaderConvert>(idx >> 2);
-	bool depth_out = (idx >> 0) & 1;
-	Filter filter = static_cast<Filter>((idx >> 1) & 1);
-	return ShaderConvertSelector(convert, 0xf, depth_out, filter);
+	ShaderConvert convert = static_cast<ShaderConvert>(idx >> 4);
+	bool integer_in = (idx >> 0) & 1;
+	bool integer_out = (idx >> 1) & 1;
+	bool depth_out = (idx >> 2) & 1;
+	Filter filter = BilnIf((idx >> 3) & 1);
+	return ShaderConvertSelector(convert, 0xf, integer_in, integer_out, depth_out, filter);
 }
 
 static constexpr bool RemapIndexIsValid(u32 idx)
 {
-	ShaderConvert convert = static_cast<ShaderConvert>(idx >> 2);
-	bool depth_out = (idx >> 0) & 1;
-	Filter filter = static_cast<Filter>((idx >> 1) & 1);
+	ShaderConvert convert = static_cast<ShaderConvert>(idx >> 4);
+	bool integer_in = (idx >> 0) & 1;
+	bool integer_out = (idx >> 1) & 1;
+	bool depth_out = (idx >> 2) & 1;
+	Filter filter = BilnIf((idx >> 3) & 1);
 	if (HasVariableWriteMask(convert) && !depth_out && filter == Nearest)
 		return false; // Handled as variable write mask
-	if (depth_out && !HasFloat32Output(convert))
+	if (integer_in && !HasDepthLikeInput(convert))
+		return false;
+	if (integer_out && !HasDepthLikeOutput(convert))
+		return false;
+	if (depth_out && !HasDepthLikeOutput(convert))
+		return false;
+	if (integer_out && depth_out)
 		return false;
 	if (filter == Biln && !SupportsBilinear(convert))
 		return false;

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -49,7 +49,7 @@ enum class ShaderConvert
 	RTA_CORRECTION,
 	RTA_DECORRECTION,
 	TRANSPARENCY_FILTER,
-	DEPTH32_TO_16_BITS,
+	DEPTH16_TO_16_BITS,
 	DEPTH32_TO_32_BITS,
 	DEPTH32_TO_RGBA8,
 	DEPTH32_TO_RGB8,
@@ -135,7 +135,7 @@ static inline constexpr bool HasColorOutput(ShaderConvert shader)
 	}
 }
 
-static inline constexpr bool HasFloat32Output(ShaderConvert shader)
+static inline constexpr bool HasDepthLikeOutput(ShaderConvert shader)
 {
 	switch (shader)
 	{
@@ -151,12 +151,12 @@ static inline constexpr bool HasFloat32Output(ShaderConvert shader)
 	}
 }
 
-static inline constexpr bool HasFloat32Input(ShaderConvert shader)
+static inline constexpr bool HasDepthLikeInput(ShaderConvert shader)
 {
 	switch (shader)
 	{
 		case ShaderConvert::DEPTH_COPY:
-		case ShaderConvert::DEPTH32_TO_16_BITS:
+		case ShaderConvert::DEPTH16_TO_16_BITS:
 		case ShaderConvert::DEPTH32_TO_32_BITS:
 		case ShaderConvert::DEPTH32_TO_RGBA8:
 		case ShaderConvert::DEPTH32_TO_RGB8:
@@ -193,7 +193,7 @@ static inline constexpr int IntegerOutputBpp(ShaderConvert shader)
 	{
 		case ShaderConvert::DEPTH32_TO_32_BITS:
 			return 32;
-		case ShaderConvert::DEPTH32_TO_16_BITS:
+		case ShaderConvert::DEPTH16_TO_16_BITS:
 		case ShaderConvert::RGB5A1_TO_16_BITS:
 			return 16;
 		default:
@@ -268,6 +268,8 @@ class ShaderConvertSelector
 		{
 			u32 shader : 8; // Main shader
 			u32 mask : 8; // Variable color mask
+			u32 integer_in : 1; // Integer texture input
+			u32 integer_out : 1; // Integer texture output
 			u32 depth_out : 1; // Depth texture output
 			u32 filter : 1; // Shader filter (HW filter is specified separately)
 		};
@@ -279,10 +281,10 @@ class ShaderConvertSelector
 
 public:
 	constexpr ShaderConvertSelector(ShaderConvert shader = ShaderConvert::COPY, u8 mask = 0xf,
- 		bool depth_out = false, Filter filter = Filter::Nearest)
+ 		bool integer_in = false, bool integer_out = false, bool depth_out = false, Filter filter = Filter::Nearest)
 		: fields { static_cast<u32>(shader) }
 	{
-		*this = SetMask(mask).SetDepthOutput(depth_out).SetFilter(filter);
+		*this = SetMask(mask).SetIntegerInput(integer_in).SetIntegerOutput(integer_out).SetDepthOutput(depth_out).SetFilter(filter);
 	}
 
 	constexpr ShaderConvert Shader() const
@@ -320,6 +322,11 @@ public:
 		return ::SupportsBilinear(Shader());
 	}
 
+	constexpr bool IntegerInput() const
+	{
+		return fields.integer_in;
+	}
+
 	constexpr bool ColorOutput() const
 	{
 		return HasColorOutput(Shader());
@@ -340,19 +347,34 @@ public:
 		return IsDATMConvertShader(Shader());
 	}
 
-	constexpr bool Float32Output() const
+	constexpr bool DepthLikeOutput() const
 	{
-		return HasFloat32Output(Shader());
+		return HasDepthLikeOutput(Shader());
 	}
 
-	constexpr bool Float32Input() const
+	constexpr bool DepthLikeInput() const
 	{
-		return HasFloat32Input(Shader());
+		return HasDepthLikeInput(Shader());
 	}
 
 	constexpr int IntegerOutputBpp() const
 	{
-		return ::IntegerOutputBpp(Shader());
+		return fields.integer_out ? 32 : ::IntegerOutputBpp(Shader());
+	}
+
+	constexpr int IntegerOutput() const
+	{
+		return IntegerOutputBpp() != 0;
+	}
+
+	constexpr bool Float32Input() const
+	{
+		return DepthLikeInput() && !IntegerInput();
+	}
+
+	constexpr bool Float32Output() const
+	{
+		return DepthLikeOutput() && !IntegerOutput();
 	}
 
 	constexpr bool VariableWriteMask() const
@@ -387,10 +409,24 @@ public:
 		return SetMask((wr ? 1 : 0) | (wg ? 2 : 0) | (wb ? 4 : 0) | (wa ? 8 : 0));
 	}
 
+	constexpr ShaderConvertSelector SetIntegerInput(bool integer_in) const
+	{
+		ShaderConvertSelector tmp = *this;
+		tmp.fields.integer_in = DepthLikeInput() && integer_in;
+		return tmp;
+	}
+
+	constexpr ShaderConvertSelector SetIntegerOutput(bool integer_out) const
+	{
+		ShaderConvertSelector tmp = *this;
+		tmp.fields.integer_out = DepthLikeOutput() && integer_out;
+		return tmp;
+	}
+
 	constexpr ShaderConvertSelector SetDepthOutput(bool depth_out) const
 	{
 		ShaderConvertSelector tmp = *this;
-		tmp.fields.depth_out = Float32Output() && depth_out;
+		tmp.fields.depth_out = DepthLikeOutput() && depth_out;
 		return tmp;
 	}
 
@@ -401,14 +437,23 @@ public:
 		return tmp;
 	}
 
+	// For debugging
+	const char* InputFormat() const
+	{
+		if (DepthLikeInput())
+			return IntegerInput() ? "DepthInteger" : "Depth";
+		else
+			return "Color";
+	}
+
 	GSTexture::Format OutputFormat() const
 	{
 		if (DepthOutput())
 			return GSTexture::Format::DepthStencil;
 		else if (int bpp = IntegerOutputBpp())
 			return bpp == 16 ? GSTexture::Format::UInt16 : GSTexture::Format::UInt32;
-		else if (Float32Output())
-			return GSTexture::Format::DepthColor;
+		else if (DepthLikeOutput())
+			return IntegerOutput() ? GSTexture::Format::DepthInteger : GSTexture::Format::DepthColor;
 		else if (ColorOutput())
 			return GSTexture::Format::Color;
 		else if (ColorClipOutput())
@@ -420,7 +465,7 @@ public:
 private:
 	// Helper variables for packing valid shaders into a contiguous range.
 	static const std::span<const ShaderConvertSelector> SHADERS;
-	static const std::array<u8, static_cast<u32>(ShaderConvert::Count) * 4> INDEX_REMAP;
+	static const std::array<u8, static_cast<u32>(ShaderConvert::Count) * 16> INDEX_REMAP;
 	static const u32 NUM_REMAPPED_SHADERS;
 
 public:
@@ -431,9 +476,11 @@ public:
 	{
 		if (VariableWriteMask() && !fields.depth_out && Nearest())
 			return GetShaderIndexForMask(Shader(), fields.mask) + NUM_REMAPPED_SHADERS;
-		u32 remapped = INDEX_REMAP[(fields.depth_out << 0) +
-		                           (fields.filter    << 1) +
-		                           (fields.shader    << 2)];
+		u32 remapped = INDEX_REMAP[(fields.integer_in  << 0) +
+		                           (fields.integer_out << 1) +
+		                           (fields.depth_out   << 2) +
+		                           (fields.filter      << 3) +
+		                           (fields.shader      << 4)];
 		pxAssert(remapped < NUM_REMAPPED_SHADERS);
 		return remapped;
 	}
@@ -458,6 +505,7 @@ static inline ShaderConvertSelector GetConvertShader(GSTexture::Format src, GSTe
 					pxAssert(src_bpp == 32 && dst_bpp == 32);
 					shader = ShaderConvert::COPY; // bpp is handled by mask
 					break;
+				case GSTexture::Format::DepthInteger:
 				case GSTexture::Format::DepthColor:
 				case GSTexture::Format::DepthStencil:
 					switch (dst_bpp)
@@ -483,6 +531,7 @@ static inline ShaderConvertSelector GetConvertShader(GSTexture::Format src, GSTe
 					break;
 			}
 			break;
+		case GSTexture::Format::DepthInteger:
 		case GSTexture::Format::DepthColor:
 		case GSTexture::Format::DepthStencil:
 			switch (dst)
@@ -505,6 +554,7 @@ static inline ShaderConvertSelector GetConvertShader(GSTexture::Format src, GSTe
 							break;
 					}
 					break;
+				case GSTexture::Format::DepthInteger:
 				case GSTexture::Format::DepthColor:
 				case GSTexture::Format::DepthStencil:
 					switch (dst_bpp)
@@ -531,7 +581,10 @@ static inline ShaderConvertSelector GetConvertShader(GSTexture::Format src, GSTe
 			break;
 	}
 
-	return ShaderConvertSelector(shader, mask, dst == GSTexture::Format::DepthStencil);
+	return ShaderConvertSelector(shader, mask,
+		src == GSTexture::Format::DepthInteger,
+		dst == GSTexture::Format::DepthInteger,
+		dst == GSTexture::Format::DepthStencil);
 }
 
 static inline ShaderConvertSelector GetConvertShader(const GSTexture* src, const GSTexture* dst, u32 src_bpp, u32 dst_bpp, u8 mask = 0xf)
@@ -550,6 +603,56 @@ static inline ShaderConvertSelector GetConvertShaderMask(const GSTexture* src, c
 	u32 src_bpp, u32 dst_bpp, bool red = true, bool green = true, bool blue = true, bool alpha = true)
 {
 	return GetConvertShaderMask(src->GetFormat(), dst->GetFormat(), src_bpp, dst_bpp, red, green, blue, alpha);
+}
+
+static inline ShaderConvertSelector GetConvertToBitsShader(GSTexture::Format src, u32 bpp, bool alpha_scaled)
+{
+	ShaderConvert shader = static_cast<ShaderConvert>(-1);
+	if (bpp == 32)
+	{
+		switch (src)
+		{
+			case GSTexture::Format::Color:
+				shader = alpha_scaled ? ShaderConvert::RTA_DECORRECTION : ShaderConvert::COPY;
+				break;
+			case GSTexture::Format::DepthInteger:
+			case GSTexture::Format::DepthColor:
+			case GSTexture::Format::DepthStencil:
+				shader = ShaderConvert::DEPTH32_TO_32_BITS;
+				break;
+			default:
+				pxAssert(false);
+				break;
+		}
+	}
+	else if (bpp == 16)
+	{
+		switch (src)
+		{
+			case GSTexture::Format::Color:
+				shader = ShaderConvert::RGB5A1_TO_16_BITS;
+				break;
+			case GSTexture::Format::DepthInteger:
+			case GSTexture::Format::DepthColor:
+			case GSTexture::Format::DepthStencil:
+				shader = ShaderConvert::DEPTH16_TO_16_BITS;
+				break;
+			default:
+				pxAssert(false);
+				break;
+		}
+	}
+	else
+	{
+		pxAssert(false);
+	}
+	return ShaderConvertSelector(shader, 0xf, src == GSTexture::Format::DepthInteger);
+}
+
+
+static inline ShaderConvertSelector GetConvertToBitsShader(GSTexture* src, u32 bpp, bool alpha_scaled)
+{
+	return GetConvertToBitsShader(src->GetFormat(), bpp, alpha_scaled);
 }
 
 enum ChannelFetch
@@ -668,11 +771,12 @@ struct alignas(16) GSHWDrawConfig
 		Line,
 		Triangle,
 	};
-	using VSExpand = GSShader::VSExpand;
-	using PS_ATST  = GSShader::PS_ATST;
-	using PS_AFAIL = GSShader::PS_AFAIL;
-	using PS_AA1   = GSShader::PS_AA1;
+	using VSExpand     = GSShader::VSExpand;
+	using PS_ATST      = GSShader::PS_ATST;
+	using PS_AFAIL     = GSShader::PS_AFAIL;
+	using PS_AA1       = GSShader::PS_AA1;
 	using PS_ROV_DEPTH = GSShader::PS_ROV_DEPTH;
+	using PS_Z_INTEGER = GSShader::PS_Z_INTEGER;
 #pragma pack(push, 1)
 	struct VSSelector
 	{
@@ -684,21 +788,36 @@ struct alignas(16) GSHWDrawConfig
 				u8 tme : 1;
 				u8 iip : 1;
 				u8 point_size : 1;		///< Set when points need to be expanded without VS expanding.
-				VSExpand expand : 3;
-				u8 _free : 1;
+				VSExpand expand : 4;
+				u8 zint : 1;
 			};
-			u8 key;
+			u16 key;
 		};
 		VSSelector(): key(0) {}
-		VSSelector(u8 k): key(k) {}
+		VSSelector(u16 k): key(k) {}
 
 		/// Returns true if the fixed index buffer should be used.
 		__fi bool UseFixedExpandIndexBuffer() const { return (expand == VSExpand::Point || expand == VSExpand::Sprite); }
 		
 		/// Return true if the index buffer should be bound as a vertex shader resource.
-		__fi bool UseVSExpandIndexBuffer() const { return (expand == VSExpand::TriangleAA1); }
+		__fi bool UseVSExpandIndexBuffer() const
+		{
+			return (expand == VSExpand::TriangleAA1 || expand == VSExpand::TriangleZInteger ||
+				expand == VSExpand::LineZInteger);
+		}
+		
+		/// Remove the Z integer expand shader.
+		__fi void RemoveZIntegerExpand()
+		{
+			if ((expand == GSHWDrawConfig::VSExpand::PointZInteger) ||
+				(expand == GSHWDrawConfig::VSExpand::LineZInteger) ||
+				(expand == GSHWDrawConfig::VSExpand::TriangleZInteger))
+			{
+				expand = GSHWDrawConfig::VSExpand::None;
+			}
+		}
 	};
-	static_assert(sizeof(VSSelector) == 1, "VSSelector is a single byte");
+	static_assert(sizeof(VSSelector) == 2, "VSSelector is two bytes");
 
 	struct PSSelector
 	{
@@ -797,6 +916,11 @@ struct alignas(16) GSHWDrawConfig
 				// ROVs
 				u32 rov_color : 1;
 				PS_ROV_DEPTH rov_depth : 2;
+
+				// Integer depth
+				u32 z_rt_slot : 2;
+				PS_Z_INTEGER zint : 2;
+				u32 texint : 1;
 			};
 
 			struct
@@ -839,7 +963,8 @@ struct alignas(16) GSHWDrawConfig
 			const bool afail_needs_depth = afail == PS_AFAIL::FB_ONLY || afail == PS_AFAIL::RGB_ONLY_SW_Z;
 			const bool ztst_needs_depth = ztst == ZTST_GEQUAL || ztst == ZTST_GREATER;
 			const bool aa1_needs_depth = aa1 == PS_AA1::TRIANGLE_SW_Z;
-			return afail_needs_depth || ztst_needs_depth || aa1_needs_depth;
+			const bool zint_needs_depth = zint != PS_Z_INTEGER::NONE;
+			return afail_needs_depth || ztst_needs_depth || aa1_needs_depth || zint_needs_depth;
 		}
 
 		__fi bool HasShaderDiscard() const
@@ -880,6 +1005,11 @@ struct alignas(16) GSHWDrawConfig
 			{
 				rov_depth = PS_ROV_DEPTH::READ_ONLY;
 			}
+
+			if (zint == PS_Z_INTEGER::READ_WRITE)
+			{
+				zint = PS_Z_INTEGER::READ_ONLY;
+			}
 		}
 
 		__fi bool HasColorOutput() const
@@ -889,7 +1019,8 @@ struct alignas(16) GSHWDrawConfig
 
 		__fi bool HasDepthOutput() const
 		{
-			return zfloor || zclamp || IsFeedbackLoopDepth() || (rov_depth == PS_ROV_DEPTH::READ_WRITE);
+			return zfloor || zclamp || IsFeedbackLoopDepth() || (rov_depth == PS_ROV_DEPTH::READ_WRITE) ||
+				(zint == PS_Z_INTEGER::READ_WRITE);
 		}
 
 		__fi bool HasColorROV() const
@@ -906,8 +1037,24 @@ struct alignas(16) GSHWDrawConfig
 		{
 			return rov_depth == PS_ROV_DEPTH::READ_WRITE;
 		}
+
+		__fi bool HasZInteger() const
+		{
+			return zint == PS_Z_INTEGER::READ_ONLY || zint == PS_Z_INTEGER::READ_WRITE;
+		}
+
+		__fi bool HasZIntegerWrite() const
+		{
+			return zint == PS_Z_INTEGER::READ_WRITE;
+		}
+		
+		/// Does the pixel shader do SW depth test.
+		__fi bool DepthTest() const
+		{
+			return ztst == ZTST_GEQUAL || ztst == ZTST_GREATER;
+		}
 	};
-	static_assert(sizeof(PSSelector) == 16, "PSSelector is 12 bytes");
+	static_assert(sizeof(PSSelector) == 16, "PSSelector is 16 bytes");
 #pragma pack(pop)
 	struct PSSelectorHash
 	{
@@ -1239,6 +1386,7 @@ struct alignas(16) GSHWDrawConfig
 
 	GSTexture* rt;         ///< Render target
 	GSTexture* ds;         ///< Depth stencil
+	GSTexture* ds_int;     ///< Integer depth (actually a R32_UINT RT)
 	GSTexture* tex;        ///< Source texture
 	GSTexture* pal;        ///< Palette texture
 	const GSVertex* verts; ///< Vertices to draw
@@ -1321,7 +1469,7 @@ struct alignas(16) GSHWDrawConfig
 		return ps.IsFeedbackLoopDepth() || (tex_hazard == TEX_HAZARD_DEPTH);
 	}
 	
-	bool IsBlending()
+	bool IsBlending() const
 	{
 		return blend.enable || blend_multi_pass.enable || ps.IsSWBlending();
 	}
@@ -1401,6 +1549,7 @@ public:
 		bool depth_feedback       : 1; ///< Depth feedback loops can be done with DS directly (otherwise need to copy to separate RT).  Implies `feedback_loops`.
 		bool aa1                  : 1; ///< Supports the GS AA1 feature.
 		bool rov                  : 1; ///< Supports rasterizer ordered views for both depth and color.
+		bool depth_integer        : 1; ///< Supports 32 bit integer for depth buffer.
 		FeatureSupport()
 		{
 			memset(this, 0, sizeof(*this));
@@ -1628,8 +1777,7 @@ public:
 	/// Sleeps to the time the next frame can be displayed.
 	void ThrottlePresentation();
 
-	void ClearRenderTarget(GSTexture* t, u32 c);
-	void ClearDepth(GSTexture* t, float d);
+	void ClearRenderTarget(GSTexture* t, u32 value);
 	bool ProcessClearsBeforeCopy(GSTexture* sTex, GSTexture* dTex, const bool full_copy);
 	void InvalidateRenderTarget(GSTexture* t);
 
@@ -1647,9 +1795,9 @@ public:
 	GSTexture* CreateFeedbackTarget(const GSVector2i& size, GSTexture::Format format, bool clear = true, bool prefer_reuse = true);
 	GSTexture* CreateShaderWriteTarget(int w, int h, GSTexture::Format format, bool clear = true, bool prefer_reuse = true);
 	GSTexture* CreateShaderWriteTarget(const GSVector2i& size, GSTexture::Format format, bool clear = true, bool prefer_reuse = true);
+	GSTexture* CreateTexture(int w, int h, int mipmap_levels, GSTexture::Format format, bool prefer_reuse = false);
 	GSTexture* CreateDepthStencil(int w, int h, bool clear = true, bool prefer_reuse = true);
 	GSTexture* CreateDepthStencil(const GSVector2i& size, bool clear = true, bool prefer_reuse = true);
-	GSTexture* CreateTexture(int w, int h, int mipmap_levels, GSTexture::Format format, bool prefer_reuse = false);
 	GSTexture* CreateTexture(const GSVector2i& size, int mipmap_levels, GSTexture::Format format, bool prefer_reuse = false);
 	GSTexture* CreateCompatible(GSTexture* tex, bool clear = true, bool prefer_reuse = true);
 	GSTexture* CreateCompatible(GSTexture* tex, const GSVector2i& size, bool clear = true, bool prefer_reuse = true);

--- a/pcsx2/GS/Renderers/Common/GSShaderEnums.h
+++ b/pcsx2/GS/Renderers/Common/GSShaderEnums.h
@@ -11,12 +11,15 @@ namespace GSShader {
 
 enum class VSExpand : uint8_t
 {
-	None        = 0,
-	Point       = 1,
-	Line        = 2,
-	Sprite      = 3,
-	LineAA1     = 4,
-	TriangleAA1 = 5,
+	None             = 0,
+	Point            = 1,
+	Line             = 2,
+	Sprite           = 3,
+	LineAA1          = 4,
+	TriangleAA1      = 5,
+	PointZInteger    = 6,
+	LineZInteger     = 7,
+	TriangleZInteger = 8,
 };
 
 enum class PS_ATST : uint32_t
@@ -58,9 +61,16 @@ enum class PS_AA1 : uint32_t
 
 enum class PS_ROV_DEPTH : uint32_t
 {
-	NONE = 0,
+	NONE       = 0,
 	READ_WRITE = 1,
-	READ_ONLY = 2,
+	READ_ONLY  = 2,
+};
+
+enum class PS_Z_INTEGER : uint32_t
+{
+	NONE       = 0,
+	READ_WRITE = 1,
+	READ_ONLY  = 2,
 };
 
 } // namespace GSShader

--- a/pcsx2/GS/Renderers/Common/GSTexture.cpp
+++ b/pcsx2/GS/Renderers/Common/GSTexture.cpp
@@ -44,7 +44,7 @@ bool GSTexture::Save(const std::string& fn)
 {
 	// Depth textures need special treatment - we have a stencil component.
 	// Just re-use the existing conversion shader instead.
-	if (m_format == Format::DepthStencil || m_format == Format::DepthColor)
+	if (m_format == Format::DepthStencil || m_format == Format::DepthColor || m_format == Format::DepthInteger)
 	{
 		GSTexture* temp = g_gs_device->CreateRenderTarget(GetWidth(), GetHeight(), Format::Color, false);
 		if (!temp)
@@ -98,6 +98,7 @@ const char* GSTexture::GetFormatName(Format format)
 		case Format::ColorClip:    return "ColorClip";
 		case Format::DepthStencil: return "DepthStencil";
 		case Format::DepthColor:   return "DepthColor";
+		case Format::DepthInteger: return "DepthInteger";
 		case Format::UNorm8:       return "UNorm8";
 		case Format::UInt16:       return "UInt16";
 		case Format::UInt32:       return "UInt32";
@@ -201,12 +202,22 @@ u32 GSTexture::CalcUploadSize(Format format, u32 height, u32 pitch)
 bool GSTexture::IsFeedbackFormat(Format format)
 {
 	return format == Format::Color || format == Format::ColorClip ||
-		format == Format::DepthColor || format == Format::DepthStencil;
+		format == Format::DepthColor || format == Format::DepthStencil ||
+		format == Format::DepthInteger;
 }
 
 bool GSTexture::IsShaderWriteFormat(Format format)
 {
-	return format == Format::Color || format == Format::DepthColor;
+	return format == Format::Color || format == Format::DepthColor || format == Format::DepthInteger;
+}
+
+bool GSTexture::AreFormatsEquivalent(Format format1, Format format2)
+{
+	return (format1 == format2) ||
+	       (format1 == Format::DepthColor && format2 == Format::PrimID) ||
+	       (format1 == Format::PrimID && format2 == Format::DepthColor) ||
+	       (format1 == Format::DepthInteger && format2 == Format::UInt32) ||
+	       (format1 == Format::UInt32 && format2 == Format::DepthInteger);
 }
 
 void GSTexture::GenerateMipmapsIfNeeded()

--- a/pcsx2/GS/Renderers/Common/GSTexture.h
+++ b/pcsx2/GS/Renderers/Common/GSTexture.h
@@ -54,6 +54,7 @@ public:
 		ColorClip,    ///< Color texture with more bits for colclip (wrap) emulation, given that blending requires 9bpc (RGBA16Unorm)
 		DepthStencil, ///< Depth stencil texture
 		DepthColor,   ///< For treating depth texture as RT
+		DepthInteger, ///< For full 32-bit integer depth emulation
 		UNorm8,       ///< A8UNorm texture for paletted textures and the OSD font
 		UInt16,       ///< UInt16 texture for reading back 16-bit depth
 		UInt32,       ///< UInt32 texture for reading back 24 and 32-bit depth
@@ -74,12 +75,6 @@ public:
 		Invalidated
 	};
 
-	union ClearValue
-	{
-		u32 color;
-		float depth;
-	};
-
 protected:
 	GSVector2i m_size{};
 	int m_mipmap_levels = 0;
@@ -92,7 +87,7 @@ protected:
 	u32 m_last_frame_used = 0;
 
 	bool m_needs_mipmaps_generated = true;
-	ClearValue m_clear_value = {};
+	u32 m_clear_value = 0;
 
 #ifdef PCSX2_DEVBUILD
 	std::string m_debug_name;
@@ -137,6 +132,7 @@ public:
 	static u32 CalcUploadSize(Format format, u32 height, u32 pitch);
 	static bool IsFeedbackFormat(Format format);
 	static bool IsShaderWriteFormat(Format format);
+	static bool AreFormatsEquivalent(Format format1, Format format2);
 
 	u32 GetCompressedBytesPerBlock() const;
 	u32 GetCompressedBlockSize() const;
@@ -159,6 +155,10 @@ public:
 	static __fi bool IsDepthColor(Usage usage, Format format)
 	{
 		return IsRenderTarget(usage) && (format == Format::DepthColor);
+	}
+	static __fi bool IsDepthInteger(Usage usage, Format format)
+	{
+		return IsRenderTarget(usage) && (format == Format::DepthInteger);
 	}
 	static __fi bool IsTexture(Usage usage)
 	{
@@ -198,6 +198,10 @@ public:
 	{
 		return IsDepthColor(m_usage, m_format);
 	}
+	__fi bool IsDepthInteger() const
+	{
+		return IsDepthInteger(m_usage, m_format);
+	}
 	__fi bool IsTexture() const
 	{
 		return IsTexture(m_usage);
@@ -218,11 +222,18 @@ public:
 	{
 		return IsFeedbackOrShaderWrite(m_usage);
 	}
-
 	virtual bool IsShaderWriteMode() const
 	{
 		// Backends that track state explicitly can specialize this to use the actual state.
 		return IsShaderWrite();
+	}
+	__fi bool IsFloat32Like() const
+	{
+		return IsDepthStencil() || IsDepthColor();
+	}
+	__fi bool IsIntegerFormat() const
+	{
+		return m_format == Format::UInt16 || m_format == Format::UInt32 || m_format == Format::DepthInteger;
 	}
 
 	__fi State GetState() const { return m_state; }
@@ -231,24 +242,13 @@ public:
 	__fi u32 GetLastFrameUsed() const { return m_last_frame_used; }
 	void SetLastFrameUsed(u32 frame) { m_last_frame_used = frame; }
 
-	__fi u32 GetClearColor() const { return m_clear_value.color; }
-	__fi float GetClearDepth() const { return m_clear_value.depth; }
-	__fi GSVector4 GetUNormClearColor() const { return GSVector4::unorm8(m_clear_value.color); }
-	__fi GSVector4 GetClearForFormat() const
-	{
-		return IsDepthLike() ? GSVector4(m_clear_value.depth, 0.0f, 0.0f, 0.0f) : GetUNormClearColor();
-	}
-
-	__fi void SetClearColor(u32 color)
+	__fi u32 GetClearValue() const { return m_clear_value; }
+	__fi void SetClearValue(u32 value)
 	{
 		m_state = State::Cleared;
-		m_clear_value.color = color;
+		m_clear_value = value;
 	}
-	__fi void SetClearDepth(float depth)
-	{
-		m_state = State::Cleared;
-		m_clear_value.depth = depth;
-	}
+	__fi float GetClearDepth() const { return static_cast<float>(m_clear_value) * 0x1p-32; }
 
 	void GenerateMipmapsIfNeeded();
 	void ClearMipmapGenerationFlag() { m_needs_mipmaps_generated = false; }

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -79,6 +79,7 @@ GSDevice11::GSDevice11()
 	m_features.test_and_sample_depth = false;
 	m_features.depth_feedback = false;
 	m_features.aa1 = false;
+	m_features.depth_integer = false;
 }
 
 GSDevice11::~GSDevice11() = default;
@@ -251,7 +252,8 @@ bool GSDevice11::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 		sm_ps.AddMacro("PIXEL_SHADER", 1);
 		sm_ps.AddMacro("HAS_BILN", static_cast<int>(shader.Biln()));
 		sm_ps.AddMacro("HAS_STENCIL_OUTPUT", static_cast<int>(shader.StencilOutput()));
-		sm_ps.AddMacro("HAS_INTEGER_OUTPUT", static_cast<int>(shader.IntegerOutputBpp() != 0));
+		sm_ps.AddMacro("HAS_INTEGER_INPUT", static_cast<int>(shader.IntegerInput()));
+		sm_ps.AddMacro("HAS_INTEGER_OUTPUT", static_cast<int>(shader.IntegerOutput()));
 		sm_ps.AddMacro("HAS_DEPTH_OUTPUT", static_cast<int>(shader.DepthOutput()));
 		sm_ps.AddMacro("HAS_FLOAT32_INPUT", static_cast<int>(shader.Float32Input()));
 		sm_ps.AddMacro("HAS_FLOAT32_OUTPUT", static_cast<int>(shader.Float32Output()));
@@ -437,7 +439,7 @@ bool GSDevice11::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 		}
 	}
 
-	if (m_features.aa1)
+	if (UseVSExpandIndexBuffer())
 	{
 		bd.ByteWidth = INDEX_BUFFER_SIZE;
 		bd.BindFlags = D3D11_BIND_SHADER_RESOURCE;
@@ -715,6 +717,7 @@ void GSDevice11::SetFeatures(IDXGIAdapter1* adapter)
 	m_features.test_and_sample_depth = (m_feature_level >= D3D_FEATURE_LEVEL_11_0);
 	m_features.depth_feedback = m_features.multidraw_fb_copy && GSConfig.DepthFeedbackMode == GSDepthFeedbackMode::Depth;
 	m_features.aa1 = GSConfig.HWAA1 && m_features.vs_expand && m_features.feedback_loops();
+	m_features.depth_integer = GSConfig.HWZIntegerMode != GSHardwareZIntegerMode::Disabled && m_features.vs_expand;
 
 	m_max_texture_size = (m_feature_level >= D3D_FEATURE_LEVEL_11_0) ?
 	                         D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION :
@@ -1417,7 +1420,7 @@ void GSDevice11::CommitClear(GSTexture* t)
 		if (T->GetState() == GSTexture::State::Invalidated)
 			m_ctx->DiscardView(static_cast<ID3D11RenderTargetView*>(*T));
 		else
-			m_ctx->ClearRenderTargetView(*T, T->GetClearForFormat().F32);
+			m_ctx->ClearRenderTargetView(*T, T->GetDX11ClearValue().F32);
 	}
 
 	T->SetState(GSTexture::State::Dirty);
@@ -1971,6 +1974,7 @@ void GSDevice11::SetupVS(VSSelector sel, const GSHWDrawConfig::VSConstantBuffer*
 		sm.AddMacro("VS_FST", sel.fst);
 		sm.AddMacro("VS_IIP", sel.iip);
 		sm.AddMacro("VS_EXPAND", static_cast<int>(sel.expand));
+		sm.AddMacro("VS_Z_INTEGER", sel.zint);
 
 		static constexpr const D3D11_INPUT_ELEMENT_DESC layout[] =
 			{
@@ -2081,6 +2085,9 @@ void GSDevice11::SetupPS(const PSSelector& sel, const GSHWDrawConfig::PSConstant
 		sm.AddMacro("PS_ANISOTROPIC_FILTERING", sel.sw_aniso);
 		sm.AddMacro("PS_ROV_COLOR", sel.rov_color);
 		sm.AddMacro("PS_ROV_DEPTH", static_cast<u32>(sel.rov_depth));
+		sm.AddMacro("PS_Z_RT_SLOT", sel.z_rt_slot);
+		sm.AddMacro("PS_Z_INTEGER", static_cast<u32>(sel.zint));
+		sm.AddMacro("PS_TEX_INTEGER", sel.texint);
 
 		wil::com_ptr_nothrow<ID3D11PixelShader> ps = m_shader_cache.GetPixelShader(m_dev.get(), m_tfx_source, sm.GetPtr(), "ps_main");
 		i = m_ps.try_emplace(sel, std::move(ps)).first;
@@ -2234,6 +2241,14 @@ void GSDevice11::SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, u8 
 			bd.RenderTarget[0].RenderTargetWriteMask |= D3D11_COLOR_WRITE_ENABLE_BLUE;
 		if (bsel.colormask.wa)
 			bd.RenderTarget[0].RenderTargetWriteMask |= D3D11_COLOR_WRITE_ENABLE_ALPHA;
+
+		if (bsel.ds_as_rt)
+		{
+			bd.RenderTarget[bsel.ds_as_rt_slot].BlendEnable = false;
+			bd.RenderTarget[bsel.ds_as_rt_slot].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
+
+			bd.IndependentBlendEnable = (bsel.ds_as_rt_slot != 0);
+		}
 
 		wil::com_ptr_nothrow<ID3D11BlendState> bs;
 		m_dev->CreateBlendState(&bd, bs.put());
@@ -2820,14 +2835,16 @@ void GSDevice11::PSUpdateShaderState(const bool sr_update, const bool ss_update)
 	}
 }
 
-void GSDevice11::PSUnbindConflictingSRVs(GSTexture* tex1, GSTexture* tex2)
+void GSDevice11::PSUnbindConflictingSRVs(GSTexture* tex1, GSTexture* tex2, GSTexture* tex3)
 {
 	// Make sure no SRVs are bound using the same texture before binding it to a RTV.
 	bool changed = false;
 	for (size_t i = 0; i < MAX_TEXTURES; i++)
 	{
 		// We chech against what's currently bound, then update pending state which calls PSUpdateShaderState to update gpu state.
-		if ((tex1 && m_state.ps_current_srv[i] == *static_cast<GSTexture11*>(tex1)) || (tex2 && m_state.ps_current_srv[i] == *static_cast<GSTexture11*>(tex2)))
+		if ((tex1 && m_state.ps_current_srv[i] == *static_cast<GSTexture11*>(tex1)) ||
+			(tex2 && m_state.ps_current_srv[i] == *static_cast<GSTexture11*>(tex2)) ||
+			(tex3 && m_state.ps_current_srv[i] == *static_cast<GSTexture11*>(tex3)))
 		{
 			// Local and gpu cached state can differ, if it does check if it conflicts and if it doesn't then we can bind that instead of unbinding.
 			const bool unbind_needed = (tex1 && m_state.ps_pending_srv[i] == *static_cast<GSTexture11*>(tex1)) || (tex2 && m_state.ps_pending_srv[i] == *static_cast<GSTexture11*>(tex2));
@@ -2926,7 +2943,7 @@ void GSDevice11::OMSetRenderTargets(GSTexture* rt, GSTexture* ds_as_rt, GSTextur
 			m_state.dsv_as_rtv->Release();
 		if (dsv_as_rtv)
 			dsv_as_rtv->AddRef();
-		m_state.rtv = dsv_as_rtv;
+		m_state.dsv_as_rtv = dsv_as_rtv;
 		m_state.current_ds_as_rt = ds_as_rt;
 	}
 	if (m_state.dsv != dsv)
@@ -2984,6 +3001,7 @@ void GSDevice11::OMSetRenderTargets(GSTexture* rt, GSTexture* ds_as_rt, GSTextur
 	{
 		const GSVector2i size =
 			rt ? rt->GetSize() :
+			ds_as_rt ? ds_as_rt->GetSize() :
 			ds ? ds->GetSize() :
 			(rt_uav_tex && rt_uav_tex != m_null_texture) ? rt_uav_tex->GetSize() :
 			ds_uav_tex->GetSize();
@@ -3047,15 +3065,18 @@ D3D_SHADER_MACRO* GSDevice11::ShaderMacro::GetPtr()
 
 void GSDevice11::RenderHW(GSHWDrawConfig& config)
 {
-	const GSVector2i rtsize = (config.rt ? config.rt : config.ds)->GetSize();
+	const GSVector2i rtsize = (config.rt ? config.rt : (config.ds ? config.ds : config.ds_int))->GetSize();
 	GSTexture* colclip_rt = g_gs_device->GetColorClipTexture();
 	GSTexture* draw_rt = config.ps.HasColorROV() ? nullptr : config.rt;
-	GSTexture* draw_ds_as_rt = m_ds_as_rt;
-	GSTexture* draw_ds = config.ps.HasDepthROV() ? nullptr : config.ds;
+	GSTexture* draw_ds_as_rt = config.ps.HasDepthROV() ? nullptr : (config.ds_int ? config.ds_int : m_ds_as_rt);
+	GSTexture* draw_ds = (config.ps.HasDepthROV() || config.ds_int) ? nullptr : config.ds;
+	const bool ds_as_rt_write = !config.ps.HasDepthROV() && config.ds_int && (config.ps.zint == GSHWDrawConfig::PS_Z_INTEGER::READ_WRITE);
+	const u32 ds_as_rt_slot = ds_as_rt_write ? config.ps.z_rt_slot : 0;
 	GSTexture* draw_rt_rov = config.ps.HasColorROV() ? config.rt : nullptr;
-	GSTexture* draw_ds_rov = config.ps.HasDepthROV() ? config.ds : nullptr;
+	GSTexture* draw_ds_rov = config.ps.HasDepthROV() ? (config.ds_int ? config.ds_int : config.ds) : nullptr;
 	GSTexture* draw_rt_clone = nullptr;
 	GSTexture* draw_ds_clone = nullptr;
+	GSTexture* draw_ds_as_rt_clone = nullptr;
 	GSTexture* primid_texture = nullptr;
 	
 	ScopedGuard recycle_temp_textures([&]() {
@@ -3191,7 +3212,7 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 		const OMBlendSelector blend(GSHWDrawConfig::ColorMaskSelector(1),
 			GSHWDrawConfig::BlendState(true, CONST_ONE, CONST_ONE, 3 /* MIN */, CONST_ONE, CONST_ZERO, false, 0));
 		SetupOM(dss, blend, 0);
-		OMSetRenderTargets(primid_texture, nullptr, config.ds, nullptr, nullptr, &config.scissor, read_only_dsv);
+		OMSetRenderTargets(primid_texture, nullptr, draw_ds, nullptr, nullptr, &config.scissor, read_only_dsv);
 		SetRenderHWShaderResources(config, nullptr);
 		Draw(config);
 
@@ -3220,8 +3241,8 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 		draw_ds_rov = m_state.current_ds_uav;
 	}
 
-	const bool rt_feedbackloop_pass1 = config.IsFeedbackLoopRT(config.ps);
-	const bool rt_feedbackloop_pass2 = config.IsFeedbackLoopRT(config.alpha_second_pass.ps);
+	const bool rt_feedbackloop_pass1 = draw_rt && config.IsFeedbackLoopRT(config.ps);
+	const bool rt_feedbackloop_pass2 = draw_rt && config.IsFeedbackLoopRT(config.alpha_second_pass.ps);
 	if (draw_rt && !draw_rt_rov && (((config.require_one_barrier || (config.require_full_barrier && m_features.multidraw_fb_copy)) &&
 		(rt_feedbackloop_pass1 || rt_feedbackloop_pass2))))
 	{
@@ -3234,7 +3255,7 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 
 	const bool ds_feedbackloop_pass1 = config.IsFeedbackLoopDepth(config.ps);
 	const bool ds_feedbackloop_pass2 = config.IsFeedbackLoopDepth(config.alpha_second_pass.ps);
-	if (draw_ds && !draw_ds_rov && (config.require_one_barrier || (config.require_full_barrier && m_features.multidraw_fb_copy)) &&
+	if ((draw_ds || draw_ds_as_rt) && !draw_ds_rov && (config.require_one_barrier || (config.require_full_barrier && m_features.multidraw_fb_copy)) &&
 		(ds_feedbackloop_pass1 || ds_feedbackloop_pass2))
 	{
 		// Requires a copy of the DS.
@@ -3246,14 +3267,14 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 
 	OMSetRenderTargets(draw_rt, draw_ds_as_rt, draw_ds, draw_rt_rov, draw_ds_rov, &config.scissor, read_only_dsv);
 	SetRenderHWShaderResources(config, primid_texture);
-	SetupOM(config.depth, OMBlendSelector(config.colormask, config.blend), config.blend.constant);
+	SetupOM(config.depth, OMBlendSelector(config.colormask, config.blend, ds_as_rt_write, ds_as_rt_slot), config.blend.constant);
 
 	// Clear stencil as close as possible to the RT bind, to avoid framebuffer swaps.
 	if (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::StencilOne && need_barrier)
 		m_ctx->ClearDepthStencilView(*static_cast<GSTexture11*>(draw_ds), D3D11_CLEAR_STENCIL, 0.0f, 1);
 
-	SendHWDraw(config, rt_feedbackloop_pass1 ? draw_rt_clone : nullptr, draw_rt, ds_feedbackloop_pass1 ? draw_ds_clone : nullptr, draw_ds_as_rt ? draw_ds_as_rt : draw_ds,
-		config.require_one_barrier, config.require_full_barrier, rtsize);
+	SendHWDraw(config, rt_feedbackloop_pass1 ? draw_rt_clone : nullptr, draw_rt, ds_feedbackloop_pass1 ? draw_ds_clone : nullptr,
+		draw_ds_as_rt ? draw_ds_as_rt : draw_ds, config.require_one_barrier, config.require_full_barrier, rtsize);
 
 	if (config.blend_multi_pass.enable)
 	{
@@ -3302,21 +3323,22 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 }
 
 void GSDevice11::FeedbackCopyAndBind(const GSHWDrawConfig& config,
-	GSTexture* rt, GSTexture* rt_clone, GSTexture* ds, GSTexture* ds_clone, const GSVector4i& copyarea)
+	GSTexture* rt, GSTexture* rt_clone,
+	GSTexture* ds, GSTexture* ds_clone, const GSVector4i& copyarea)
 {
 	if (rt_clone)
 	{
 		CopyRect(rt, rt_clone, copyarea, copyarea.left, copyarea.top);
-		PSSetShaderResource(2, rt_clone);
+		PSSetShaderResource(TEXTURE_RT, rt_clone);
 		if (config.tex_hazard == GSHWDrawConfig::TEX_HAZARD_RT)
-			PSSetShaderResource(0, rt_clone);
+			PSSetShaderResource(TEXTURE_TEXTURE, rt_clone);
 	}
 	if (ds_clone)
 	{
 		CopyRect(ds, ds_clone, copyarea, copyarea.left, copyarea.top);
-		PSSetShaderResource(4, ds_clone);
+		PSSetShaderResource(TEXTURE_DEPTH, ds_clone);
 		if (config.tex_hazard == GSHWDrawConfig::TEX_HAZARD_DEPTH)
-			PSSetShaderResource(0, ds_clone);
+			PSSetShaderResource(TEXTURE_TEXTURE, ds_clone);
 	}
 }
 
@@ -3354,7 +3376,8 @@ void GSDevice11::FeedbackCopyAndBind(const GSHWDrawConfig& config,
 };
 
 void GSDevice11::SendHWDraw(const GSHWDrawConfig& config,
-	GSTexture* draw_rt_clone, GSTexture* draw_rt, GSTexture* draw_ds_clone, GSTexture* draw_ds,
+	GSTexture* draw_rt_clone, GSTexture* draw_rt,
+	GSTexture* draw_ds_clone, GSTexture* draw_ds,
 	const bool one_barrier, const bool full_barrier, GSVector2i rtsize)
 {
 #ifdef PCSX2_DEVBUILD
@@ -3391,7 +3414,8 @@ void GSDevice11::SendHWDraw(const GSHWDrawConfig& config,
 
 	if (one_barrier)
 	{
-		FeedbackCopyAndBind(config, draw_rt, draw_rt_clone, draw_ds, draw_ds_clone, config.drawarea, config.samplearea);
+		FeedbackCopyAndBind(config, draw_rt, draw_rt_clone, draw_ds, draw_ds_clone,
+			config.drawarea, config.samplearea);
 	}
 
 	Draw(config);

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -34,17 +34,22 @@ public:
 		struct
 		{
 			GSHWDrawConfig::ColorMaskSelector colormask;
-			u8 pad[3];
+			u8 ds_as_rt;
+			u8 ds_as_rt_slot;
+			u8 pad[1];
 			GSHWDrawConfig::BlendState blend;
 		};
 		u64 key;
 
 		constexpr OMBlendSelector() : key(0) {}
-		constexpr OMBlendSelector(GSHWDrawConfig::ColorMaskSelector colormask_, GSHWDrawConfig::BlendState blend_)
+		constexpr OMBlendSelector(GSHWDrawConfig::ColorMaskSelector colormask_, GSHWDrawConfig::BlendState blend_,
+			bool ds_as_rt_ = false, u8 ds_as_rt_slot_ = 0)
 		{
 			key = 0;
 			colormask = colormask_;
 			blend = blend_;
+			ds_as_rt = ds_as_rt_;
+			ds_as_rt_slot = ds_as_rt_slot_;
 		}
 	};
 	static_assert(sizeof(OMBlendSelector) == sizeof(u64));
@@ -97,6 +102,8 @@ private:
 	};
 
 	void SetFeatures(IDXGIAdapter1* adapter);
+
+	bool UseVSExpandIndexBuffer() const { return m_features.aa1 || m_features.depth_integer; }
 
 	u32 GetSwapChainBufferCount() const;
 	bool CreateSwapChain();
@@ -397,7 +404,7 @@ public:
 	void PSSetShaderResource(int i, GSTexture* sr);
 	void PSSetShader(ID3D11PixelShader* ps, ID3D11Buffer* ps_cb);
 	void PSUpdateShaderState(const bool sr_update, const bool ss_update);
-	void PSUnbindConflictingSRVs(GSTexture* tex1 = nullptr, GSTexture* tex2 = nullptr);
+	void PSUnbindConflictingSRVs(GSTexture* tex1 = nullptr, GSTexture* tex2 = nullptr, GSTexture* tex3 = nullptr);
 	void PSSetSamplerState(ID3D11SamplerState* ss0);
 
 	void OMSetDepthStencilState(ID3D11DepthStencilState* dss, u8 sref);

--- a/pcsx2/GS/Renderers/DX11/GSTexture11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSTexture11.cpp
@@ -34,6 +34,7 @@ DXGI_FORMAT GSTexture11::GetDXGIFormat(Format format)
 		case GSTexture::Format::ColorClip:    return DXGI_FORMAT_R16G16B16A16_UNORM;
 		case GSTexture::Format::DepthStencil: return DXGI_FORMAT_R32G8X24_TYPELESS;
 		case GSTexture::Format::DepthColor:   return DXGI_FORMAT_R32_FLOAT;
+		case GSTexture::Format::DepthInteger: return DXGI_FORMAT_R32_UINT;
 		case GSTexture::Format::UNorm8:       return DXGI_FORMAT_A8_UNORM;
 		case GSTexture::Format::UInt16:       return DXGI_FORMAT_R16_UINT;
 		case GSTexture::Format::UInt32:       return DXGI_FORMAT_R32_UINT;
@@ -196,6 +197,30 @@ ID3D11DepthStencilView* GSTexture11::ReadOnlyDepthStencilView()
 	return m_read_only_dsv.get();
 }
 
+GSVector4 GSTexture11::GetDX11ClearValue()
+{
+	if (IsDepthStencil())
+	{
+		return GSVector4(GetClearDepth(), 0.0f, 0.0f, 0.0f);
+	}
+	else if (IsRenderTarget())
+	{
+		if (IsDepthInteger())
+		{
+			return GSVector4(static_cast<float>(GetClearValue()), 0.0f, 0.0f, 0.0f);
+		}
+		else
+		{
+			return GSVector4::unorm8(GetClearValue());
+		}
+	}
+	else
+	{
+		pxAssert(false);
+		return GSVector4::zero();
+	}
+}
+
 GSDownloadTexture11::GSDownloadTexture11(wil::com_ptr_nothrow<ID3D11Texture2D> tex, u32 width, u32 height, GSTexture::Format format)
 	: GSDownloadTexture(width, height, format)
 	, m_texture(std::move(tex))
@@ -235,7 +260,7 @@ std::unique_ptr<GSDownloadTexture11> GSDownloadTexture11::Create(u32 width, u32 
 void GSDownloadTexture11::CopyFromTexture(
 	const GSVector4i& drc, GSTexture* stex, const GSVector4i& src, u32 src_level, bool use_transfer_pitch)
 {
-	pxAssert(stex->GetFormat() == m_format);
+	pxAssert(GSTexture::AreFormatsEquivalent(stex->GetFormat(), m_format));
 	pxAssert(drc.width() == src.width() && drc.height() == src.height());
 	pxAssert(src.z <= stex->GetWidth() && src.w <= stex->GetHeight());
 	pxAssert(static_cast<u32>(drc.z) <= m_width && static_cast<u32>(drc.w) <= m_height);

--- a/pcsx2/GS/Renderers/DX11/GSTexture11.h
+++ b/pcsx2/GS/Renderers/DX11/GSTexture11.h
@@ -43,6 +43,8 @@ public:
 	operator ID3D11UnorderedAccessView*();
 
 	ID3D11DepthStencilView* ReadOnlyDepthStencilView();
+
+	GSVector4 GetDX11ClearValue();
 };
 
 class GSDownloadTexture11 final : public GSDownloadTexture

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -1504,6 +1504,8 @@ bool GSDevice12::CheckFeatures(const u32& vendor_id)
 	m_features.vs_expand = !GSConfig.DisableVertexShaderExpand;
 	m_features.depth_feedback = false;
 	m_features.aa1 = GSConfig.HWAA1 && m_features.vs_expand && m_features.feedback_loops();
+	m_features.depth_integer = GSConfig.HWZIntegerMode != GSHardwareZIntegerMode::Disabled &&
+		m_features.vs_expand && m_features.feedback_loops();
 
 	m_features.dxt_textures = SupportsTextureFormat(DXGI_FORMAT_BC1_UNORM) &&
 	                          SupportsTextureFormat(DXGI_FORMAT_BC2_UNORM) &&
@@ -1630,6 +1632,7 @@ void GSDevice12::LookupNativeFormat(GSTexture::Format format, DXGI_FORMAT* d3d_f
 			{DXGI_FORMAT_D32_FLOAT_S8X24_UINT, DXGI_FORMAT_R32_FLOAT_X8X24_TYPELESS, DXGI_FORMAT_UNKNOWN,
 				DXGI_FORMAT_D32_FLOAT_S8X24_UINT, DXGI_FORMAT_R32_FLOAT}, // DepthStencil
 			{DXGI_FORMAT_R32_FLOAT, DXGI_FORMAT_R32_FLOAT, DXGI_FORMAT_R32_FLOAT, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R32_FLOAT}, // DepthColor
+			{DXGI_FORMAT_R32_UINT, DXGI_FORMAT_R32_UINT, DXGI_FORMAT_R32_UINT, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R32_UINT}, // DepthInteger
 			{DXGI_FORMAT_A8_UNORM, DXGI_FORMAT_A8_UNORM, DXGI_FORMAT_A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_A8_UNORM}, // UNorm8
 			{DXGI_FORMAT_R16_UINT, DXGI_FORMAT_R16_UINT, DXGI_FORMAT_R16_UINT, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R16_UINT}, // UInt16
 			{DXGI_FORMAT_R32_UINT, DXGI_FORMAT_R32_UINT, DXGI_FORMAT_R32_UINT, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R32_UINT}, // UInt32
@@ -1721,7 +1724,7 @@ void GSDevice12::CopyRect(GSTexture* sTex, GSTexture* dTex, const GSVector4i& r,
 			{
 				dTex12->TransitionToState(GSTexture12::ResourceState::RenderTarget);
 				GetCommandList().list4->ClearRenderTargetView(
-					dTex12->GetWriteDescriptor(), sTex12->GetClearForFormat().v, 0, nullptr);
+					dTex12->GetWriteDescriptor(), sTex12->GetDX12ClearValue().v, 0, nullptr);
 			}
 			else
 			{
@@ -2010,14 +2013,17 @@ void GSDevice12::BeginRenderPassForStretchRect(
 		BeginRenderPass(load_op, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE,
 			D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
 			D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
-			dTex->GetClearForFormat());
+			D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
+			dTex->GetDX12ClearValue());
 	}
 	else
 	{
-		BeginRenderPass(D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS,
-			D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS, load_op, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE,
+		BeginRenderPass(
 			D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
-			GSVector4::zero(), dTex->GetClearDepth());
+			D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
+			load_op, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE,
+			D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
+			GSVector4::zero(), GSVector4::zero(), dTex->GetClearDepth());
 	}
 }
 
@@ -2103,10 +2109,10 @@ void GSDevice12::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 	// transition everything before starting the new render pass
 	const bool has_input_0 =
 		(sTex[0] && (sTex[0]->GetState() == GSTexture::State::Dirty ||
-						(sTex[0]->GetState() == GSTexture::State::Cleared || sTex[0]->GetClearColor() != 0)));
+						(sTex[0]->GetState() == GSTexture::State::Cleared || sTex[0]->GetClearValue() != 0)));
 	const bool has_input_1 = (PMODE.SLBG == 0 || feedback_write_2_but_blend_bg) && sTex[1] &&
 	                         (sTex[1]->GetState() == GSTexture::State::Dirty ||
-	                             (sTex[1]->GetState() == GSTexture::State::Cleared || sTex[1]->GetClearColor() != 0));
+	                             (sTex[1]->GetState() == GSTexture::State::Cleared || sTex[1]->GetClearValue() != 0));
 	if (has_input_0)
 	{
 		static_cast<GSTexture12*>(sTex[0])->CommitClear();
@@ -2136,10 +2142,12 @@ void GSDevice12::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 		// Note: value outside of dRect must contains the background color (c)
 		OMSetRenderTargets(dTex, nullptr, nullptr, darea);
 		SetUtilityTexture(sTex[1], sampler);
-		BeginRenderPass(D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_CLEAR,
-			D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE, D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS,
-			D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS, D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS,
-			D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS, GSVector4::unorm8(c));
+		BeginRenderPass(
+			D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_CLEAR, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE,
+			D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
+			D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
+			D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
+			GSVector4::unorm8(c));
 		SetUtilityRootSignature();
 		SetPipeline(GetConvertPipeline(ShaderConvert::COPY));
 		DrawStretchRect(sRect[1], PMODE.SLBG ? dRect[2] : dRect[1], dsize);
@@ -2179,7 +2187,9 @@ void GSDevice12::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 	{
 		EndRenderPass();
 		OMSetRenderTargets(dTex, nullptr, nullptr, darea);
-		BeginRenderPass(D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_CLEAR, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE,
+		BeginRenderPass(
+			D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_CLEAR, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE,
+			D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
 			D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
 			D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
 			GSVector4::unorm8(c));
@@ -2711,9 +2721,10 @@ GSDevice12::ComPtr<ID3DBlob> GSDevice12::GetUtilityVertexShader(const std::strin
 	return m_shader_cache.GetVertexShader(source, sm_model.GetPtr(), entry_point);
 }
 
-GSDevice12::ComPtr<ID3DBlob> GSDevice12::GetUtilityPixelShader(const std::string& source, const char* entry_point)
+GSDevice12::ComPtr<ID3DBlob> GSDevice12::GetUtilityPixelShader(const std::string& source, const char* entry_point, bool integer_input)
 {
 	ShaderMacro sm_model;
+	sm_model.AddMacro("HAS_INTEGER_INPUT", integer_input ? "1" : "0");
 	return m_shader_cache.GetPixelShader(source, sm_model.GetPtr(), entry_point);
 }
 
@@ -2744,7 +2755,7 @@ bool GSDevice12::CreateBuffers()
 		return false;
 	}
 
-	if (!m_expand_index_stream_buffer.Create(m_features.aa1 ? INDEX_BUFFER_SIZE : 4, false))
+	if (!m_expand_index_stream_buffer.Create(UseVSExpandIndexBuffer() ? INDEX_BUFFER_SIZE : 4, false))
 	{
 		Host::ReportErrorAsync("GS", "Failed to allocate expansion index buffer (VS resource)");
 		return false;
@@ -2879,7 +2890,8 @@ bool GSDevice12::CompileConvertPipelines()
 		sm.AddMacro("PIXEL_SHADER", 1);
 		sm.AddMacro("HAS_BILN", static_cast<int>(shader.Biln()));
 		sm.AddMacro("HAS_STENCIL_OUTPUT", static_cast<int>(shader.StencilOutput()));
-		sm.AddMacro("HAS_INTEGER_OUTPUT", static_cast<int>(shader.IntegerOutputBpp() != 0));
+		sm.AddMacro("HAS_INTEGER_INPUT", static_cast<int>(shader.IntegerInput()));
+		sm.AddMacro("HAS_INTEGER_OUTPUT", static_cast<int>(shader.IntegerOutput()));
 		sm.AddMacro("HAS_DEPTH_OUTPUT", static_cast<int>(shader.DepthOutput()));
 		sm.AddMacro("HAS_FLOAT32_INPUT", static_cast<int>(shader.Float32Input()));
 		sm.AddMacro("HAS_FLOAT32_OUTPUT", static_cast<int>(shader.Float32Output()));
@@ -2897,9 +2909,9 @@ bool GSDevice12::CompileConvertPipelines()
 			return false;
 
 		D3D12::SetObjectName(pipe.get(),
-			TinyString::from_format("Convert pipeline ({}, mask={:x}, depth={}, biln={})",
-				shader.Name(), shader.Mask(), static_cast<int>(shader.DepthOutput()),
-				static_cast<int>(shader.Biln())));
+			TinyString::from_format("Convert pipeline ({}, mask={:x}, int_in={}, int_out={}, depth_out={}, biln={})",
+				shader.Name(), shader.Mask(), static_cast<int>(shader.IntegerInput()), static_cast<int>(shader.IntegerOutput()),
+			static_cast<int>(shader.DepthOutput()), static_cast<int>(shader.Biln())));
 
 		m_convert[i] = pipe;
 
@@ -3218,6 +3230,7 @@ const ID3DBlob* GSDevice12::GetTFXVertexShader(GSHWDrawConfig::VSSelector sel)
 	sm.AddMacro("VS_FST", sel.fst);
 	sm.AddMacro("VS_IIP", sel.iip);
 	sm.AddMacro("VS_EXPAND", static_cast<int>(sel.expand));
+	sm.AddMacro("VS_Z_INTEGER", sel.zint);
 
 	const char* entry_point = (sel.expand != GSHWDrawConfig::VSExpand::None) ? "vs_main_expand" : "vs_main";
 	ComPtr<ID3DBlob> vs(m_shader_cache.GetVertexShader(m_tfx_source, sm.GetPtr(), entry_point));
@@ -3298,6 +3311,9 @@ const ID3DBlob* GSDevice12::GetTFXPixelShader(const GSHWDrawConfig::PSSelector& 
 	sm.AddMacro("PS_ANISOTROPIC_FILTERING", sel.sw_aniso);
 	sm.AddMacro("PS_ROV_COLOR", sel.rov_color);
 	sm.AddMacro("PS_ROV_DEPTH", static_cast<u32>(sel.rov_depth));
+	sm.AddMacro("PS_Z_RT_SLOT", sel.z_rt_slot);
+	sm.AddMacro("PS_Z_INTEGER", static_cast<u32>(sel.zint));
+	sm.AddMacro("PS_TEX_INTEGER", sel.texint);
 
 	ComPtr<ID3DBlob> ps(m_shader_cache.GetPixelShader(m_tfx_source, sm.GetPtr(), "ps_main"));
 	it = m_tfx_pixel_shaders.emplace(sel, std::move(ps)).first;
@@ -3343,9 +3359,13 @@ GSDevice12::ComPtr<ID3D12PipelineState> GSDevice12::CreateTFXPipeline(const Pipe
 		LookupNativeFormat(format, nullptr, nullptr, &native_format, nullptr, nullptr);
 		gpb.SetRenderTarget(num_rts++, native_format);
 	}
-	if (p.ds_as_rt)
+	if (p.ds_as_rt == 1)
 	{
 		gpb.SetRenderTarget(num_rts++, DXGI_FORMAT_R32_FLOAT);
+	}
+	else if (p.ds_as_rt == 2)
+	{
+		gpb.SetRenderTarget(num_rts++, DXGI_FORMAT_R32_UINT);
 	}
 	if (p.ds)
 		gpb.SetDepthStencilFormat(DXGI_FORMAT_D32_FLOAT_S8X24_UINT);
@@ -3418,7 +3438,7 @@ GSDevice12::ComPtr<ID3D12PipelineState> GSDevice12::CreateTFXPipeline(const Pipe
 	if (p.ds_as_rt)
 	{
 		gpb.SetBlendState(num_rts - 1, false, D3D12_BLEND_ONE, D3D12_BLEND_ZERO, D3D12_BLEND_OP_ADD, D3D12_BLEND_ONE,
-			D3D12_BLEND_ZERO, D3D12_BLEND_OP_ADD);
+			D3D12_BLEND_ZERO, D3D12_BLEND_OP_ADD, p.ds_as_rt_write ? 0xF : 0);
 	}
 
 	ComPtr<ID3D12PipelineState> pipeline(gpb.Create(m_device.get(), m_shader_cache));
@@ -3650,6 +3670,7 @@ void GSDevice12::PSSetROVs(GSTexture* rt, GSTexture* ds, bool write_rt, bool wri
 	GSTexture12* d12Ds = static_cast<GSTexture12*>(ds);
 
 	pxAssert(!(d12Rt || d12Ds) || m_features.rov);
+	pxAssert(!d12Ds || d12Ds->IsDepthColor() || d12Ds->IsDepthInteger());
 
 	if (d12Rt)
 	{
@@ -3896,10 +3917,12 @@ bool GSDevice12::InRenderPass()
 	return m_in_render_pass;
 }
 
-void GSDevice12::BeginRenderPass(D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE color_begin,
-	D3D12_RENDER_PASS_ENDING_ACCESS_TYPE color_end, D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE depth_begin,
-	D3D12_RENDER_PASS_ENDING_ACCESS_TYPE depth_end, D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE stencil_begin,
-	D3D12_RENDER_PASS_ENDING_ACCESS_TYPE stencil_end, GSVector4 clear_color, float clear_depth, u8 clear_stencil)
+void GSDevice12::BeginRenderPass(
+	D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE color_begin, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE color_end, 
+	D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE depth_color_begin, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE depth_color_end,
+	D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE depth_begin, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE depth_end,
+	D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE stencil_begin, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE stencil_end,
+	GSVector4 clear_color, GSVector4 clear_depth_color, float clear_depth, u8 clear_stencil)
 {
 	if (m_in_render_pass)
 		EndRenderPass();
@@ -3930,8 +3953,14 @@ void GSDevice12::BeginRenderPass(D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE color_b
 	if (m_current_depth_render_target)
 	{
 		rt[num_rts].cpuDescriptor = m_current_depth_render_target->GetWriteDescriptor();
-		rt[num_rts].EndingAccess.Type = D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE;
-		rt[num_rts].BeginningAccess.Type = D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_PRESERVE;
+		rt[num_rts].EndingAccess.Type = depth_color_end;
+		rt[num_rts].BeginningAccess.Type = depth_color_begin;
+		if (depth_color_begin == D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_CLEAR)
+		{
+			LookupNativeFormat(m_current_depth_render_target->GetFormat(), nullptr,
+				&rt[num_rts].BeginningAccess.Clear.ClearValue.Format, nullptr, nullptr, nullptr);
+			GSVector4::store<false>(rt[num_rts].BeginningAccess.Clear.ClearValue.Color, clear_depth_color);
+		}
 		num_rts++;
 	}
 
@@ -4256,10 +4285,12 @@ void GSDevice12::SetupDATE(GSTexture* rt, GSTexture* ds, SetDATM datm, const GSV
 	SetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
 	SetPipeline(GetConvertPipeline(SetDATMShader(datm)));
 	// Reference stencil value set on Create()
-	BeginRenderPass(D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
+	BeginRenderPass(
+		D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
+		D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
 		D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_PRESERVE, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE,
 		D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_CLEAR, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE,
-		GSVector4::zero(), 0.0f, 0);
+		GSVector4::zero(), GSVector4::zero(), 0);
 	if (ApplyUtilityState())
 		DrawPrimitive();
 
@@ -4291,12 +4322,14 @@ GSTexture12* GSDevice12::SetupPrimitiveTrackingDATE(GSHWDrawConfig& config, Pipe
 	OMSetRenderTargets(image, nullptr, config.ds, config.drawarea);
 
 	// if the depth target has been cleared, we need to preserve that clear
-	BeginRenderPass(D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_DISCARD, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE,
+	BeginRenderPass(
+		D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_DISCARD, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE,
+		D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
 		config.ds ? GetLoadOpForTexture(static_cast<GSTexture12*>(config.ds)) :
 					D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS,
 		config.ds ? D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE : D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
 		D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
-		GSVector4::zero(), config.ds ? config.ds->GetClearDepth() : 0.0f);
+		GSVector4::zero(), GSVector4::zero(), config.ds ? config.ds->GetClearDepth() : 0.0f);
 
 	// draw the quad to prefill the image
 	const GSVector4 src = GSVector4(config.drawarea) / GSVector4(rtsize).xyxy();
@@ -4324,9 +4357,15 @@ GSTexture12* GSDevice12::SetupPrimitiveTrackingDATE(GSHWDrawConfig& config, Pipe
 	init_pipe.cms.wrgba = 0;
 	init_pipe.bs = {};
 	init_pipe.rt = true;
+	init_pipe.ds_as_rt = 0;
 	init_pipe.ps.blend_a = init_pipe.ps.blend_b = init_pipe.ps.blend_c = init_pipe.ps.blend_d = false;
 	init_pipe.ps.no_color = false;
 	init_pipe.ps.no_color1 = true;
+	init_pipe.ps.texint = false;
+	init_pipe.ps.zint = GSHWDrawConfig::PS_Z_INTEGER::NONE;
+	init_pipe.vs.zint = false;
+	init_pipe.vs.RemoveZIntegerExpand();
+
 	if (BindDrawPipeline(init_pipe))
 		Draw(config);
 
@@ -4371,17 +4410,16 @@ void GSDevice12::FeedbackBarrier(const GSTexture12* texture)
 
 void GSDevice12::RenderHW(GSHWDrawConfig& config)
 {
+	GSVector2i rtsize(config.rt ? config.rt->GetSize() : (config.ds_int ? config.ds_int->GetSize() : config.ds->GetSize()));
 	GSTexture12* colclip_rt = static_cast<GSTexture12*>(g_gs_device->GetColorClipTexture());
 	GSTexture12* draw_rt = config.ps.HasColorROV() ? nullptr : static_cast<GSTexture12*>(config.rt);
-	GSTexture12* draw_ds = config.ps.HasDepthROV() ? nullptr : static_cast<GSTexture12*>(config.ds);
+	GSTexture12* draw_ds = (config.ps.HasDepthROV() || config.ds_int) ? nullptr : static_cast<GSTexture12*>(config.ds);
+	GSTexture12* draw_ds_as_rt = config.ps.HasDepthROV() ? nullptr : static_cast<GSTexture12*>(config.ds_int ? config.ds_int : m_ds_as_rt);
 	GSTexture12* draw_rt_rov = config.ps.HasColorROV() ? static_cast<GSTexture12*>(config.rt) : nullptr;
-	GSTexture12* draw_ds_rov = config.ps.HasDepthROV() ? static_cast<GSTexture12*>(config.ds) : nullptr;
+	GSTexture12* draw_ds_rov = config.ps.HasDepthROV() ? static_cast<GSTexture12*>(config.ds_int ? config.ds_int : config.ds) : nullptr;
 	GSTexture12* draw_rt_clone = nullptr;
 
 	const bool feedback = draw_rt && (config.require_one_barrier || (config.require_full_barrier && m_features.texture_barrier) || (config.tex && config.tex == config.rt));
-
-	// Align the render area to 128x128, hopefully avoiding render pass restarts for small render area changes (e.g. Ratchet and Clank).
-	const GSVector2i rtsize(config.rt ? config.rt->GetSize() : config.ds->GetSize());
 
 	PipelineSelector& pipe = m_pipeline_selector;
 
@@ -4402,11 +4440,16 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 			OMSetRenderTargets(draw_rt, nullptr, draw_ds, config.colclip_update_area);
 
 			// if this target was cleared and never drawn to, perform the clear as part of the resolve here.
-			BeginRenderPass(GetLoadOpForTexture(draw_rt), D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE,
+			BeginRenderPass(
+				GetLoadOpForTexture(draw_rt),
+				D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE,
+				GetLoadOpForTexture(draw_ds_as_rt),
+				draw_ds_as_rt ? D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE : D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
 				GetLoadOpForTexture(draw_ds),
 				draw_ds ? D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE : D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
 				D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
-				draw_rt->GetClearForFormat(), 0.0f, 0);
+				draw_rt->GetDX12ClearValue(),
+				draw_ds_as_rt ? draw_ds_as_rt->GetDX12ClearValue() : GSVector4::zero(), 0.0f, 0);
 
 			const GSVector4 sRect(GSVector4(config.colclip_update_area) / GSVector4(rtsize.x, rtsize.y).xyxy());
 			SetPipeline(m_colclip_finish_pipelines[pipe.ds].get());
@@ -4457,7 +4500,7 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 	// bind textures before checking the render pass, in case we need to transition them
 	if (config.tex)
 	{
-		PSSetShaderResource(TEXTURE_TEXTURE, config.tex, config.tex != config.rt && config.tex != config.ds);
+		PSSetShaderResource(TEXTURE_TEXTURE, config.tex, config.tex != config.rt && config.tex != config.ds && config.tex != draw_ds_as_rt);
 		PSSetSampler(config.sampler);
 	}
 	if (config.pal)
@@ -4507,7 +4550,7 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 			if (draw_rt->GetState() == GSTexture::State::Cleared)
 			{
 				colclip_rt->SetState(GSTexture::State::Cleared);
-				colclip_rt->SetClearColor(draw_rt->GetClearColor());
+				colclip_rt->SetClearValue(draw_rt->GetClearValue());
 			}
 			else if (draw_rt->GetState() == GSTexture::State::Dirty)
 			{
@@ -4530,24 +4573,22 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 
 	// Avoid restarting the render pass just to switch from rt+depth to rt and vice versa.
 	// Keep the depth even if doing colclip hw draws, because the next draw will probably re-enable depth.
-	if (InRenderPass() && !(draw_rt || draw_rt_rov) && draw_ds && m_current_render_target && config.tex != m_current_render_target && 
+	if (InRenderPass() && !(draw_rt || draw_rt_rov || draw_ds_as_rt) && draw_ds && m_current_render_target && config.tex != m_current_render_target && 
 		m_current_render_target->GetSize() == draw_ds->GetSize())
 	{
 		draw_rt = m_current_render_target;
 		m_pipeline_selector.rt = true;
 	}
-	else if (InRenderPass() && !(draw_ds || draw_ds_rov) && draw_rt && m_current_depth_target && config.tex != m_current_depth_target &&
+	else if (InRenderPass() && !(draw_ds || draw_ds_rov || draw_ds_as_rt) && draw_rt && m_current_depth_target && config.tex != m_current_depth_target &&
 		m_current_depth_target->GetSize() == draw_rt->GetSize())
 	{
 		draw_ds = m_current_depth_target;
 		m_pipeline_selector.ds = true;
 	}
 
-	GSTexture12* draw_ds_as_rt = static_cast<GSTexture12*>(m_ds_as_rt);
-
 	const bool feedback_rt = draw_rt && (((config.require_one_barrier || (config.require_full_barrier && m_features.texture_barrier)) && (config.IsFeedbackLoopRT(config.ps) ||
 		config.IsFeedbackLoopRT(config.alpha_second_pass.ps))));
-	const bool feedback_depth = draw_ds_as_rt != nullptr;
+	const bool feedback_depth = pipe.ds_as_rt && config.IsFeedbackLoopDepth(config.ps);
 
 	if (feedback_rt && !m_features.texture_barrier)
 	{
@@ -4598,7 +4639,7 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 	// For depth testing and sampling, use a read only dsv, otherwise use a write dsv
 	OMSetRenderTargets(draw_rt, draw_ds_as_rt, draw_ds, config.scissor,
 		config.tex && (config.tex == draw_ds || config.ps.IsFeedbackLoopDepth()) && !config.depth.zwe && !config.ps.HasDepthROV(),
-		config.rt ? config.rt->GetSize() : config.ds->GetSize());
+		rtsize);
 
 	// DX12 equivalent of vkCmdClearAttachments for StencilOne
 	if (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::StencilOne)
@@ -4614,7 +4655,7 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 	// Begin render pass if new target or out of the area.
 	if (!InRenderPass())
 	{
-		GSVector4 clear_color = draw_rt ? draw_rt->GetClearForFormat() : GSVector4::zero();
+		GSVector4 clear_color = draw_rt ? draw_rt->GetDX12ClearValue() : GSVector4::zero();
 		if (pipe.ps.colclip_hw)
 		{
 			// Denormalize clear color for hw colclip.
@@ -4626,6 +4667,8 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 
 		BeginRenderPass(GetLoadOpForTexture(draw_rt),
 			draw_rt ? D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE : D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
+			GetLoadOpForTexture(draw_ds_as_rt),
+			draw_ds_as_rt ? D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE : D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
 			GetLoadOpForTexture(draw_ds),
 			draw_ds ? D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE : D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
 			draw_ds ? (stencil_DATE ? D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_PRESERVE :
@@ -4634,7 +4677,9 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 			draw_ds ? ((stencil_DATE && need_barrier) ? D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE :
 														D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_DISCARD) :
 					  D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
-			clear_color, draw_ds ? draw_ds->GetClearDepth() : 0.0f, 1);
+			clear_color,
+			draw_ds_as_rt ? draw_ds_as_rt->GetDX12ClearValue() : GSVector4::zero(),
+			draw_ds ? draw_ds->GetClearDepth() : 0.0f, 1);
 	}
 
 	// rt -> colclip hw blit if enabled
@@ -4718,11 +4763,15 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 			OMSetRenderTargets(draw_rt, nullptr, draw_ds, config.colclip_update_area);
 
 			// if this target was cleared and never drawn to, perform the clear as part of the resolve here.
-			BeginRenderPass(GetLoadOpForTexture(draw_rt), D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE,
+			BeginRenderPass(
+				GetLoadOpForTexture(draw_rt),
+				D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE,
+				GetLoadOpForTexture(draw_ds_as_rt),
+				draw_ds_as_rt ? D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE : D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
 				GetLoadOpForTexture(draw_ds),
 				draw_ds ? D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE : D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
 				D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
-				draw_rt->GetClearForFormat(), 0.0f, 0);
+				draw_rt->GetDX12ClearValue(), GSVector4::zero(), 0.0f, 0);
 
 			const GSVector4 sRect(GSVector4(config.colclip_update_area) / GSVector4(rtsize.x, rtsize.y).xyxy());
 			SetPipeline(m_colclip_finish_pipelines[pipe.ds].get());
@@ -4814,14 +4863,29 @@ void GSDevice12::UpdateHWPipelineSelector(GSHWDrawConfig& config)
 	m_pipeline_selector.vs.key = config.vs.key;
 	m_pipeline_selector.ps.key_hi = config.ps.key_hi;
 	m_pipeline_selector.ps.key_lo = config.ps.key_lo;
-	m_pipeline_selector.dss.key = config.ps.HasDepthROV() ? GSHWDrawConfig::DepthStencilSelector::NoDepth().key : config.depth.key;
+	m_pipeline_selector.dss.key = (config.ps.HasDepthROV() || config.ds_int) ? GSHWDrawConfig::DepthStencilSelector::NoDepth().key : config.depth.key;
 	m_pipeline_selector.bs.key = config.ps.HasColorROV() ? GSHWDrawConfig::BlendState().key : config.blend.key;
 	m_pipeline_selector.bs.constant = 0; // don't dupe states with different alpha values
 	m_pipeline_selector.cms.key = config.ps.HasColorROV() ? GSHWDrawConfig::ColorMaskSelector().key : config.colormask.key;
 	m_pipeline_selector.topology = static_cast<u32>(config.topology);
 	m_pipeline_selector.rt = config.rt != nullptr && !config.ps.HasColorROV();
-	m_pipeline_selector.ds = config.ds != nullptr && !config.ps.HasDepthROV();
-	m_pipeline_selector.ds_as_rt = m_ds_as_rt != nullptr && !config.ps.HasDepthROV();
+	m_pipeline_selector.ds = config.ds != nullptr && !config.ps.HasDepthROV() && !config.ds_int;
+	const GSTexture* ds_as_rt = config.ds_int ? config.ds_int : m_ds_as_rt;
+	if (!config.ps.HasDepthROV() && config.ds_int)
+	{
+		m_pipeline_selector.ds_as_rt = 2; // U32 depth
+		m_pipeline_selector.ds_as_rt_write = config.ps.zint == GSHWDrawConfig::PS_Z_INTEGER::READ_WRITE;
+	}
+	else if (!config.ps.HasDepthROV() && m_ds_as_rt)
+	{
+		m_pipeline_selector.ds_as_rt = 1; // F32 depth
+		m_pipeline_selector.ds_as_rt_write = 1; // Always written as this path is only for feedback.
+	}
+	else
+	{
+		m_pipeline_selector.ds_as_rt = 0;
+		m_pipeline_selector.ds_as_rt_write = 0;
+	}
 }
 
 void GSDevice12::UploadHWDrawVerticesAndIndices(GSHWDrawConfig& config)

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.h
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.h
@@ -104,6 +104,11 @@ public:
 
 	bool UseEnhancedBarriers() const { return m_enhanced_barriers; }
 
+	bool UseVSExpandIndexBuffer() const
+	{
+		return m_features.aa1 || m_features.depth_integer;
+	}
+
 	/// Returns the current command list, commands can be recorded directly.
 	const D3D12CommandList& GetCommandList() const
 	{
@@ -268,7 +273,8 @@ public:
 			{
 				u32 topology : 2;
 				u32 rt : 1;
-				u32 ds_as_rt : 1;
+				u32 ds_as_rt : 2; // 0: none, 1: Float32, 2: UInt32
+				u32 ds_as_rt_write : 1;
 				u32 ds : 1;
 			};
 
@@ -473,7 +479,7 @@ private:
 	const ID3D12PipelineState* GetTFXPipeline(const PipelineSelector& p);
 
 	ComPtr<ID3DBlob> GetUtilityVertexShader(const std::string& source, const char* entry_point);
-	ComPtr<ID3DBlob> GetUtilityPixelShader(const std::string& source, const char* entry_point);
+	ComPtr<ID3DBlob> GetUtilityPixelShader(const std::string& source, const char* entry_point, bool integer_input = false);
 
 	void FeedbackBarrier(const GSTexture12* texture);
 
@@ -629,11 +635,13 @@ public:
 	void BeginRenderPass(
 		D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE color_begin = D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS,
 		D3D12_RENDER_PASS_ENDING_ACCESS_TYPE color_end = D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
+		D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE depth_color_begin = D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS,
+		D3D12_RENDER_PASS_ENDING_ACCESS_TYPE depth_color_end = D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
 		D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE depth_begin = D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS,
 		D3D12_RENDER_PASS_ENDING_ACCESS_TYPE depth_end = D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
 		D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE stencil_begin = D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS,
 		D3D12_RENDER_PASS_ENDING_ACCESS_TYPE stencil_end = D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
-		GSVector4 clear_color = GSVector4::zero(), float clear_depth = 0.0f, u8 clear_stencil = 0);
+		GSVector4 clear_color = GSVector4::zero(), GSVector4 clear_depth_color = GSVector4::zero(), float clear_depth = 0.0f, u8 clear_stencil = 0);
 	void EndRenderPass();
 
 	void SetViewport(const D3D12_VIEWPORT& viewport);

--- a/pcsx2/GS/Renderers/DX12/GSTexture12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSTexture12.cpp
@@ -1143,19 +1143,45 @@ void GSTexture12::CommitClear()
 
 void GSTexture12::CommitClear(const D3D12CommandList& cmdlist)
 {
+	pxAssert(IsRenderTargetOrDepthStencil());
+
 	if (IsDepthStencil())
 	{
 		TransitionToState(cmdlist, ResourceState::DepthWriteStencil);
 		cmdlist.list4->ClearDepthStencilView(
-			GetWriteDescriptor(), D3D12_CLEAR_FLAG_DEPTH, m_clear_value.depth, 0, 0, nullptr);
+			GetWriteDescriptor(), D3D12_CLEAR_FLAG_DEPTH, GetClearDepth(), 0, 0, nullptr);
 	}
-	else
+	else if (IsRenderTarget())
 	{
 		TransitionToState(cmdlist, ResourceState::RenderTarget);
-		cmdlist.list4->ClearRenderTargetView(GetWriteDescriptor(), GetClearForFormat().v, 0, nullptr);
+		cmdlist.list4->ClearRenderTargetView(GetWriteDescriptor(), GetDX12ClearValue().v, 0, nullptr);
 	}
 
 	SetState(GSTexture::State::Dirty);
+}
+
+GSVector4 GSTexture12::GetDX12ClearValue() const
+{
+	if (IsDepthStencil())
+	{
+		return GSVector4(GetClearDepth(), 0.0f, 0.0f, 0.0f);
+	}
+	else if (IsRenderTarget())
+	{
+		if (IsDepthInteger())
+		{
+			return GSVector4(static_cast<float>(GetClearValue()), 0.0f, 0.0f, 0.0f);
+		}
+		else
+		{
+			return GSVector4::unorm8(GetClearValue());
+		}
+	}
+	else
+	{
+		pxAssert(false);
+		return GSVector4::zero();
+	}
 }
 
 GSDownloadTexture12::GSDownloadTexture12(u32 width, u32 height, GSTexture::Format format)
@@ -1214,7 +1240,7 @@ void GSDownloadTexture12::CopyFromTexture(
 {
 	GSTexture12* const tex12 = static_cast<GSTexture12*>(stex);
 
-	pxAssert(tex12->GetFormat() == m_format);
+	pxAssert(GSTexture::AreFormatsEquivalent(tex12->GetFormat(), m_format));
 	pxAssert(drc.width() == src.width() && drc.height() == src.height());
 	pxAssert(src.z <= tex12->GetWidth() && src.w <= tex12->GetHeight());
 	pxAssert(static_cast<u32>(drc.z) <= m_width && static_cast<u32>(drc.w) <= m_height);

--- a/pcsx2/GS/Renderers/DX12/GSTexture12.h
+++ b/pcsx2/GS/Renderers/DX12/GSTexture12.h
@@ -72,6 +72,7 @@ public:
 	void TransitionToState(ResourceState state);
 	void CommitClear();
 	void CommitClear(const D3D12CommandList& cmdlist);
+	GSVector4 GetDX12ClearValue() const;
 
 	void Destroy(bool defer = true);
 

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -822,8 +822,7 @@ bool GSHwHack::GSC_Battlefield2(GSRendererHW& r, int& skip)
 
 			if (dst)
 			{
-				float dc = r.m_vertex->buff[1].XYZ.Z;
-				g_gs_device->ClearDepth(dst->m_texture, dc * std::exp2(-32.0f));
+				g_gs_device->ClearRenderTarget(dst->m_texture, r.m_vertex->buff[1].XYZ.Z);
 			}
 		}
 	}
@@ -1084,7 +1083,7 @@ bool GSHwHack::OI_RozenMaidenGebetGarden(GSRendererHW& r, GSTexture* rt, GSTextu
 			if (GSTextureCache::Target* tmp_ds = g_texture_cache->LookupDrawTarget(TEX0, r.GetTargetSize(), r.GetTextureScaleFactor(), GSTextureCache::DepthStencil))
 			{
 				GL_INS("OI_RozenMaidenGebetGarden ZB clear");
-				g_gs_device->ClearDepth(tmp_ds->m_texture, 0.0f);
+				g_gs_device->ClearRenderTarget(tmp_ds->m_texture, 0);
 			}
 
 			return false;
@@ -1206,7 +1205,7 @@ bool GSHwHack::OI_ArTonelico2(GSRendererHW& r, GSTexture* rt, GSTexture* ds, GST
 	if (ds && r.m_vertex->next == 2 && !RPRIM->TME && RFRAME.FBW == 10 && v->XYZ.Z == 0 && RTEST.ZTST == ZTST_ALWAYS)
 	{
 		GL_INS("OI_ArTonelico2");
-		g_gs_device->ClearDepth(ds, 0.0f);
+		g_gs_device->ClearRenderTarget(ds, 0);
 	}
 
 	return true;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -20,6 +20,7 @@ GSRendererHW::GSRendererHW()
 {
 	MULTI_ISA_SELECT(GSRendererHWPopulateFunctions)(*this);
 	m_mipmap = GSConfig.HWMipmap;
+	UpdateZIntegerEnabled();
 	SetTCOffset();
 
 	pxAssert(!g_texture_cache);
@@ -2758,6 +2759,38 @@ void GSRendererHW::RoundSpriteOffset()
 	}
 }
 
+void GSRendererHW::HandleZIntegerConversion(GSTextureCache::Target* ds)
+{
+	// Convert the Z buffer F32<->U32 depending on whether the Z integer feature is enabled and the upper bits of Z are set.
+	if (ds && ds->m_texture->IsDepthStencil() && g_gs_device->Features().depth_integer && m_mem.m_psm[m_cached_ctx.ZBUF.PSM].bpp == 32 &&
+		((GSConfig.HWZIntegerMode == GSHardwareZIntegerMode::Enabled && ((static_cast<int>(m_vt.m_max.p.z) >> 24) || ds->m_alpha_max)) ||
+			GSConfig.HWZIntegerMode == GSHardwareZIntegerMode::Always))
+	{
+		// F32 -> U32
+		const int w = ds->m_texture->GetWidth();
+		const int h = ds->m_texture->GetHeight();
+		GL_PUSH("HW: Convert Z target @ 0x%x (%d x %d) F32 to U32 (alpha curr=%x, alpha draw=%x).",
+			ds->m_TEX0.TBP0, w, h, ds->m_alpha_max, static_cast<int>(m_vt.m_max.p.z) >> 24);
+		GSTexture* tmp = g_gs_device->CreateFeedbackTarget(w, h, GSTexture::Format::DepthInteger, false);
+		g_gs_device->StretchRectAuto(ds->m_texture, tmp, Nearest);
+		g_gs_device->Recycle(ds->m_texture);
+		ds->m_texture = tmp;
+	}
+	else if (ds && ds->m_texture->IsDepthInteger() && GSConfig.HWZIntegerMode < GSHardwareZIntegerMode::Always &&
+		!((static_cast<int>(m_vt.m_max.p.z) >> 24) || ds->m_alpha_max))
+	{
+		// U32 -> F32
+		const int w = ds->m_texture->GetWidth();
+		const int h = ds->m_texture->GetHeight();
+		GL_PUSH("HW: Convert Z target @ 0x%x (%d x %d) U32 to F32 (alpha curr=%x, alpha draw=%x).",
+			ds->m_TEX0.TBP0, w, h, ds->m_alpha_max, static_cast<int>(m_vt.m_max.p.z) >> 24);
+		GSTexture* tmp = g_gs_device->CreateDepthStencil(w, h, false);
+		g_gs_device->StretchRectAuto(ds->m_texture, tmp, Nearest);
+		g_gs_device->Recycle(ds->m_texture);
+		ds->m_texture = tmp;
+	}
+}
+
 void GSRendererHW::Draw()
 {
 	static u32 num_skipped_channel_shuffle_draws = 0;
@@ -3720,8 +3753,13 @@ void GSRendererHW::Draw()
 
 		if (!ds && m_cached_ctx.FRAME.FBP != m_cached_ctx.ZBUF.ZBP)
 		{
+			// Use Z integer if using Z32 and and incoming Zs are large.
+			const bool z_integer = g_gs_device->Features().depth_integer && m_mem.m_psm[m_cached_ctx.ZBUF.PSM].bpp == 32 &&
+				                   ((GSConfig.HWZIntegerMode == GSHardwareZIntegerMode::Enabled && (static_cast<int>(m_vt.m_max.p.z) >> 24)) ||
+									   GSConfig.HWZIntegerMode == GSHardwareZIntegerMode::Always);
+
 			ds = g_texture_cache->CreateTarget(ZBUF_TEX0, t_size, GetValidSize(src, possible_shuffle), target_scale, GSTextureCache::DepthStencil,
-				true, 0, false, force_preload, preserve_depth, m_r, src);
+				true, 0, false, force_preload, preserve_depth, m_r, src, z_integer);
 			if (!ds) [[unlikely]]
 			{
 				GL_INS("HW: ERROR: Failed to create ZBUF target, skipping.");
@@ -3909,6 +3947,8 @@ void GSRendererHW::Draw()
 				}
 			}
 		}
+
+		HandleZIntegerConversion(ds);
 	}
 
 	if (!no_rt)
@@ -4880,7 +4920,6 @@ void GSRendererHW::Draw()
 
 			ds->ResizeTexture(new_w, new_h);
 
-
 			if (m_using_temp_z)
 			{
 				const int z_width = g_texture_cache->GetTemporaryZ()->GetWidth() / ds->m_scale;
@@ -4888,7 +4927,8 @@ void GSRendererHW::Draw()
 
 				if (z_width != new_w || z_height != new_h)
 				{
-					if (GSTexture* tex = g_gs_device->CreateDepthStencil(new_w * ds->m_scale, new_h * ds->m_scale, true))
+					if (GSTexture* tex = g_gs_device->CreateCompatible(
+						g_texture_cache->GetTemporaryZ(), new_w * ds->m_scale, new_h * ds->m_scale, true))
 					{
 						g_gs_device->StretchRectAuto(g_texture_cache->GetTemporaryZ(), tex, Nearest);
 						g_texture_cache->InvalidateTemporaryZ();
@@ -5454,6 +5494,11 @@ void GSRendererHW::SetupIA(float target_scale, float sx, float sy, bool req_vert
 					// M1 requires point size output on *all* points.
 					m_conf.vs.point_size = true;
 				}
+
+				if (m_conf.vs.zint && m_conf.vs.expand == GSHWDrawConfig::VSExpand::None)
+				{
+					m_conf.vs.expand = GSHWDrawConfig::VSExpand::PointZInteger;
+				}
 			}
 			break;
 
@@ -5505,6 +5550,11 @@ void GSRendererHW::SetupIA(float target_scale, float sx, float sy, bool req_vert
 						m_conf.indices_per_prim = 6;
 						ExpandLineIndices();
 					}
+				}
+
+				if (m_conf.vs.zint && m_conf.vs.expand == GSHWDrawConfig::VSExpand::None)
+				{
+					m_conf.vs.expand = GSHWDrawConfig::VSExpand::LineZInteger;
 				}
 			}
 			break;
@@ -5574,6 +5624,11 @@ void GSRendererHW::SetupIA(float target_scale, float sx, float sy, bool req_vert
 						v_st = (v_st / v_q).insert32<2, 2>(v_st);
 						GSVector4::store<true>(&v[i].ST, v_st);
 					}
+				}
+
+				if (m_conf.vs.zint && m_conf.vs.expand == GSHWDrawConfig::VSExpand::None)
+				{
+					m_conf.vs.expand = GSHWDrawConfig::VSExpand::TriangleZInteger;
 				}
 			}
 			break;
@@ -5987,6 +6042,13 @@ void GSRendererHW::EmulateDATESelectMethod(DATEOptions& date_options, GSTextureC
 		GL_PERF("DATE: Fast with FBA, all pixels will be >= 128");
 		date_options.stencil_one = !m_cached_ctx.TEST.DATM;
 	}
+	else if (m_conf.ds_int)
+	{
+		// Integer depth requires full barriers anyway.
+		GL_PERF("DATE: Accurate with integer depth");
+		m_conf.require_full_barrier = true;
+		date_options.barrier = true;
+	}
 	else if (m_conf.colormask.wa && !complex_alpha_test && !(m_cached_ctx.FRAME.FBMSK & 0x80000000))
 	{
 		// Performance note: check alpha range with GetAlphaMinMax()
@@ -6083,37 +6145,8 @@ void GSRendererHW::EmulateDATEGetConfig(DATEOptions& date_options, bool scale_rt
 		m_conf.datm = static_cast<SetDATM>(m_cached_ctx.TEST.DATM);
 
 	// DATE Stencil always needs a depth stencil texture.
-	const bool date_stencil_needs_ds = !m_conf.ds &&
-		(m_conf.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::Stencil || m_conf.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::StencilOne);
-	if (date_stencil_needs_ds)
-	{
-		const bool need_barrier = m_conf.require_one_barrier || (m_conf.require_full_barrier && features.feedback_loops());
-		if ((temp_ds.reset(g_gs_device->CreateDepthStencil(m_conf.rt->GetWidth(), m_conf.rt->GetHeight(), false)), temp_ds))
-		{
-			m_conf.ds = temp_ds.get();
-		}
-		else if (need_barrier)
-		{
-			date_options.stencil_one = false;
-			date_options.barrier = true;
-			m_conf.destination_alpha = GSHWDrawConfig::DestinationAlphaMode::Full;
-			DevCon.Warning("HW: Depth buffer creation failed for Stencil Date. Fallback to Full.");
-		}
-		else if (features.primitive_id && !(m_conf.ps.scanmsk & 2))
-		{
-			date_options.stencil_one = false;
-			date_options.primid = true;
-			m_conf.destination_alpha = GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking;
-			DevCon.Warning("HW: Depth buffer creation failed for Stencil Date. Fallback to PrimIDTracking.");
-		}
-		else
-		{
-			date_options.enabled = false;
-			date_options.stencil_one = false;
-			m_conf.destination_alpha = GSHWDrawConfig::DestinationAlphaMode::Off;
-			DevCon.Warning("HW: Depth buffer creation failed for Stencil Date.");
-		}
-	}
+	// If we're doing stencil DATE and we don't have a depth buffer, we need to allocate a temporary one.
+	HandleTemporaryDSForDATE(temp_ds, date_options);
 
 	if (date_options.barrier)
 	{
@@ -6216,7 +6249,7 @@ void GSRendererHW::DetermineVSConfig(GSTextureCache::Target* rt, float rtscale, 
 	m_conf.vs.iip = !IsFlatShaded();
 }
 
-void GSRendererHW::DetermineBarriers(GSTextureCache::Target* rt, GSTextureCache::Source* tex)
+void GSRendererHW::DetermineBarriers(GSTextureCache::Target* rt, GSTextureCache::Target* ds, GSTextureCache::Source* tex)
 {
 	const GSDevice::FeatureSupport& features = g_gs_device->Features();
 
@@ -6256,7 +6289,7 @@ void GSRendererHW::DetermineBarriers(GSTextureCache::Target* rt, GSTextureCache:
 
 	if (m_conf.require_full_barrier && features.feedback_loops())
 	{
-		ComputeDrawlistGetSize(rt->m_scale);
+		ComputeDrawlistGetSize(rt ? rt->m_scale : ds->m_scale);
 		m_conf.drawlist = &m_drawlist;
 		m_conf.drawlist_bbox = &m_drawlist_bbox;
 	}
@@ -7023,7 +7056,8 @@ void GSRendererHW::EmulateBlending(int rt_alpha_min, int rt_alpha_max, DATEOptio
 
 		// If we are doing depth feedback with a second RT we must use SW blending to avoid
 		// mixing dual source blending with multiple render targets.
-		(m_conf.ps.IsFeedbackLoopDepth() && !features.depth_feedback) ||
+		// Integer depth also uses a second RT (regardless of whether feedback is needed).
+		((m_conf.ps.IsFeedbackLoopDepth() && !features.depth_feedback) || m_conf.ds_int) ||
 		
 		// Force SW blending with barriers.
 		GSConfig.UseDebugBlend;
@@ -7826,22 +7860,40 @@ void GSRendererHW::ConvertTextureTypeROVSingle(GSTextureCache::Target* tgt, bool
 {
 	const bool depth = (tgt->m_type == GSTextureCache::DepthStencil);
 
-	GSTexture* old_tex = depth ? m_conf.ds : m_conf.rt;
+	GSTexture* old_tex = depth ?  (m_conf.ds_int ? m_conf.ds_int : m_conf.ds) : m_conf.rt;
 
-	const GSTexture::Usage usage = shader_write ? GSTexture::ShaderWriteTarget : GSTexture::FeedbackTarget;
-	if (GSTexture* new_tex = depth ?
-		(shader_write ?
-			g_gs_device->FetchSurface(usage, old_tex->GetSize(), 1, GSTexture::Format::DepthColor, false, true) :
-			g_gs_device->CreateDepthStencil(old_tex->GetSize(), false, true)) :
-			g_gs_device->FetchSurface(usage, old_tex->GetSize(), 1, GSTexture::Format::Color, false, true))
+	GSTexture* new_tex;
+	if (depth)
+	{
+		if (shader_write)
+		{
+			new_tex = m_conf.ps.HasZInteger() ?
+				g_gs_device->CreateShaderWriteTarget(old_tex->GetSize(), GSTexture::Format::DepthInteger, false, true) :
+				g_gs_device->CreateShaderWriteTarget(old_tex->GetSize(), GSTexture::Format::DepthColor, false, true);
+		}
+		else
+		{
+			new_tex = g_gs_device->CreateDepthStencil(old_tex->GetSize(), false, true);
+		}
+	}
+	else
+	{
+		pxAssert(shader_write); // We shouldn't be switching back to non-shader-write color.
+		new_tex = g_gs_device->CreateShaderWriteTarget(old_tex->GetSize(), GSTexture::Format::Color, false, true);
+	}
+	
+	if (!new_tex)
+	{
+		Console.Error("HW: Failed to create texture for ROV");
+		pxFail("Failed to create texture for ROV");
+	}
+
+	if (new_tex)
 	{
 		switch (old_tex->GetState())
 		{
 			case GSTexture::State::Cleared:
-				if (depth)
-					g_gs_device->ClearDepth(new_tex, old_tex->GetClearDepth());
-				else
-					g_gs_device->ClearRenderTarget(new_tex, old_tex->GetClearColor());
+				g_gs_device->ClearRenderTarget(new_tex, old_tex->GetClearValue());
 				break;
 			case GSTexture::State::Invalidated:
 				g_gs_device->InvalidateRenderTarget(new_tex);
@@ -7891,15 +7943,25 @@ void GSRendererHW::ConvertTextureTypeROV(GSTextureCache::Target* rt, GSTextureCa
 	if (ds)
 	{
 		// Note: we must use m_conf.ds because it might be the temporary Z texture.
-		if (m_conf.ps.HasDepthROV() && !m_conf.ds->IsShaderWrite())
+		if (m_conf.ps.HasDepthROV())
 		{
-			GL_PUSH("HW: Convert DepthStencil -> DepthColor for ROV.");
-			ConvertTextureTypeROVSingle(ds, true);
+			const GSTexture::Format need_format = m_conf.ps.HasZInteger() ?
+				GSTexture::Format::DepthInteger : GSTexture::Format::DepthColor;
+			if (!m_conf.ds->IsShaderWrite() || m_conf.ds->GetFormat() != need_format)
+			{
+				GL_PUSH("HW: Convert depth texture for ROV.");
+				ConvertTextureTypeROVSingle(ds, true);
+			}
 		}
-		else if (!m_conf.ps.HasDepthROV() && !m_conf.ds->IsDepthStencil())
+		else
 		{
-			GL_PUSH("HW: Convert DepthColor -> DepthStencil for non-ROV.");
-			ConvertTextureTypeROVSingle(ds, false);
+			const GSTexture::Format need_format = m_conf.ps.HasZInteger() ?
+				GSTexture::Format::DepthInteger : GSTexture::Format::DepthStencil;
+			if (m_conf.ds->GetFormat() != need_format)
+			{
+				GL_PUSH("HW: Convert depth texture for non-ROV.");
+				ConvertTextureTypeROVSingle(ds, false);
+			}
 		}
 	}
 
@@ -8045,6 +8107,7 @@ __ri void GSRendererHW::EmulateTextureSampler(const GSTextureCache::Target* rt, 
 		if (psm.depth)
 		{
 			m_conf.ps.depth_fmt = !tex->m_texture->IsDepthLike() ? 3 : tex->m_32_bits_fmt ? 1 : 2;
+			m_conf.ps.texint = tex->m_texture->IsDepthInteger();
 		}
 
 		// Shuffle is a 16 bits format, so aem is always required
@@ -8131,6 +8194,10 @@ __ri void GSRendererHW::EmulateTextureSampler(const GSTextureCache::Target* rt, 
 
 			// Don't force interpolation on depth format
 			bilinear &= m_vt.IsLinear();
+
+			// Use integer directly if using integer depth
+			m_conf.ps.texint = g_gs_device->Features().depth_integer && tex->m_texture->IsDepthInteger();
+			bilinear &= !m_conf.ps.texint; // No bilinear for integer
 		}
 
 		const GSVector4 half_pixel = RealignTargetTextureCoordinate(tex);
@@ -8646,7 +8713,7 @@ __ri void GSRendererHW::HandleTextureHazards(const GSTextureCache::Target* rt, c
 	if (m_downscale_source)
 	{
 		// Can't use box filtering on depth (yet), or fractional scales.
-		if (src_target->m_texture->IsDepthStencil() || std::floor(src_target->GetScale()) != src_target->GetScale())
+		if (src_target->m_texture->IsDepthLike() || std::floor(src_target->GetScale()) != src_target->GetScale())
 		{
 			GSVector4 src_rect = GSVector4(tmm.coverage) / GSVector4(GSVector4i::loadh(src_unscaled_size).zwzw());
 			const GSVector4 dst_rect = GSVector4(tmm.coverage);
@@ -8959,7 +9026,8 @@ void GSRendererHW::EmulateAlphaTest(DATEOptions& date_options)
 
 	// Flags to determine if we can achieve full accuracy with less passes.
 	const bool simple_fb_only = (afail == AFAIL_FB_ONLY) && independent_z;
-	const bool simple_rgb_only = (afail == AFAIL_RGB_ONLY) && independent_z && independent_rgb;
+	const bool simple_rgb_only = (afail == AFAIL_RGB_ONLY) && independent_z && independent_rgb &&
+	                             !UsingMultipleRenderTargets(); // Do not use simple RGB dual source blend with MRTs.
 	const bool simple_zb_only = (afail == AFAIL_ZB_ONLY) && independent_z;
 
 	// Determine where RT and/or depth are needed for the feedback methods.
@@ -8981,17 +9049,21 @@ void GSRendererHW::EmulateAlphaTest(DATEOptions& date_options)
 	// Determine if we have the correct features for depth feedback.
 	const bool depth_feedback_supported = features.feedback_loops();
 
+	// Depth integer already involves feedback so we will select feedback in that case.
+	const bool using_integer_depth = static_cast<bool>(m_conf.ds_int);
+
 	// We need depth feedback but do not have the correct features.
 	const bool avoid_feedback = afail_needs_depth && !depth_feedback_supported;
 
 	// Prefer feedback method only if it's free (color only feedback) or enabled.
 	const bool prefer_feedback = free_barrier_feedback || free_fbfetch_feedback ||
-	                             GSConfig.HWAccurateAlphaTest;
+	                             GSConfig.HWAccurateAlphaTest || using_integer_depth;
 
 	// The simple cases can be handle accurately in two passes so no point
 	// in requiring barriers if they are not already required.
 	const bool prefer_two_pass = !(free_fbfetch_feedback || free_barrier_feedback) &&
-	                             (simple_fb_only || simple_rgb_only || simple_zb_only);
+	                             (simple_fb_only || simple_rgb_only || simple_zb_only) &&
+	                             !using_integer_depth;
 	
 	if (prefer_feedback && !prefer_two_pass && !avoid_feedback)
 	{
@@ -9203,6 +9275,7 @@ void GSRendererHW::EmulateAlphaTestSecondPass()
 	// Finally, if the first pass is never used do only the second pass.
 	if (!(m_conf.colormask.wrgba || m_conf.depth.zwe))
 	{
+		GL_INS("Alpha test: First pass has no output, disabling.");
 		std::memcpy(&m_conf.ps, &m_conf.alpha_second_pass.ps, sizeof(m_conf.ps));
 		std::memcpy(&m_conf.colormask, &m_conf.alpha_second_pass.colormask, sizeof(m_conf.colormask));
 		std::memcpy(&m_conf.depth, &m_conf.alpha_second_pass.depth, sizeof(m_conf.depth));
@@ -9272,6 +9345,8 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 		area_out.x, area_out.y, area_out.z, area_out.w);
 #endif
 
+	const GSDevice::FeatureSupport features = g_gs_device->Features();
+
 	const GSDrawingEnvironment& env = *m_draw_env;
 
 	DATEOptions date_options;
@@ -9286,6 +9361,7 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 	m_conf.ps.scanmsk = env.SCANMSK.MSK;
 	m_conf.rt = rt ? rt->m_texture : nullptr;
 	m_conf.ds = ds ? (m_using_temp_z ? g_texture_cache->GetTemporaryZ() : ds->m_texture) : nullptr;
+	m_conf.ds_int = (features.depth_integer && m_conf.ds && m_conf.ds->IsDepthInteger()) ? m_conf.ds : nullptr;
 
 	pxAssert(!ds || !rt || (m_conf.ds->GetSize().x == m_conf.rt->GetSize().x && m_conf.ds->GetSize().y == m_conf.rt->GetSize().y));
 
@@ -9445,7 +9521,7 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 	const GSVector2i texsize = tex ? tex->GetTexture()->GetSize() : GSVector2i(0, 0);
 
 	// Vertex shader config
-	float vs_scale_x, vs_scale_y;
+	float vs_scale_x = FLT_MAX, vs_scale_y = FLT_MAX;
 	DetermineVSConfig(rt, rtscale, rtsize, rt_unscaled_size, vs_scale_x, vs_scale_y);
 
 	m_conf.ps.iip = !IsFlatShaded();
@@ -9473,13 +9549,16 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 		m_conf.ps.rta_correction = rt->m_rt_alpha_scale;
 	}
 
+	// Handle integer depth
+	EmulateDepthInteger();
+
 	// Call before computing the full drawlist in case ROV is used and we don't need it.
 	DetermineROVUsage(rt, ds);
 	ConvertTextureTypeROV(rt, ds);
 
 	// Barriers must be determined before indices are modified via HandleFlatShadedVertices/SetupIA.
 	// This also computes the drawlist if needed.
-	DetermineBarriers(rt, tex);
+	DetermineBarriers(rt, ds, tex);
 
 	// Perform second pass setup here once barriers are determined.
 	EmulateAlphaTestSecondPass();
@@ -9506,7 +9585,8 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 
 	SetupIA(rtscale, vs_scale_x, vs_scale_y, m_channel_shuffle_width != 0, no_rt);
 
-	if (m_conf.ds && m_conf.ps.IsFeedbackLoopDepth() && !g_gs_device->Features().depth_feedback && !m_conf.ps.HasDepthROV())
+	if (m_conf.ds && m_conf.ps.IsFeedbackLoopDepth() && !g_gs_device->Features().depth_feedback &&
+		!m_conf.ps.HasDepthROV() && !m_conf.ds_int)
 	{
 		GL_PUSH("HW: Creating temporary R32 RT for depth feedback");
 
@@ -10265,9 +10345,8 @@ bool GSRendererHW::TryTargetClear(GSTextureCache::Target* rt, GSTextureCache::Ta
 		{
 			const u32 max_z = 0xFFFFFFFF >> (GSLocalMemory::m_psm[m_cached_ctx.ZBUF.PSM].fmt * 8);
 			const u32 z = std::min(max_z, m_vertex->buff[1].XYZ.Z);
-			const float d = static_cast<float>(z) * 0x1p-32f;
-			GL_INS("HW: TryTargetClear(): DS at %x <= %f", ds->m_TEX0.TBP0, d);
-			g_gs_device->ClearDepth(ds->m_texture, d);
+			GL_INS("HW: TryTargetClear(): DS at %x <= %d", ds->m_TEX0.TBP0, z);
+			g_gs_device->ClearRenderTarget(ds->m_texture, z);
 			ds->m_dirty.clear();
 			ds->m_alpha_max = z >> 24;
 			ds->m_alpha_min = z >> 24;
@@ -11052,6 +11131,8 @@ void GSRendererHW::EndHLEHardwareDraw(bool force_copy_on_hazard /* = false */)
 	                      (!GSDevice::IsDualSourceBlendFactor(config.blend.src_factor) &&
 	                       !GSDevice::IsDualSourceBlendFactor(config.blend.dst_factor));
 
+	config.ps.texint = config.tex && config.tex->IsIntegerFormat();
+
 	g_gs_device->RenderHW(m_conf);
 
 	if (copy)
@@ -11071,4 +11152,114 @@ std::size_t GSRendererHW::ComputeDrawlistGetSize(float scale)
 bool GSRendererHW::IsCoverageAlphaSupported()
 {
 	return IsCoverageAlpha() && IsRTWritten() && g_gs_device->Features().aa1;
+}
+
+bool GSRendererHW::UsingMultipleRenderTargets()
+{
+	const bool mrt_for_zint = m_conf.ds_int != nullptr;
+
+	const bool mrt_for_depth_feedback = m_conf.ps.IsFeedbackLoopDepth() && !g_gs_device->Features().depth_feedback;
+
+	return mrt_for_zint || mrt_for_depth_feedback;
+}
+
+void GSRendererHW::HandleTemporaryDSForDATE(GSDevice::RecycledTexture& temp_ds, DATEOptions& date_options)
+{
+	const GSDevice::FeatureSupport& features = g_gs_device->Features();
+
+	if (m_conf.destination_alpha >= GSHWDrawConfig::DestinationAlphaMode::Stencil &&
+		m_conf.destination_alpha <= GSHWDrawConfig::DestinationAlphaMode::StencilOne &&
+		(!m_conf.ds || !m_conf.ds->IsDepthStencil()))
+	{
+		const bool is_one_barrier = (features.texture_barrier && m_conf.require_full_barrier && (m_prim_overlap == PRIM_OVERLAP_NO || m_conf.ps.shuffle || m_channel_shuffle));
+		temp_ds.reset(g_gs_device->CreateDepthStencil(m_conf.rt->GetWidth(), m_conf.rt->GetHeight(), false));
+		if (temp_ds)
+		{
+			m_conf.ds = temp_ds.get();
+		}
+		else if (features.primitive_id && !(m_conf.ps.scanmsk & 2) && (!m_conf.require_full_barrier || is_one_barrier))
+		{
+			date_options.stencil_one = false;
+			date_options.primid = true;
+			m_conf.destination_alpha = GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking;
+			DevCon.Warning("HW: Depth buffer creation failed for Stencil Date. Fallback to PrimIDTracking.");
+		}
+		else
+		{
+			date_options.enabled = false;
+			date_options.stencil_one = false;
+			m_conf.destination_alpha = GSHWDrawConfig::DestinationAlphaMode::Off;
+			DevCon.Warning("HW: Depth buffer creation failed for Stencil Date.");
+		}
+	}
+}
+
+// Do the depth integer setup if needed for the draw.
+void GSRendererHW::EmulateDepthInteger()
+{
+	if (!m_conf.ds_int)
+		return;
+
+	GL_PUSH("HW: Depth integer setup");
+
+	if (!(m_cached_ctx.DepthRead() || m_cached_ctx.DepthWrite()))
+	{
+		GL_INS("HW: No depth read/write, disable depth integer.");
+		m_conf.ds = (m_conf.ds == m_conf.ds_int) ? nullptr : m_conf.ds;
+		m_conf.ds_int = nullptr;
+		return;
+	}
+
+	// Should not be using dual source blend with MRTs
+	pxAssert(m_conf.ps.no_color1);
+	// Should have device depth integer feature.
+	pxAssert(g_gs_device->Features().depth_integer);
+
+	m_conf.vs.zint = true;
+
+	// Setup for pixel shader.
+	const GSLocalMemory::psm_t& psm = GSLocalMemory::m_psm[m_cached_ctx.ZBUF.PSM];
+	const bool need_clamp = psm.trbpp < 32;
+
+	// Enable SW Z to correctly mask depth bits.
+	const u32 max_z = (0xFFFFFFFF >> (GSLocalMemory::m_psm[m_cached_ctx.ZBUF.PSM].fmt * 8));
+	m_conf.cb_ps.TA_MaxDepth_Af.z = std::bit_cast<float>(max_z);
+	m_conf.ps.zclamp = need_clamp;
+	if (m_conf.alpha_second_pass.enable)
+	{
+		m_conf.alpha_second_pass.ps.zclamp = m_conf.ps.zclamp;
+	}
+
+	if (m_cached_ctx.DepthWrite())
+	{
+		GL_INS("HW: Read/write, mask=%x", max_z);
+		m_conf.ps.zint = GSHWDrawConfig::PS_Z_INTEGER::READ_WRITE;
+
+		// We don't consider the case where depth is write-only and may not need barriers.
+		// This should be relatively rare.
+		m_conf.require_full_barrier |= (m_prim_overlap != PRIM_OVERLAP_NO);
+		m_conf.require_one_barrier |= (m_prim_overlap == PRIM_OVERLAP_NO);
+	}
+	else
+	{
+		m_conf.ps.zint = GSHWDrawConfig::PS_Z_INTEGER::READ_ONLY;
+		m_conf.require_one_barrier = true;
+	}
+
+	// Enable SW depth test if needed.
+	if (m_cached_ctx.DepthRead() && !m_conf.ps.DepthTest())
+	{
+		m_conf.ps.ztst = m_conf.depth.ztst;
+	}
+
+	GL_INS("HW: Pixel shader ZTST = %s", GSUtil::GetZTSTName(m_conf.ps.ztst));
+
+	// Disable HW depth
+	m_conf.depth.zwe = false;
+	m_conf.depth.ztst = ZTST_ALWAYS;
+
+	// Tell pixel shader which slot the depth as integer texture is bound to.
+	m_conf.ps.z_rt_slot = m_conf.rt ? 1 : 0;
+
+	GL_INS("HW: Depth integer slot = %d", m_conf.ps.z_rt_slot);
 }

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -212,6 +212,8 @@ private:
 	template <bool linear>
 	void RoundSpriteOffset();
 
+	void HandleZIntegerConversion(GSTextureCache::Target* ds);
+
 	void DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Target* ds, GSTextureCache::Source* tex, const TextureMinMaxResult& tmm);
 
 	void ResetStates();
@@ -246,12 +248,16 @@ private:
 	bool EmulateDATEEarlyFail(DATEOptions& date, GSTextureCache::Target* rt);
 	void EmulateDATESelectMethod(DATEOptions& date, GSTextureCache::Target* rt, int& blend_alpha_min, int& blend_alpha_max);
 	void EmulateDATEGetConfig(DATEOptions& date, bool scale_rt_alpha, GSDevice::RecycledTexture& temp_ds);
+	void HandleTemporaryDSForDATE(GSDevice::RecycledTexture& temp_ds, DATEOptions& date);
+
+	bool UsingMultipleRenderTargets();
+	void EmulateDepthInteger();
 
 	void EmulateDither();
 
 	void DetermineVSConfig(GSTextureCache::Target* rt, float rtscale, const GSVector2i& rtsize,
 		const GSVector2i& unscaled_size, float& vs_scale_x, float& vs_scale_y);
-	void DetermineBarriers(GSTextureCache::Target* rt, GSTextureCache::Source* tex);
+	void DetermineBarriers(GSTextureCache::Target* rt, GSTextureCache::Target* ds, GSTextureCache::Source* tex);
 
 	void GetForcedROVUsage(bool& color_cov, bool& depth_rov); // Whether having color or depth with the current config forces the other.
 	void DetermineROVUsage(GSTextureCache::Target* rt, GSTextureCache::Target* ds); // Heuristics to determine whether to enable/disable ROV
@@ -345,6 +351,9 @@ private:
 	std::vector<GSVertexSW> m_sw_vertex_buffer;
 	std::unique_ptr<GSTextureCacheSW::Texture> m_sw_texture[7 + 1];
 	std::unique_ptr<GSVirtualAlignedClass<32>> m_sw_rasterizer;
+
+	// DS as RT
+	bool m_temp_ds_as_rt = false;
 
 public:
 	GSRendererHW();

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2868,9 +2868,7 @@ GSTextureCache::Target* GSTextureCache::LookupDrawTarget(GIFRegTEX0 TEX0, const 
 			const bool fmt_16_bits = (psm_s.bpp == 16 && GSLocalMemory::m_psm[dst_match->m_TEX0.PSM].bpp == 16 && !dst->m_32_bits_fmt);
 
 			u32 src_bpp = fmt_16_bits ? 16 : 32;
-
 			u32 dst_bpp;
-
 			if (type == DepthStencil)
 			{
 				GL_CACHE("TC: Lookup Target(Depth) %dx%d, hit Color (0x%x, TBW %d, %s was %s)",
@@ -2911,16 +2909,16 @@ GSTextureCache::Target* GSTextureCache::LookupDrawTarget(GIFRegTEX0 TEX0, const 
 					{
 						if (type == DepthStencil)
 						{
-							const u32 cc = dst_match->m_texture->GetClearColor();
-							const float cd = ConvertColorToDepth(cc, src_bpp, dst_bpp);
-							GL_INS("TC: Convert clear color[%08X] to depth[%f]", cc, cd);
-							g_gs_device->ClearDepth(dst->m_texture, cd);
+							const u32 cc = dst_match->m_texture->GetClearValue();
+							const u32 cd = ConvertColorToDepth(cc, src_bpp, dst_bpp);
+							GL_INS("TC: Convert clear color[%08X] to depth[%08X]", cc, cd);
+							g_gs_device->ClearRenderTarget(dst->m_texture, cd);
 						}
 						else
 						{
-							const float cd = dst_match->m_texture->GetClearDepth();
+							const u32 cd = dst_match->m_texture->GetClearValue();
 							const u32 cc = ConvertDepthToColor(cd, dst_bpp);
-							GL_INS("TC: Convert clear depth[%f] to color[%08X]", cd, cc);
+							GL_INS("TC: Convert clear depth[%08X] to color[%08X]", cd, cc);
 							g_gs_device->ClearRenderTarget(dst->m_texture, cc);
 						}
 					}
@@ -3021,7 +3019,7 @@ GSTextureCache::Target* GSTextureCache::ProcessTargetAfterLookup(RescaleHelper& 
 		rescaler.m_scale = dst->m_scale;
 
 	// Game is changing from 32bit depth to 24bit, meaning any top values in the depth will no longer be valid, I hope no games rely on these values being maintained, else we're screwed.
-	if (type == DepthStencil && dst->m_type == DepthStencil && GSLocalMemory::m_psm[dst->m_TEX0.PSM].trbpp == 32 && GSLocalMemory::m_psm[TEX0.PSM].trbpp == 24 && dst->m_alpha_max > 0)
+	if (type == DepthStencil && dst->m_type == DepthStencil && GSLocalMemory::m_psm[dst->m_TEX0.PSM].trbpp == 32 && GSLocalMemory::m_psm[TEX0.PSM].trbpp == 24 && dst->m_alpha_max > 0 && !dst->m_texture->IsDepthInteger())
 	{
 		rescaler.CalcRescale(dst);
 		GSTexture* tex = g_gs_device->CreateCompatible(dst->m_texture, rescaler.m_new_scaled_size, false);
@@ -3261,10 +3259,7 @@ GSTextureCache::Target* GSTextureCache::ProcessTargetAfterLookup(RescaleHelper& 
 				(rescaler.m_scale > 1.0f && GSConfig.UserHacks_HalfPixelOffset >= GSHalfPixelOffset::Native) ? "[clearing] " : "", dst->m_TEX0.TBP0);
 			if (rescaler.m_scale > 1.0f && GSConfig.UserHacks_HalfPixelOffset < GSHalfPixelOffset::Native)
 			{
-				if (dst->m_type == RenderTarget)
-					g_gs_device->ClearRenderTarget(dst->m_texture, 0);
-				else
-					g_gs_device->ClearDepth(dst->m_texture, 0.0f);
+				g_gs_device->ClearRenderTarget(dst->m_texture, 0);
 			}
 			else
 			{
@@ -3277,7 +3272,7 @@ GSTextureCache::Target* GSTextureCache::ProcessTargetAfterLookup(RescaleHelper& 
 }
 
 GSTextureCache::Target* GSTextureCache::CreateTarget(GIFRegTEX0 TEX0, const GSVector2i& size, const GSVector2i& valid_size, float scale, int type,
-	bool used, u32 fbmask, bool is_frame, bool preload, bool preserve_target, const GSVector4i draw_rect, GSTextureCache::Source* src)
+	bool used, u32 fbmask, bool is_frame, bool preload, bool preserve_target, const GSVector4i draw_rect, GSTextureCache::Source* src, bool z_integer)
 {
 	if (type == DepthStencil)
 	{
@@ -3293,7 +3288,7 @@ GSTextureCache::Target* GSTextureCache::CreateTarget(GIFRegTEX0 TEX0, const GSVe
 	if (GSVector4i::loadh(size).rempty())
 		return nullptr;
 
-	Target* dst = Target::Create(TEX0, size.x, size.y, scale, type, true);
+	Target* dst = Target::Create(TEX0, size.x, size.y, scale, type, true, z_integer);
 	if (!dst) [[unlikely]]
 		return nullptr;
 
@@ -4316,19 +4311,18 @@ void GSTextureCache::ScaleTargetForDisplay(Target* t, const GIFRegTEX0& dispfb, 
 	GetTargetSize(t->m_TEX0.TBP0, t->m_TEX0.TBW, t->m_TEX0.PSM, new_width, static_cast<u32>(needed_height));
 }
 
-float GSTextureCache::ConvertColorToDepth(u32 c, u32 src_bpp, u32 dst_bpp)
+u32 GSTextureCache::ConvertColorToDepth(u32 c, u32 src_bpp, u32 dst_bpp)
 {
-	const float mult = std::exp2(-32.0f);
 	switch (dst_bpp)
 	{
 		case 32:
 		default:
 			pxAssert(src_bpp == 32);
-			return static_cast<float>(c) * mult;
+			return c;
 
 		case 24:
 			pxAssert(src_bpp == 32);
-			return static_cast<float>(c & 0x00FFFFFF) * mult;
+			return c & 0x00FFFFFF;
 
 		case 16:
 			pxAssert(src_bpp == 16 || src_bpp == 32);
@@ -4338,30 +4332,29 @@ float GSTextureCache::ConvertColorToDepth(u32 c, u32 src_bpp, u32 dst_bpp)
 				const u32 g = (c >>  6) & 0x03E0u;
 				const u32 b = (c >>  9) & 0x7C00u;
 				const u32 a = (c >> 16) & 0x8000u;
-				return static_cast<float>(r | g | b | a) * mult;
+				return r | g | b | a;
 			}
 			else
 			{
-				return static_cast<float>(c & 0x0000ffff) * mult;
+				return c & 0x0000ffff;
 			}
 	}
 }
 
-u32 GSTextureCache::ConvertDepthToColor(float d, u32 dst_bpp)
+u32 GSTextureCache::ConvertDepthToColor(u32 d, u32 dst_bpp)
 {
 	pxAssert(dst_bpp == 32 || dst_bpp == 16);
-	const u32 cc = static_cast<u32>(d * 0x1p32);
 	if (dst_bpp == 16)
 	{
-		const u32 r = (cc <<  3) & 0x000000FF;
-		const u32 g = (cc <<  6) & 0x0000F800;
-		const u32 b = (cc <<  9) & 0x00F80000;
-		const u32 a = (cc << 16) & 0x80000000;
+		const u32 r = (d <<  3) & 0x000000FF;
+		const u32 g = (d <<  6) & 0x0000F800;
+		const u32 b = (d <<  9) & 0x00F80000;
+		const u32 a = (d << 16) & 0x80000000;
 		return r | g | b | a;
 	}
 	else
 	{
-		return cc;
+		return d;
 	}
 }
 
@@ -4412,7 +4405,7 @@ bool GSTextureCache::CopyRGBFromDepthToColor(Target* dst, Target* depth_src)
 
 	if (depth_src->m_texture->GetState() == GSTexture::State::Cleared)
 	{
-		g_gs_device->ClearRenderTarget(tex, ConvertDepthToColor(depth_src->m_texture->GetClearDepth(), 32));
+		g_gs_device->ClearRenderTarget(tex, ConvertDepthToColor(depth_src->m_texture->GetClearValue(), 32));
 	}
 	else if (depth_src->m_texture->GetState() != GSTexture::State::Invalidated)
 	{
@@ -7213,15 +7206,25 @@ void GSTextureCache::AgeHashCache()
 	}
 }
 
-GSTextureCache::Target* GSTextureCache::Target::Create(GIFRegTEX0 TEX0, int w, int h, float scale, int type, bool clear)
+GSTextureCache::Target* GSTextureCache::Target::Create(GIFRegTEX0 TEX0, int w, int h, float scale, int type, bool clear, bool z_integer)
 {
 	pxAssert(type == RenderTarget || type == DepthStencil);
 
+	z_integer = (type == DepthStencil) && g_gs_device->Features().depth_integer &&
+		(GSConfig.HWZIntegerMode == GSHardwareZIntegerMode::Always || z_integer);
+
 	const int scaled_w = static_cast<int>(std::ceil(static_cast<float>(w) * scale));
 	const int scaled_h = static_cast<int>(std::ceil(static_cast<float>(h) * scale));
-	GSTexture::Usage usage = type == RenderTarget ? GSTexture::FeedbackTarget : g_gs_device->GetDepthStencilUsage();
-	GSTexture::Format format = type == RenderTarget ? GSTexture::Format::Color : GSTexture::Format::DepthStencil;
-	GSTexture* texture = g_gs_device->FetchSurface(usage, scaled_w, scaled_h, 1, format, clear, PreferReusedLabelledTexture());
+	GSTexture* texture;
+	if (type == RenderTarget || z_integer)
+	{
+		const GSTexture::Format format = z_integer ? GSTexture::Format::DepthInteger : GSTexture::Format::Color;
+		texture = g_gs_device->CreateFeedbackTarget(scaled_w, scaled_h, format, clear, PreferReusedLabelledTexture());
+	}
+	else
+	{
+		texture = g_gs_device->CreateDepthStencil(scaled_w, scaled_h, clear, PreferReusedLabelledTexture());
+	}
 	if (!texture)
 		return nullptr;
 
@@ -7335,53 +7338,19 @@ void GSTextureCache::Read(Target* t, const GSVector4i& r)
 
 	const GIFRegTEX0& TEX0 = t->m_TEX0;
 	const bool is_depth = (t->m_type == DepthStencil);
+	const u16 bpp = GSLocalMemory::m_psm[TEX0.PSM].bpp;
 
-	GSTexture::Format fmt;
-	ShaderConvert ps_shader;
-	std::unique_ptr<GSDownloadTexture>* dltex;
-	switch (TEX0.PSM)
-	{
-		case PSMCT32:
-		case PSMCT24:
-		case PSMZ32:
-		case PSMZ24:
-		{
-			// If we're downloading a depth buffer that's been reinterpreted as a color
-			// format, convert it to integer. The format/swizzle is likely wrong, but it's
-			// better than writing back FP values to local memory.
-			if (is_depth)
-			{
-				fmt = GSTexture::Format::UInt32;
-				ps_shader = ShaderConvert::DEPTH32_TO_32_BITS;
-				dltex = &m_uint32_download_texture;
-			}
-			else
-			{
-				fmt = GSTexture::Format::Color;
-				if (t->m_rt_alpha_scale)
-					ps_shader = ShaderConvert::RTA_DECORRECTION;
-				else
-					ps_shader = ShaderConvert::COPY;
+	if (bpp != 32 && bpp != 16)
+		return;
 
-				dltex = &m_color_download_texture;
-			}
-		}
-		break;
-
-		case PSMCT16:
-		case PSMCT16S:
-		case PSMZ16:
-		case PSMZ16S:
-		{
-			fmt = GSTexture::Format::UInt16;
-			ps_shader = is_depth ? ShaderConvert::DEPTH32_TO_16_BITS : ShaderConvert::RGB5A1_TO_16_BITS;
-			dltex = &m_uint16_download_texture;
-		}
-		break;
-
-		default:
-			return;
-	}
+	const GSTexture::Format fmt = (bpp == 32) ?
+		(is_depth ? GSTexture::Format::UInt32 : GSTexture::Format::Color) :
+		GSTexture::Format::UInt16;
+	std::unique_ptr<GSDownloadTexture>* dltex = (bpp == 32) ?
+		(is_depth ? &m_uint32_download_texture : &m_color_download_texture) :
+		&m_uint16_download_texture;
+	const ShaderConvertSelector shader = GetConvertToBitsShader(t->m_texture, bpp, t->m_rt_alpha_scale);
+	const bool direct_read = (t->GetScale() == 1.0f && bpp == 32) && (is_depth || !t->m_rt_alpha_scale);
 
 	// Don't overwrite bits which aren't used in the target's format.
 	// Stops Burnout 3's sky from breaking when flushing targets to local memory.
@@ -7396,7 +7365,6 @@ void GSTextureCache::Read(Target* t, const GSVector4i& r)
 
 	const GSVector4 src(GSVector4(r) * GSVector4(t->m_scale) / GSVector4(t->m_texture->GetSize()).xyxy());
 	const GSVector4i drc(0, 0, r.width(), r.height());
-	const bool direct_read = t->m_type == RenderTarget && t->m_scale == 1.0f && ps_shader == ShaderConvert::COPY;
 
 	if (!PrepareDownloadTexture(drc.z, drc.w, fmt, dltex))
 		return;
@@ -7410,7 +7378,7 @@ void GSTextureCache::Read(Target* t, const GSVector4i& r)
 		GSTexture* tmp = g_gs_device->CreateRenderTarget(drc.z, drc.w, fmt, false);
 		if (tmp)
 		{
-			g_gs_device->StretchRect(t->m_texture, src, tmp, GSVector4(drc), ps_shader, Nearest);
+			g_gs_device->StretchRect(t->m_texture, src, tmp, GSVector4(drc), shader, Nearest);
 			dltex->get()->CopyFromTexture(drc, tmp, drc, 0, true);
 			g_gs_device->Recycle(tmp);
 		}
@@ -7430,24 +7398,13 @@ void GSTextureCache::Read(Target* t, const GSVector4i& r)
 	u8* bits = const_cast<u8*>(dltex->get()->GetMapPointer());
 	const u32 pitch = dltex->get()->GetMapPitch();
 
-	switch (TEX0.PSM)
+	if (bpp == 32)
 	{
-		case PSMCT32:
-		case PSMZ32:
-		case PSMCT24:
-		case PSMZ24:
-			g_gs_renderer->m_mem.WritePixel32(bits, pitch, off, r, write_mask);
-			break;
-		case PSMCT16:
-		case PSMCT16S:
-		case PSMZ16:
-		case PSMZ16S:
-			g_gs_renderer->m_mem.WritePixel16(bits, pitch, off, r);
-			break;
-
-		default:
-			Console.Error("Unknown PSM %u on Read", TEX0.PSM);
-			break;
+		g_gs_renderer->m_mem.WritePixel32(bits, pitch, off, r, write_mask);
+	}
+	else
+	{
+		g_gs_renderer->m_mem.WritePixel16(bits, pitch, off, r);
 	}
 
 	dltex->get()->Unmap();
@@ -8251,10 +8208,7 @@ bool GSTextureCache::Target::ResizeTexture(int new_unscaled_width, int new_unsca
 	else if (m_texture->GetState() == GSTexture::State::Cleared)
 	{
 		// Otherwise just pass the clear through.
-		if (tex->IsDepthLike())
-			g_gs_device->ClearDepth(tex, m_texture->GetClearDepth());
-		else
-			g_gs_device->ClearRenderTarget(tex, m_texture->GetClearColor());
+		g_gs_device->ClearRenderTarget(tex, m_texture->GetClearValue());
 	}
 	else
 	{

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.h
@@ -259,7 +259,7 @@ public:
 		Target(GIFRegTEX0 TEX0, int type, const GSVector2i& unscaled_size, float scale, GSTexture* texture);
 		~Target();
 
-		static Target* Create(GIFRegTEX0 TEX0, int w, int h, float scale, int type, bool clear);
+		static Target* Create(GIFRegTEX0 TEX0, int w, int h, float scale, int type, bool clear, bool z_integer = false);
 
 		bool OverlapsValid(u32 bp, u32 bw, u32 psm, const GSVector4i& rect) const;
 
@@ -542,7 +542,7 @@ private:
 public:
 	Target* CreateTarget(GIFRegTEX0 TEX0, const GSVector2i& size, const GSVector2i& valid_size, float scale, int type, bool used = true,
 		u32 fbmask = 0, bool is_frame = false, bool preload = GSConfig.PreloadFrameWithGSData, bool preserve_target = true,
-		const GSVector4i draw_rc = GSVector4i::zero(), GSTextureCache::Source* src = nullptr);
+		const GSVector4i draw_rc = GSVector4i::zero(), GSTextureCache::Source* src = nullptr, bool z_integer = false);
 
 	Target* LookupDisplayTarget(GIFRegTEX0 TEX0, const GSVector2i& size, float scale, bool is_feedback);
 
@@ -573,12 +573,12 @@ public:
 	/// Removes any sources which point to the same address as a new target.
 	void ReplaceSourceTexture(Source* s, GSTexture* new_texture, float new_scale, const GSVector2i& new_unscaled_size,
 		HashCacheEntry* hc_entry, bool new_texture_is_shared);
-
+	
 	/// Converts single color value to depth using the specified shader expression.
-	static float ConvertColorToDepth(u32 c, u32 src_bpp, u32 dst_bpp);
+	static u32 ConvertColorToDepth(u32 c, u32 src_bpp, u32 dst_bpp);
 
 	/// Converts single depth value to colour using the specified shader expression.
-	static u32 ConvertDepthToColor(float d, u32 dst_bpp);
+	static u32 ConvertDepthToColor(u32 d, u32 dst_bpp);
 
 	/// Copies RGB channels from depth target to a color target.
 	bool CopyRGBFromDepthToColor(Target* dst, Target* depth_src);

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -413,7 +413,7 @@ static GSVector4 GetRTLoadInfo(GSTextureMTL* tex, MTLLoadAction* load_action)
 		else if (tex->GetState() == GSTexture::State::Cleared && *load_action != MTLLoadActionDontCare)
 		{
 			*load_action = MTLLoadActionClear;
-			return tex->GetClearForFormat();
+			return tex->GetMTLClearValue();
 		}
 	}
 	return {};
@@ -589,6 +589,7 @@ static constexpr MTLPixelFormat ConvertPixelFormat(GSTexture::Format format)
 	{
 		case GSTexture::Format::DepthColor:   return MTLPixelFormatR32Float;
 		case GSTexture::Format::PrimID:       return MTLPixelFormatR32Float;
+		case GSTexture::Format::DepthInteger: return MTLPixelFormatR32Uint;
 		case GSTexture::Format::UInt32:       return MTLPixelFormatR32Uint;
 		case GSTexture::Format::UInt16:       return MTLPixelFormatR16Uint;
 		case GSTexture::Format::UNorm8:       return MTLPixelFormatA8Unorm;
@@ -652,9 +653,9 @@ GSTexture* GSDeviceMTL::CreateSurface(GSTexture::Usage usage, int width, int hei
 	{
 		MRCOwned<id<MTLTexture>> rov_tex = needs_rov_tex ? MRCTransfer([tex newTextureViewWithPixelFormat:MTLPixelFormatR32Uint]) : nil;
 		GSTextureMTL* t = new GSTextureMTL(this, tex, rov_tex, usage, format);
+		ClearRenderTarget(t, 0);
 		if (GSTexture::IsRenderTarget(usage))
 		{
-			ClearRenderTarget(t, 0);
 		}
 		else if (GSTexture::IsDepthStencil(usage))
 		{
@@ -1290,8 +1291,9 @@ bool GSDeviceMTL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 			name = [name stringByAppendingString:[NSString stringWithFormat:@" Mask=%x", shader.Mask()]];
 		if (shader.Biln())
 			name = [name stringByAppendingString:@" Biln"];
-		if (shader.Float32Output())
-			name = [name stringByAppendingString:shader.DepthOutput() ? @" → Depth" : @" → Float"];
+		name = [name stringByAppendingString:[NSString stringWithUTF8String:shader.InputFormat()]];
+		name = [name stringByAppendingString:@" → "];
+		name = [name stringByAppendingString:[NSString stringWithUTF8String:GSTexture::GetFormatName(shader.OutputFormat())]];
 
 		const u32 scmask = shader.Mask();
 		MTLColorWriteMask mask = MTLColorWriteMaskNone;
@@ -1300,8 +1302,10 @@ bool GSDeviceMTL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 		if (scmask & 4) mask |= MTLColorWriteMaskBlue;
 		if (scmask & 8) mask |= MTLColorWriteMaskAlpha;
 		pdesc.colorAttachments[0].writeMask = mask;
-		setFnConstantB(m_fn_constants, shader.Biln(),        GSMTLConstantIndex_BILN);
-		setFnConstantB(m_fn_constants, shader.DepthOutput(), GSMTLConstantIndex_DEPTH_OUT);
+		setFnConstantB(m_fn_constants, shader.Biln(),          GSMTLConstantIndex_BILN);
+		setFnConstantB(m_fn_constants, shader.IntegerInput(),  GSMTLConstantIndex_INTEGER_IN);
+		setFnConstantB(m_fn_constants, shader.IntegerOutput(), GSMTLConstantIndex_INTEGER_OUT);
+		setFnConstantB(m_fn_constants, shader.DepthOutput(),   GSMTLConstantIndex_DEPTH_OUT);
 		m_convert_pipeline[shader.Index()] = MakePipeline(pdesc, vs_convert, LoadShader(shader_name), name);
 	}
 	pdesc.colorAttachments[0].writeMask = MTLColorWriteMaskAll;
@@ -2426,7 +2430,7 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 				case GSTexture::State::Cleared:
 				{
 					BeginRenderPass(@"ColorClip Clear", colclip_rt, MTLLoadActionDontCare, nullptr, MTLLoadActionDontCare);
-					GSVector4 color = GSVector4::rgba32(config.rt->GetClearColor()) / GSVector4::cxpr(65535, 65535, 65535, 255);
+					GSVector4 color = GSVector4::rgba32(config.rt->GetClearValue()) / GSVector4::cxpr(65535, 65535, 65535, 255);
 					[m_current_render.encoder setFragmentBytes:&color length:sizeof(color) atIndex:GSMTLBufferIndexUniforms];
 					RenderCopy(nullptr, m_colclip_clear_pipeline, copy_rect);
 					break;

--- a/pcsx2/GS/Renderers/Metal/GSMTLShaderCommon.h
+++ b/pcsx2/GS/Renderers/Metal/GSMTLShaderCommon.h
@@ -37,16 +37,24 @@ struct ConvertPSDepthRes
 	}
 };
 
+static inline float4 convert_depth32_rgba8(uint value)
+{
+	return float4(as_type<uchar4>(value));
+}
+
 static inline float4 convert_depth32_rgba8(float value)
 {
-	uint val = uint(value * 0x1p32);
-	return float4(as_type<uchar4>(val));
+	return convert_depth32_rgba8(uint(value * 0x1p32));
+}
+
+static inline float4 convert_depth16_rgba8(uint value)
+{
+	return float4(uint4(value << 3, value >> 2, value >> 7, value >> 8) & uint4(0xf8, 0xf8, 0xf8, 0x80));
 }
 
 static inline float4 convert_depth16_rgba8(float value)
 {
-	uint val = uint(value * 0x1p32);
-	return float4(uint4(val << 3, val >> 2, val >> 7, val >> 8) & uint4(0xf8, 0xf8, 0xf8, 0x80));
+	return convert_depth16_rgba8(uint(value * 0x1p32));
 }
 
 #ifndef __HAVE_MUL24__

--- a/pcsx2/GS/Renderers/Metal/GSMTLSharedHeader.h
+++ b/pcsx2/GS/Renderers/Metal/GSMTLSharedHeader.h
@@ -161,6 +161,8 @@ enum GSMTLAttributes
 enum GSMTLFnConstants
 {
 	GSMTLConstantIndex_BILN,
+	GSMTLConstantIndex_INTEGER_IN,
+	GSMTLConstantIndex_INTEGER_OUT,
 	GSMTLConstantIndex_DEPTH_OUT,
 	GSMTLConstantIndex_CAS_SHARPEN_ONLY,
 	GSMTLConstantIndex_FRAMEBUFFER_FETCH,

--- a/pcsx2/GS/Renderers/Metal/GSTextureMTL.h
+++ b/pcsx2/GS/Renderers/Metal/GSTextureMTL.h
@@ -45,6 +45,8 @@ public:
 	id<MTLTexture> GetTexture() { return m_texture; }
 	id<MTLTexture> GetROVTexture() { return m_rov_texture; }
 
+	GSVector4 GetMTLClearValue() const;
+
 #ifdef PCSX2_DEVBUILD
 	void SetDebugName(std::string_view name) override;
 #endif

--- a/pcsx2/GS/Renderers/Metal/GSTextureMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSTextureMTL.mm
@@ -129,6 +129,30 @@ void GSTextureMTL::GenerateMipmap()
 	}
 }}
 
+GSVector4 GSTextureMTL::GetMTLClearValue() const
+{
+	if (IsDepthStencil())
+	{
+		return GSVector4(GetClearDepth(), 0.0f, 0.0f, 0.0f);
+	}
+	else if (IsRenderTarget())
+	{
+		if (IsDepthInteger())
+		{
+			return GSVector4(static_cast<float>(GetClearValue()), 0.0f, 0.0f, 0.0f);
+		}
+		else
+		{
+			return GSVector4::unorm8(GetClearValue());
+		}
+	}
+	else
+	{
+		pxAssert(false);
+		return GSVector4::zero();
+	}
+}
+
 #ifdef PCSX2_DEVBUILD
 
 void GSTextureMTL::SetDebugName(std::string_view name)
@@ -181,7 +205,7 @@ void GSDownloadTextureMTL::CopyFromTexture(
 { @autoreleasepool {
 	GSTextureMTL* const mtlTex = static_cast<GSTextureMTL*>(stex);
 
-	pxAssert(mtlTex->GetFormat() == m_format);
+	pxAssert(GSTexture::AreFormatsEquivalent(mtlTex->GetFormat(), m_format));
 	pxAssert(drc.width() == src.width() && drc.height() == src.height());
 	pxAssert(src.z <= mtlTex->GetWidth() && src.w <= mtlTex->GetHeight());
 	pxAssert(static_cast<u32>(drc.z) <= m_width && static_cast<u32>(drc.w) <= m_height);

--- a/pcsx2/GS/Renderers/Metal/convert.metal
+++ b/pcsx2/GS/Renderers/Metal/convert.metal
@@ -5,9 +5,13 @@
 
 using namespace metal;
 
-constant bool BILN      [[function_constant(GSMTLConstantIndex_BILN)]];
-constant bool DEPTH_OUT [[function_constant(GSMTLConstantIndex_DEPTH_OUT)]];
-constant bool COLOR_OUT = !DEPTH_OUT;
+constant bool BILN        [[function_constant(GSMTLConstantIndex_BILN)]];
+constant bool INTEGER_IN  [[function_constant(GSMTLConstantIndex_INTEGER_IN)]];
+constant bool INTEGER_OUT [[function_constant(GSMTLConstantIndex_INTEGER_OUT)]];
+constant bool FLOAT_IN  = !INTEGER_IN;
+constant bool FLOAT_OUT = !INTEGER_OUT;
+constant bool DEPTH_OUT   [[function_constant(GSMTLConstantIndex_DEPTH_OUT)]];
+constant bool COLOR_OUT = !DEPTH_OUT && !INTEGER_OUT;
 
 struct ConvertVSIn
 {
@@ -160,24 +164,51 @@ fragment float4 ps_filter_transparency(ConvertShaderData data [[stage_in]], Conv
 	return float4(c.rgb, 1.0);
 }
 
-fragment uint ps_convert_depth32_32bits(ConvertShaderData data [[stage_in]], ConvertPSDepthRes res)
+struct FloatOrUIntDepth
 {
-	return uint(0x1p32 * res.sample(data.t));
+	float f;
+	uint u;
+	explicit FloatOrUIntDepth(float value): f(value), u(value * 0x1p32) {}
+	explicit FloatOrUIntDepth(uint value): f(value * 0x1p-32), u(value) {}
+};
+
+struct DepthOrColorOut
+{
+	float color [[color(0), function_constant(COLOR_OUT)]];
+	float depth [[depth(any), function_constant(DEPTH_OUT)]];
+	uint ucolor [[color(0), function_constant(INTEGER_OUT)]];
+	DepthOrColorOut(float value): color(value), depth(value), ucolor(value * 0x1p32) {}
+	DepthOrColorOut(uint value): color(value * 0x1p-32), depth(value * 0x1p-32), ucolor(value) {}
+	DepthOrColorOut(FloatOrUIntDepth value)
+		: color(FLOAT_IN ? value.f : float(value.u) * 0x1p-32)
+		, depth(FLOAT_IN ? value.f : float(value.u) * 0x1p-32)
+		, ucolor(FLOAT_IN ? uint(value.f * 0x1p32) : value.u) {}
+};
+
+struct ConvertPSDepthOrColorRes
+{
+	texture2d<float> f [[texture(GSMTLTextureIndexNonHW), function_constant(FLOAT_IN)]];
+	texture2d<uint> u [[texture(GSMTLTextureIndexNonHW), function_constant(INTEGER_IN)]];
+	sampler s [[sampler(0)]];
+	FloatOrUIntDepth sample(float2 coord)
+	{
+		return FLOAT_IN ? FloatOrUIntDepth(f.sample(s, coord).x) : FloatOrUIntDepth(u.sample(s, coord).x);
+	}
+};
+
+fragment uint ps_convert_depth32_32bits(ConvertShaderData data [[stage_in]], ConvertPSDepthOrColorRes res)
+{
+	return res.sample(data.t).u;
 }
 
-fragment float4 ps_convert_depth32_rgba8(ConvertShaderData data [[stage_in]], ConvertPSDepthRes res)
+fragment float4 ps_convert_depth32_rgba8(ConvertShaderData data [[stage_in]], ConvertPSDepthOrColorRes res)
 {
-	return convert_depth32_rgba8(res.sample(data.t)) / 255.f;
+	return (FLOAT_IN ? convert_depth32_rgba8(res.sample(data.t).f) : convert_depth32_rgba8(res.sample(data.t).u)) / 255.f;
 }
 
-fragment float4 ps_convert_depth16_rgb5a1(ConvertShaderData data [[stage_in]], ConvertPSDepthRes res)
+fragment float4 ps_convert_depth16_rgb5a1(ConvertShaderData data [[stage_in]], ConvertPSDepthOrColorRes res)
 {
-	return convert_depth16_rgba8(res.sample(data.t)) / 255.f;
-}
-
-fragment float ps_convert_float32_depth_to_color(ConvertShaderData data [[stage_in]], ConvertPSDepthRes res)
-{
-	return res.sample(data.t);
+	return (FLOAT_IN ? convert_depth16_rgba8(res.sample(data.t).f) :  convert_depth16_rgba8(res.sample(data.t).u)) / 255.f;
 }
 
 fragment float4 ps_downsample_copy(ConvertShaderData data [[stage_in]],
@@ -196,44 +227,34 @@ fragment float4 ps_downsample_copy(ConvertShaderData data [[stage_in]],
 	return result;
 }
 
-static float rgba8_to_depth32(half4 unorm)
+static FloatOrUIntDepth rgba8_to_depth32(half4 unorm)
 {
-	return float(as_type<uint>(uchar4(unorm * 255.5h))) * 0x1p-32f;
+	return FloatOrUIntDepth(as_type<uint>(uchar4(unorm * 255.5h)));
 }
 
-static float rgba8_to_depth24(half4 unorm)
+static FloatOrUIntDepth rgba8_to_depth24(half4 unorm)
 {
 	return rgba8_to_depth32(half4(unorm.rgb, 0));
 }
 
-static float rgba8_to_depth16(half4 unorm)
+static FloatOrUIntDepth rgba8_to_depth16(half4 unorm)
 {
-	return float(as_type<ushort>(uchar2(unorm.rg * 255.5h))) * 0x1p-32f;
+	return FloatOrUIntDepth(uint(as_type<ushort>(uchar2(unorm.rg * 255.5h))));
 }
 
-static float rgb5a1_to_depth16(half4 unorm)
+static FloatOrUIntDepth rgb5a1_to_depth16(half4 unorm)
 {
 	uint4 cu = uint4(unorm * 255.5h);
 	uint out = (cu.x >> 3) | ((cu.y << 2) & 0x03e0) | ((cu.z << 7) & 0x7c00) | ((cu.w << 8) & 0x8000);
-	return float(out) * 0x1p-32f;
+	return FloatOrUIntDepth(out);
 }
 
-struct DepthOrColorOut
+static FloatOrUIntDepth lerp_depth(FloatOrUIntDepth a, FloatOrUIntDepth b, float c)
 {
-	float color [[color(0), function_constant(COLOR_OUT)]];
-	float depth [[depth(any), function_constant(DEPTH_OUT)]];
-	DepthOrColorOut(float value): color(value), depth(value) {}
-};
-
-struct ConvertPSDepthOrColorRes
-{
-	texture2d<float> texture [[texture(GSMTLTextureIndexNonHW)]];
-	sampler s [[sampler(0)]];
-	float sample(float2 coord)
-	{
-		return texture.sample(s, coord).x;
-	}
-};
+  uint absdiff = a.u > b.u ? a.u - b.u : b.u - a.u;
+  uint adjust = min(uint(round(float(absdiff) * c)), absdiff);
+  return FLOAT_IN ? FloatOrUIntDepth(mix(a.f, b.f, c)) : FloatOrUIntDepth(a.u > b.u ? a.u - adjust : a.u + adjust);
+}
 
 struct ConvertToDepthRes
 {
@@ -247,8 +268,8 @@ struct ConvertToDepthRes
 	}
 
 	/// Manual bilinear sampling where we do the bilinear *after* rgba → depth conversion
-	template <float (&convert)(half4)>
-	float sample_biln(float2 coord)
+	template <FloatOrUIntDepth (&convert)(half4)>
+	FloatOrUIntDepth sample_biln(float2 coord)
 	{
 		uint2 dimensions = uint2(texture.get_width(), texture.get_height());
 		float2 top_left_f = coord * float2(dimensions) - 0.5f;
@@ -256,15 +277,15 @@ struct ConvertToDepthRes
 		uint4 coords = uint4(clamp(int4(top_left, top_left + 1), 0, int2(dimensions - 1).xyxy));
 		float2 mix_vals = fract(top_left_f);
 
-		float depthTL = convert(texture.read(coords.xy));
-		float depthTR = convert(texture.read(coords.zy));
-		float depthBL = convert(texture.read(coords.xw));
-		float depthBR = convert(texture.read(coords.zw));
-		return mix(mix(depthTL, depthTR, mix_vals.x), mix(depthBL, depthBR, mix_vals.x), mix_vals.y);
+		FloatOrUIntDepth depthTL = convert(texture.read(coords.xy));
+		FloatOrUIntDepth depthTR = convert(texture.read(coords.zy));
+		FloatOrUIntDepth depthBL = convert(texture.read(coords.xw));
+		FloatOrUIntDepth depthBR = convert(texture.read(coords.zw));
+		return lerp_depth(lerp_depth(depthTL, depthTR, mix_vals.x), lerp_depth(depthBL, depthBR, mix_vals.x), mix_vals.y);
 	}
 
-	template <float (&convert)(half4)>
-	float sample_maybe_biln(float2 coord)
+	template <FloatOrUIntDepth (&convert)(half4)>
+	FloatOrUIntDepth sample_maybe_biln(float2 coord)
 	{
 		if (BILN)
 			return sample_biln<convert>(coord);
@@ -278,9 +299,9 @@ fragment DepthOrColorOut ps_depth_copy(ConvertShaderData data [[stage_in]], Conv
 	return res.sample(data.t);
 }
 
-static float depth32_to_depth24(float d)
+static FloatOrUIntDepth depth32_to_depth24(FloatOrUIntDepth d)
 {
-	return float(uint(d * exp2(32.0f)) & 0xffffff) * exp2(-32.0f); 
+	return FloatOrUIntDepth(d.u & 0xffffff); 
 }
 
 fragment DepthOrColorOut ps_convert_depth32_depth24(ConvertShaderData data [[stage_in]], ConvertPSDepthOrColorRes res)

--- a/pcsx2/GS/Renderers/OpenGL/GLState.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GLState.cpp
@@ -24,6 +24,8 @@ namespace GLState
 	u8 bf;
 	u8 wrgba;
 
+	bool ds_as_rt_mask;
+
 	bool depth;
 	GLenum depth_func;
 	bool depth_mask;
@@ -67,6 +69,8 @@ namespace GLState
 		f_dA = GL_ZERO;
 		bf = 0;
 		wrgba = 0xF;
+
+		ds_as_rt_mask = false;
 
 		depth = false;
 		depth_func = GL_LESS;

--- a/pcsx2/GS/Renderers/OpenGL/GLState.h
+++ b/pcsx2/GS/Renderers/OpenGL/GLState.h
@@ -28,6 +28,8 @@ namespace GLState
 	extern u8 bf;
 	extern u8 wrgba;
 
+	extern bool ds_as_rt_mask;
+
 	extern bool depth;
 	extern GLenum depth_func;
 	extern bool depth_mask;

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -387,7 +387,7 @@ bool GSDeviceOGL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 			glBindBufferRange(GL_SHADER_STORAGE_BUFFER, g_vs_vb_index, m_vertex_stream_buffer->GetGLBufferId(), 0, VERTEX_BUFFER_SIZE);
 		}
 
-		if (m_features.aa1)
+		if (UseVSExpandIndexBuffer())
 		{
 			glGenVertexArrays(1, &m_dummy_vao);
 			glBindBufferRange(GL_SHADER_STORAGE_BUFFER, g_vs_ib_index, m_expand_index_stream_buffer->GetGLBufferId(), 0, INDEX_BUFFER_SIZE);
@@ -434,7 +434,8 @@ bool GSDeviceOGL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 			std::string macro;
 			macro += fmt::format("#define HAS_BILN {}\n", static_cast<int>(shader.Biln()));
 			macro += fmt::format("#define HAS_STENCIL_OUTPUT {}\n", static_cast<int>(shader.StencilOutput()));
-			macro += fmt::format("#define HAS_INTEGER_OUTPUT {}\n", static_cast<int>(shader.IntegerOutputBpp() != 0));
+			macro += fmt::format("#define HAS_INTEGER_INPUT {}\n", static_cast<int>(shader.IntegerInput()));
+			macro += fmt::format("#define HAS_INTEGER_OUTPUT {}\n", static_cast<int>(shader.IntegerOutput()));
 			macro += fmt::format("#define HAS_DEPTH_OUTPUT {}\n", static_cast<int>(shader.DepthOutput()));
 			macro += fmt::format("#define HAS_FLOAT32_INPUT {}\n", static_cast<int>(shader.Float32Input()));
 			macro += fmt::format("#define HAS_FLOAT32_OUTPUT {}\n", static_cast<int>(shader.Float32Output()));
@@ -446,9 +447,9 @@ bool GSDeviceOGL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 			if (!m_shader_cache.GetProgram(&prog, m_convert.vs, ps))
 				return false;
 
-			prog.SetFormattedName("Convert pipeline (%s, mask=%x, depth=%d, biln=%d)",
-				shader.Name(), shader.Mask(), static_cast<int>(shader.DepthOutput()),
-				static_cast<int>(shader.Biln()));
+			prog.SetFormattedName("Convert pipeline (%s, mask=%x, int_in=%d, int_out=%d, depth_out=%d, biln=%d)",
+				shader.Name(), shader.Mask(), static_cast<int>(shader.IntegerInput()), static_cast<int>(shader.IntegerOutput()),
+				static_cast<int>(shader.DepthOutput()), static_cast<int>(shader.Biln()));
 
 			if (shader.Shader() == ShaderConvert::RGBA_TO_8I || shader.Shader() == ShaderConvert::RGB5A1_TO_8I)
 			{
@@ -487,6 +488,13 @@ bool GSDeviceOGL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 		m_convert.dss_write->EnableDepth();
 		m_convert.dss_write->SetDepth(GL_ALWAYS, true);
 	}
+
+	// ****************************************************************
+	// feedback
+	// ****************************************************************
+	// Make sure we only point sample RT and DS.
+	glBindSampler(3, m_convert.pt);
+	glBindSampler(4, m_convert.pt);
 
 	// ****************************************************************
 	// present
@@ -660,7 +668,7 @@ bool GSDeviceOGL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 	m_gpu_pipeline_statistics_supported = (GLAD_GL_ARB_pipeline_statistics_query != 0);
 
 	// Basic to ensure structures are correctly packed
-	static_assert(sizeof(VSSelector) == 1, "Wrong VSSelector size");
+	static_assert(sizeof(VSSelector) == 2, "Wrong VSSelector size");
 	static_assert(sizeof(PSSelector) == 16, "Wrong PSSelector size");
 	static_assert(sizeof(PSSamplerSelector) == 1, "Wrong PSSamplerSelector size");
 	static_assert(sizeof(OMDepthStencilSelector) == 1, "Wrong OMDepthStencilSelector size");
@@ -912,6 +920,8 @@ bool GSDeviceOGL::CheckFeatures()
 	
 	m_features.aa1 = GSConfig.HWAA1 && m_features.vs_expand && m_features.feedback_loops();
 	
+	m_features.depth_integer = GSConfig.HWZIntegerMode != GSHardwareZIntegerMode::Disabled && m_features.vs_expand;
+
 	return true;
 }
 
@@ -1419,18 +1429,22 @@ void GSDeviceOGL::CommitClear(GSTexture* t, bool use_write_fbo)
 			const u32 old_color_mask = GLState::wrgba;
 			OMSetColorMaskState();
 
-			const GSVector4 c_unorm = T->GetClearForFormat();
+			const GSVector4 c = T->GetGLClearValue();
 
-			if (T->IsIntegerFormat())
+			if (T->IsDepthInteger())
+			{
+				glClearBufferuiv(GL_COLOR, 0, c.U32);
+			}
+			else if (T->IsIntegerFormat())
 			{
 				if (T->IsUnsignedFormat())
-					glClearBufferuiv(GL_COLOR, 0, c_unorm.U32);
+					glClearBufferuiv(GL_COLOR, 0, c.U32);
 				else
-					glClearBufferiv(GL_COLOR, 0, c_unorm.I32);
+					glClearBufferiv(GL_COLOR, 0, c.I32);
 			}
 			else
 			{
-				glClearBufferfv(GL_COLOR, 0, c_unorm.v);
+				glClearBufferfv(GL_COLOR, 0, c.F32);
 			}
 
 			OMSetColorMaskState(OMColorMaskSelector(old_color_mask));
@@ -1640,7 +1654,8 @@ std::string GSDeviceOGL::GetVSSource(VSSelector sel)
 	std::string macro = fmt::format("#define VS_FST {}\n", static_cast<u32>(sel.fst))
 		+ fmt::format("#define VS_IIP {}\n", static_cast<u32>(sel.iip))
 		+ fmt::format("#define VS_POINT_SIZE {}\n", static_cast<u32>(sel.point_size))
-		+ fmt::format("#define VS_EXPAND {}\n", static_cast<int>(sel.expand));
+		+ fmt::format("#define VS_EXPAND {}\n", static_cast<int>(sel.expand))
+		+ fmt::format("#define VS_Z_INTEGER {}\n", static_cast<u32>(sel.zint));
 
 	std::string src = GenGlslHeader("vs_main", GL_VERTEX_SHADER, macro);
 	src += m_shader_tfx_vgs;
@@ -1713,6 +1728,9 @@ std::string GSDeviceOGL::GetPSSource(const PSSelector& sel)
 		+ fmt::format("#define PS_ANISOTROPIC_FILTERING {}\n", sel.sw_aniso)
 		+ fmt::format("#define PS_ROV_COLOR {}\n", 0)
 		+ fmt::format("#define PS_ROV_DEPTH {}\n", 0)
+		+ fmt::format("#define PS_Z_RT_SLOT {}\n", sel.z_rt_slot)
+		+ fmt::format("#define PS_Z_INTEGER {}\n", static_cast<u32>(sel.zint))
+		+ fmt::format("#define PS_TEX_INTEGER {}\n", sel.texint)
 	;
 
 	std::string src = GenGlslHeader("ps_main", GL_FRAGMENT_SHADER, macro);
@@ -2646,13 +2664,20 @@ void GSDeviceOGL::OMSetDepthStencilState(GSDepthStencilOGL* dss)
 	dss->SetupStencil();
 }
 
-void GSDeviceOGL::OMSetColorMaskState(OMColorMaskSelector sel)
+void GSDeviceOGL::OMSetColorMaskState(OMColorMaskSelector sel, bool ds_as_rt_mask)
 {
 	if (sel.wrgba != GLState::wrgba)
 	{
 		GLState::wrgba = sel.wrgba;
 
 		glColorMaski(0, sel.wr, sel.wg, sel.wb, sel.wa);
+	}
+
+	if (GLState::ds_as_rt_mask != ds_as_rt_mask)
+	{
+		GLState::ds_as_rt_mask = ds_as_rt_mask;
+
+		glColorMaski(1, ds_as_rt_mask, ds_as_rt_mask, ds_as_rt_mask, ds_as_rt_mask);
 	}
 }
 
@@ -2848,12 +2873,14 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 	if (config.pal)
 		CommitClear(config.pal, true);
 
-	const GSVector2i rtsize = (config.rt ? config.rt : config.ds)->GetSize();
+	const GSVector2i rtsize = (config.rt ? config.rt : (config.ds ? config.ds : config.ds_int))->GetSize();
 	GSTexture* colclip_rt = g_gs_device->GetColorClipTexture();
 	GSTexture* draw_rt = config.rt;
-	GSTexture* draw_ds = config.ds;
-	GSTexture* draw_ds_as_rt = m_ds_as_rt;
+	GSTexture* draw_ds = config.ds_int ? nullptr : config.ds;
+	GSTexture* draw_ds_as_rt = config.ds_int ? config.ds_int : (m_features.depth_feedback ? nullptr : m_ds_as_rt);
+	const bool ds_as_rt_mask = config.ds_int ? (config.ps.zint == GSHWDrawConfig::PS_Z_INTEGER::READ_WRITE) : (draw_ds_as_rt != nullptr);
 	GSTexture* draw_rt_clone = nullptr;
+	GSTexture* draw_ds_as_rt_clone = nullptr;
 	GSTexture* draw_ds_clone = nullptr;
 	GSTexture* primid_texture = nullptr;
 
@@ -2921,7 +2948,7 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 		case GSHWDrawConfig::DestinationAlphaMode::Full:
 			break; // No setup
 		case GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking:
-			primid_texture = InitPrimDateTexture(colclip_rt ? colclip_rt : config.rt, config.drawarea, config.datm);
+			primid_texture = InitPrimDateTexture(draw_rt, config.drawarea, config.datm);
 			if (!primid_texture)
 			{
 				Console.Warning("GL: Failed to allocate DATE image, aborting draw.");
@@ -2936,7 +2963,7 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 			}
 			[[fallthrough]];
 		case GSHWDrawConfig::DestinationAlphaMode::Stencil:
-			SetupDATE(colclip_rt ? colclip_rt : config.rt, config.ds, config.datm, config.drawarea);
+			SetupDATE(draw_rt, config.ds, config.datm, config.drawarea);
 			break;
 	}
 
@@ -2973,9 +3000,9 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 	if (config.pal)
 		PSSetShaderResource(TEXTURE_PALETTE, config.pal);
 	if (m_features.texture_barrier && (config.require_one_barrier || config.require_full_barrier))
-		PSSetShaderResource(TEXTURE_RT, colclip_rt ? colclip_rt : config.rt);
+		PSSetShaderResource(TEXTURE_RT, draw_rt);
 	if (m_features.texture_barrier && (config.require_one_barrier || config.require_full_barrier) && config.ps.IsFeedbackLoopDepth())
-		PSSetShaderResource(TEXTURE_DEPTH, m_features.depth_feedback ? config.ds : m_ds_as_rt);
+		PSSetShaderResource(TEXTURE_DEPTH, draw_ds_as_rt ? draw_ds_as_rt : draw_ds);
 
 	SetupSampler(config.sampler);
 
@@ -3106,8 +3133,8 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 			Console.Warning("GL: Failed to allocate temp texture for RT copy.");
 	}
 
-	const bool ds_feedbackloop_pass1 = config.ps.IsFeedbackLoopDepth();
-	const bool ds_feedbackloop_pass2 = config.alpha_second_pass.ps.IsFeedbackLoopDepth();
+	const bool ds_feedbackloop_pass1 = draw_ds && config.ps.IsFeedbackLoopDepth();
+	const bool ds_feedbackloop_pass2 = draw_ds && config.alpha_second_pass.ps.IsFeedbackLoopDepth();
 	if (draw_ds && !m_features.texture_barrier && m_features.depth_feedback &&
 		(config.require_one_barrier || (config.require_full_barrier && m_features.multidraw_fb_copy)) && (ds_feedbackloop_pass1 || ds_feedbackloop_pass2))
 	{
@@ -3118,8 +3145,20 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 			Console.Warning("GL: Failed to allocate temp texture for DS copy.");
 	}
 
+	const bool ds_as_rt_feedbackloop_pass1 = draw_ds_as_rt && config.ps.IsFeedbackLoopDepth();
+	const bool ds_as_rt_feedbackloop_pass2 = draw_ds_as_rt && config.alpha_second_pass.ps.IsFeedbackLoopDepth();
+	if (draw_ds_as_rt && !m_features.texture_barrier &&
+		(config.require_one_barrier || (config.require_full_barrier && m_features.multidraw_fb_copy)) && (ds_as_rt_feedbackloop_pass1 || ds_as_rt_feedbackloop_pass2))
+	{
+		// Requires a copy of the DS.
+		draw_ds_as_rt_clone = CreateTexture(rtsize.x, rtsize.y, 1, draw_ds_as_rt->GetFormat(), true);
+
+		if (!draw_ds_as_rt_clone)
+			Console.Warning("GL: Failed to allocate temp texture for DS as RT copy.");
+	}
+
 	OMSetRenderTargets(draw_rt, draw_ds_as_rt, draw_ds, &config.scissor);
-	OMSetColorMaskState(config.colormask);
+	OMSetColorMaskState(config.colormask, ds_as_rt_mask);
 	SetupOM(config.depth);
 
 	// Clear stencil as close as possible to the RT bind, to avoid framebuffer swaps.
@@ -3129,9 +3168,11 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 		glClearBufferiv(GL_STENCIL, 0, &clear_color);
 	}
 
-	SendHWDraw(config, rt_feedbackloop_pass1 ? draw_rt_clone : nullptr, draw_rt, ds_feedbackloop_pass1 ? draw_ds_clone : nullptr, draw_ds,
+	SendHWDraw(config, rt_feedbackloop_pass1 ? draw_rt_clone : nullptr, draw_rt,
+		ds_as_rt_feedbackloop_pass1 ? draw_ds_as_rt_clone : nullptr, draw_ds_as_rt,
+		ds_feedbackloop_pass1 ? draw_ds_clone : nullptr, draw_ds,
 		config.require_one_barrier, config.require_full_barrier);
-
+	
 	if (config.blend_multi_pass.enable)
 	{
 		if (config.blend.IsEffective(config.colormask))
@@ -3177,7 +3218,9 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 		}
 		const bool one_barrier = config.alpha_second_pass.require_one_barrier && m_features.feedback_loops();
 		SetupOM(config.alpha_second_pass.depth);
-		SendHWDraw(config, rt_feedbackloop_pass2 ? draw_rt_clone : nullptr, draw_rt, ds_feedbackloop_pass2 ? draw_ds_clone : nullptr, draw_ds,
+		SendHWDraw(config, rt_feedbackloop_pass2 ? draw_rt_clone : nullptr, draw_rt,
+			ds_as_rt_feedbackloop_pass2 ? draw_ds_as_rt_clone : nullptr, draw_ds_as_rt,
+			ds_feedbackloop_pass2 ? draw_ds_clone : nullptr, draw_ds,
 			one_barrier, config.alpha_second_pass.require_full_barrier);
 	}
 
@@ -3199,27 +3242,38 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 }
 
 void GSDeviceOGL::FeedbackCopyAndBind(const GSHWDrawConfig& config,
-	GSTexture* rt, GSTexture* rt_clone, GSTexture* ds, GSTexture* ds_clone, const GSVector4i& copyarea)
+	GSTexture* rt, GSTexture* rt_clone,
+	GSTexture* ds_as_rt, GSTexture* ds_as_rt_clone,
+	GSTexture* ds, GSTexture* ds_clone, const GSVector4i& copyarea)
 {
 	if (rt_clone)
 	{
 		CopyRect(rt, rt_clone, copyarea, copyarea.left, copyarea.top);
-		PSSetShaderResource(2, rt_clone);
+		PSSetShaderResource(TEXTURE_RT, rt_clone);
 		if (config.tex_hazard == GSHWDrawConfig::TEX_HAZARD_RT)
 			PSSetShaderResource(0, rt_clone);
+	}
+	if (ds_as_rt_clone)
+	{
+		CopyRect(ds_as_rt, ds_as_rt_clone, copyarea, copyarea.left, copyarea.top);
+		PSSetShaderResource(TEXTURE_DEPTH, ds_as_rt_clone);
+		if (config.tex_hazard == GSHWDrawConfig::TEX_HAZARD_DEPTH)
+			PSSetShaderResource(TEXTURE_TEXTURE, ds_as_rt_clone);
 	}
 	if (ds_clone)
 	{
 		CopyRect(ds, ds_clone, copyarea, copyarea.left, copyarea.top);
-		PSSetShaderResource(4, ds_clone);
+		PSSetShaderResource(TEXTURE_DEPTH, ds_clone);
 		if (config.tex_hazard == GSHWDrawConfig::TEX_HAZARD_DEPTH)
-			PSSetShaderResource(0, ds_clone);
+			PSSetShaderResource(TEXTURE_TEXTURE, ds_clone);
 	}
 }
 
 // Choose the best copy area based on the hazards and whether we need RT and/or DS copies.
 void GSDeviceOGL::FeedbackCopyAndBind(const GSHWDrawConfig& config,
-	GSTexture* rt, GSTexture* rt_clone, GSTexture* ds, GSTexture* ds_clone,
+	GSTexture* rt, GSTexture* rt_clone,
+	GSTexture* ds_as_rt, GSTexture* ds_as_rt_clone,
+	GSTexture* ds, GSTexture* ds_clone,
 	const GSVector4i& copyarea, const GSVector4i& samplearea)
 {
 	const GSVector4i rtsize = (rt ? rt : ds)->GetRect();
@@ -3234,23 +3288,25 @@ void GSDeviceOGL::FeedbackCopyAndBind(const GSHWDrawConfig& config,
 		// Do an individual copy if the union is larger than the sum of individual areas.
 		if (size_union > size_indiv)
 		{
-			FeedbackCopyAndBind(config, rt, rt_clone, ds, ds_clone, ProcessCopyArea(rtsize, config.drawarea));
-			FeedbackCopyAndBind(config, rt, rt_clone, ds, ds_clone, ProcessCopyArea(rtsize, config.samplearea));
+			FeedbackCopyAndBind(config, rt, rt_clone, ds_as_rt, ds_as_rt_clone, ds, ds_clone, ProcessCopyArea(rtsize, config.drawarea));
+			FeedbackCopyAndBind(config, rt, rt_clone, ds_as_rt, ds_as_rt_clone, ds, ds_clone, ProcessCopyArea(rtsize, config.samplearea));
 		}
 		else
 		{
-			FeedbackCopyAndBind(config, rt, rt_clone, ds, ds_clone, ProcessCopyArea(rtsize, union_rect));
+			FeedbackCopyAndBind(config, rt, rt_clone, ds_as_rt, ds_as_rt_clone, ds, ds_clone, ProcessCopyArea(rtsize, union_rect));
 		}
 	}
 	else
 	{
 		// No RT/DS hazards so just need the draw area.
-		FeedbackCopyAndBind(config, rt, rt_clone, ds, ds_clone, ProcessCopyArea(rtsize, config.drawarea));
+		FeedbackCopyAndBind(config, rt, rt_clone, ds_as_rt, ds_as_rt_clone, ds, ds_clone, ProcessCopyArea(rtsize, config.drawarea));
 	}
 }
 
 void GSDeviceOGL::SendHWDraw(const GSHWDrawConfig& config,
-	GSTexture* draw_rt_clone, GSTexture* draw_rt, GSTexture* draw_ds_clone, GSTexture* draw_ds,
+	GSTexture* draw_rt_clone, GSTexture* draw_rt,
+	GSTexture* draw_ds_as_rt_clone, GSTexture* draw_ds_as_rt,
+	GSTexture* draw_ds_clone, GSTexture* draw_ds,
 	const bool one_barrier, const bool full_barrier)
 {
 #ifdef PCSX2_DEVBUILD
@@ -3271,7 +3327,7 @@ void GSDeviceOGL::SendHWDraw(const GSHWDrawConfig& config,
 			pxAssert(config.drawlist_bbox && static_cast<u32>(config.drawlist_bbox->size()) == draw_list_size);
 
 		if (!m_features.texture_barrier && config.tex_hazard != config.TEX_HAZARD_NONE)
-			FeedbackCopyAndBind(config, draw_rt, draw_rt_clone, draw_ds, draw_ds_clone, config.samplearea);
+			FeedbackCopyAndBind(config, draw_rt, draw_rt_clone, draw_ds_as_rt, draw_ds_as_rt_clone, draw_ds, draw_ds_clone, config.samplearea);
 
 		for (u32 n = 0, p = 0; n < draw_list_size; n++)
 		{
@@ -3284,7 +3340,8 @@ void GSDeviceOGL::SendHWDraw(const GSHWDrawConfig& config,
 			else
 			{
 				const GSVector4i bbox = config.drawlist_bbox->at(n).rintersect(config.drawarea);
-				FeedbackCopyAndBind(config, draw_rt, draw_rt_clone, draw_ds, draw_ds_clone, bbox);
+				FeedbackCopyAndBind(config, draw_rt, draw_rt_clone, draw_ds_as_rt, draw_ds_as_rt_clone, draw_ds, draw_ds_clone,
+					bbox);
 			}
 
 			Draw(config, p, count);
@@ -3304,7 +3361,8 @@ void GSDeviceOGL::SendHWDraw(const GSHWDrawConfig& config,
 		else
 		{
 			// Optimization: For alpha second pass we can reuse the copy snapshot from the first pass.
-			FeedbackCopyAndBind(config, draw_rt, draw_rt_clone, draw_ds, draw_ds_clone, config.drawarea, config.samplearea);
+			FeedbackCopyAndBind(config, draw_rt, draw_rt_clone, draw_ds_as_rt, draw_ds_as_rt_clone, draw_ds, draw_ds_clone,
+				config.drawarea, config.samplearea);
 		}
 	}
 

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -128,7 +128,7 @@ public:
 	{
 		PSSelector ps;
 		VSSelector vs;
-		u8 pad[15];
+		u8 pad[14];
 
 		__fi bool operator==(const ProgramSelector& p) const { return BitEqual(*this, p); }
 		__fi bool operator!=(const ProgramSelector& p) const { return !BitEqual(*this, p); }
@@ -330,6 +330,7 @@ public:
 	__fi bool IsDownloadPBODisabled() const { return m_disable_download_pbo; }
 	__fi u32 GetFBORead() const { return m_fbo_read; }
 	__fi u32 GetFBOWrite() const { return m_fbo_write; }
+	__fi bool UseVSExpandIndexBuffer() const { return m_features.aa1 || m_features.depth_integer; }
 	__fi GLStreamBuffer* GetTextureUploadBuffer() const { return m_texture_upload_buffer.get(); }
 	void CommitClear(GSTexture* t, bool use_write_fbo);
 
@@ -391,12 +392,18 @@ public:
 
 	void RenderHW(GSHWDrawConfig& config) override;
 	void FeedbackCopyAndBind(const GSHWDrawConfig& config,
-		GSTexture* rt, GSTexture* rt_clone, GSTexture* ds, GSTexture* ds_clone, const GSVector4i& copyarea);
+		GSTexture* rt, GSTexture* rt_clone,
+		GSTexture* ds_as_rt, GSTexture* ds_as_rt_clone,
+		GSTexture* ds, GSTexture* ds_clone, const GSVector4i& copyarea);
 	void FeedbackCopyAndBind(const GSHWDrawConfig& config,
-		GSTexture* rt, GSTexture* rt_clone, GSTexture* ds, GSTexture* ds_clone,
+		GSTexture* rt, GSTexture* rt_clone,
+		GSTexture* ds_as_rt, GSTexture* ds_as_rt_clone,
+		GSTexture* ds, GSTexture* ds_clone,
 		const GSVector4i& copyarea, const GSVector4i& samplearea);
 	void SendHWDraw(const GSHWDrawConfig& config,
-		GSTexture* draw_rt_clone, GSTexture* draw_rt, GSTexture* draw_ds_clone, GSTexture* draw_ds,
+		GSTexture* draw_rt_clone, GSTexture* draw_rt,
+		GSTexture* draw_ds_as_rt_clone, GSTexture* draw_ds_as_rt,
+		GSTexture* draw_ds_clone, GSTexture* draw_ds,
 		const bool one_barrier, const bool full_barrier);
 	void SetupDATE(GSTexture* rt, GSTexture* ds, SetDATM datm, const GSVector4i& bbox);
 
@@ -418,7 +425,7 @@ public:
 	void OMSetBlendState(bool enable = false, GLenum src_factor = GL_ONE, GLenum dst_factor = GL_ZERO, GLenum op = GL_FUNC_ADD,
 		GLenum src_factor_alpha = GL_ONE, GLenum dst_factor_alpha = GL_ZERO, bool is_constant = false, u8 constant = 0);
 	void OMSetRenderTargets(GSTexture* rt, GSTexture* ds_as_rt, GSTexture* ds, const GSVector4i* scissor = nullptr);
-	void OMSetColorMaskState(OMColorMaskSelector sel = OMColorMaskSelector());
+	void OMSetColorMaskState(OMColorMaskSelector sel = OMColorMaskSelector(), bool ds_as_rt_write = false);
 	void OMUnbindTexture(GSTextureOGL* tex);
 
 	void SetViewport(const GSVector2i& viewport);

--- a/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.cpp
@@ -69,6 +69,14 @@ GSTextureOGL::GSTextureOGL(Usage usage, int width, int height, int levels, Forma
 			m_int_type = GL_FLOAT;
 			m_int_shift = 2;
 			break;
+		
+		// 1 channel integer
+		case Format::DepthInteger:
+			m_gl_format = GL_R32UI;
+			m_int_format = GL_RED_INTEGER;
+			m_int_type = GL_UNSIGNED_INT;
+			m_int_shift = 2;
+			break;
 
 		// 4 channel normalized
 		case Format::Color:
@@ -422,7 +430,7 @@ void GSDownloadTextureOGL::CopyFromTexture(
 	GSTextureOGL* const glTex = static_cast<GSTextureOGL*>(stex);
 	GSDeviceOGL::GetInstance()->CommitClear(glTex, true);
 
-	pxAssert(glTex->GetFormat() == m_format);
+	pxAssert(GSTexture::AreFormatsEquivalent(glTex->GetFormat(), m_format));
 	pxAssert(drc.width() == src.width() && drc.height() == src.height());
 	pxAssert(src.z <= glTex->GetWidth() && src.w <= glTex->GetHeight());
 	pxAssert(static_cast<u32>(drc.z) <= m_width && static_cast<u32>(drc.w) <= m_height);

--- a/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.h
@@ -36,6 +36,22 @@ public:
 	__fi u32 GetIntShift() const { return m_int_shift; }
 	__fi u32 GetGLFormat() const { return m_gl_format; }
 
+	__fi GSVector4 GetGLClearValue()
+	{
+		if (IsDepthStencil() || IsDepthColor())
+		{
+			return GSVector4(static_cast<float>(GetClearValue()), 0.0f, 0.0f, 0.0f);
+		}
+		else if (IsDepthInteger())
+		{
+			return GSVector4::cast(GSVector4i(GetClearValue(), 0, 0, 0));
+		}
+		else
+		{
+			return GSVector4::unorm8(GetClearValue());
+		}
+	}
+
 	void* GetNativeHandle() const override;
 
 	bool Update(const GSVector4i& r, const void* data, int pitch, int layer = 0) override;

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -463,6 +463,7 @@ bool GSDeviceVK::SelectDeviceFeatures()
 	m_device_features.geometryShader = available_features.geometryShader;
 	m_device_features.fragmentStoresAndAtomics = available_features.fragmentStoresAndAtomics;
 	m_device_features.pipelineStatisticsQuery = available_features.pipelineStatisticsQuery;
+	m_device_features.independentBlend = available_features.independentBlend;
 
 	return true;
 }
@@ -1018,21 +1019,28 @@ bool GSDeviceVK::CreateGlobalDescriptorPool()
 	return true;
 }
 
-VkRenderPass GSDeviceVK::GetRenderPass(VkFormat color_format, VkFormat depth_format, VkAttachmentLoadOp color_load_op,
-	VkAttachmentStoreOp color_store_op, VkAttachmentLoadOp depth_load_op, VkAttachmentStoreOp depth_store_op,
-	VkAttachmentLoadOp stencil_load_op, VkAttachmentStoreOp stencil_store_op, bool color_feedback_loop,
-	bool depth_sampling)
+VkRenderPass GSDeviceVK::GetRenderPass(
+	VkFormat color_format, VkFormat depth_as_color_format, VkFormat depth_format,
+	VkAttachmentLoadOp color_load_op, VkAttachmentStoreOp color_store_op,
+	VkAttachmentLoadOp depth_as_color_load_op, VkAttachmentStoreOp depth_as_color_store_op,
+	VkAttachmentLoadOp depth_load_op, VkAttachmentStoreOp depth_store_op,
+	VkAttachmentLoadOp stencil_load_op, VkAttachmentStoreOp stencil_store_op,
+	bool color_feedback_loop, bool depth_as_color_feedback_loop, bool depth_sampling)
 {
 	RenderPassCacheKey key = {};
 	key.color_format = color_format;
+	key.depth_as_color_format = depth_as_color_format;
 	key.depth_format = depth_format;
 	key.color_load_op = color_load_op;
 	key.color_store_op = color_store_op;
+	key.depth_as_color_load_op = depth_as_color_load_op;
+	key.depth_as_color_store_op = depth_as_color_store_op;
 	key.depth_load_op = depth_load_op;
 	key.depth_store_op = depth_store_op;
 	key.stencil_load_op = stencil_load_op;
 	key.stencil_store_op = stencil_store_op;
 	key.color_feedback_loop = color_feedback_loop;
+	key.depth_as_color_feedback_loop = depth_as_color_feedback_loop;
 	key.depth_sampling = depth_sampling;
 
 	auto it = m_render_pass_cache.find(key.key);
@@ -1053,6 +1061,8 @@ VkRenderPass GSDeviceVK::GetRenderPassForRestarting(VkRenderPass pass)
 		modified_key.key = it.first;
 		if (modified_key.color_load_op == VK_ATTACHMENT_LOAD_OP_CLEAR)
 			modified_key.color_load_op = VK_ATTACHMENT_LOAD_OP_LOAD;
+		if (modified_key.depth_as_color_load_op == VK_ATTACHMENT_LOAD_OP_CLEAR)
+			modified_key.depth_as_color_load_op = VK_ATTACHMENT_LOAD_OP_LOAD;
 		if (modified_key.depth_load_op == VK_ATTACHMENT_LOAD_OP_CLEAR)
 			modified_key.depth_load_op = VK_ATTACHMENT_LOAD_OP_LOAD;
 		if (modified_key.stencil_load_op == VK_ATTACHMENT_LOAD_OP_CLEAR)
@@ -1602,30 +1612,32 @@ void GSDeviceVK::DisableDebugUtils()
 
 VkRenderPass GSDeviceVK::CreateCachedRenderPass(RenderPassCacheKey key)
 {
-	VkAttachmentReference color_reference;
-	VkAttachmentReference* color_reference_ptr = nullptr;
+	std::array<VkAttachmentReference, 2> color_reference;
+	u32 num_color_attachments = 0;
 	VkAttachmentReference depth_reference;
 	VkAttachmentReference* depth_reference_ptr = nullptr;
-	std::array<VkAttachmentReference, 2> input_reference;
+	std::array<VkAttachmentReference, 3> input_reference;
 	u32 num_subpass_inputs = 0;
-	std::array<VkSubpassDependency, 2> subpass_dependency;
+	std::array<VkSubpassDependency, 3> subpass_dependency;
 	u32 num_subpass_dependencies = 0;
-	std::array<VkAttachmentDescription, 2> attachments;
+	std::array<VkAttachmentDescription, 3> attachments;
 	u32 num_attachments = 0;
-	if (key.color_format != VK_FORMAT_UNDEFINED)
-	{
-		const VkImageLayout layout =
-			key.color_feedback_loop ? (UseFeedbackLoopLayout() ? VK_IMAGE_LAYOUT_ATTACHMENT_FEEDBACK_LOOP_OPTIMAL_EXT :
-																 VK_IMAGE_LAYOUT_GENERAL) :
-									  VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-		attachments[num_attachments] = {0, static_cast<VkFormat>(key.color_format), VK_SAMPLE_COUNT_1_BIT,
-			static_cast<VkAttachmentLoadOp>(key.color_load_op), static_cast<VkAttachmentStoreOp>(key.color_store_op),
-			VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE, layout, layout};
-		color_reference.attachment = num_attachments;
-		color_reference.layout = layout;
-		color_reference_ptr = &color_reference;
 
-		if (key.color_feedback_loop)
+	auto AddColorAttachment = [&input_reference, &num_subpass_inputs, &subpass_dependency, &num_subpass_dependencies,
+		&color_reference, &num_color_attachments, &attachments, &num_attachments, this](
+		u32 format, u32 load_op, u32 store_op, bool feedback_loop) {
+		const VkImageLayout layout =
+			feedback_loop ? (UseFeedbackLoopLayout() ? VK_IMAGE_LAYOUT_ATTACHMENT_FEEDBACK_LOOP_OPTIMAL_EXT :
+				VK_IMAGE_LAYOUT_GENERAL) :
+			VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+		attachments[num_attachments] = { 0, static_cast<VkFormat>(format), VK_SAMPLE_COUNT_1_BIT,
+			static_cast<VkAttachmentLoadOp>(load_op), static_cast<VkAttachmentStoreOp>(store_op),
+			VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE, layout, layout };
+		color_reference[num_color_attachments].attachment = num_attachments;
+		color_reference[num_color_attachments].layout = layout;
+		num_color_attachments++;
+
+		if (feedback_loop)
 		{
 			if (!UseFeedbackLoopLayout())
 			{
@@ -1647,28 +1659,33 @@ VkRenderPass GSDeviceVK::CreateCachedRenderPass(RenderPassCacheKey key)
 					UseFeedbackLoopLayout() ? VK_ACCESS_SHADER_READ_BIT : VK_ACCESS_INPUT_ATTACHMENT_READ_BIT;
 				subpass_dependency[num_subpass_dependencies].dependencyFlags =
 					UseFeedbackLoopLayout() ? (VK_DEPENDENCY_BY_REGION_BIT | VK_DEPENDENCY_FEEDBACK_LOOP_BIT_EXT) :
-											  VK_DEPENDENCY_BY_REGION_BIT;
+					VK_DEPENDENCY_BY_REGION_BIT;
 				num_subpass_dependencies++;
 			}
 		}
 
 		num_attachments++;
-	}
-	if (key.depth_format != VK_FORMAT_UNDEFINED)
+	};
+
+	auto AddDepthStencilAttachment = [&input_reference, &num_subpass_inputs, &subpass_dependency, &num_subpass_dependencies,
+		&attachments, &num_attachments, this](
+		u32 depth_format, u32 depth_load_op, u32 depth_store_op,
+		u32 stencil_load_op, u32 stencil_store_op, bool depth_sampling,
+		VkAttachmentReference& attachment_ref, VkAttachmentReference*& attachment_ref_ptr)
 	{
 		const VkImageLayout layout =
-			key.depth_sampling ? (UseFeedbackLoopLayout() ? VK_IMAGE_LAYOUT_ATTACHMENT_FEEDBACK_LOOP_OPTIMAL_EXT :
-															VK_IMAGE_LAYOUT_GENERAL) :
-								 VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-		attachments[num_attachments] = {0, static_cast<VkFormat>(key.depth_format), VK_SAMPLE_COUNT_1_BIT,
-			static_cast<VkAttachmentLoadOp>(key.depth_load_op), static_cast<VkAttachmentStoreOp>(key.depth_store_op),
-			static_cast<VkAttachmentLoadOp>(key.stencil_load_op),
-			static_cast<VkAttachmentStoreOp>(key.stencil_store_op), layout, layout};
-		depth_reference.attachment = num_attachments;
-		depth_reference.layout = layout;
-		depth_reference_ptr = &depth_reference;
+			depth_sampling ? (UseFeedbackLoopLayout() ? VK_IMAGE_LAYOUT_ATTACHMENT_FEEDBACK_LOOP_OPTIMAL_EXT :
+				VK_IMAGE_LAYOUT_GENERAL) :
+			VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+		attachments[num_attachments] = { 0, static_cast<VkFormat>(depth_format), VK_SAMPLE_COUNT_1_BIT,
+			static_cast<VkAttachmentLoadOp>(depth_load_op), static_cast<VkAttachmentStoreOp>(depth_store_op),
+			static_cast<VkAttachmentLoadOp>(stencil_load_op),
+			static_cast<VkAttachmentStoreOp>(stencil_store_op), layout, layout };
+		attachment_ref.attachment = num_attachments;
+		attachment_ref.layout = layout;
+		attachment_ref_ptr = &attachment_ref;
 
-		if (key.depth_sampling)
+		if (depth_sampling)
 		{
 			if (!UseFeedbackLoopLayout())
 			{
@@ -1691,12 +1708,27 @@ VkRenderPass GSDeviceVK::CreateCachedRenderPass(RenderPassCacheKey key)
 					UseFeedbackLoopLayout() ? VK_ACCESS_SHADER_READ_BIT : VK_ACCESS_INPUT_ATTACHMENT_READ_BIT;
 				subpass_dependency[num_subpass_dependencies].dependencyFlags =
 					UseFeedbackLoopLayout() ? (VK_DEPENDENCY_BY_REGION_BIT | VK_DEPENDENCY_FEEDBACK_LOOP_BIT_EXT) :
-											  VK_DEPENDENCY_BY_REGION_BIT;
+					VK_DEPENDENCY_BY_REGION_BIT;
 				num_subpass_dependencies++;
 			}
 		}
 
 		num_attachments++;
+	};
+
+	if (key.color_format != VK_FORMAT_UNDEFINED)
+	{
+		AddColorAttachment(key.color_format, key.color_load_op, key.color_store_op, key.color_feedback_loop);
+	}
+	if (key.depth_as_color_format != VK_FORMAT_UNDEFINED)
+	{
+		AddColorAttachment(key.depth_as_color_format, key.depth_as_color_load_op, key.depth_as_color_store_op,
+			key.depth_as_color_feedback_loop);
+	}
+	if (key.depth_format != VK_FORMAT_UNDEFINED)
+	{
+		AddDepthStencilAttachment(key.depth_format, key.depth_load_op, key.depth_store_op, key.stencil_load_op,
+			key.stencil_store_op, key.depth_sampling, depth_reference, depth_reference_ptr);
 	}
 
 	const VkSubpassDescriptionFlags subpass_flags =
@@ -1704,8 +1736,8 @@ VkRenderPass GSDeviceVK::CreateCachedRenderPass(RenderPassCacheKey key)
 			VK_SUBPASS_DESCRIPTION_RASTERIZATION_ORDER_ATTACHMENT_COLOR_ACCESS_BIT_EXT :
 			0;
 	const VkSubpassDescription subpass = {subpass_flags, VK_PIPELINE_BIND_POINT_GRAPHICS, num_subpass_inputs,
-		num_subpass_inputs ? input_reference.data() : nullptr, color_reference_ptr ? 1u : 0u,
-		color_reference_ptr ? color_reference_ptr : nullptr, nullptr, depth_reference_ptr, 0, nullptr};
+		num_subpass_inputs ? input_reference.data() : nullptr, num_color_attachments,
+		color_reference.data(), nullptr, depth_reference_ptr, 0, nullptr};
 	const VkRenderPassCreateInfo pass_info = {VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO, nullptr, 0u, num_attachments,
 		attachments.data(), 1u, &subpass, num_subpass_dependencies, num_subpass_dependencies ? subpass_dependency.data() : nullptr};
 
@@ -2496,8 +2528,8 @@ GSDevice::PresentResult GSDeviceVK::BeginPresent(bool frame_skip)
 		return GSDevice::PresentResult::FrameSkipped;
 
 	const VkRenderPassBeginInfo rp = {VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO, nullptr,
-		GetRenderPass(swap_chain_texture->GetVkFormat(), VK_FORMAT_UNDEFINED, VK_ATTACHMENT_LOAD_OP_CLEAR,
-			VK_ATTACHMENT_STORE_OP_STORE),
+		GetRenderPass(swap_chain_texture->GetVkFormat(), VK_FORMAT_UNDEFINED, VK_FORMAT_UNDEFINED,
+			VK_ATTACHMENT_LOAD_OP_CLEAR, VK_ATTACHMENT_STORE_OP_STORE),
 		fb,
 		{{0, 0}, {static_cast<u32>(swap_chain_texture->GetWidth()), static_cast<u32>(swap_chain_texture->GetHeight())}},
 		1u, &s_present_clear_color};
@@ -2802,6 +2834,8 @@ bool GSDeviceVK::CheckFeatures()
 
 	m_features.depth_feedback = m_features.feedback_loops();
 	m_features.aa1 = GSConfig.HWAA1 && m_features.vs_expand && m_features.feedback_loops();
+	m_features.depth_integer = GSConfig.HWZIntegerMode != GSHardwareZIntegerMode::Disabled &&
+		m_features.vs_expand && m_features.feedback_loops();
 
 	DevCon.WriteLn("Optional features:%s%s%s%s%s", m_features.primitive_id ? " primitive_id" : "",
 		m_features.texture_barrier ? " texture_barrier" : "", m_features.framebuffer_fetch ? " framebuffer_fetch" : "",
@@ -2925,6 +2959,7 @@ VkFormat GSDeviceVK::LookupNativeFormat(GSTexture::Format format) const
 		VK_FORMAT_R16G16B16A16_UNORM, // ColorClip
 		VK_FORMAT_D32_SFLOAT_S8_UINT, // DepthStencil
 		VK_FORMAT_R32_SFLOAT, // DepthColor
+		VK_FORMAT_R32_UINT, // DepthInteger
 		VK_FORMAT_R8_UNORM, // UNorm8
 		VK_FORMAT_R16_UINT, // UInt16
 		VK_FORMAT_R32_UINT, // UInt32
@@ -2983,14 +3018,14 @@ void GSDeviceVK::CopyRect(GSTexture* sTex, GSTexture* dTex, const GSVector4i& r,
 
 			// Do an attachment clear.
 			const bool depth = dTexVK->IsDepthStencil();
-			OMSetRenderTargets(depth ? nullptr : dTexVK, depth ? dTexVK : nullptr, dst_rect);
+			OMSetRenderTargets(depth ? nullptr : dTexVK, nullptr, depth ? dTexVK : nullptr, dst_rect);
 			BeginRenderPassForStretchRect(
 				dTexVK, dst_rect, GSVector4i(destX, destY, destX + r.width(), destY + r.height()));
 
 			// so use an attachment clear
 			VkClearAttachment ca;
 			ca.aspectMask = depth ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_COLOR_BIT;
-			GSVector4::store<false>(ca.clearValue.color.float32, sTexVK->GetClearForFormat());
+			ca.clearValue = sTexVK->GetVkClearValue();
 			ca.clearValue.depthStencil.depth = sTexVK->GetClearDepth();
 			ca.clearValue.depthStencil.stencil = 0;
 			ca.colorAttachment = 0;
@@ -3173,7 +3208,7 @@ void GSDeviceVK::DoMultiStretchRects(
 
 	// Even though we're batching, a cmdbuffer submit could've messed this up.
 	const GSVector4i rc(dTex->GetRect());
-	OMSetRenderTargets(dTex->IsRenderTarget() ? dTex : nullptr, dTex->IsDepthStencil() ? dTex : nullptr, rc);
+	OMSetRenderTargets(dTex->IsRenderTarget() ? dTex : nullptr, nullptr, dTex->IsDepthStencil() ? dTex : nullptr, rc);
 	if (!InRenderPass())
 		BeginRenderPassForStretchRect(dTex, rc, rc, false);
 	SetUtilityTexture(rects[0].src, rects[0].filter == Biln ? m_linear_sampler : m_point_sampler);
@@ -3204,7 +3239,7 @@ void GSDeviceVK::BeginRenderPassForStretchRect(
 	else if (dTex->GetFormat() == GSTexture::Format::Color)
 	{
 		if (load_op == VK_ATTACHMENT_LOAD_OP_CLEAR)
-			BeginClearRenderPass(m_utility_color_render_pass_clear, dtex_rc, dTex->GetClearColor());
+			BeginClearRenderPass(m_utility_color_render_pass_clear, dtex_rc, dTex->GetClearValue());
 		else
 			BeginRenderPass((load_op == VK_ATTACHMENT_LOAD_OP_DONT_CARE) ? m_utility_color_render_pass_discard :
 			                                                               m_utility_color_render_pass_load, dtex_rc);
@@ -3212,11 +3247,12 @@ void GSDeviceVK::BeginRenderPassForStretchRect(
 	else
 	{
 		// integer formats, etc
-		const VkRenderPass rp = GetRenderPass(dTex->GetVkFormat(), VK_FORMAT_UNDEFINED, load_op,
-			VK_ATTACHMENT_STORE_OP_STORE, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE);
+		const VkRenderPass rp = GetRenderPass(dTex->GetVkFormat(), VK_FORMAT_UNDEFINED, VK_FORMAT_UNDEFINED, load_op,
+			VK_ATTACHMENT_STORE_OP_STORE, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
+			VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE);
 		if (load_op == VK_ATTACHMENT_LOAD_OP_CLEAR)
 		{
-			BeginClearRenderPass(rp, dtex_rc, dTex->GetClearColor());
+			BeginClearRenderPass(rp, dtex_rc, dTex->GetClearValue());
 		}
 		else
 		{
@@ -3247,7 +3283,7 @@ void GSDeviceVK::DoStretchRect(GSTextureVK* sTex, const GSVector4& sRect, GSText
 	// switch rts (which might not end the render pass), so check the bounds
 	if (!is_present)
 	{
-		OMSetRenderTargets(depth ? nullptr : dTex, depth ? dTex : nullptr, dst_rc);
+		OMSetRenderTargets(depth ? nullptr : dTex, nullptr, depth ? dTex : nullptr, dst_rc);
 		if (InRenderPass() && dTex->GetState() == GSTexture::State::Cleared)
 			EndRenderPass();
 	}
@@ -3397,9 +3433,9 @@ void GSDeviceVK::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 
 	// transition everything before starting the new render pass
 	const bool has_input_0 = (sTex[0] &&
-		(sTex[0]->GetState() == GSTexture::State::Dirty || (sTex[0]->GetState() == GSTexture::State::Cleared || sTex[0]->GetClearColor() != 0)));
+		(sTex[0]->GetState() == GSTexture::State::Dirty || (sTex[0]->GetState() == GSTexture::State::Cleared || sTex[0]->GetClearValue() != 0)));
 	const bool has_input_1 = (PMODE.SLBG == 0 || feedback_write_2_but_blend_bg) && sTex[1] &&
-		(sTex[1]->GetState() == GSTexture::State::Dirty || (sTex[1]->GetState() == GSTexture::State::Cleared || sTex[1]->GetClearColor() != 0));
+		(sTex[1]->GetState() == GSTexture::State::Dirty || (sTex[1]->GetState() == GSTexture::State::Cleared || sTex[1]->GetClearValue() != 0));
 	if (has_input_0)
 	{
 		static_cast<GSTextureVK*>(sTex[0])->CommitClear();
@@ -3422,7 +3458,7 @@ void GSDeviceVK::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 		if (sTex[1]->GetState() == GSTexture::State::Dirty)
 		{
 			static_cast<GSTextureVK*>(sTex[1])->TransitionToLayout(GSTextureVK::Layout::ShaderReadOnly);
-			OMSetRenderTargets(dTex, nullptr, darea);
+			OMSetRenderTargets(dTex, nullptr, nullptr, darea);
 			SetUtilityTexture(sTex[1], sampler);
 			BeginClearRenderPass(m_utility_color_render_pass_clear, darea, c);
 			SetPipeline(GetConvertPipeline(ShaderConvert::COPY));
@@ -3438,7 +3474,7 @@ void GSDeviceVK::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 	if (feedback_write_2)
 	{
 		EndRenderPass();
-		OMSetRenderTargets(sTex[2], nullptr, fbarea);
+		OMSetRenderTargets(sTex[2], nullptr, nullptr, fbarea);
 		if (dcleared)
 			SetUtilityTexture(dTex, sampler);
 		// sTex[2] can be sTex[0], in which case it might be cleared (e.g. Xenosaga).
@@ -3462,13 +3498,13 @@ void GSDeviceVK::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 	if (feedback_write_2_but_blend_bg || !dcleared)
 	{
 		EndRenderPass();
-		OMSetRenderTargets(dTex, nullptr, darea);
+		OMSetRenderTargets(dTex, nullptr, nullptr, darea);
 		BeginClearRenderPass(m_utility_color_render_pass_clear, darea, c);
 		dTex->SetState(GSTexture::State::Dirty);
 	}
 	else if (!InRenderPass())
 	{
-		OMSetRenderTargets(dTex, nullptr, darea);
+		OMSetRenderTargets(dTex, nullptr, nullptr, darea);
 		BeginRenderPass(m_utility_color_render_pass_load, darea);
 	}
 
@@ -3487,7 +3523,7 @@ void GSDeviceVK::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, 
 		SetPipeline(GetConvertPipeline(ShaderConvert::YUV));
 		SetUtilityTexture(dTex, sampler);
 		SetUtilityPushConstants(yuv_constants, sizeof(yuv_constants));
-		OMSetRenderTargets(sTex[2], nullptr, fbarea);
+		OMSetRenderTargets(sTex[2], nullptr, nullptr, fbarea);
 		BeginRenderPass(m_utility_color_render_pass_load, fbarea);
 		DrawStretchRect(full_r, dRect[2], dsize);
 	}
@@ -3508,7 +3544,7 @@ void GSDeviceVK::DoInterlace(GSTexture* sTex, const GSVector4& sRect, GSTexture*
 	const GSVector4i dtex_rc = dTex->GetRect();
 	const GSVector4i clamped_rc = rc.rintersect(dtex_rc);
 	EndRenderPass();
-	OMSetRenderTargets(dTex, nullptr, clamped_rc);
+	OMSetRenderTargets(dTex, nullptr, nullptr, clamped_rc);
 	SetUtilityTexture(sTex, filter == Biln ? m_linear_sampler : m_point_sampler);
 	BeginRenderPassForStretchRect(static_cast<GSTextureVK*>(dTex), dTex->GetRect(), clamped_rc, false);
 	SetPipeline(m_interlace[static_cast<int>(shader)]);
@@ -3524,7 +3560,7 @@ void GSDeviceVK::DoShadeBoost(GSTexture* sTex, GSTexture* dTex, const float para
 	const GSVector4 sRect = GSVector4(0.0f, 0.0f, 1.0f, 1.0f);
 	const GSVector4i dRect = dTex->GetRect();
 	EndRenderPass();
-	OMSetRenderTargets(dTex, nullptr, dRect);
+	OMSetRenderTargets(dTex, nullptr, nullptr, dRect);
 	SetUtilityTexture(sTex, m_point_sampler);
 	BeginRenderPass(m_utility_color_render_pass_discard, dRect);
 	dTex->SetState(GSTexture::State::Dirty);
@@ -3541,7 +3577,7 @@ void GSDeviceVK::DoFXAA(GSTexture* sTex, GSTexture* dTex)
 	const GSVector4 sRect = GSVector4(0.0f, 0.0f, 1.0f, 1.0f);
 	const GSVector4i dRect = dTex->GetRect();
 	EndRenderPass();
-	OMSetRenderTargets(dTex, nullptr, dRect);
+	OMSetRenderTargets(dTex, nullptr, nullptr, dRect);
 	SetUtilityTexture(sTex, m_linear_sampler);
 	BeginRenderPass(m_utility_color_render_pass_discard, dRect);
 	dTex->SetState(GSTexture::State::Dirty);
@@ -3599,13 +3635,14 @@ void GSDeviceVK::VSSetIndexBuffer(const void* index, size_t count)
 }
 
 void GSDeviceVK::OMSetRenderTargets(
-	GSTexture* rt, GSTexture* ds, const GSVector4i& scissor, FeedbackLoopFlag feedback_loop,
+	GSTexture* rt, GSTexture* ds_as_rt, GSTexture* ds, const GSVector4i& scissor, FeedbackLoopFlag feedback_loop,
 	const GSVector2i& viewport_size)
 {
 	GSTextureVK* vkRt = static_cast<GSTextureVK*>(rt);
+	GSTextureVK* vkDsRt = static_cast<GSTextureVK*>(ds_as_rt);
 	GSTextureVK* vkDs = static_cast<GSTextureVK*>(ds);
 
-	if (m_current_render_target != vkRt || m_current_depth_target != vkDs ||
+	if (m_current_render_target != vkRt || m_current_depth_render_target != vkDsRt || m_current_depth_target != vkDs ||
 		m_current_framebuffer_feedback_loop != feedback_loop ||
 		m_current_framebuffer == VK_NULL_HANDLE)
 	{
@@ -3615,15 +3652,23 @@ void GSDeviceVK::OMSetRenderTargets(
 		if (vkRt)
 		{
 			m_current_framebuffer =
-				vkRt->GetLinkedFramebuffer(vkDs,
+				vkRt->GetLinkedFramebuffer(vkDsRt, vkDs,
 					(feedback_loop & FeedbackLoopFlag_ReadAndWriteRT) != 0,
+					(feedback_loop & FeedbackLoopFlag_ReadAndWriteDepthRT) != 0,
+					(feedback_loop & (FeedbackLoopFlag_ReadAndWriteDepth | FeedbackLoopFlag_ReadDepth)) != 0);
+		}
+		else if (vkDsRt)
+		{
+			m_current_framebuffer =
+				vkDsRt->GetLinkedFramebuffer(nullptr, vkDs, false,
+					(feedback_loop & FeedbackLoopFlag_ReadAndWriteDepthRT) != 0,
 					(feedback_loop & (FeedbackLoopFlag_ReadAndWriteDepth | FeedbackLoopFlag_ReadDepth)) != 0);
 		}
 		else if (vkDs)
 		{
 			pxAssert(!(feedback_loop & FeedbackLoopFlag_ReadAndWriteRT));
 			m_current_framebuffer = vkDs->GetLinkedFramebuffer(
-				nullptr, false, (feedback_loop & (FeedbackLoopFlag_ReadAndWriteDepth | FeedbackLoopFlag_ReadDepth)) != 0);
+				nullptr, nullptr, false, false, (feedback_loop & (FeedbackLoopFlag_ReadAndWriteDepth | FeedbackLoopFlag_ReadDepth)) != 0);
 		}
 		else
 		{
@@ -3640,67 +3685,53 @@ void GSDeviceVK::OMSetRenderTargets(
 			// between draws that are testing depth which precede it. The result is flickering where Z tests
 			// should be failing. Breaking/restarting the render pass isn't enough to work around the bug,
 			// it needs an explicit pipeline barrier.
-			if (vkRt && vkRt->GetState() != GSTexture::State::Dirty)
-			{
-				if (vkRt->GetState() == GSTexture::State::Cleared)
+			auto IssueBarrierDirty = [this](GSTextureVK* tex) {
+				if (tex && tex->GetState() != GSTexture::State::Dirty)
 				{
-					EndRenderPass();
-					vkRt->TransitionSubresourcesToLayout(GetCurrentCommandBuffer(), 0, 1,
-						vkRt->GetLayout(), vkRt->GetLayout());
+					if (tex->GetState() == GSTexture::State::Cleared)
+					{
+						EndRenderPass();
+						tex->TransitionSubresourcesToLayout(GetCurrentCommandBuffer(), 0, 1,
+							tex->GetLayout(), tex->GetLayout());
+					}
+					else
+					{
+						// Invalidated -> Dirty.
+						tex->SetState(GSTexture::State::Dirty);
+					}
 				}
-				else
-				{
-					// Invalidated -> Dirty.
-					vkRt->SetState(GSTexture::State::Dirty);
-				}
-			}
-			if (vkDs && vkDs->GetState() != GSTexture::State::Dirty)
-			{
-				if (vkDs->GetState() == GSTexture::State::Cleared)
-				{
-					EndRenderPass();
-					vkDs->TransitionSubresourcesToLayout(GetCurrentCommandBuffer(), 0, 1,
-						vkDs->GetLayout(), vkDs->GetLayout());
-				}
-				else
-				{
-					// Invalidated -> Dirty.
-					vkDs->SetState(GSTexture::State::Dirty);
-				}
-			}
+			};
+
+			IssueBarrierDirty(vkRt);
+			IssueBarrierDirty(vkDsRt);
+			IssueBarrierDirty(vkDs);
 		}
 		else
 		{
-			std::array<VkClearAttachment, 2> cas;
+			std::array<VkClearAttachment, 3> cas;
 			u32 num_ca = 0;
-			if (vkRt && vkRt->GetState() != GSTexture::State::Dirty)
-			{
-				if (vkRt->GetState() == GSTexture::State::Cleared)
+			auto AddClearAttachment = [&cas, &num_ca](GSTextureVK* tex, u32 colorAttachment, bool depth) {
+				if (tex && tex->GetState() != GSTexture::State::Dirty)
 				{
-					VkClearAttachment& ca = cas[num_ca++];
-					ca.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-					ca.colorAttachment = 0;
-					GSVector4::store<false>(ca.clearValue.color.float32, vkRt->GetClearForFormat());
-				}
+					if (tex->GetState() == GSTexture::State::Cleared)
+					{
+						VkClearAttachment& ca = cas[num_ca++];
+						ca.aspectMask = depth ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_COLOR_BIT;
+						ca.clearValue = tex->GetVkClearValue();
+						ca.colorAttachment = depth ? 0 : colorAttachment;
+					}
 
-				vkRt->SetState(GSTexture::State::Dirty);
-			}
-			if (vkDs && vkDs->GetState() != GSTexture::State::Dirty)
-			{
-				if (vkDs->GetState() == GSTexture::State::Cleared)
-				{
-					VkClearAttachment& ca = cas[num_ca++];
-					ca.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
-					ca.colorAttachment = 1;
-					ca.clearValue.depthStencil = {vkDs->GetClearDepth()};
+					tex->SetState(GSTexture::State::Dirty);
 				}
+			};
 
-				vkDs->SetState(GSTexture::State::Dirty);
-			}
+			AddClearAttachment(vkRt, 0, false);
+			AddClearAttachment(vkDsRt, vkRt ? 1 : 0, false);
+			AddClearAttachment(vkDs, 0, true);
 
 			if (num_ca > 0)
 			{
-				const GSVector2i size = vkRt ? vkRt->GetSize() : vkDs->GetSize();
+				const GSVector2i size = vkRt ? vkRt->GetSize() : (vkDsRt ? vkDsRt->GetSize() : vkDs->GetSize());
 				const VkClearRect cr = {{{0, 0}, {static_cast<u32>(size.x), static_cast<u32>(size.y)}}, 0u, 1u};
 				vkCmdClearAttachments(GetCurrentCommandBuffer(), num_ca, cas.data(), 1, &cr);
 			}
@@ -3708,72 +3739,63 @@ void GSDeviceVK::OMSetRenderTargets(
 	}
 
 	m_current_render_target = vkRt;
+	m_current_depth_render_target = vkDsRt;
 	m_current_depth_target = vkDs;
 	m_current_framebuffer_feedback_loop = feedback_loop;
 
 	if (!InRenderPass())
 	{
-		if (vkRt)
-		{
-			if (feedback_loop & FeedbackLoopFlag_ReadAndWriteRT)
+		auto HandleTransition = [this](GSTextureVK* tex, bool depth, bool feedback_loop, u32 tex_index) {
+			if (tex)
 			{
-				// NVIDIA drivers appear to return random garbage when sampling the RT via a feedback loop, if the load op for
-				// the render pass is CLEAR. Using vkCmdClearAttachments() doesn't work, so we have to clear the image instead.
-				if (vkRt->GetState() == GSTexture::State::Cleared && IsDeviceNVIDIA())
-					vkRt->CommitClear();
-
-				if (vkRt->GetLayout() != GSTextureVK::Layout::FeedbackLoop)
+				if (feedback_loop)
 				{
-					// need to update descriptors to reflect the new layout
-					m_dirty_flags |= (DIRTY_FLAG_TFX_TEXTURE_0 << TFX_TEXTURE_RT);
-					if (m_tfx_textures[TFX_TEXTURE_TEXTURE] == vkRt)
-						m_dirty_flags |= DIRTY_FLAG_TFX_TEXTURE_0 << TFX_TEXTURE_TEXTURE;
-					vkRt->TransitionToLayout(GSTextureVK::Layout::FeedbackLoop);
+					// NVIDIA drivers appear to return random garbage when sampling the RT via a feedback loop, if the load op for
+					// the render pass is CLEAR. Using vkCmdClearAttachments() doesn't work, so we have to clear the image instead.
+					if (tex->GetState() == GSTexture::State::Cleared && IsDeviceNVIDIA())
+						tex->CommitClear();
+
+					if (tex->GetLayout() != GSTextureVK::Layout::FeedbackLoop)
+					{
+						// need to update descriptors to reflect the new layout
+						m_dirty_flags |= (DIRTY_FLAG_TFX_TEXTURE_0 << tex_index);
+						if (m_tfx_textures[TFX_TEXTURE_TEXTURE] == tex)
+							m_dirty_flags |= DIRTY_FLAG_TFX_TEXTURE_0 << TFX_TEXTURE_TEXTURE;	
+						tex->TransitionToLayout(GSTextureVK::Layout::FeedbackLoop);
+					}
+				}
+				else
+				{
+					tex->TransitionToLayout(depth ? GSTextureVK::Layout::DepthStencilAttachment : GSTextureVK::Layout::ColorAttachment);
 				}
 			}
-			else
-			{
-				vkRt->TransitionToLayout(GSTextureVK::Layout::ColorAttachment);
-			}
+		};
+
+		// We should not have feedback loops on both the depth as RT and depthstencil.
+		// If they are both present it's only because the read depthstencil is needed for stencil.
+		pxAssert(!(static_cast<bool>(feedback_loop & FeedbackLoopFlag_ReadAndWriteDepthRT) &&
+			static_cast<bool>(feedback_loop & (FeedbackLoopFlag_ReadAndWriteDepth | FeedbackLoopFlag_ReadDepth))));
+
+		HandleTransition(vkRt, false, (feedback_loop & FeedbackLoopFlag_ReadAndWriteRT) != 0, TFX_TEXTURE_RT);
+
+		HandleTransition(vkDsRt, false, (feedback_loop & FeedbackLoopFlag_ReadAndWriteDepthRT) != 0, TFX_TEXTURE_DEPTH);
+
+		if ((feedback_loop & FeedbackLoopFlag_ReadAndWriteDepth) != 0)
+		{
+			HandleTransition(vkDs, true, true, TFX_TEXTURE_DEPTH);
 		}
-		if (vkDs)
+		else if ((feedback_loop & FeedbackLoopFlag_ReadDepth) != 0)
 		{
-			// need to update descriptors to reflect the new layout
-			if (feedback_loop & FeedbackLoopFlag_ReadAndWriteDepth)
-			{
-				// NVIDIA drivers appear to return random garbage when sampling the RT via a feedback loop, if the load op for
-				// the render pass is CLEAR. Using vkCmdClearAttachments() doesn't work, so we have to clear the image instead.
-				// Note: DS feedback loop was added later - we will assume that the same issue is relevant.
-				if (vkDs->GetState() == GSTexture::State::Cleared && IsDeviceNVIDIA())
-					vkDs->CommitClear();
-
-				if (vkDs->GetLayout() != GSTextureVK::Layout::FeedbackLoop)
-				{
-					m_dirty_flags |= (DIRTY_FLAG_TFX_TEXTURE_0 << TFX_TEXTURE_DEPTH);
-					if (m_tfx_textures[TFX_TEXTURE_TEXTURE] == vkDs)
-						m_dirty_flags |= DIRTY_FLAG_TFX_TEXTURE_0 << TFX_TEXTURE_TEXTURE;
-					vkDs->TransitionToLayout(GSTextureVK::Layout::FeedbackLoop);
-				}
-			}
-			else if (feedback_loop & FeedbackLoopFlag_ReadDepth)
-			{
-				if (vkDs->GetLayout() != GSTextureVK::Layout::FeedbackLoop)
-				{
-					m_dirty_flags |= (DIRTY_FLAG_TFX_TEXTURE_0 << TFX_TEXTURE_TEXTURE);
-					if (m_tfx_textures[TFX_TEXTURE_TEXTURE] == vkDs)
-						m_dirty_flags |= DIRTY_FLAG_TFX_TEXTURE_0 << TFX_TEXTURE_TEXTURE;
-					vkDs->TransitionToLayout(GSTextureVK::Layout::FeedbackLoop);
-				}
-			}
-			else
-			{
-				vkDs->TransitionToLayout(GSTextureVK::Layout::DepthStencilAttachment);
-			}
+			HandleTransition(vkDs, true, true, TFX_TEXTURE_TEXTURE);
+		}
+		else
+		{
+			HandleTransition(vkDs, true, false, TFX_TEXTURE_TEXTURE);
 		}
 	}
 
 	// This is used to set/initialize the framebuffer for tfx rendering.
-	const GSVector2i size = (vkRt ? vkRt->GetSize() : (vkDs ? vkDs->GetSize() : viewport_size));
+	const GSVector2i size = vkRt ? vkRt->GetSize() : (vkDsRt ? vkDsRt->GetSize() : (vkDs ? vkDs->GetSize() : viewport_size));
 	const VkViewport vp{0.0f, 0.0f, static_cast<float>(size.x), static_cast<float>(size.y), 0.0f, 1.0f};
 
 	SetViewport(vp);
@@ -3941,7 +3963,8 @@ bool GSDeviceVK::CreateBuffers()
 		return false;
 	}
 
-	if (!m_expand_index_stream_buffer.Create(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, m_features.aa1 ? INDEX_BUFFER_SIZE : 4))
+	if (!m_expand_index_stream_buffer.Create(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
+		UseVSExpandIndexBuffer() ? INDEX_BUFFER_SIZE : 4))
 	{
 		Host::ReportErrorAsync("GS", "Failed to allocate expansion index buffer (VS resource)");
 		return false;
@@ -4009,7 +4032,7 @@ bool GSDeviceVK::CreatePipelineLayouts()
 		dslb.AddBinding(2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT);
 		plb.AddPushConstants(VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(GSHWDrawConfig::VSPushConstants));
 	}
-	if (m_features.aa1)
+	if (UseVSExpandIndexBuffer())
 		dslb.AddBinding(3, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT);
 	if ((m_tfx_ubo_ds_layout = dslb.Create(dev)) == VK_NULL_HANDLE)
 		return false;
@@ -4047,15 +4070,18 @@ bool GSDeviceVK::CreateRenderPasses()
 	do \
 	{ \
 		dest = GetRenderPass( \
-			(rt), (depth), ((rt) != VK_FORMAT_UNDEFINED) ? (opa) : VK_ATTACHMENT_LOAD_OP_DONT_CARE, /* color load */ \
+			(rt), VK_FORMAT_UNDEFINED, (depth), ((rt) != VK_FORMAT_UNDEFINED) ? (opa) : VK_ATTACHMENT_LOAD_OP_DONT_CARE, /* color load */ \
 			((rt) != VK_FORMAT_UNDEFINED) ? VK_ATTACHMENT_STORE_OP_STORE : \
 											VK_ATTACHMENT_STORE_OP_DONT_CARE, /* color store */ \
+			VK_ATTACHMENT_LOAD_OP_DONT_CARE, /* depth as color load */ \
+			VK_ATTACHMENT_STORE_OP_DONT_CARE, /* depth as color store */ \
 			((depth) != VK_FORMAT_UNDEFINED) ? (opb) : VK_ATTACHMENT_LOAD_OP_DONT_CARE, /* depth load */ \
 			((depth) != VK_FORMAT_UNDEFINED) ? VK_ATTACHMENT_STORE_OP_STORE : \
 											   VK_ATTACHMENT_STORE_OP_DONT_CARE, /* depth store */ \
 			((depth) != VK_FORMAT_UNDEFINED) ? (opc) : VK_ATTACHMENT_LOAD_OP_DONT_CARE, /* stencil load */ \
 			VK_ATTACHMENT_STORE_OP_DONT_CARE, /* stencil store */ \
 			(fbl), /* feedback loop */ \
+			false, /* depth as color feedback loop */ \
 			(dsp) /* depth sampling */ \
 		); \
 		if (dest == VK_NULL_HANDLE) \
@@ -4113,8 +4139,10 @@ bool GSDeviceVK::CreateRenderPasses()
 	GET(m_utility_depth_render_pass_discard, VK_FORMAT_UNDEFINED, depth_format, false, false,
 		VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_LOAD_OP_DONT_CARE);
 
-	m_date_setup_render_pass = GetRenderPass(VK_FORMAT_UNDEFINED, depth_format, VK_ATTACHMENT_LOAD_OP_LOAD,
-		VK_ATTACHMENT_STORE_OP_STORE, VK_ATTACHMENT_LOAD_OP_LOAD, VK_ATTACHMENT_STORE_OP_STORE,
+	m_date_setup_render_pass = GetRenderPass(VK_FORMAT_UNDEFINED, VK_FORMAT_UNDEFINED, depth_format,
+		VK_ATTACHMENT_LOAD_OP_LOAD, VK_ATTACHMENT_STORE_OP_STORE,
+		VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
+		VK_ATTACHMENT_LOAD_OP_LOAD, VK_ATTACHMENT_STORE_OP_STORE,
 		m_features.stencil_buffer ? VK_ATTACHMENT_LOAD_OP_CLEAR : VK_ATTACHMENT_LOAD_OP_DONT_CARE,
 		m_features.stencil_buffer ? VK_ATTACHMENT_STORE_OP_STORE : VK_ATTACHMENT_STORE_OP_DONT_CARE);
 	if (m_date_setup_render_pass == VK_NULL_HANDLE)
@@ -4164,6 +4192,7 @@ bool GSDeviceVK::CompileConvertPipelines()
 		{
 			rp = GetRenderPass(
 				LookupNativeFormat(GSTexture::Format::Invalid),
+				LookupNativeFormat(GSTexture::Format::Invalid),
 				LookupNativeFormat(GSTexture::Format::DepthStencil),
 				VK_ATTACHMENT_LOAD_OP_DONT_CARE);
 		}
@@ -4171,6 +4200,7 @@ bool GSDeviceVK::CompileConvertPipelines()
 		{
 			rp = GetRenderPass(
 				LookupNativeFormat(shader.OutputFormat()),
+				LookupNativeFormat(GSTexture::Format::Invalid),
 				LookupNativeFormat(GSTexture::Format::Invalid),
 				VK_ATTACHMENT_LOAD_OP_DONT_CARE);
 		}
@@ -4198,7 +4228,8 @@ bool GSDeviceVK::CompileConvertPipelines()
 		std::string macro;
 		macro += fmt::format("#define HAS_BILN {}\n", static_cast<int>(shader.Biln()));
 		macro += fmt::format("#define HAS_STENCIL_OUTPUT {}\n", static_cast<int>(shader.StencilOutput()));
-		macro += fmt::format("#define HAS_INTEGER_OUTPUT {}\n", static_cast<int>(shader.IntegerOutputBpp() != 0));
+		macro += fmt::format("#define HAS_INTEGER_INPUT {}\n", static_cast<int>(shader.IntegerInput()));
+		macro += fmt::format("#define HAS_INTEGER_OUTPUT {}\n", static_cast<int>(shader.IntegerOutput()));
 		macro += fmt::format("#define HAS_DEPTH_OUTPUT {}\n", static_cast<int>(shader.DepthOutput()));
 		macro += fmt::format("#define HAS_FLOAT32_INPUT {}\n", static_cast<int>(shader.Float32Input()));
 		macro += fmt::format("#define HAS_FLOAT32_OUTPUT {}\n", static_cast<int>(shader.Float32Output()));
@@ -4219,9 +4250,9 @@ bool GSDeviceVK::CompileConvertPipelines()
 
 		m_convert[i] = pipe;
 
-		Vulkan::SetObjectName(m_device, pipe, "Convert pipeline (%s, mask=%x, depth=%d, biln=%d)",
-			shader.Name(), shader.Mask(), static_cast<int>(shader.DepthOutput()),
-			static_cast<int>(shader.Biln()));
+		Vulkan::SetObjectName(m_device, pipe, "Convert pipeline (%s, mask=%x, int_in=%d, int_out=%d, depth_out=%d, biln=%d)",
+			shader.Name(), shader.Mask(), static_cast<int>(shader.IntegerInput()), static_cast<int>(shader.IntegerOutput()),
+			static_cast<int>(shader.DepthOutput()), static_cast<int>(shader.Biln()));
 
 		if (shader.Shader() == ShaderConvert::COLCLIP_INIT || shader.Shader() == ShaderConvert::COLCLIP_RESOLVE)
 		{
@@ -4233,8 +4264,9 @@ bool GSDeviceVK::CompileConvertPipelines()
 				{
 					pxAssert(!arr[ds][fbl]);
 
-					gpb.SetRenderPass(GetTFXRenderPass(true, ds != 0, is_setup, false, fbl != 0, false,
-						VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_LOAD_OP_DONT_CARE),
+					gpb.SetRenderPass(
+						GetTFXRenderPass(true, false, ds != 0, is_setup, false, fbl != 0, false, false,
+							VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_LOAD_OP_DONT_CARE),
 						0);
 					arr[ds][fbl] = gpb.Create(m_device, g_vulkan_shader_cache->GetPipelineCache(true), false);
 					if (!arr[ds][fbl])
@@ -4252,7 +4284,9 @@ bool GSDeviceVK::CompileConvertPipelines()
 	{
 		for (u32 clear = 0; clear < 2; clear++)
 		{
-			m_primid_image_setup_render_passes[ds][clear] = GetRenderPass(LookupNativeFormat(GSTexture::Format::PrimID),
+			m_primid_image_setup_render_passes[ds][clear] = GetRenderPass(
+				LookupNativeFormat(GSTexture::Format::PrimID),
+				VK_FORMAT_UNDEFINED,
 				ds ? LookupNativeFormat(GSTexture::Format::DepthStencil) : VK_FORMAT_UNDEFINED,
 				VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_STORE,
 				ds ? (clear ? VK_ATTACHMENT_LOAD_OP_CLEAR : VK_ATTACHMENT_LOAD_OP_LOAD) :
@@ -4298,7 +4332,8 @@ bool GSDeviceVK::CompilePresentPipelines()
 {
 	// we may not have a swap chain if running in headless mode.
 	m_swap_chain_render_pass =
-		GetRenderPass(m_swap_chain ? m_swap_chain->GetTextureFormat() : VK_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_UNDEFINED);
+		GetRenderPass(m_swap_chain ? m_swap_chain->GetTextureFormat() : VK_FORMAT_R8G8B8A8_UNORM,
+			VK_FORMAT_UNDEFINED, VK_FORMAT_UNDEFINED);
 	if (m_swap_chain_render_pass == VK_NULL_HANDLE)
 		return false;
 
@@ -4360,7 +4395,8 @@ bool GSDeviceVK::CompileInterlacePipelines()
 	}
 
 	VkRenderPass rp =
-		GetRenderPass(LookupNativeFormat(GSTexture::Format::Color), VK_FORMAT_UNDEFINED, VK_ATTACHMENT_LOAD_OP_LOAD);
+		GetRenderPass(LookupNativeFormat(GSTexture::Format::Color), VK_FORMAT_UNDEFINED, VK_FORMAT_UNDEFINED,
+			VK_ATTACHMENT_LOAD_OP_LOAD);
 	if (!rp)
 		return false;
 
@@ -4411,7 +4447,8 @@ bool GSDeviceVK::CompileMergePipelines()
 	}
 
 	VkRenderPass rp =
-		GetRenderPass(LookupNativeFormat(GSTexture::Format::Color), VK_FORMAT_UNDEFINED, VK_ATTACHMENT_LOAD_OP_LOAD);
+		GetRenderPass(LookupNativeFormat(GSTexture::Format::Color), VK_FORMAT_UNDEFINED,
+			VK_FORMAT_UNDEFINED, VK_ATTACHMENT_LOAD_OP_LOAD);
 	if (!rp)
 		return false;
 
@@ -4456,7 +4493,8 @@ bool GSDeviceVK::CompileMergePipelines()
 bool GSDeviceVK::CompilePostProcessingPipelines()
 {
 	VkRenderPass rp =
-		GetRenderPass(LookupNativeFormat(GSTexture::Format::Color), VK_FORMAT_UNDEFINED, VK_ATTACHMENT_LOAD_OP_LOAD);
+		GetRenderPass(LookupNativeFormat(GSTexture::Format::Color), VK_FORMAT_UNDEFINED,
+			VK_FORMAT_UNDEFINED, VK_ATTACHMENT_LOAD_OP_LOAD);
 	if (!rp)
 		return false;
 
@@ -4922,6 +4960,7 @@ VkShaderModule GSDeviceVK::GetTFXVertexShader(GSHWDrawConfig::VSSelector sel)
 	AddMacro(ss, "VS_IIP", sel.iip);
 	AddMacro(ss, "VS_POINT_SIZE", sel.point_size);
 	AddMacro(ss, "VS_EXPAND", static_cast<int>(sel.expand));
+	AddMacro(ss, "VS_Z_INTEGER", sel.zint);
 	AddMacro(ss, "VS_PROVOKING_VERTEX_LAST", static_cast<int>(m_features.provoking_vertex_last));
 	ss << m_tfx_source;
 
@@ -5004,6 +5043,9 @@ VkShaderModule GSDeviceVK::GetTFXFragmentShader(const GSHWDrawConfig::PSSelector
 	AddMacro(ss, "PS_ANISOTROPIC_FILTERING", sel.sw_aniso);
 	AddMacro(ss, "PS_ROV_COLOR", sel.rov_color);
 	AddMacro(ss, "PS_ROV_DEPTH", static_cast<u32>(sel.rov_depth));
+	AddMacro(ss, "PS_Z_RT_SLOT", sel.z_rt_slot);
+	AddMacro(ss, "PS_Z_INTEGER", static_cast<u32>(sel.zint));
+	AddMacro(ss, "PS_TEX_INTEGER", sel.texint);
 	ss << m_tfx_source;
 
 	VkShaderModule mod = g_vulkan_shader_cache->GetFragmentShader(ss.str());
@@ -5049,9 +5091,10 @@ VkPipeline GSDeviceVK::CreateTFXPipeline(const PipelineSelector& p)
 	else
 	{
 		gpb.SetRenderPass(
-			GetTFXRenderPass(p.rt, p.ds, p.ps.colclip_hw, p.dss.date,
-				p.IsRTFeedbackLoop(), p.IsTestingAndSamplingDepth(),
+			GetTFXRenderPass(p.rt, p.ds_as_rt, p.ds, p.ps.colclip_hw, p.dss.date,
+				p.IsRTFeedbackLoop(), p.IsDepthRTFeedbackLoop(), p.IsTestingAndSamplingDepth(),
 				p.rt ? VK_ATTACHMENT_LOAD_OP_LOAD : VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+				p.ds_as_rt ? VK_ATTACHMENT_LOAD_OP_LOAD : VK_ATTACHMENT_LOAD_OP_DONT_CARE,
 				p.ds ? VK_ATTACHMENT_LOAD_OP_LOAD : VK_ATTACHMENT_LOAD_OP_DONT_CARE),
 			0);
 	}
@@ -5123,6 +5166,12 @@ VkPipeline GSDeviceVK::CreateTFXPipeline(const PipelineSelector& p)
 	{
 		gpb.SetBlendAttachment(0, false, VK_BLEND_FACTOR_ONE, VK_BLEND_FACTOR_ZERO, VK_BLEND_OP_ADD,
 			VK_BLEND_FACTOR_ONE, VK_BLEND_FACTOR_ZERO, VK_BLEND_OP_ADD, p.cms.wrgba);
+	}
+
+	if (p.ds_as_rt)
+	{
+		gpb.SetBlendAttachment(p.rt ? 1 : 0, false, VK_BLEND_FACTOR_ONE, VK_BLEND_FACTOR_ZERO, VK_BLEND_OP_ADD,
+			VK_BLEND_FACTOR_ONE, VK_BLEND_FACTOR_ZERO, VK_BLEND_OP_ADD, p.ds_as_rt_write ? 0xF : 0);
 	}
 
 	// Tests have shown that it's faster to just enable rast order on the entire pass, rather than alternating
@@ -5205,7 +5254,7 @@ bool GSDeviceVK::CreatePersistentDescriptorSets()
 		dsub.AddBufferDescriptorWrite(m_tfx_ubo_descriptor_set, 2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
 			m_vertex_stream_buffer.GetBuffer(), 0, VERTEX_BUFFER_SIZE);
 	}
-	if (m_features.aa1)
+	if (UseVSExpandIndexBuffer())
 	{
 		dsub.AddBufferDescriptorWrite(m_tfx_ubo_descriptor_set, 3, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
 			m_expand_index_stream_buffer.GetBuffer(), 0, INDEX_BUFFER_SIZE);
@@ -5250,6 +5299,7 @@ void GSDeviceVK::ExecuteCommandBufferAndRestartRenderPass(bool wait_for_completi
 	const GSVector4i render_pass_area = m_current_render_pass_area;
 	const GSVector4i scissor = m_scissor;
 	GSTexture* const current_rt = m_current_render_target;
+	GSTexture* const current_ds_as_rt = m_current_depth_render_target;
 	GSTexture* const current_ds = m_current_depth_target;
 	const FeedbackLoopFlag current_feedback_loop = m_current_framebuffer_feedback_loop;
 
@@ -5259,7 +5309,7 @@ void GSDeviceVK::ExecuteCommandBufferAndRestartRenderPass(bool wait_for_completi
 	if (render_pass != VK_NULL_HANDLE)
 	{
 		// rebind framebuffer
-		OMSetRenderTargets(current_rt, current_ds, scissor, current_feedback_loop);
+		OMSetRenderTargets(current_rt, current_ds_as_rt, current_ds, scissor, current_feedback_loop);
 
 		// restart render pass
 		BeginRenderPass(GetRenderPassForRestarting(render_pass), render_pass_area);
@@ -5285,8 +5335,8 @@ void GSDeviceVK::ExecuteCommandBufferAndRestartPresent(bool wait_for_completion,
 	pxAssert(fb);
 
 	const VkRenderPassBeginInfo rp = {VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO, nullptr,
-		GetRenderPass(swap_chain_texture->GetVkFormat(), VK_FORMAT_UNDEFINED, VK_ATTACHMENT_LOAD_OP_LOAD,
-			VK_ATTACHMENT_STORE_OP_STORE),
+		GetRenderPass(swap_chain_texture->GetVkFormat(), VK_FORMAT_UNDEFINED, VK_FORMAT_UNDEFINED,
+			VK_ATTACHMENT_LOAD_OP_LOAD, VK_ATTACHMENT_STORE_OP_STORE),
 		fb,
 		{{0, 0}, {static_cast<u32>(swap_chain_texture->GetWidth()), static_cast<u32>(swap_chain_texture->GetHeight())}},
 		0u, nullptr};
@@ -5368,6 +5418,7 @@ void GSDeviceVK::PSSetROVs(GSTexture* rt, GSTexture* ds, bool write_rt, bool wri
 	if (!(vkRt || vkDs || oldVkRt || oldVkDs))
 		return;
 
+	pxAssert(!vkDs || vkDs->IsDepthColor() || vkDs->IsDepthInteger());
 	pxAssert(!(vkRt || vkDs) || m_features.rov);
 
 	if (vkRt)
@@ -5890,7 +5941,7 @@ void GSDeviceVK::SetupDATE(GSTexture* rt, GSTexture* ds, SetDATM datm, const GSV
 	// sfex3 (after the capcom logo), vf4 (first menu fading in), ffxii shadows, rumble roses shadows, persona4 shadows
 	EndRenderPass();
 	SetUtilityTexture(rt, m_point_sampler);
-	OMSetRenderTargets(nullptr, ds, bbox);
+	OMSetRenderTargets(nullptr, nullptr, ds, bbox);
 	IASetVertexBuffer(vertices, sizeof(vertices[0]), 4);
 	SetPipeline(GetConvertPipeline(SetDATMShader(datm)));
 	BeginClearRenderPass(m_date_setup_render_pass, bbox, 0.0f, 0);
@@ -5922,7 +5973,7 @@ GSTextureVK* GSDeviceVK::SetupPrimitiveTrackingDATE(GSHWDrawConfig& config)
 
 	// setup the fill quad to prefill with existing alpha values
 	SetUtilityTexture(config.rt, m_point_sampler);
-	OMSetRenderTargets(image, config.ds, config.drawarea);
+	OMSetRenderTargets(image, nullptr, config.ds, config.drawarea);
 
 	// if the depth target has been cleared, we need to preserve that clear
 	const VkAttachmentLoadOp ds_load_op = GetLoadOpForTexture(static_cast<GSTextureVK*>(config.ds));
@@ -5969,9 +6020,15 @@ GSTextureVK* GSDeviceVK::SetupPrimitiveTrackingDATE(GSHWDrawConfig& config)
 	pipe.bs = {};
 	pipe.feedback_loop_flags = FeedbackLoopFlag_None;
 	pipe.rt = true;
+	pipe.ds_as_rt = false;
 	pipe.ps.blend_a = pipe.ps.blend_b = pipe.ps.blend_c = pipe.ps.blend_d = false;
 	pipe.ps.no_color = false;
 	pipe.ps.no_color1 = true;
+	pipe.ps.texint = false;
+	pipe.ps.zint = GSHWDrawConfig::PS_Z_INTEGER::NONE;
+	pipe.vs.zint = false;
+	pipe.vs.RemoveZIntegerExpand();
+
 	if (BindDrawPipeline(pipe))
 		Draw(config);
 
@@ -5990,11 +6047,12 @@ GSTextureVK* GSDeviceVK::SetupPrimitiveTrackingDATE(GSHWDrawConfig& config)
 
 void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 {
-	const GSVector2i rtsize(config.rt ? config.rt->GetSize() : config.ds->GetSize());
+	const GSVector2i rtsize(config.rt ? config.rt->GetSize() : (config.ds ? config.ds->GetSize() : config.ds_int->GetSize()));
 	GSTextureVK* draw_rt = config.ps.HasColorROV() ? nullptr : static_cast<GSTextureVK*>(config.rt);
-	GSTextureVK* draw_ds = config.ps.HasDepthROV() ? nullptr : static_cast<GSTextureVK*>(config.ds);
+	GSTextureVK* draw_ds = (config.ps.HasDepthROV() || config.ds_int) ? nullptr : static_cast<GSTextureVK*>(config.ds);
 	GSTextureVK* draw_rt_rov = config.ps.HasColorROV() ? static_cast<GSTextureVK*>(config.rt) : nullptr;
-	GSTextureVK* draw_ds_rov = config.ps.HasDepthROV() ? static_cast<GSTextureVK*>(config.ds) : nullptr;
+	GSTextureVK* draw_ds_rov = config.ps.HasDepthROV() ? static_cast<GSTextureVK*>(config.ds ? config.ds : config.ds_int) : nullptr;
+	GSTextureVK* draw_ds_as_rt = config.ps.HasDepthROV() ? nullptr : static_cast<GSTextureVK*>(config.ds_int);
 	GSTextureVK* draw_rt_clone = nullptr;
 	GSTextureVK* colclip_rt = static_cast<GSTextureVK*>(g_gs_device->GetColorClipTexture());
 
@@ -6005,7 +6063,7 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 	// bind textures before checking the render pass, in case we need to transition them
 	if (config.tex)
 	{
-		PSSetShaderResource(TFX_TEXTURE_TEXTURE, config.tex, config.tex != config.rt && config.tex != config.ds);
+		PSSetShaderResource(TFX_TEXTURE_TEXTURE, config.tex, config.tex != config.rt && config.tex != draw_ds_as_rt && config.tex != config.ds);
 		PSSetSampler(config.sampler);
 	}
 	if (config.pal)
@@ -6053,28 +6111,32 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 			colclip_rt->TransitionToLayout(GSTextureVK::Layout::ShaderReadOnly);
 
 			draw_rt = static_cast<GSTextureVK*>(config.rt);
-			OMSetRenderTargets(draw_rt, draw_ds, GSVector4i::loadh(rtsize), static_cast<FeedbackLoopFlag>(pipe.feedback_loop_flags));
+			OMSetRenderTargets(draw_rt, nullptr, draw_ds,
+				GSVector4i::loadh(rtsize), static_cast<FeedbackLoopFlag>(pipe.feedback_loop_flags));
 
 			// if this target was cleared and never drawn to, perform the clear as part of the resolve here.
 			if (draw_rt->GetState() == GSTexture::State::Cleared)
 			{
 				alignas(16) VkClearValue cvs[2];
 				u32 cv_count = 0;
-				GSVector4::store<true>(&cvs[cv_count++].color, draw_rt->GetClearForFormat());
+				cvs[cv_count++] = draw_rt->GetVkClearValue();
 				if (draw_ds)
-					cvs[cv_count++].depthStencil = {draw_ds->GetClearDepth(), 1};
+					cvs[cv_count++] = draw_ds->GetVkClearValue();
 
-				BeginClearRenderPass(GetTFXRenderPass(true, pipe.ds, false, false, pipe.IsRTFeedbackLoop(),
-										 pipe.IsTestingAndSamplingDepth(), VK_ATTACHMENT_LOAD_OP_CLEAR,
-										 pipe.ds ? VK_ATTACHMENT_LOAD_OP_LOAD : VK_ATTACHMENT_LOAD_OP_DONT_CARE),
+				BeginClearRenderPass(GetTFXRenderPass(
+						true, false, pipe.ds, false, false, pipe.IsRTFeedbackLoop(), false, pipe.IsTestingAndSamplingDepth(),
+						VK_ATTACHMENT_LOAD_OP_CLEAR, VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+						pipe.ds ? VK_ATTACHMENT_LOAD_OP_LOAD : VK_ATTACHMENT_LOAD_OP_DONT_CARE),
 					draw_rt->GetRect(), cvs, cv_count);
 				draw_rt->SetState(GSTexture::State::Dirty);
 			}
 			else
 			{
-				BeginRenderPass(GetTFXRenderPass(true, pipe.ds, false, false, pipe.IsRTFeedbackLoop(),
-									pipe.IsTestingAndSamplingDepth(), VK_ATTACHMENT_LOAD_OP_LOAD,
-									pipe.ds ? VK_ATTACHMENT_LOAD_OP_LOAD : VK_ATTACHMENT_LOAD_OP_DONT_CARE),
+				BeginRenderPass(
+					GetTFXRenderPass(true, false, pipe.ds, false, false,
+						pipe.IsRTFeedbackLoop(), false, pipe.IsTestingAndSamplingDepth(),
+						VK_ATTACHMENT_LOAD_OP_LOAD, VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+						pipe.ds ? VK_ATTACHMENT_LOAD_OP_LOAD : VK_ATTACHMENT_LOAD_OP_DONT_CARE),
 					draw_rt->GetRect());
 			}
 
@@ -6145,7 +6207,7 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 			if (draw_rt->GetState() == GSTexture::State::Cleared)
 			{
 				colclip_rt->SetState(GSTexture::State::Cleared);
-				colclip_rt->SetClearColor(draw_rt->GetClearColor());
+				colclip_rt->SetClearValue(draw_rt->GetClearValue());
 
 				// If depth is cleared, we need to commit it, because we're only going to draw to the active part of the FB.
 				if (draw_ds && draw_ds->GetState() == GSTexture::State::Cleared && !config.drawarea.eq(GSVector4i::loadh(rtsize)))
@@ -6179,7 +6241,8 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 	}
 	else if (InRenderPass() &&
 		((draw_rt && m_current_render_target == draw_rt) ||
-		(draw_ds && m_current_depth_target == draw_ds)))
+		(draw_ds && m_current_depth_target == draw_ds)) &&
+		!draw_ds_as_rt)
 	{
 		// avoid restarting the render pass just to switch from rt+depth to rt and vice versa
 		// keep the depth even if doing colclip hw draws, because the next draw will probably re-enable depth.
@@ -6266,9 +6329,23 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 		PSSetShaderResource(TFX_TEXTURE_RT, nullptr, false);
 	}
 	
-	if (pipe.IsDepthFeedbackLoop() && draw_ds)
+	if (pipe.IsDepthRTFeedbackLoop() && draw_ds_as_rt)
 	{
 		pxAssertMsg(m_features.texture_barrier, "Texture barriers enabled");
+		pxAssert(!pipe.IsDepthFeedbackLoop()); // Should not have depth as color and depth feedback loop simultaneously.
+		PSSetShaderResource(TFX_TEXTURE_DEPTH, draw_ds_as_rt, false);
+
+		if (m_tfx_textures[TFX_TEXTURE_DEPTH_ROV] == draw_ds_as_rt)
+		{
+			// Unbind to avoid conflicts.
+			PSSetShaderResource(TFX_TEXTURE_DEPTH_ROV, nullptr, false);
+			m_dirty_flags |= static_cast<u32>(DIRTY_FLAG_TFX_TEXTURE_DEPTH_ROV);
+		}
+	}
+	else if (pipe.IsDepthFeedbackLoop() && draw_ds)
+	{
+		pxAssertMsg(m_features.texture_barrier, "Texture barriers enabled");
+		pxAssert(!pipe.IsDepthRTFeedbackLoop()); // Should not have depth as color and depth feedback loop simultaneously.
 		PSSetShaderResource(TFX_TEXTURE_DEPTH, draw_ds, false);
 
 		if (m_tfx_textures[TFX_TEXTURE_DEPTH_ROV] == draw_ds)
@@ -6286,17 +6363,20 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 	
 	PSSetROVs(draw_rt_rov, draw_ds_rov, config.ps.HasColorOutput(), config.ps.HasDepthROVWrite());
 
-	OMSetRenderTargets(draw_rt, draw_ds, config.scissor, static_cast<FeedbackLoopFlag>(pipe.feedback_loop_flags), rtsize);
+	OMSetRenderTargets(draw_rt, draw_ds_as_rt, draw_ds, config.scissor,
+		static_cast<FeedbackLoopFlag>(pipe.feedback_loop_flags), rtsize);
 
 	// Begin render pass if new target or out of the area.
 	if (!InRenderPass())
 	{
 		const VkAttachmentLoadOp rt_op = GetLoadOpForTexture(draw_rt);
+		const VkAttachmentLoadOp ds_as_rt_op = GetLoadOpForTexture(draw_ds_as_rt);
 		const VkAttachmentLoadOp ds_op = GetLoadOpForTexture(draw_ds);
-		const VkRenderPass rp = GetTFXRenderPass(pipe.rt, pipe.ds, pipe.ps.colclip_hw,
+		const VkRenderPass rp = GetTFXRenderPass(pipe.rt, pipe.ds_as_rt, pipe.ds, pipe.ps.colclip_hw,
 			config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::Stencil, pipe.IsRTFeedbackLoop(),
-			pipe.IsTestingAndSamplingDepth(), rt_op, ds_op);
-		const bool is_clearing_rt = (rt_op == VK_ATTACHMENT_LOAD_OP_CLEAR || ds_op == VK_ATTACHMENT_LOAD_OP_CLEAR);
+			pipe.IsDepthRTFeedbackLoop(), pipe.IsTestingAndSamplingDepth(), rt_op, ds_as_rt_op, ds_op);
+		const bool is_clearing_rt = rt_op == VK_ATTACHMENT_LOAD_OP_CLEAR || ds_as_rt_op == VK_ATTACHMENT_LOAD_OP_CLEAR ||
+			                        ds_op == VK_ATTACHMENT_LOAD_OP_CLEAR;
 
 		// Only draw to the active area of the colclip hw target. Except when depth is cleared, we need to use the full
 		// buffer size, otherwise it'll only clear the draw part of the depth buffer.
@@ -6307,20 +6387,21 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 		if (is_clearing_rt)
 		{
 			// when we're clearing, we set the draw area to the whole fb, otherwise part of it will be undefined
-			alignas(16) VkClearValue cvs[2];
+			alignas(16) VkClearValue cvs[3];
 			u32 cv_count = 0;
 			if (draw_rt)
 			{
-				GSVector4 clear_color = draw_rt->GetClearForFormat();
-				if (pipe.ps.colclip_hw)
-				{
-					// Denormalize clear color for hw colclip.
-					clear_color *= GSVector4::cxpr(255.0f / 65535.0f, 255.0f / 65535.0f, 255.0f / 65535.0f, 1.0f);
-				}
-				GSVector4::store<true>(&cvs[cv_count++].color, clear_color);
+				const float normalize = pipe.ps.colclip_hw ? 65535.0f : 255.0f;
+				GSVector4::store<true>(&cvs[cv_count++].color, GSVector4::rgba32(draw_rt->GetClearValue()) / normalize);
+			}
+			if (pipe.ds_as_rt)
+			{
+				cvs[cv_count++] = static_cast<GSTextureVK*>(draw_ds_as_rt)->GetVkClearValue();
 			}
 			if (draw_ds)
-				cvs[cv_count++].depthStencil = {draw_ds->GetClearDepth(), 0};
+			{
+				cvs[cv_count++] = static_cast<GSTextureVK*>(draw_ds)->GetVkClearValue();
+			}
 
 			BeginClearRenderPass(rp, render_area, cvs, cv_count);
 		}
@@ -6342,7 +6423,8 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 	// rt -> colclip hw blit if enabled
 	if (colclip_rt && (config.colclip_mode == GSHWDrawConfig::ColClipMode::ConvertOnly || config.colclip_mode == GSHWDrawConfig::ColClipMode::ConvertAndResolve) && config.rt->GetState() == GSTexture::State::Dirty)
 	{
-		OMSetRenderTargets(draw_rt, draw_ds, GSVector4i::loadh(rtsize), static_cast<FeedbackLoopFlag>(pipe.feedback_loop_flags));
+		OMSetRenderTargets(draw_rt, nullptr, draw_ds, GSVector4i::loadh(rtsize),
+			static_cast<FeedbackLoopFlag>(pipe.feedback_loop_flags));
 		SetUtilityTexture(static_cast<GSTextureVK*>(config.rt), m_point_sampler);
 		SetPipeline(m_colclip_setup_pipelines[pipe.ds][pipe.IsRTFeedbackLoop()]);
 
@@ -6351,7 +6433,7 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 		DrawStretchRect(sRect, drawareaf, rtsize);
 
 		GL_POP();
-		OMSetRenderTargets(draw_rt, draw_ds, config.scissor, static_cast<FeedbackLoopFlag>(pipe.feedback_loop_flags));
+		OMSetRenderTargets(draw_rt, nullptr, draw_ds, config.scissor, static_cast<FeedbackLoopFlag>(pipe.feedback_loop_flags));
 	}
 
 	// VB/IB upload, if we did DATE setup and it's not colclip hw this has already been done
@@ -6360,8 +6442,8 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 
 	// now we can do the actual draw
 	if (BindDrawPipeline(pipe))
-		SendHWDraw(config, pipe.IsRTFeedbackLoop() ? draw_rt : nullptr, pipe.IsDepthFeedbackLoop() ? draw_ds : nullptr,
-			config.require_one_barrier, config.require_full_barrier);
+		SendHWDraw(config, pipe.IsRTFeedbackLoop() ? draw_rt : nullptr, pipe.IsDepthRTFeedbackLoop() ? draw_ds_as_rt : nullptr,
+			pipe.IsDepthFeedbackLoop() ? draw_ds : nullptr, config.require_one_barrier, config.require_full_barrier);
 
 	// blend second pass
 	if (config.blend_multi_pass.enable)
@@ -6396,8 +6478,9 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 		pipe.bs = config.blend;
 		if (BindDrawPipeline(pipe))
 		{
-			SendHWDraw(config, pipe.IsRTFeedbackLoop() ? draw_rt : nullptr, pipe.IsDepthFeedbackLoop() ? draw_ds : nullptr,
-				config.alpha_second_pass.require_one_barrier, config.alpha_second_pass.require_full_barrier);
+			SendHWDraw(config, pipe.IsRTFeedbackLoop() ? draw_rt : nullptr, pipe.IsDepthRTFeedbackLoop() ? draw_ds_as_rt : nullptr,
+				pipe.IsDepthFeedbackLoop() ? draw_ds : nullptr, config.alpha_second_pass.require_one_barrier,
+				config.alpha_second_pass.require_full_barrier);
 		}
 	}
 
@@ -6421,28 +6504,29 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 			colclip_rt->TransitionToLayout(GSTextureVK::Layout::ShaderReadOnly);
 
 			draw_rt = static_cast<GSTextureVK*>(config.rt);
-			OMSetRenderTargets(draw_rt, draw_ds, (config.colclip_mode == GSHWDrawConfig::ColClipMode::ResolveOnly) ? GSVector4i::loadh(rtsize) : config.scissor, static_cast<FeedbackLoopFlag>(pipe.feedback_loop_flags));
+			OMSetRenderTargets(draw_rt, nullptr, draw_ds,
+				(config.colclip_mode == GSHWDrawConfig::ColClipMode::ResolveOnly) ? GSVector4i::loadh(rtsize) : config.scissor, static_cast<FeedbackLoopFlag>(pipe.feedback_loop_flags));
 
 			// if this target was cleared and never drawn to, perform the clear as part of the resolve here.
 			if (draw_rt->GetState() == GSTexture::State::Cleared)
 			{
 				alignas(16) VkClearValue cvs[2];
 				u32 cv_count = 0;
-				GSVector4::store<true>(&cvs[cv_count++].color, draw_rt->GetClearForFormat());
+				cvs[cv_count++] = draw_rt->GetVkClearValue();
 				if (draw_ds)
-					cvs[cv_count++].depthStencil = {draw_ds->GetClearDepth(), 1};
+					cvs[cv_count++] = draw_ds->GetVkClearValue();
 
-				BeginClearRenderPass(GetTFXRenderPass(true, pipe.ds, false, false, pipe.IsRTFeedbackLoop(),
-										 pipe.IsTestingAndSamplingDepth(), VK_ATTACHMENT_LOAD_OP_CLEAR,
-										 pipe.ds ? VK_ATTACHMENT_LOAD_OP_LOAD : VK_ATTACHMENT_LOAD_OP_DONT_CARE),
+				BeginClearRenderPass(GetTFXRenderPass(true, false, pipe.ds, false, false, pipe.IsRTFeedbackLoop(),
+					false, pipe.IsTestingAndSamplingDepth(), VK_ATTACHMENT_LOAD_OP_CLEAR, VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+					pipe.ds ? VK_ATTACHMENT_LOAD_OP_LOAD : VK_ATTACHMENT_LOAD_OP_DONT_CARE),
 					draw_rt->GetRect(), cvs, cv_count);
 				draw_rt->SetState(GSTexture::State::Dirty);
 			}
 			else
 			{
-				BeginRenderPass(GetTFXRenderPass(true, pipe.ds, false, false, pipe.IsRTFeedbackLoop(),
-									pipe.IsTestingAndSamplingDepth(), VK_ATTACHMENT_LOAD_OP_LOAD,
-									pipe.ds ? VK_ATTACHMENT_LOAD_OP_LOAD : VK_ATTACHMENT_LOAD_OP_DONT_CARE),
+				BeginRenderPass(GetTFXRenderPass(true, false, pipe.ds, false, false, pipe.IsRTFeedbackLoop(),
+						false, pipe.IsTestingAndSamplingDepth(), VK_ATTACHMENT_LOAD_OP_LOAD,
+						VK_ATTACHMENT_LOAD_OP_DONT_CARE, pipe.ds ? VK_ATTACHMENT_LOAD_OP_LOAD : VK_ATTACHMENT_LOAD_OP_DONT_CARE),
 					draw_rt->GetRect());
 			}
 
@@ -6465,13 +6549,15 @@ void GSDeviceVK::UpdateHWPipelineSelector(GSHWDrawConfig& config, PipelineSelect
 	pipe.vs.key = config.vs.key;
 	pipe.ps.key_hi = config.ps.key_hi;
 	pipe.ps.key_lo = config.ps.key_lo;
-	pipe.dss.key = config.ps.HasDepthROV() ? GSHWDrawConfig::DepthStencilSelector::NoDepth().key : config.depth.key;
+	pipe.dss.key = (config.ps.HasDepthROV() || config.ds_int) ? GSHWDrawConfig::DepthStencilSelector::NoDepth().key : config.depth.key;
 	pipe.bs.key = config.ps.HasColorROV() ? GSHWDrawConfig::BlendState().key : config.blend.key;
 	pipe.bs.constant = 0; // don't dupe states with different alpha values
 	pipe.cms.key = config.ps.HasColorROV() ? GSHWDrawConfig::ColorMaskSelector().key : config.colormask.key;
 	pipe.topology = static_cast<u32>(config.topology);
 	pipe.rt = config.rt != nullptr && !config.ps.HasColorROV();
-	pipe.ds = config.ds != nullptr && !config.ps.HasDepthROV();
+	pipe.ds = config.ds != nullptr && !config.ps.HasDepthROV() && !config.ds_int;
+	pipe.ds_as_rt = config.ds_int && !config.ps.HasDepthROV();
+	pipe.ds_as_rt_write = pipe.ds_as_rt && config.ps.zint == GSHWDrawConfig::PS_Z_INTEGER::READ_WRITE;
 	pipe.line_width = config.line_expand;
 	pipe.feedback_loop_flags = FeedbackLoopFlag_None;
 	if (m_features.texture_barrier && (config.require_one_barrier || config.require_full_barrier))
@@ -6479,8 +6565,13 @@ void GSDeviceVK::UpdateHWPipelineSelector(GSHWDrawConfig& config, PipelineSelect
 		if (config.IsFeedbackLoopRT(config.ps))
 			pipe.feedback_loop_flags |= FeedbackLoopFlag_ReadAndWriteRT;
 
-		if (config.IsFeedbackLoopDepth(config.ps))
+		// Only one of DS or DS as RT should use feedback.
+		// If both are bound, the real DS should only be used for stencil.
+		if (pipe.ds_as_rt && config.IsFeedbackLoopDepth(config.ps))
+			pipe.feedback_loop_flags |= FeedbackLoopFlag_ReadAndWriteDepthRT;
+		else if (pipe.ds && config.IsFeedbackLoopDepth(config.ps))
 			pipe.feedback_loop_flags |= FeedbackLoopFlag_ReadAndWriteDepth;
+
 	}
 	if (pipe.ds && !(pipe.feedback_loop_flags & FeedbackLoopFlag_ReadAndWriteDepth))
 	{
@@ -6541,7 +6632,8 @@ VkDependencyFlags GSDeviceVK::GetFeedbackBarrierDependencyFlags() const
 	                                 VK_DEPENDENCY_BY_REGION_BIT;
 }
 
-void GSDeviceVK::SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt, GSTextureVK* draw_ds,
+void GSDeviceVK::SendHWDraw(const GSHWDrawConfig& config,
+	GSTextureVK* draw_rt, GSTextureVK* draw_ds_as_rt, GSTextureVK* draw_ds,
 	bool one_barrier, bool full_barrier)
 {
 	if (!m_features.texture_barrier) [[unlikely]]
@@ -6556,34 +6648,39 @@ void GSDeviceVK::SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt, 
 #endif
 	VkDependencyFlags barrier_flags = GetFeedbackBarrierDependencyFlags();
 
-	std::array<VkImageMemoryBarrier, 2> barriers;
-	u32 n_barriers = 0;
+	std::array<VkImageMemoryBarrier, 2> barriers_color;
+	u32 n_barriers_color = 0;
+	VkImageMemoryBarrier barrier_depth;
 	if (full_barrier || one_barrier)
 	{
 		if (draw_rt)
 		{
-			barriers[0] = GetColorBufferFeedbackBarrier(draw_rt);
-			n_barriers++;
+			barriers_color[n_barriers_color++] = GetColorBufferFeedbackBarrier(draw_rt);
+		}
+		if (draw_ds_as_rt)
+		{
+			barriers_color[n_barriers_color++] = GetColorBufferFeedbackBarrier(draw_ds_as_rt);
 		}
 		if (draw_ds)
 		{
-			barriers[1] = GetDepthStencilBufferFeedbackBarrier(draw_ds);
-			n_barriers++;
+			barrier_depth = GetDepthStencilBufferFeedbackBarrier(draw_ds);
 		}
 	}
+	const u32 n_barriers = n_barriers_color + (draw_ds ? 1 : 0);
 
 	const auto IssueBarriers = [&]() {
-		if (draw_rt)
+		if (n_barriers_color)
 		{
 			vkCmdPipelineBarrier(GetCurrentCommandBuffer(),
 				VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-				VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, barrier_flags, 0, nullptr, 0, nullptr, 1, &barriers[0]);
+				VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, barrier_flags, 0, nullptr, 0, nullptr,
+				n_barriers_color, barriers_color.data());
 		}
 		if (draw_ds)
 		{
 			vkCmdPipelineBarrier(GetCurrentCommandBuffer(),
 				VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
-				VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, barrier_flags, 0, nullptr, 0, nullptr, 1, &barriers[1]);
+				VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, barrier_flags, 0, nullptr, 0, nullptr, 1, &barrier_depth);
 		}
 	};
 

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -66,6 +66,11 @@ public:
 		       !m_optional_extensions.vk_ext_rasterization_order_attachment_access;
 	}
 
+	__fi bool UseVSExpandIndexBuffer() const
+	{
+		return m_features.aa1 || m_features.depth_integer;
+	}
+
 	// Helpers for getting constants
 	__fi u32 GetBufferCopyOffsetAlignment() const
 	{
@@ -83,13 +88,17 @@ public:
 	__fi bool IsDeviceAMD() const { return (m_device_properties.vendorID == 0x1002); }
 
 	// Creates a simple render pass.
-	VkRenderPass GetRenderPass(VkFormat color_format, VkFormat depth_format,
+	VkRenderPass GetRenderPass(VkFormat color_format, VkFormat depth_as_color_format, VkFormat depth_format,
 		VkAttachmentLoadOp color_load_op = VK_ATTACHMENT_LOAD_OP_LOAD,
 		VkAttachmentStoreOp color_store_op = VK_ATTACHMENT_STORE_OP_STORE,
+		VkAttachmentLoadOp depth_as_color_load_op = VK_ATTACHMENT_LOAD_OP_LOAD,
+		VkAttachmentStoreOp depth_as_color_store_op = VK_ATTACHMENT_STORE_OP_STORE,
 		VkAttachmentLoadOp depth_load_op = VK_ATTACHMENT_LOAD_OP_LOAD,
 		VkAttachmentStoreOp depth_store_op = VK_ATTACHMENT_STORE_OP_STORE,
 		VkAttachmentLoadOp stencil_load_op = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
-		VkAttachmentStoreOp stencil_store_op = VK_ATTACHMENT_STORE_OP_DONT_CARE, bool color_feedback_loop = false,
+		VkAttachmentStoreOp stencil_store_op = VK_ATTACHMENT_STORE_OP_DONT_CARE,
+		bool color_feedback_loop = false,
+		bool depth_as_color_feedback_loop = false,
 		bool depth_sampling = false);
 
 	// Gets a non-clearing version of the specified render pass. Slow, don't call in hot path.
@@ -167,19 +176,23 @@ private:
 	{
 		struct
 		{
-			u32 color_format : 8;
-			u32 depth_format : 8;
-			u32 color_load_op : 2;
-			u32 color_store_op : 1;
-			u32 depth_load_op : 2;
-			u32 depth_store_op : 1;
-			u32 stencil_load_op : 2;
-			u32 stencil_store_op : 1;
-			u32 color_feedback_loop : 1;
-			u32 depth_sampling : 1;
+			u64 color_format : 8;
+			u64 depth_as_color_format : 8;
+			u64 depth_format : 8;
+			u64 color_load_op : 2;
+			u64 color_store_op : 1;
+			u64 depth_as_color_load_op : 2;
+			u64 depth_as_color_store_op : 1;
+			u64 depth_load_op : 2;
+			u64 depth_store_op : 1;
+			u64 stencil_load_op : 2;
+			u64 stencil_store_op : 1;
+			u64 color_feedback_loop : 1;
+			u64 depth_as_color_feedback_loop : 1;
+			u64 depth_sampling : 1;
 		};
 
-		u32 key;
+		u64 key;
 	};
 
 	using ExtensionList = std::vector<const char*>;
@@ -298,7 +311,7 @@ private:
 
 	bool m_last_submit_failed = false;
 
-	std::map<u32, VkRenderPass> m_render_pass_cache;
+	std::map<u64, VkRenderPass> m_render_pass_cache;
 
 	VkDebugUtilsMessengerEXT m_debug_messenger_callback = VK_NULL_HANDLE;
 
@@ -316,6 +329,7 @@ public:
 		FeedbackLoopFlag_ReadAndWriteRT = 1,
 		FeedbackLoopFlag_ReadDepth = 2,
 		FeedbackLoopFlag_ReadAndWriteDepth = 4,
+		FeedbackLoopFlag_ReadAndWriteDepthRT = 8,
 	};
 
 	enum class ResourceType
@@ -347,9 +361,11 @@ public:
 			{
 				u32 topology : 2;
 				u32 rt : 1;
+				u32 ds_as_rt : 1;
+				u32 ds_as_rt_write : 1;
 				u32 ds : 1;
 				u32 line_width : 1;
-				u32 feedback_loop_flags : 3;
+				u32 feedback_loop_flags : 4;
 			};
 
 			u32 key;
@@ -369,6 +385,7 @@ public:
 		__fi bool IsRTFeedbackLoop() const { return ((feedback_loop_flags & FeedbackLoopFlag_ReadAndWriteRT) != 0); }
 		__fi bool IsDepthFeedbackLoop() const { return ((feedback_loop_flags & FeedbackLoopFlag_ReadAndWriteDepth) != 0); }
 		__fi bool IsTestingAndSamplingDepth() const { return ((feedback_loop_flags & (FeedbackLoopFlag_ReadDepth | FeedbackLoopFlag_ReadAndWriteDepth)) != 0); }
+		__fi bool IsDepthRTFeedbackLoop() const { return ((feedback_loop_flags & FeedbackLoopFlag_ReadAndWriteDepthRT) != 0); }
 	};
 	static_assert(sizeof(PipelineSelector) == 32, "Pipeline selector is 32 bytes");
 
@@ -548,10 +565,27 @@ public:
 	/// Returns true if Vulkan is suitable as a default for the devices in the system.
 	static bool IsSuitableDefaultRenderer();
 
-	__fi VkRenderPass GetTFXRenderPass(bool rt, bool ds, bool colclip, bool stencil, bool fbl, bool dsp,
-		VkAttachmentLoadOp rt_op, VkAttachmentLoadOp ds_op) const
+	__fi VkRenderPass GetTFXRenderPass(
+		bool rt, bool ds_as_rt, bool ds, bool colclip, bool stencil,
+		bool fbl, bool fbl_ds_as_rt, bool dsp,
+		VkAttachmentLoadOp rt_op, VkAttachmentLoadOp ds_as_rt_op, VkAttachmentLoadOp ds_op)
 	{
-		return m_tfx_render_pass[rt][ds][colclip][stencil][fbl][dsp][rt_op][ds_op];
+		if (ds_as_rt)
+		{
+			return GetRenderPass(
+				rt ? LookupNativeFormat(GSTexture::Format::Color) : VK_FORMAT_UNDEFINED,
+				LookupNativeFormat(GSTexture::Format::DepthInteger),
+				ds ? LookupNativeFormat(GSTexture::Format::DepthStencil) : VK_FORMAT_UNDEFINED,
+				rt ? rt_op : VK_ATTACHMENT_LOAD_OP_DONT_CARE, rt ? VK_ATTACHMENT_STORE_OP_STORE : VK_ATTACHMENT_STORE_OP_DONT_CARE,
+				ds_as_rt_op, VK_ATTACHMENT_STORE_OP_STORE,
+				ds ? ds_op : VK_ATTACHMENT_LOAD_OP_DONT_CARE, ds ? VK_ATTACHMENT_STORE_OP_STORE : VK_ATTACHMENT_STORE_OP_DONT_CARE,
+				ds ? ds_op : VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
+				fbl, fbl_ds_as_rt, dsp);
+		}
+		else
+		{
+			return m_tfx_render_pass[rt][ds][colclip][stencil][fbl][dsp][rt_op][ds_op];
+		}
 	}
 	__fi VkSampler GetPointSampler() const { return m_point_sampler; }
 	__fi VkSampler GetLinearSampler() const { return m_linear_sampler; }
@@ -630,8 +664,8 @@ public:
 	void PSSetShaderResource(int i, GSTexture* sr, bool check_state, ResourceType type = ResourceType::SRV);
 	void PSSetSampler(GSHWDrawConfig::SamplerSelector sel);
 
-	void OMSetRenderTargets(GSTexture* rt, GSTexture* ds, const GSVector4i& scissor,
-		FeedbackLoopFlag feedback_loop = FeedbackLoopFlag_None, const GSVector2i& viewport_size = {});
+	void OMSetRenderTargets(GSTexture* rt, GSTexture* ds_as_rt, GSTexture* ds,
+		const GSVector4i& scissor, FeedbackLoopFlag feedback_loop = FeedbackLoopFlag_None, const GSVector2i& viewport_size = {});
 
 	void SetVSConstantBuffer(const GSHWDrawConfig::VSConstantBuffer& cb);
 	void SetPSConstantBuffer(const GSHWDrawConfig::PSConstantBuffer& cb);
@@ -644,7 +678,8 @@ public:
 	VkImageMemoryBarrier GetColorBufferFeedbackBarrier(GSTextureVK* rt) const;
 	VkImageMemoryBarrier GetDepthStencilBufferFeedbackBarrier(GSTextureVK* ds) const;
 	VkDependencyFlags GetFeedbackBarrierDependencyFlags() const;
-	void SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt, GSTextureVK* draw_ds,
+	void SendHWDraw(const GSHWDrawConfig& config,
+		GSTextureVK* draw_rt, GSTextureVK* draw_ds_as_rt, GSTextureVK* draw_ds,
 		bool one_barrier, bool full_barrier);
 
 	//////////////////////////////////////////////////////////////////////////
@@ -750,6 +785,7 @@ private:
 	VkBuffer m_index_buffer = VK_NULL_HANDLE;
 
 	GSTextureVK* m_current_render_target = nullptr;
+	GSTextureVK* m_current_depth_render_target = nullptr;
 	GSTextureVK* m_current_depth_target = nullptr;
 	VkFramebuffer m_current_framebuffer = VK_NULL_HANDLE;
 	VkRenderPass m_current_render_pass = VK_NULL_HANDLE;

--- a/pcsx2/GS/Renderers/Vulkan/GSTextureVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSTextureVK.cpp
@@ -16,8 +16,12 @@ VkFramebuffer GSTextureVK::CreateNullFramebuffer(u32 w, u32 h)
 	const VkRenderPass rp = GSDeviceVK::GetInstance()->GetRenderPass(
 		VK_FORMAT_UNDEFINED,
 		VK_FORMAT_UNDEFINED,
-		VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE, VK_ATTACHMENT_LOAD_OP_DONT_CARE,
-		VK_ATTACHMENT_STORE_OP_DONT_CARE, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE, false, false);
+		VK_FORMAT_UNDEFINED,
+		VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
+		VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
+		VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
+		VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
+		false, false, false);
 
 	if (!rp)
 		return VK_NULL_HANDLE;
@@ -202,16 +206,19 @@ void GSTextureVK::Destroy(bool defer)
 
 	if (IsRenderTargetOrDepthStencil())
 	{
-		for (const auto& [other_tex, fb, feedback_color, feedback_depth] : m_framebuffers)
+		for (const auto& [other_tex0, other_tex1, fb, feedback_color, feedback_depth_as_color, feedback_depth] : m_framebuffers)
 		{
-			if (other_tex)
+			for (GSTextureVK* other : std::array{ other_tex0, other_tex1 })
 			{
-				for (auto other_it = other_tex->m_framebuffers.begin(); other_it != other_tex->m_framebuffers.end(); ++other_it)
+				if (other)
 				{
-					if (std::get<0>(*other_it) == this)
+					for (auto other_it = other->m_framebuffers.begin(); other_it != other->m_framebuffers.end(); ++other_it)
 					{
-						other_tex->m_framebuffers.erase(other_it);
-						break;
+						if (std::get<0>(*other_it) == this || std::get<1>(*other_it) == this)
+						{
+							other->m_framebuffers.erase(other_it);
+							break;
+						}
 					}
 				}
 			}
@@ -553,14 +560,13 @@ void GSTextureVK::CommitClear(VkCommandBuffer cmdbuf)
 
 	if (IsDepthStencil())
 	{
-		const VkClearDepthStencilValue cv = {m_clear_value.depth};
+		const VkClearDepthStencilValue cv = GetVkClearValue().depthStencil;
 		const VkImageSubresourceRange srr = {VK_IMAGE_ASPECT_DEPTH_BIT, 0u, 1u, 0u, 1u};
 		vkCmdClearDepthStencilImage(cmdbuf, m_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &cv, 1, &srr);
 	}
 	else if (IsRenderTarget())
 	{
-		alignas(16) VkClearColorValue cv;
-		GSVector4::store<true>(cv.float32, GetClearForFormat());
+		alignas(16) VkClearColorValue cv = GetVkClearValue().color;
 		const VkImageSubresourceRange srr = {VK_IMAGE_ASPECT_COLOR_BIT, 0u, 1u, 0u, 1u};
 		vkCmdClearColorImage(cmdbuf, m_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &cv, 1, &srr);
 	}
@@ -570,6 +576,35 @@ void GSTextureVK::CommitClear(VkCommandBuffer cmdbuf)
 	}
 
 	SetState(GSTexture::State::Dirty);
+}
+
+VkClearValue GSTextureVK::GetVkClearValue() const
+{
+	VkClearValue cv{};
+	if (IsDepthStencil())
+	{
+		if (IsDepthColor())
+		{
+			cv.color.float32[0] = GetClearDepth();
+		}
+		else
+		{
+			cv.depthStencil.depth = GetClearDepth();
+			cv.depthStencil.stencil = 1;
+		}
+	}
+	else if (IsRenderTarget())
+	{
+		if (IsDepthInteger())
+		{
+			cv.color.uint32[0] = GetClearValue();
+		}
+		else
+		{
+			GSVector4::store<true>(cv.color.float32, GSVector4::unorm8(GetClearValue()));
+		}
+	}
+	return cv;
 }
 
 void GSTextureVK::OverrideImageLayout(Layout new_layout)
@@ -794,29 +829,46 @@ void GSTextureVK::TransitionSubresourcesToLayout(
 
 VkFramebuffer GSTextureVK::GetFramebuffer(bool feedback_loop)
 {
-	return GetLinkedFramebuffer(nullptr, feedback_loop, false);
+	return GetLinkedFramebuffer(nullptr, nullptr, feedback_loop, false, false);
 }
 
-VkFramebuffer GSTextureVK::GetLinkedFramebuffer(GSTextureVK* depth_texture, bool feedback_loop_color, bool feedback_loop_depth)
+VkFramebuffer GSTextureVK::GetLinkedFramebuffer(GSTextureVK* depth_as_color_texture, GSTextureVK* depth_texture,
+	bool feedback_loop_color, bool feedback_loop_depth_as_color, bool feedback_loop_depth)
 {
 	pxAssertRel(!IsTexture(), "Texture is a render target");
 
-	for (const auto& [other_tex, fb, other_feedback_loop_color, other_feedback_loop_depth] : m_framebuffers)
+	for (const auto& [other_tex0, other_tex1, fb,
+		other_feedback_loop_color, other_feedback_loop_depth_as_color, other_feedback_loop_depth] : m_framebuffers)
 	{
-		if (other_tex == depth_texture && other_feedback_loop_color == feedback_loop_color && other_feedback_loop_depth == feedback_loop_depth)
+		if (other_tex0 == depth_as_color_texture &&
+			other_tex1 == depth_texture &&
+			other_feedback_loop_color == feedback_loop_color &&
+			other_feedback_loop_depth_as_color == feedback_loop_depth_as_color &&
+			other_feedback_loop_depth == feedback_loop_depth)
+		{
 			return fb;
+		}
 	}
 
-	const VkRenderPass rp = GSDeviceVK::GetInstance()->GetRenderPass(
-		!IsDepthStencil() ? m_vk_format : VK_FORMAT_UNDEFINED,
-		!IsDepthStencil() ? (depth_texture ? depth_texture->m_vk_format : VK_FORMAT_UNDEFINED) : m_vk_format,
-		VK_ATTACHMENT_LOAD_OP_LOAD, VK_ATTACHMENT_STORE_OP_STORE, VK_ATTACHMENT_LOAD_OP_LOAD,
-		VK_ATTACHMENT_STORE_OP_STORE, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE, feedback_loop_color, feedback_loop_depth);
+	const VkFormat format_color = (IsRenderTarget() && !IsDepthInteger()) ? m_vk_format : VK_FORMAT_UNDEFINED;
+	const VkFormat format_depth_as_color = IsDepthInteger() ? m_vk_format :
+		(depth_as_color_texture ? depth_as_color_texture->m_vk_format : VK_FORMAT_UNDEFINED);
+	const VkFormat format_depth = IsDepthStencil() ? m_vk_format :
+		(depth_texture ? depth_texture->m_vk_format : VK_FORMAT_UNDEFINED);
+
+	const VkRenderPass rp = GSDeviceVK::GetInstance()->GetRenderPass(format_color, format_depth_as_color, format_depth,
+		VK_ATTACHMENT_LOAD_OP_LOAD, VK_ATTACHMENT_STORE_OP_STORE,
+		VK_ATTACHMENT_LOAD_OP_LOAD, VK_ATTACHMENT_STORE_OP_STORE,
+		VK_ATTACHMENT_LOAD_OP_LOAD, VK_ATTACHMENT_STORE_OP_STORE,
+		VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
+		feedback_loop_color, feedback_loop_depth_as_color, feedback_loop_depth);
 	if (!rp)
 		return VK_NULL_HANDLE;
 
 	Vulkan::FramebufferBuilder fbb;
 	fbb.AddAttachment(m_view);
+	if (depth_as_color_texture)
+		fbb.AddAttachment(depth_as_color_texture->m_view);
 	if (depth_texture)
 		fbb.AddAttachment(depth_texture->m_view);
 	fbb.SetSize(m_size.x, m_size.y, 1);
@@ -826,9 +878,14 @@ VkFramebuffer GSTextureVK::GetLinkedFramebuffer(GSTextureVK* depth_texture, bool
 	if (!fb)
 		return VK_NULL_HANDLE;
 
-	m_framebuffers.emplace_back(depth_texture, fb, feedback_loop_color, feedback_loop_depth);
+	m_framebuffers.emplace_back(depth_as_color_texture, depth_texture, fb, feedback_loop_color,
+		feedback_loop_depth_as_color, feedback_loop_depth);
+	if (depth_as_color_texture)
+		depth_as_color_texture->m_framebuffers.emplace_back(this, depth_texture, fb, feedback_loop_color,
+			feedback_loop_depth_as_color, feedback_loop_depth);
 	if (depth_texture)
-		depth_texture->m_framebuffers.emplace_back(this, fb, feedback_loop_color, feedback_loop_depth);
+		depth_texture->m_framebuffers.emplace_back(this, depth_as_color_texture, fb, feedback_loop_color,
+			feedback_loop_depth_as_color, feedback_loop_depth);
 	return fb;
 }
 
@@ -881,7 +938,7 @@ void GSDownloadTextureVK::CopyFromTexture(
 {
 	GSTextureVK* const vkTex = static_cast<GSTextureVK*>(stex);
 
-	pxAssert(vkTex->GetFormat() == m_format);
+	pxAssert(GSTexture::AreFormatsEquivalent(vkTex->GetFormat(), m_format));
 	pxAssert(drc.width() == src.width() && drc.height() == src.height());
 	pxAssert(src.z <= vkTex->GetWidth() && src.w <= vkTex->GetHeight());
 	pxAssert(static_cast<u32>(drc.z) <= m_width && static_cast<u32>(drc.w) <= m_height);

--- a/pcsx2/GS/Renderers/Vulkan/GSTextureVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSTextureVK.h
@@ -62,6 +62,7 @@ public:
 	void TransitionToLayout(Layout layout);
 	void CommitClear();
 	void CommitClear(VkCommandBuffer cmdbuf);
+	VkClearValue GetVkClearValue() const;
 
 	// Used when the render pass is changing the image layout, or to force it to
 	// VK_IMAGE_LAYOUT_UNDEFINED, if the existing contents of the image is
@@ -77,7 +78,8 @@ public:
 	/// Framebuffers are lazily allocated.
 	VkFramebuffer GetFramebuffer(bool feedback_loop);
 
-	VkFramebuffer GetLinkedFramebuffer(GSTextureVK* depth_texture, bool feedback_loop_color, bool feedback_loop_depth);
+	VkFramebuffer GetLinkedFramebuffer(GSTextureVK* depth_as_color_texture, GSTextureVK* depth_texture,
+		bool feedback_loop_color, bool feedback_loop_depth_as_color, bool feedback_loop_depth);
 
 	// Call when the texture is bound to the pipeline, or read from in a copy.
 	__fi void SetUseFenceCounter(u64 counter) { m_use_fence_counter = counter; }
@@ -107,7 +109,7 @@ private:
 
 	// linked framebuffer is combined with depth texture
 	// list of color textures this depth texture is linked to or vice versa
-	std::vector<std::tuple<GSTextureVK*, VkFramebuffer, bool, bool>> m_framebuffers;
+	std::vector<std::tuple<GSTextureVK*, GSTextureVK*, VkFramebuffer, bool, bool, bool>> m_framebuffers;
 };
 
 class GSDownloadTextureVK final : public GSDownloadTexture

--- a/pcsx2/GS/Renderers/Vulkan/VKBuilders.h
+++ b/pcsx2/GS/Renderers/Vulkan/VKBuilders.h
@@ -272,7 +272,7 @@ namespace Vulkan
 	{
 		enum : u32
 		{
-			MAX_ATTACHMENTS = 2,
+			MAX_ATTACHMENTS = 3,
 		};
 
 	public:

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -962,6 +962,9 @@ __ri void ImGuiManager::DrawSettingsOverlay(float scale, float margin, float spa
 		if (GSConfig.HWROVBarriersVK)
 			APPEND("RBVK ");
 
+		if (GSConfig.HWZIntegerMode != GSHardwareZIntegerMode::Disabled)
+			APPEND("ZINT={} ", static_cast<int>(GSConfig.HWZIntegerMode));
+
 		// deliberately test global and print local here for auto values
 		if (EmuConfig.GS.TextureFiltering != BiFiltering::PS2)
 			APPEND("BF={} ", static_cast<unsigned>(GSConfig.TextureFiltering));

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -746,6 +746,7 @@ Pcsx2Config::GSOptions::GSOptions()
 	OsdShowTextureReplacements = false;
 
 	HWDownloadMode = GSHardwareDownloadMode::Enabled;
+	HWZIntegerMode = GSHardwareZIntegerMode::Disabled;
 	HWSpinGPUForReadbacks = false;
 	HWSpinCPUForReadbacks = false;
 	GPUPaletteConversion = false;
@@ -862,6 +863,7 @@ bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 		OpEqu(UserHacks_BilinearHack) &&
 		OpEqu(OverrideTextureBarriers) &&
 		OpEqu(DepthFeedbackMode) &&
+		OpEqu(HWZIntegerMode) &&
 
 		OpEqu(CAS_Sharpness) &&
 		OpEqu(ShadeBoost_Brightness) &&
@@ -915,6 +917,8 @@ bool Pcsx2Config::GSOptions::RestartOptionsAreEqual(const GSOptions& right) cons
 		   OpEqu(OverrideTextureBarriers) &&
 		   OpEqu(DepthFeedbackMode) &&
 		   OpEqu(HWAA1) &&
+		   ((HWZIntegerMode == GSHardwareZIntegerMode::Disabled) ==
+			   (right.HWZIntegerMode == GSHardwareZIntegerMode::Disabled)) &&
 		   OpEqu(ExclusiveFullscreenControl);
 }
 
@@ -1056,6 +1060,7 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapIntEnumEx(TexturePreloading, "texture_preloading");
 	SettingsWrapIntEnumEx(GSDumpCompression, "GSDumpCompression");
 	SettingsWrapIntEnumEx(HWDownloadMode, "HWDownloadMode");
+	SettingsWrapIntEnumEx(HWZIntegerMode, "HWZIntegerMode");
 	SettingsWrapIntEnumEx(CASMode, "CASMode");
 	SettingsWrapBitfieldEx(CAS_Sharpness, "CASSharpness");
 	SettingsWrapBitfieldEx(Dithering, "dithering_ps2");


### PR DESCRIPTION
Status: this is a WIP for early testing. There are several performance and code cleanup issues to be addressed. Committed on top of ROV, but has not been fully tested.

### Description of Changes
Adds support for integer depth format to DX12/VK/GL/DX11.

Procedure for interpolating 32 bit Z values was given by @TellowKrinkle:
1. In the vertex shader send the minimum Z value of each triangle as a flat uint attribute, along with the offset as an interpolated float attribute.
2. In the fragment shader add the flat minimum value to the interpolated float value.

This should work as long as each triangle's Z range fits in 24 bits (which appears to be the case in all GS dumps examined so far).

### Rationale behind Changes
Makes depth accuracy about the same as SW when the full 32 bit range is used non-trivially (i.e., upper bits of depth take multiple values). I don't know of many cases where this is actually needed, so this is more of a "nice to have" feature. It comes at a significant performance cost, so a less expensive fix is preferable (Z floor and/or limit 24 bit setting) unless absolutely required.

Draws with integer depth will usually require full barriers since we need to read/write the buffer for depth testing. This might be impractical in many cases, though it could be more usable when combined with ROVs.

### Suggested Testing Steps
Use the following setting in the INI:
```
[EmuCore/GS]
HWZIntegerMode = 1
```
The values are:
- `HWZIntegerMode = 0`: Disabled.
- `HWZIntegerMode = 1`: Enabled. Use integer depth when the Z values go outside the 24 bit range and switch back to regular depth if the range goes back.
- `HWZIntegerMode = 2`: Always. Always use integer depth. This is more more testing than for practical use.
Then use VK and/or DX12.

### Example

The only case I know where 32 bit Z is used non-trivially (thanks @refractionpcsx2 ): 

Shox_SLUS-20533_20260111064920.gs.xz (see the signs in the distance and sides of the road)

Master VK
<img width="512" height="448" alt="03186_f00023_fr-1_00000_C_16_master" src="https://github.com/user-attachments/assets/97cd3344-54cc-47fb-8c5b-072d0025ee5e" />

Master SW
<img width="512" height="448" alt="03186_f00023_fr-1_00000_C_16_sw" src="https://github.com/user-attachments/assets/f66dda33-b3c5-4cf7-b8b8-f835d2cdb086" />

PR VK
<img width="512" height="448" alt="03186_f00023_fr-1_00000_C_16_pr" src="https://github.com/user-attachments/assets/07e6a038-2038-4405-9b61-22e58516c002" />

### Did you use AI to help find, test, or implement this issue or feature?
Yes, to get help with the API usage/shader programming and info about extensions. Also, for reviewing the 64 bit arithmetic code.
