### PR TITLE
GameDB: remove  left over schemea options

### DIFF
--- a/pcsx2/Docs/gamedb-schema.json
+++ b/pcsx2/Docs/gamedb-schema.json
@@ -229,11 +229,6 @@
               "minimum": 0,
               "maximum": 100000
             },
-            "halfBottomOverride": {
-              "type": "integer",
-              "minimum": 0,
-              "maximum": 1
-            },
             "halfPixelOffset": {
               "type": "integer",
               "minimum": 0,

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -380,7 +380,6 @@ static const char* s_gs_hw_fix_names[] = {
 	"trilinearFiltering",
 	"skipDrawStart",
 	"skipDrawEnd",
-	"halfBottomOverride",
 	"halfPixelOffset",
 	"roundSprite",
 	"nativeScaling",

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -65,7 +65,6 @@ namespace GameDatabaseSchema
 		TrilinearFiltering,
 		SkipDrawStart,
 		SkipDrawEnd,
-		HalfBottomOverride,
 		HalfPixelOffset,
 		RoundSprite,
 		NativeScaling,


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
removes halfBottomOverride from the gameDB scheme and options 
### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
halfBottomOverride was removed long ago and this was forgotten about 
### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
look at the deletion 
### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
no 