### PR TITLE
GS/HW: On EE->GS transfer only invalidate area actually transferred

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -1915,6 +1915,11 @@ void GSState::FlushWrite()
 			
 			// Just setting the height should be okay...
 			r.w = std::max(r.y + calculated_height, psm_s.bs.y);
+
+			if (m_draw_transfers.size() > 0 && m_tr.m_blit.DBP == m_draw_transfers.back().blit.DBP)
+			{
+				m_draw_transfers.back().rect = r;
+			}
 		}
 	}
 


### PR DESCRIPTION
### Description of Changes
Corrects the rect area used for invalidation on EE->GS transfer to accurately* reflect what has been uploaded.

### Rationale behind Changes
Star Wars - Clone Wars will say it's uploading 16x4096, which it doesn't, it actually uploads 16x96. The problem was we were passing the fake rect to the texture cache for invalidation, which because of it's humongous size, even limited to the 2048 a transfer can do, it was overlapping the rendering for the frame, causing it to load bad data from GS memory.

### Suggested Testing Steps
test Star Wars - Clone Wars and a handful of other games as a smoke test.

### Did you use AI to help find, test, or implement this issue or feature?
No

Fixes Star Wars - Clone Wars

Master:
<img width="596" height="447" alt="image" src="https://github.com/user-attachments/assets/f0b29e83-964d-4a7f-bbac-343f91300c4f" />

PR:
<img width="596" height="447" alt="image" src="https://github.com/user-attachments/assets/6bd2e9bb-c768-44f0-9b5d-d5d8ee58f208" />
