### PR TITLE
Revert "GS/VK: Use the compute queues for present"

### DIFF
--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -481,72 +481,26 @@ bool GSDeviceVK::CreateDevice(VkSurfaceKHR surface, bool enable_validation_layer
 	vkGetPhysicalDeviceQueueFamilyProperties(m_physical_device, &queue_family_count, queue_family_properties.data());
 	DevCon.WriteLn("%u vulkan queue families", queue_family_count);
 
-	std::vector<uint32_t> queue_family_users(queue_family_count, 0);
-
+	// Find graphics and present queues.
 	m_graphics_queue_family_index = queue_family_count;
 	m_present_queue_family_index = queue_family_count;
-	u32 present_queue_index = 0;
 	m_spin_queue_family_index = queue_family_count;
 	u32 spin_queue_index = 0;
-
-	// Graphics Queue
 	for (uint32_t i = 0; i < queue_family_count; i++)
 	{
-		if (queue_family_properties[i].queueFlags & VK_QUEUE_GRAPHICS_BIT)
+		VkBool32 graphics_supported = queue_family_properties[i].queueFlags & VK_QUEUE_GRAPHICS_BIT;
+		if (graphics_supported)
 		{
 			m_graphics_queue_family_index = i;
-			queue_family_users[i]++;
-			break;
+			// Quit now, no need for a present queue.
+			if (!surface)
+			{
+				break;
+			}
 		}
-	}
 
-	// Spinwait Queue
-	for (uint32_t i = 0; i < queue_family_count; i++)
-	{
-		if (queue_family_properties[i].queueCount == queue_family_users[i])
-			continue;
-		if (!(queue_family_properties[i].queueFlags & VK_QUEUE_COMPUTE_BIT))
-			continue;
-		if (queue_family_properties[i].timestampValidBits == 0)
-			continue; // We need timing
-
-		if (!(queue_family_properties[i].queueFlags & VK_QUEUE_GRAPHICS_BIT))
+		if (surface)
 		{
-			m_spin_queue_family_index = i;
-			break;
-		}
-		else if (m_spin_queue_family_index == queue_family_count)
-			m_spin_queue_family_index = i;
-	}
-
-	if (m_spin_queue_family_index != queue_family_count)
-	{
-		spin_queue_index = queue_family_users[m_spin_queue_family_index];
-		queue_family_users[m_spin_queue_family_index]++;
-		m_spin_queue_is_graphics_queue = false;
-	}
-	else
-	{
-		// No spare queue? Try the graphics queue.
-		if ((queue_family_properties[m_graphics_queue_family_index].queueFlags & VK_QUEUE_COMPUTE_BIT) &&
-			(queue_family_properties[m_graphics_queue_family_index].timestampValidBits != 0))
-		{
-			m_spin_queue_family_index = m_graphics_queue_family_index;
-			spin_queue_index = 0;
-			m_spin_queue_is_graphics_queue = true;
-		}
-		else
-			m_spin_queue_is_graphics_queue = false;
-	}
-
-	// Present Queue
-	if (surface)
-	{
-		for (uint32_t i = 0; i < queue_family_count; i++)
-		{
-			if (queue_family_properties[i].queueCount == queue_family_users[i])
-				continue;
-
 			VkBool32 present_supported;
 			VkResult res = vkGetPhysicalDeviceSurfaceSupportKHR(m_physical_device, i, surface, &present_supported);
 			if (res != VK_SUCCESS)
@@ -555,48 +509,35 @@ bool GSDeviceVK::CreateDevice(VkSurfaceKHR surface, bool enable_validation_layer
 				return false;
 			}
 
-			if (!present_supported)
-				continue;
-
-			// Perfer aync compute queue
-			if ((queue_family_properties[i].queueFlags & VK_QUEUE_COMPUTE_BIT) &&
-				!(queue_family_properties[i].queueFlags & VK_QUEUE_GRAPHICS_BIT))
-			{
-				m_present_queue_family_index = i;
-				break;
-			}
-			else if (m_present_queue_family_index == queue_family_count)
-				m_present_queue_family_index = i;
-		}
-
-		if (m_present_queue_family_index != queue_family_count)
-		{
-			present_queue_index = queue_family_users[m_present_queue_family_index];
-			queue_family_users[m_present_queue_family_index]++;
-		}
-		else
-		{
-			// No spare queue? Try the graphics queue.
-			VkBool32 present_supported;
-			VkResult res = vkGetPhysicalDeviceSurfaceSupportKHR(m_physical_device, m_graphics_queue_family_index, surface, &present_supported);
-			if (res != VK_SUCCESS)
-			{
-				LOG_VULKAN_ERROR(res, "vkGetPhysicalDeviceSurfaceSupportKHR failed: ");
-				return false;
-			}
-
 			if (present_supported)
 			{
-				m_present_queue_family_index = m_graphics_queue_family_index;
-				present_queue_index = 0;
+				m_present_queue_family_index = i;
+			}
+
+			// Prefer one queue family index that does both graphics and present.
+			if (graphics_supported && present_supported)
+			{
+				break;
 			}
 		}
 	}
-
-	// Swap spin and present to simplify queue priorities logic.
-	if (!m_spin_queue_is_graphics_queue && m_present_queue_family_index == m_spin_queue_family_index)
-		std::swap(spin_queue_index, present_queue_index);
-
+	for (uint32_t i = 0; i < queue_family_count; i++)
+	{
+		// Pick a queue for spinning
+		if (!(queue_family_properties[i].queueFlags & VK_QUEUE_COMPUTE_BIT))
+			continue; // We need compute
+		if (queue_family_properties[i].timestampValidBits == 0)
+			continue; // We need timing
+		const bool queue_is_used = i == m_graphics_queue_family_index || i == m_present_queue_family_index;
+		if (queue_is_used && m_spin_queue_family_index != queue_family_count)
+			continue; // Found a non-graphics queue to use
+		spin_queue_index = 0;
+		m_spin_queue_family_index = i;
+		if (queue_is_used && queue_family_properties[i].queueCount > 1)
+			spin_queue_index = 1;
+		if (!(queue_family_properties[i].queueFlags & VK_QUEUE_GRAPHICS_BIT))
+			break; // Async compute queue, definitely pick this one
+	}
 	if (m_graphics_queue_family_index == queue_family_count)
 	{
 		Console.Error("VK: Failed to find an acceptable graphics queue.");
@@ -614,16 +555,14 @@ bool GSDeviceVK::CreateDevice(VkSurfaceKHR surface, bool enable_validation_layer
 	device_info.flags = 0;
 	device_info.queueCreateInfoCount = 0;
 
-	// Low priority for the spin queue
-	static constexpr float queue_priorities[] = {1.0f, 1.0f, 0.0f}; 
-
+	static constexpr float queue_priorities[] = {1.0f, 0.0f}; // Low priority for the spin queue
 	std::array<VkDeviceQueueCreateInfo, 3> queue_infos;
 	VkDeviceQueueCreateInfo& graphics_queue_info = queue_infos[device_info.queueCreateInfoCount++];
 	graphics_queue_info.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
 	graphics_queue_info.pNext = nullptr;
 	graphics_queue_info.flags = 0;
 	graphics_queue_info.queueFamilyIndex = m_graphics_queue_family_index;
-	graphics_queue_info.queueCount = queue_family_users[m_graphics_queue_family_index];
+	graphics_queue_info.queueCount = 1;
 	graphics_queue_info.pQueuePriorities = queue_priorities;
 
 	if (surface != VK_NULL_HANDLE && m_graphics_queue_family_index != m_present_queue_family_index)
@@ -633,19 +572,19 @@ bool GSDeviceVK::CreateDevice(VkSurfaceKHR surface, bool enable_validation_layer
 		present_queue_info.pNext = nullptr;
 		present_queue_info.flags = 0;
 		present_queue_info.queueFamilyIndex = m_present_queue_family_index;
-		present_queue_info.queueCount = queue_family_users[m_present_queue_family_index];
+		present_queue_info.queueCount = 1;
 		present_queue_info.pQueuePriorities = queue_priorities;
 	}
 
 	if (m_spin_queue_family_index == m_graphics_queue_family_index)
 	{
-		if (spin_queue_index == 1)
-			graphics_queue_info.pQueuePriorities = queue_priorities + 1;
+		if (spin_queue_index != 0)
+			graphics_queue_info.queueCount = 2;
 	}
 	else if (m_spin_queue_family_index == m_present_queue_family_index)
 	{
-		if (spin_queue_index == 1)
-			queue_infos[1].pQueuePriorities = queue_priorities + 1;
+		if (spin_queue_index != 0)
+			queue_infos[1].queueCount = 2; // present queue
 	}
 	else if (m_spin_queue_family_index != queue_family_count)
 	{
@@ -655,7 +594,7 @@ bool GSDeviceVK::CreateDevice(VkSurfaceKHR surface, bool enable_validation_layer
 		spin_queue_info.flags = 0;
 		spin_queue_info.queueFamilyIndex = m_spin_queue_family_index;
 		spin_queue_info.queueCount = 1;
-		spin_queue_info.pQueuePriorities = queue_priorities + 2;
+		spin_queue_info.pQueuePriorities = queue_priorities + 1;
 	}
 
 	device_info.pQueueCreateInfos = queue_infos.data();
@@ -744,11 +683,13 @@ bool GSDeviceVK::CreateDevice(VkSurfaceKHR surface, bool enable_validation_layer
 	vkGetDeviceQueue(m_device, m_graphics_queue_family_index, 0, &m_graphics_queue);
 	if (surface)
 	{
-		vkGetDeviceQueue(m_device, m_present_queue_family_index, present_queue_index, &m_present_queue);
+		vkGetDeviceQueue(m_device, m_present_queue_family_index, 0, &m_present_queue);
 	}
 	m_spinning_supported = m_spin_queue_family_index != queue_family_count &&
 	                       queue_family_properties[m_graphics_queue_family_index].timestampValidBits > 0 &&
 	                       m_device_properties.limits.timestampPeriod > 0;
+	m_spin_queue_is_graphics_queue =
+		m_spin_queue_family_index == m_graphics_queue_family_index && spin_queue_index == 0;
 
 	m_gpu_timing_supported = (m_device_properties.limits.timestampComputeAndGraphics != 0 &&
 							  queue_family_properties[m_graphics_queue_family_index].timestampValidBits > 0 &&
@@ -1348,24 +1289,8 @@ void GSDeviceVK::SubmitCommandBuffer(VKSwapChain* present_swap_chain)
 
 	if (present_swap_chain)
 	{
-		// vkQueuePresentKHR on NVidia dosn't seem to properly wait on the passed semaphore, causing artifacts.
-		// OBS capture with BPM encouters issues, but can apparently occur on the presented image aswell.
-		// Instead, wait on the RenderingFinished semaphore with vkQueueSubmit.
-		const uint32_t present_wait_bits = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
-		const VkSubmitInfo submit_present_wait_info = {VK_STRUCTURE_TYPE_SUBMIT_INFO, nullptr, 1,
-			present_swap_chain->GetRenderingFinishedSemaphorePtr(), &present_wait_bits, 0,
-			nullptr, 1, present_swap_chain->GetPresentReadySemaphorePtr()};
-
-		res = vkQueueSubmit(m_present_queue, 1, &submit_present_wait_info, nullptr);
-		if (res != VK_SUCCESS)
-		{
-			LOG_VULKAN_ERROR(res, "vkQueueSubmit failed: ");
-			m_last_submit_failed = true;
-			return;
-		}
-
 		const VkPresentInfoKHR present_info = {VK_STRUCTURE_TYPE_PRESENT_INFO_KHR, nullptr, 1,
-			present_swap_chain->GetPresentReadySemaphorePtr(), 1, present_swap_chain->GetSwapChainPtr(),
+			present_swap_chain->GetRenderingFinishedSemaphorePtr(), 1, present_swap_chain->GetSwapChainPtr(),
 			present_swap_chain->GetCurrentImageIndexPtr(), nullptr};
 
 		present_swap_chain->ResetImageAcquireResult();

--- a/pcsx2/GS/Renderers/Vulkan/VKSwapChain.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/VKSwapChain.cpp
@@ -490,18 +490,6 @@ bool VKSwapChain::CreateSwapChain()
 			sema.available_semaphore = VK_NULL_HANDLE;
 			return false;
 		}
-
-		res = vkCreateSemaphore(
-			GSDeviceVK::GetInstance()->GetDevice(), &semaphore_info, nullptr, &sema.present_ready_semaphore);
-		if (res != VK_SUCCESS)
-		{
-			LOG_VULKAN_ERROR(res, "vkCreateSemaphore failed: ");
-			vkDestroySemaphore(GSDeviceVK::GetInstance()->GetDevice(), sema.rendering_finished_semaphore, nullptr);
-			vkDestroySemaphore(GSDeviceVK::GetInstance()->GetDevice(), sema.available_semaphore, nullptr);
-			sema.rendering_finished_semaphore = VK_NULL_HANDLE;
-			sema.available_semaphore = VK_NULL_HANDLE;
-			return false;
-		}
 	}
 
 	return true;
@@ -517,8 +505,6 @@ void VKSwapChain::DestroySwapChainImages()
 	m_images.clear();
 	for (auto& it : m_semaphores)
 	{
-		if (it.present_ready_semaphore != VK_NULL_HANDLE)
-			vkDestroySemaphore(GSDeviceVK::GetInstance()->GetDevice(), it.present_ready_semaphore, nullptr);
 		if (it.rendering_finished_semaphore != VK_NULL_HANDLE)
 			vkDestroySemaphore(GSDeviceVK::GetInstance()->GetDevice(), it.rendering_finished_semaphore, nullptr);
 		if (it.available_semaphore != VK_NULL_HANDLE)

--- a/pcsx2/GS/Renderers/Vulkan/VKSwapChain.h
+++ b/pcsx2/GS/Renderers/Vulkan/VKSwapChain.h
@@ -64,14 +64,6 @@ public:
 	{
 		return &m_semaphores[m_current_semaphore].rendering_finished_semaphore;
 	}
-	__fi VkSemaphore GetPresentReadySemaphore() const
-	{
-		return m_semaphores[m_current_semaphore].present_ready_semaphore;
-	}
-	__fi const VkSemaphore* GetPresentReadySemaphorePtr() const
-	{
-		return &m_semaphores[m_current_semaphore].present_ready_semaphore;
-	}
 
 	VkFormat GetTextureFormat() const;
 	VkResult AcquireNextImage();
@@ -100,7 +92,6 @@ private:
 	{
 		VkSemaphore available_semaphore;
 		VkSemaphore rendering_finished_semaphore;
-		VkSemaphore present_ready_semaphore;
 	};
 
 	WindowInfo m_window_info;


### PR DESCRIPTION
### Description of Changes
Reverts back to using the graphics queue for presenting.

### Rationale behind Changes
Additionally sync issues on Nvidia, and ended up hurting frame-rate is some situations (tested on 591.44).
Faster present on AMD didn't seem to manifest in an observable performance increase.

### Suggested Testing Steps
Test VK, check for perf changes.

### Did you use AI to help find, test, or implement this issue or feature?
No
