### PR TITLE
cmake: remove Qt6::GuiPrivate dependency on WIN32 and APPLE

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -110,8 +110,10 @@ disable_compiler_warnings_for_target(speex)
 if(ENABLE_QT_UI)
 	find_package(Qt6 6.10.0 COMPONENTS CoreTools Core GuiTools Gui WidgetsTools Widgets LinguistTools REQUIRED)
 
-	if (Qt6_VERSION VERSION_GREATER_EQUAL 6.10.0)
-		find_package(Qt6 COMPONENTS CorePrivate GuiPrivate WidgetsPrivate REQUIRED)
+	if(NOT WIN32 AND NOT APPLE)
+		if (Qt6_VERSION VERSION_GREATER_EQUAL 6.10.0)
+			find_package(Qt6 COMPONENTS CorePrivate GuiPrivate WidgetsPrivate REQUIRED)
+		endif()
 	endif()
 
 	# The docking system for the debugger.

--- a/pcsx2-qt/CMakeLists.txt
+++ b/pcsx2-qt/CMakeLists.txt
@@ -289,10 +289,13 @@ target_link_libraries(pcsx2-qt PRIVATE
 	PCSX2
 	Qt6::Core
 	Qt6::Gui
-	Qt6::GuiPrivate
 	Qt6::Widgets
 	KDAB::kddockwidgets
 )
+
+if(NOT WIN32 AND NOT APPLE)
+	target_link_libraries(pcsx2-qt PRIVATE Qt6::GuiPrivate)
+endif()
 
 # Our Qt builds may have exceptions on, so force them off.
 target_compile_definitions(pcsx2-qt PRIVATE QT_NO_EXCEPTIONS)

--- a/pcsx2-qt/DisplayWidget.cpp
+++ b/pcsx2-qt/DisplayWidget.cpp
@@ -26,8 +26,6 @@
 
 #if defined(_WIN32)
 #include "common/RedtapeWindows.h"
-#elif !defined(APPLE)
-#include <qpa/qplatformnativeinterface.h>
 #endif
 
 DisplaySurface::DisplaySurface()


### PR DESCRIPTION
### Description of Changes
Remove Qt6::GuiPrivate dependency on WIN32 and APPLE.

### Rationale behind Changes
Qt6::GuiPrivate is only needed on Linux.

### Suggested Testing Steps
No need.

### Did you use AI to help find, test, or implement this issue or feature?
No.
