### PR TITLE
GameDB: Replace upscaling settings for Genki titles

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -70560,9 +70560,7 @@ SLUS-21236:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes ghosting during Rain.
-    alignSprite: 1 # Fixes vertical lines.
-    forceEvenSpritePosition: 1 # Fixes double image.
+    halfPixelOffset: 5 # Fixes vertical lines.
 SLUS-21237:
   name: "AND 1 Streetball"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Adds upscaling setting ``HPO AtN Offset`` to the following titles, replacing ``HPO Special + Align Sprite + Round Sprite + Force Even Sprite Position``

- Shutokou Battle 01 _(Tokyo Xtreme Racer 3)_
- Kaido Battle _(Tokyo Xtreme Racer Drift)_
- Kaido Battle 2 - Chain Reaction _(Kaido Racer)_
- Kaido - Touge no Densetsu _(Tokyo Xtreme Racer Drift 2, Kaido Racer 2)_
- Racing Battle - C1 Grand Prix
- Fu-un Shinsen-gumi
- Fu-un Bakumatsu-den

### Rationale behind Changes
Replaced ``HPO Special`` with ``HPO ATN Offset`` as the former setting causes the furthest left strip of the screen to be misaligned by one pixel.
#### HPO Special
<img width="164" height="110" alt="image" src="https://github.com/user-attachments/assets/63ea20ea-e0fd-4252-9bd9-f3fe28f7bd97" />

#### HPO ATN Offset
<img width="168" height="110" alt="image" src="https://github.com/user-attachments/assets/328d5859-c473-473c-b047-eac6e2999508" />

###

This setting also fixes the vertical lines issue, removing the need for ``Align Sprite`` and ``Round Sprite`` as well.
#### HPO Special + Align Sprite + Round Sprite
<img width="1280" height="960" alt="Shutokou Battle 01_SLPM-65308_20260123212358" src="https://github.com/user-attachments/assets/330480be-e595-454f-b13d-97cb6e7e1b13" />

#### HPO ATN Offset
<img width="1280" height="960" alt="Shutokou Battle 01_SLPM-65308_20260123212050" src="https://github.com/user-attachments/assets/6f0ca005-2f5a-4749-af31-95b66a3557ab" />

###

Removed Force Even Sprite Position as it causes UI misalignment and breaks the blur filter used in Genki titles, removing this setting brings the image closer to the intended look at native resolution.

#### Force Even Sprite Position - Enabled (2x Native)
<img width="1280" height="960" alt="Fu-un Shinsen-gumi_SLPM-65494_20260123213109" src="https://github.com/user-attachments/assets/e26f3b4d-f1fe-4c71-b635-09bc7ef461e1" />

#### Force Even Sprite Position - Disabled (2x Native)
<img width="1280" height="960" alt="Fu-un Shinsen-gumi_SLPM-65494_20260123213115" src="https://github.com/user-attachments/assets/fe7eed14-a11c-49e2-9d4a-beee86c05335" />

#### Software Renderer
<img width="1280" height="960" alt="Fu-un Shinsen-gumi_SLPM-65494_20260123214022" src="https://github.com/user-attachments/assets/57311cdb-c6d1-4f45-8af4-19a2f6ea4eae" />

### Suggested Testing Steps
Test GSdumps.
https://litter.catbox.moe/2pxv29h2palna6zl.zip

### Did you use AI to help find, test, or implement this issue or feature?
No.
