### PR TITLE
GS/VK: Fix the Nvidia present fix

### DIFF
--- a/pcsx2/GS/Renderers/Vulkan/VKSwapChain.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/VKSwapChain.cpp
@@ -490,6 +490,18 @@ bool VKSwapChain::CreateSwapChain()
 			sema.available_semaphore = VK_NULL_HANDLE;
 			return false;
 		}
+
+		res = vkCreateSemaphore(
+			GSDeviceVK::GetInstance()->GetDevice(), &semaphore_info, nullptr, &sema.present_ready_semaphore);
+		if (res != VK_SUCCESS)
+		{
+			LOG_VULKAN_ERROR(res, "vkCreateSemaphore failed: ");
+			vkDestroySemaphore(GSDeviceVK::GetInstance()->GetDevice(), sema.rendering_finished_semaphore, nullptr);
+			vkDestroySemaphore(GSDeviceVK::GetInstance()->GetDevice(), sema.available_semaphore, nullptr);
+			sema.rendering_finished_semaphore = VK_NULL_HANDLE;
+			sema.available_semaphore = VK_NULL_HANDLE;
+			return false;
+		}
 	}
 
 	return true;
@@ -505,6 +517,8 @@ void VKSwapChain::DestroySwapChainImages()
 	m_images.clear();
 	for (auto& it : m_semaphores)
 	{
+		if (it.present_ready_semaphore != VK_NULL_HANDLE)
+			vkDestroySemaphore(GSDeviceVK::GetInstance()->GetDevice(), it.present_ready_semaphore, nullptr);
 		if (it.rendering_finished_semaphore != VK_NULL_HANDLE)
 			vkDestroySemaphore(GSDeviceVK::GetInstance()->GetDevice(), it.rendering_finished_semaphore, nullptr);
 		if (it.available_semaphore != VK_NULL_HANDLE)

--- a/pcsx2/GS/Renderers/Vulkan/VKSwapChain.h
+++ b/pcsx2/GS/Renderers/Vulkan/VKSwapChain.h
@@ -64,6 +64,14 @@ public:
 	{
 		return &m_semaphores[m_current_semaphore].rendering_finished_semaphore;
 	}
+	__fi VkSemaphore GetPresentReadySemaphore() const
+	{
+		return m_semaphores[m_current_semaphore].present_ready_semaphore;
+	}
+	__fi const VkSemaphore* GetPresentReadySemaphorePtr() const
+	{
+		return &m_semaphores[m_current_semaphore].present_ready_semaphore;
+	}
 
 	VkFormat GetTextureFormat() const;
 	VkResult AcquireNextImage();
@@ -92,6 +100,7 @@ private:
 	{
 		VkSemaphore available_semaphore;
 		VkSemaphore rendering_finished_semaphore;
+		VkSemaphore present_ready_semaphore;
 	};
 
 	WindowInfo m_window_info;


### PR DESCRIPTION
### Description of Changes
Specify a valid stage bit for `vkQueueSubmit()`
Re-add a semaphore for present.

### Rationale behind Changes
The invalid stage bit was ignored on AMD.
On some AMD GPUs present needs additional synchronisation that can't be performed with a `vkQueueSubmit()`, so seemingly the exact opposite of Nvidia.

The amount of synchronisation we are doing here is approaching what is needed for exclusive images...

### Suggested Testing Steps
Test RDNA2 GPUs.
Verify that present is still fast (Done by Jordan).

### Did you use AI to help find, test, or implement this issue or feature?
No
