### PR TITLE
GS/DX11: Use Map/Unmap for updating buffers instead of UpdateSubresouce.

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -339,6 +339,7 @@ public:
 	void OMSetRenderTargets(GSTexture* rt, GSTexture* ds, const GSVector4i* scissor = nullptr, ID3D11DepthStencilView* read_only_dsv = nullptr);
 	void SetViewport(const GSVector2i& viewport);
 	void SetScissor(const GSVector4i& scissor);
+	void SetUtilityPushConstants(ID3D11Buffer* buffer, const void* data, size_t size);
 
 	void SetupVS(VSSelector sel, const GSHWDrawConfig::VSConstantBuffer* cb);
 	void SetupPS(const PSSelector& sel, const GSHWDrawConfig::PSConstantBuffer* cb, PSSamplerSelector ssel);


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/DX11: Use Map/Unmap for updating buffers instead of UpdateSubresouce.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Optimization, requires https://github.com/PCSX2/pcsx2/pull/13895 , alternative to https://github.com/PCSX2/pcsx2/pull/12987 which that pr uses caching, caching can be introduced to this as well but first I want to get the initial work out of the way, this will be faster than using UpdateSubresouce with caching.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
DX11 only testing, test a few games to make sure nothing broke, a few games might be worth for benchmarking, test OSD, shade boost that still work.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
