### PR TITLE
GS/TC: Correct some preload behaviour on merging targets

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -457,6 +457,7 @@ PAPX-90508:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     autoFlush: 1 # Helps lens flare and sun occlusion somewhat but doesn't full fix it.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
 PAPX-90511:
   name: "SIREN [体験版]"
@@ -478,6 +479,7 @@ PAPX-90512:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     autoFlush: 1 # Helps lens flare and sun occlusion somewhat but doesn't full fix it.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
 PAPX-90514:
   name: "冬のオススメソフト おためしDISC"
@@ -535,6 +537,7 @@ PAPX-90523:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     autoFlush: 1 # Helps lens flare and sun occlusion somewhat but doesn't full fix it.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
 PAPX-90524:
   name: "ワイルドアームズ ザ フィフスヴァンガード [体験版]"
@@ -753,6 +756,7 @@ PBPX-95523:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
   # vuClampMode = 2  Text in GT mode works.
 PBPX-95524:
@@ -762,6 +766,7 @@ PBPX-95524:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
   # vuClampMode = 2  Text in GT mode works.
 PBPX-95525:
@@ -781,6 +786,7 @@ PBPX-95601:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     autoFlush: 1 # Helps lens flare and sun occlusion somewhat but doesn't full fix it.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
   memcardFilters:
     - "SCAJ-20066"
@@ -1160,6 +1166,7 @@ PCPX-96649:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     autoFlush: 1 # Helps lens flare and sun occlusion somewhat but doesn't full fix it.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
 PCPX-96653:
   name: "ラチェット&クランク3 突撃！ガラクチック★レンジャーズ [店頭体験版]"
@@ -1654,6 +1661,7 @@ SCAJ-20066:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
   memcardFilters:
     - "SCAJ-20066"
@@ -2670,6 +2678,7 @@ SCAJ-30006:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     autoFlush: 1 # Helps lens flare and sun occlusion somewhat but doesn't full fix it.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
   memcardFilters:
     - "SCAJ-20066"
@@ -2693,6 +2702,7 @@ SCAJ-30007:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     autoFlush: 1 # Helps lens flare and sun occlusion somewhat but doesn't full fix it.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
 SCAJ-30008:
   name: "Gran Turismo 4 [PlayStation2 the Best]"
@@ -2704,6 +2714,7 @@ SCAJ-30008:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     autoFlush: 1 # Helps lens flare and sun occlusion somewhat but doesn't full fix it.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
   memcardFilters:
     - "SCAJ-20066"
@@ -2867,6 +2878,7 @@ SCCS-60002:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     autoFlush: 1 # Helps lens flare and sun occlusion somewhat but doesn't full fix it.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
 SCED-50041:
   name: "Tekken Tag Tournament [Demo]"
@@ -3866,6 +3878,7 @@ SCED-52578:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     autoFlush: 1 # Helps lens flare and sun occlusion somewhat but doesn't full fix it.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
 SCED-52580:
   name: "Magazine Ufficiale PlayStation 2 Italia 06/04"
@@ -3883,6 +3896,7 @@ SCED-52681:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     autoFlush: 1 # Helps lens flare and sun occlusion somewhat but doesn't full fix it.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
 SCED-52687:
   name: "Formula One 04 [Demo]"
@@ -5525,6 +5539,7 @@ SCES-51719:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     autoFlush: 1 # Helps lens flare and sun occlusion somewhat but doesn't full fix it.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
   memcardFilters:
     - "SCES-51719"
@@ -5786,6 +5801,7 @@ SCES-52438:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
   memcardFilters:
     - "SCES-51719"
@@ -7324,6 +7340,7 @@ SCKA-20022:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
   # vuClampMode = 2  Text in GT mode works.
 SCKA-20023:
@@ -8255,6 +8272,7 @@ SCKA-30001:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     autoFlush: 1 # Helps lens flare and sun occlusion somewhat but doesn't full fix it.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
 SCKA-30002:
   name: "GOD OF WAR 영혼의 반역자"
@@ -8282,6 +8300,7 @@ SCKA-30004:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     autoFlush: 1 # Helps lens flare and sun occlusion somewhat but doesn't full fix it.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
 SCKA-30005:
   name: "로그 갤럭시"
@@ -8406,6 +8425,7 @@ SCPM-85304:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     autoFlush: 1 # Helps lens flare and sun occlusion somewhat but doesn't full fix it.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
 SCPN-60101:
   name: "PlayStation BB Navigator - Version 0.10 [Prerelease] [Disc 1]"
@@ -9070,6 +9090,7 @@ SCPS-15055:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
   memcardFilters:
     - "SCAJ-20066"
@@ -9699,6 +9720,7 @@ SCPS-17001:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     autoFlush: 1 # Helps lens flare and sun occlusion somewhat but doesn't full fix it.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
   memcardFilters:
     - "SCAJ-20066"
@@ -9986,6 +10008,7 @@ SCPS-19252:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     autoFlush: 1 # Helps lens flare and sun occlusion somewhat but doesn't full fix it.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
   memcardFilters:
     - "SCAJ-20066"
@@ -10051,6 +10074,7 @@ SCPS-19304:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
   memcardFilters:
     - "SCAJ-20066"
@@ -11008,6 +11032,7 @@ SCUS-90682:
     vuClampMode: 2 # Text in GT mode works.
   gsHWFixes:
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
 SCUS-94346:
   name: "SingStar - Latino"
@@ -11892,6 +11917,7 @@ SCUS-97328:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     autoFlush: 1 # Helps lens flare and sun occlusion somewhat but doesn't full fix it.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
   memcardFilters: # Allows car imports from GT3 or something.
     - "SCUS-97328"
@@ -12324,6 +12350,7 @@ SCUS-97436:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     autoFlush: 1 # Helps lens flare and sun occlusion somewhat but doesn't full fix it.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
   memcardFilters:
     - "SCUS-97328"
@@ -12547,6 +12574,7 @@ SCUS-97483:
     recommendedBlendingLevel: 3 # Improves banding in car showcase as well as car brightness and sheen.
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
     autoFlush: 1 # Helps lens flare and sun occlusion somewhat but doesn't full fix it.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
 SCUS-97484:
   name: "Sly 3 - Honor Among Thieves [E3 Demo]"
@@ -12932,6 +12960,7 @@ SCUS-97563:
     vuClampMode: 2 # Text in GT mode works.
   gsHWFixes:
     halfPixelOffset: 4 # Fixes weird edge shadows and depth bleed which happens on the edge as well.
+    textureInsideRT: 1 # Fixes some transition effect handling.
     getSkipCount: "GSC_PolyphonyDigitalGames" # Fixes post-processing.
 SCUS-97564:
   name: "Jampack Demo Disc Vol.15 [T-Rated]"

--- a/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -803,6 +803,8 @@ bool GSHwHack::GSC_PolyphonyDigitalGames(GSRendererHW& r, int& skip)
 			dst->m_alpha_min = 0;
 			dst->m_alpha_max = 255;
 			dst->m_alpha_range = true;
+			dst->m_valid_alpha_high = true;
+			dst->m_valid_alpha_low = true;
 			dst->UpdateValidChannels(PSMCT32, fbmsk);
 			dst->UpdateValidity(GSVector4i::loadh(size));
 

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1810,7 +1810,8 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const bool is_color, const 
 					// Keep note that 2 bw is basically 1 normal page, as bw is in 64 pixels, and 8bit pages are 128 pixels wide, aka 2 bw.
 					// Also check for 4HH/HL and 8H which use the alpha channel, if the page order is wrong this can cause problems as well (Jak X font).
 					else if (!possible_shuffle && GSLocalMemory::m_psm[psm].trbpp <= 8 &&
-					         (GSUtil::GetChannelMask(t->m_TEX0.PSM) != 0xF ||
+							 ((GSUtil::GetChannelMask(t->m_TEX0.PSM) != GSUtil::GetChannelMask(psm) && 
+							 !(((GSUtil::GetChannelMask(psm) & 0x7) == 0 || t->m_valid_rgb) && ((GSUtil::GetChannelMask(psm) & 0x8) == 0 || (t->m_valid_alpha_low && t->m_valid_alpha_high)))) ||
 					          ((GSLocalMemory::m_psm[t->m_TEX0.PSM].bpp != 16 || GSLocalMemory::m_psm[psm].bpp < 16) &&
 					           (!(block_boundary_rect.w <= GSLocalMemory::m_psm[psm].pgs.y &&
 					              ((GSLocalMemory::m_psm[psm].bpp == 32) ? bw : ((bw + 1) / 2)) <= t->m_TEX0.TBW) &&


### PR DESCRIPTION
### Description of Changes
Correct some preload behaviour on merging targets

### Rationale behind Changes
Data was becoming errornously dirty or deleted when it didn't need to be, causing some problems when Tex in RT/RT in RT was enabled.

### Suggested Testing Steps
Test Gran Turismo 4 with Tex in RT enabled (required to get around related issues)

### Did you use AI to help find, test, or implement this issue or feature?
No
