### PR TITLE
GS: Rework automatic renderer pickup.

### DIFF
--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -831,11 +831,8 @@ bool GSDevice12::HasSurface() const
 	return static_cast<bool>(m_swap_chain);
 }
 
-bool GSDevice12::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
+bool GSDevice12::CheckDevice()
 {
-	if (!GSDevice::Create(vsync_mode, allow_present_throttle))
-		return false;
-
 	u32 vendor_id = 0;
 	if (!CreateDevice(vendor_id))
 		return false;
@@ -845,6 +842,17 @@ bool GSDevice12::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 		Console.Error("D3D12: Your GPU does not support the required D3D12 features.");
 		return false;
 	}
+
+	return true;
+}
+
+bool GSDevice12::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
+{
+	if (!GSDevice::Create(vsync_mode, allow_present_throttle))
+		return false;
+
+	if (!CheckDevice())
+		return false;
 
 	m_name = D3D::GetAdapterName(m_adapter.get());
 

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.h
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.h
@@ -429,6 +429,7 @@ public:
 	bool HasSurface() const override;
 
 	bool Create(GSVSyncMode vsync_mode, bool allow_present_throttle) override;
+	bool CheckDevice();
 	void Destroy() override;
 
 	bool UpdateWindow() override;

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -157,11 +157,8 @@ void GSDeviceOGL::SetVSyncMode(GSVSyncMode mode, bool allow_present_throttle)
 	SetSwapInterval();
 }
 
-bool GSDeviceOGL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
+bool GSDeviceOGL::CheckDevice()
 {
-	if (!GSDevice::Create(vsync_mode, allow_present_throttle))
-		return false;
-
 	// GL is a pain and needs the window super early to create the context.
 	if (!AcquireWindow(true))
 		return false;
@@ -181,6 +178,17 @@ bool GSDeviceOGL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 	}
 
 	if (!CheckFeatures())
+		return false;
+
+	return true;
+}
+
+bool GSDeviceOGL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
+{
+	if (!GSDevice::Create(vsync_mode, allow_present_throttle))
+		return false;
+
+	if (!CheckDevice())
 		return false;
 
 	// Store adapter name currently in use

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -293,6 +293,7 @@ public:
 	RenderAPI GetRenderAPI() const override;
 	bool HasSurface() const override;
 
+	bool CheckDevice();
 	bool Create(GSVSyncMode vsync_mode, bool allow_present_throttle) override;
 	void Destroy() override;
 

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -2065,11 +2065,8 @@ bool GSDeviceVK::HasSurface() const
 	return static_cast<bool>(m_swap_chain);
 }
 
-bool GSDeviceVK::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
+bool GSDeviceVK::CheckDevice()
 {
-	if (!GSDevice::Create(vsync_mode, allow_present_throttle))
-		return false;
-
 	if (!CreateDeviceAndSwapChain())
 		return false;
 
@@ -2078,6 +2075,17 @@ bool GSDeviceVK::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 		Host::ReportErrorAsync("GS", TRANSLATE_SV("GSDeviceVK", "Your GPU does not support the required Vulkan features."));
 		return false;
 	}
+
+	return true;
+}
+
+bool GSDeviceVK::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
+{
+	if (!GSDevice::Create(vsync_mode, allow_present_throttle))
+		return false;
+
+	if (!CheckDevice())
+		return false;
 
 	if (!CreateNullTexture())
 	{

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -502,6 +502,7 @@ public:
 	RenderAPI GetRenderAPI() const override;
 	bool HasSurface() const override;
 
+	bool CheckDevice();
 	bool Create(GSVSyncMode vsync_mode, bool allow_present_throttle) override;
 	void Destroy() override;
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS: Rework automatic renderer pickup.
Check if device can be created first, if not move on to the second best thing and so on.

GCN5 to latest.
DX12 -> VK -> GL -> DX11.

GCN 1.1 to GCN5(not including gcn5)
DX12 -> VK  -> DX11.

GCN1
DX12 -> DX11

Maxwell gen2 and up
DX12 ->VK -> GL -> DX11.

Fermi and up (VK pickup for maxwell 1)
VK -> GL -> DX11

Intel Haswell and up
GL -> DX11

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Better automatic renderer pickup, hopefully solves the crashing issues when more than one gpu is detected.

I'm not sure if all the stuff for Vulkan device creation is needed in CreateDeviceAndSwapChain, maybe some stuff can be cut out.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test various vendors, gpu series, see if it behaves correctly.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.
