### PR TITLE
GS/HW: Clear downscale source on draw to avoid cross game corruption

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3215,6 +3215,7 @@ void GSRendererHW::Draw()
 	float target_scale = GetTextureScaleFactor();
 	bool scaled_copy = false;
 	int scale_draw = IsScalingDraw(src, m_primitive_covers_without_gaps != NoGapsType::GapsFound);
+	m_downscale_source = false;
 
 	if (GSConfig.UserHacks_NativeScaling != GSNativeScaling::Off)
 	{
@@ -3248,8 +3249,6 @@ void GSRendererHW::Draw()
 				scale_draw = 1;
 				scaled_copy = true;
 			}
-
-			m_downscale_source = false;
 		}
 	}
 


### PR DESCRIPTION
### Description of Changes
Clears m_downscale_source on a new draw to avoid it being a hangover from a different game/gs dump.

### Rationale behind Changes
Discovered it while cycling through God of War dumps.

### Suggested Testing Steps
Switch between some GS dumps (God of War 2 to God of War 1 are a good combo). But honestly zero impact outside of doing this.

### Did you use AI to help find, test, or implement this issue or feature?
No.
