### PR TITLE
GS/DX12: Fix changing vsync setting on the fly

### DIFF
--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -938,6 +938,7 @@ void GSDevice12::SetVSyncMode(GSVSyncMode mode, bool allow_present_throttle)
 
 	if (GetSwapChainBufferCount() != old_buffer_count)
 	{
+		ExecuteCommandList(true);
 		DestroySwapChain();
 		if (!CreateSwapChain())
 			pxFailRel("Failed to recreate swap chain after vsync change.");


### PR DESCRIPTION
### Description of Changes
Execute the command list to ensure no work needs the about to be recreated swapchain.

### Rationale behind Changes
Toggling VSync while running could try to recreate the swapchain while the GPU was still working on it.
This could cause the renderer to stop rendering.

### Suggested Testing Steps
Flip the vsync toggle a couple times while in game/playing a gsdump, while using the DX12 renderer.

### Did you use AI to help find, test, or implement this issue or feature?
No
