### PR TITLE
GS/DX12: Don't end render passes on enhanced barriers.

### DIFF
--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -3992,10 +3992,6 @@ GSTexture12* GSDevice12::SetupPrimitiveTrackingDATE(GSHWDrawConfig& config, Pipe
 
 void GSDevice12::FeedbackBarrier(const GSTexture12* texture)
 {
-	// The DX12 spec notes "You may not read from, or consume, a write that occurred within the same render pass".
-	// The only exception being the implicit reads for render target blending or depth testing.
-	// Thus, in addition to a barrier, we need to end the render pass.
-	EndRenderPass();
 	if (m_enhanced_barriers)
 	{
 		// Enhanced barriers allows for single resource feedback.
@@ -4008,6 +4004,10 @@ void GSDevice12::FeedbackBarrier(const GSTexture12* texture)
 	}
 	else
 	{
+		// The DX12 spec notes "You may not read from, or consume, a write that occurred within the same render pass".
+		// The only exception being the implicit reads for render target blending or depth testing.
+		// Thus, in addition to a barrier, we need to end the render pass.
+		EndRenderPass();
 		// Specify null for the after resource as both resources are used after the barrier.
 		// While this may also be true before the barrier, we only write using the main resource.
 		D3D12_RESOURCE_BARRIER barrier = {D3D12_RESOURCE_BARRIER_TYPE_ALIASING, D3D12_RESOURCE_BARRIER_FLAG_NONE};


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/DX12: Don't end render passes on enhanced barriers.
Unlike aliasing barriers we don't need to end the render pass before issuing enhanced barriers.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Speed.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test variety of games, almost all will be affected with enhanced barriers, also check if any new api warnings appear.

Some big reductions, not mentioning all as almost everything is affected, especially with higher blends.
Need for Speed - Carbon_SLUS-21493_20220727201009 ['Render Passes: -1691 [1716=>25]']
Keroro Gunsou - Mero Mero Battle Royale_SLPS-25399_20230724102648 ['Render Passes: -1521 [1581=>60]']
Final Fantasy XII preload frame data texture isses ['Render Passes: -1144 [1169=>25]']

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
We were all gaslighted.
