### PR TITLE
GS/TC: Allow creation of target during GS->GS transfer with offset

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -5073,14 +5073,14 @@ bool GSTextureCache::Move(u32 SBP, u32 SBW, u32 SPSM, int sx, int sy, u32 DBP, u
 	// We use dx/dy == 0 and the TBW check as a safeguard to make sure these go through to local memory.
 	// We can also recreate the target if it's previously been created in the height cache with a valid size.
 	// Good test case for this is the Xenosaga I cutscene transitions, or Gradius V.
-	if (src && !dst && ((dx == 0 && dy == 0 && ((static_cast<u32>(w) + 63) / 64) <= DBW) || HasTargetInHeightCache(DBP, DBW, DPSM, 10)))
+	if (src && !dst && ((((dx == 0 && dy == 0) || (dx == sx && dy == sy && DBW == src->m_TEX0.TBW)) && ((static_cast<u32>(w) + 63) / 64) <= DBW) || HasTargetInHeightCache(DBP, DBW, DPSM, 10)))
 	{
 		GIFRegTEX0 new_TEX0 = {};
 		new_TEX0.TBP0 = DBP;
 		new_TEX0.TBW = DBW;
 		new_TEX0.PSM = DPSM;
 
-		const GSVector2i target_size = GetTargetSize(DBP, DBW, DPSM, Common::AlignUpPow2(w, 64), h);
+		const GSVector2i target_size = (dx == 0 && dy == 0) ? GetTargetSize(DBP, DBW, DPSM, Common::AlignUpPow2(w, 64), h) : GSVector2i(src->m_valid.z, src->m_valid.w);
 		dst = LookupTarget(new_TEX0, target_size, src->m_scale, src->m_type);
 		if (!dst)
 		{


### PR DESCRIPTION
### Description of Changes
Allows the creation of render targets in GS->GS transfer when using an offset

### Rationale behind Changes
As long as the offset and widths match then I see no problem in assuming the target is supposed to be the same size as the source.

### Suggested Testing Steps
Test Dynasty Warriors 2, Xenosaga 1 (Cutscenes apparently), Gradius V (I couldn't reproduce areas with readbacks), Time Crisis 3 and maybe any other games which do local transfers (Armored Core games, maybe?)

### Did you use AI to help find, test, or implement this issue or feature?
No

Allows Dynasty Warriors 2 menu to be upscaled, and probably makes them faster.
Time Crisis 3 gained about a 30% performance boost when it was previously reading back.

All benchmarks taken at Native x3, Full blending

<img width="688" height="280" alt="image" src="https://github.com/user-attachments/assets/13554d6e-537f-4779-83b9-0c111fe3ef23" />

(This is the Dynasty Warriors 2 main menu)

<img width="692" height="278" alt="image" src="https://github.com/user-attachments/assets/e3e51550-97f5-49d4-b9f3-cdf0c2c47b9d" />

