### PR TITLE
UI : rename fast boot option heading

### DIFF
--- a/pcsx2-qt/Settings/BIOSSettingsWidget.ui
+++ b/pcsx2-qt/Settings/BIOSSettingsWidget.ui
@@ -135,7 +135,7 @@
    <item>
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
-      <string>Options and Patches</string>
+      <string>Fast Boot Options</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -4461,7 +4461,7 @@ void FullscreenUI::DrawBIOSSettingsPage()
 			});
 	}
 
-	MenuHeading(FSUI_CSTR("Options and Patches"));
+	MenuHeading(FSUI_CSTR("Fast Boot Options"));
 	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_FORWARD_FAST, "Fast Boot"), FSUI_CSTR("Skips the intro screen, and bypasses region checks."),
 		"EmuCore", "EnableFastBoot", true);
 
@@ -9509,7 +9509,7 @@ TRANSLATE_NOOP("FullscreenUI", "Resets configuration to defaults (excluding cont
 TRANSLATE_NOOP("FullscreenUI", "BIOS Configuration");
 TRANSLATE_NOOP("FullscreenUI", "Changes the BIOS image used to start future sessions.");
 TRANSLATE_NOOP("FullscreenUI", "BIOS Selection");
-TRANSLATE_NOOP("FullscreenUI", "Options and Patches");
+TRANSLATE_NOOP("FullscreenUI", "Fast Boot Options");
 TRANSLATE_NOOP("FullscreenUI", "Skips the intro screen, and bypasses region checks.");
 TRANSLATE_NOOP("FullscreenUI", "Speed Control");
 TRANSLATE_NOOP("FullscreenUI", "Sets the speed when running without fast forwarding.");


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
improves naming of the fast boot options heading 

before /after 

<img width="729" height="140" alt="image" src="https://github.com/user-attachments/assets/92cf285c-c38f-4adf-a887-90848e700346" />



<img width="724" height="149" alt="image" src="https://github.com/user-attachments/assets/b50a90ab-d43d-46d1-859c-9ba7d11aed5b" />

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
the section no longer contains any patching options  and only fast boot option , thus is due a renaming 
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

read said heading , and check capitalization 

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
no 