### PR TITLE
GS/DX: Fix per game fullscreen mode setting

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -244,7 +244,7 @@ const char* GSDevice::RenderAPIToString(RenderAPI api)
 
 bool GSDevice::GetRequestedExclusiveFullscreenMode(u32* width, u32* height, float* refresh_rate)
 {
-	const std::string mode = Host::GetBaseStringSettingValue("EmuCore/GS", "FullscreenMode", "");
+	const std::string mode = Host::GetStringSettingValue("EmuCore/GS", "FullscreenMode", "");
 	if (!mode.empty())
 	{
 		const std::string_view mode_view = mode;


### PR DESCRIPTION
### Description of Changes
Don't force checking the base setting for fullscreen resolution mode for DX11/DX12

### Rationale behind Changes
The per-game UI options already exist and are enabled, may as well use what they set.

### Suggested Testing Steps
Test per game fullscreen mode settings in DX11/12.
Both with and without the start in fullscreen setting.

### Did you use AI to help find, test, or implement this issue or feature?
No
