### PR TITLE
GS: Default to DX12 on  NV/AMD.

### DIFF
--- a/pcsx2/GS/Renderers/DX11/D3D.cpp
+++ b/pcsx2/GS/Renderers/DX11/D3D.cpp
@@ -426,7 +426,8 @@ GSRendererType D3D::GetPreferredRenderer()
 			if (!feature_level.has_value())
 				return GSRendererType::DX11;
 			else if (feature_level == D3D_FEATURE_LEVEL_12_0)
-				return check_vulkan_supported() ? GSRendererType::VK : GSRendererType::OGL;
+				//return check_vulkan_supported() ? GSRendererType::VK : GSRendererType::OGL;
+				return GSRendererType::DX12;
 			else if (feature_level == D3D_FEATURE_LEVEL_11_0)
 				return GSRendererType::OGL;
 			else
@@ -439,7 +440,8 @@ GSRendererType D3D::GetPreferredRenderer()
 			if (!feature_level.has_value())
 				return GSRendererType::DX11;
 			else if (feature_level == D3D_FEATURE_LEVEL_12_0)
-				return check_vulkan_supported() ? GSRendererType::VK : GSRendererType::DX12;
+				//return check_vulkan_supported() ? GSRendererType::VK : GSRendererType::DX12;
+				return GSRendererType::DX12;
 			else if (feature_level == D3D_FEATURE_LEVEL_11_1)
 				return GSRendererType::DX12;
 			else


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS: Default to DX12 on  NV/AMD.
DX12 trades blows with Vulkan on AMD depending on cpu usage and will be stable on RDNA 3 so let's default to it.
NVIDIA: 590 drivers on Nvidia are bad causing performance regressions so let's switch to DX12 as the default.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Better defaults.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Smoke test the auto renderer selector.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.
