### PR TITLE
SPU: Slow down DMA

### DIFF
--- a/pcsx2/SPU2/Dma.cpp
+++ b/pcsx2/SPU2/Dma.cpp
@@ -163,7 +163,7 @@ void V_Core::StartADMAWrite(u16* pMem, u32 sz)
 	if ((AutoDMACtrl & (Index + 1)) == 0)
 	{
 		ActiveTSA = 0x2000 + (Index << 10);
-		DMAICounter = size * 4;
+		DMAICounter = size * 48;
 		LastClock = psxRegs.cycle;
 	}
 	else if (size >= 256)
@@ -191,7 +191,7 @@ void V_Core::StartADMAWrite(u16* pMem, u32 sz)
 		if (SPU2::MsgToConsole())
 			SPU2::ConLog("ADMA%c Error Size of %x too small\n", GetDmaIndexChar(), size);
 		InputDataLeft = 0;
-		DMAICounter = size * 4;
+		DMAICounter = size * 48;
 		LastClock = psxRegs.cycle;
 	}
 }
@@ -248,7 +248,7 @@ void V_Core::FinishDMAwrite()
 		DMA7LogWrite(DMAPtr, ReadSize << 1);
 #endif
 
-	u32 buff1end = ActiveTSA + std::min(ReadSize, (u32)0x100 + std::abs(DMAICounter / 4));
+	u32 buff1end = ActiveTSA + std::min(ReadSize, (u32)0x100 + std::abs(DMAICounter / 48));
 	u32 buff2end = 0;
 	if (buff1end > 0x100000)
 	{
@@ -343,7 +343,7 @@ void V_Core::FinishDMAwrite()
 	DMAPtr += TDA - ActiveTSA;
 	ReadSize -= TDA - ActiveTSA;
 
-	DMAICounter = (DMAICounter - ReadSize) * 4;
+	DMAICounter = (DMAICounter - ReadSize) * 48;
 
 	CounterUpdate(DMAICounter);
 
@@ -354,7 +354,7 @@ void V_Core::FinishDMAwrite()
 
 void V_Core::FinishDMAread()
 {
-	u32 buff1end = ActiveTSA + std::min(ReadSize, (u32)0x100 + std::abs(DMAICounter / 4));
+	u32 buff1end = ActiveTSA + std::min(ReadSize, (u32)0x100 + std::abs(DMAICounter / 48));
 	u32 buff2end = 0;
 
 	if (buff1end > 0x100000)
@@ -426,9 +426,9 @@ void V_Core::FinishDMAread()
 
 	// DMA Reads are done AFTER the delay, so to get the timing right we need to scheule one last DMA to catch IRQ's
 	if (ReadSize)
-		DMAICounter = std::min(ReadSize, (u32)0x100) * 4;
+		DMAICounter = std::min(ReadSize, (u32)0x100) * 48;
 	else
-		DMAICounter = 4;
+		DMAICounter = 48;
 
 	CounterUpdate(DMAICounter);
 
@@ -446,7 +446,7 @@ void V_Core::DoDMAread(u16* pMem, u32 size)
 	ReadSize = size;
 	IsDMARead = true;
 	LastClock = psxRegs.cycle;
-	DMAICounter = std::min(ReadSize, (u32)0x100) * 4;
+	DMAICounter = (std::min(ReadSize, (u32)0x100) * 48);
 	Regs.STATX &= ~0x80;
 	Regs.STATX |= 0x400;
 	//Regs.ATTR |= 0x30;
@@ -470,7 +470,7 @@ void V_Core::DoDMAwrite(u16* pMem, u32 size)
 	{
 		Regs.STATX &= ~0x80;
 		//Regs.ATTR |= 0x30;
-		DMAICounter = 1 * 4;
+		DMAICounter = 1 * 48;
 		LastClock = psxRegs.cycle;
 		return;
 	}


### PR DESCRIPTION
### Description of Changes
Slows down SPU DMA to be in the same ballpark as a real PS2.

ps2:
```
DMA transfer [0] of 64 bytes to 10000 took 3558 cycles
DMA transfer [1] of 128 bytes to 10000 took 5001 cycles
DMA transfer [2] of 256 bytes to 10000 took 8449 cycles
DMA transfer [3] of 512 bytes to 10000 took 14544 cycles
DMA transfer [4] of 1024 bytes to 10000 took 26835 cycles
DMA transfer [5] of 2048 bytes to 10000 took 51484 cycles
DMA transfer [6] of 4096 bytes to 10000 took 100565 cycles
DMA transfer [7] of 8192 bytes to 10000 took 198864 cycles
DMA transfer [8] of 16384 bytes to 10000 took 395469 cycles
DMA transfer [9] of 32768 bytes to 10000 took 788694 cycles
```

pcsx2 (master):
```
DMA transfer [0] of 64 bytes to 10000 took 2154 cycles
DMA transfer [1] of 128 bytes to 10000 took 2177 cycles
DMA transfer [2] of 256 bytes to 10000 took 2177 cycles
DMA transfer [3] of 512 bytes to 10000 took 2873 cycles
DMA transfer [4] of 1024 bytes to 10000 took 4210 cycles
DMA transfer [5] of 2048 bytes to 10000 took 5656 cycles
DMA transfer [6] of 4096 bytes to 10000 took 10585 cycles
DMA transfer [7] of 8192 bytes to 10000 took 18713 cycles
DMA transfer [8] of 16384 bytes to 10000 took 35082 cycles
DMA transfer [9] of 32768 bytes to 10000 took 68549 cycles
```

pcsx2 (new):
```
DMA transfer [0] of 64 bytes to 10000 took 3142 cycles
DMA transfer [1] of 128 bytes to 10000 took 4632 cycles
DMA transfer [2] of 256 bytes to 10000 took 7704 cycles
DMA transfer [3] of 512 bytes to 10000 took 13848 cycles
DMA transfer [4] of 1024 bytes to 10000 took 26777 cycles
DMA transfer [5] of 2048 bytes to 10000 took 51311 cycles
DMA transfer [6] of 4096 bytes to 10000 took 100675 cycles
DMA transfer [7] of 8192 bytes to 10000 took 199635 cycles
DMA transfer [8] of 16384 bytes to 10000 took 396755 cycles
DMA transfer [9] of 32768 bytes to 10000 took 794041 cycles
```

So it comes out to around 24 IOP cycles per byte. (48 per word, hence the `DMAICounter` value.)

### Rationale behind Changes
Proposed fix for #13913. The game seems to update the IRQ address after doing the DMA, which is currently so fast that it completes before the SPU voice moves into the next block. This causes the IRQ to retrigger when the block header is fetched again, tripping the game up.

### Suggested Testing Steps
This really affects everything that uses the SPU. So just play random games I guess.

### Did you use AI to help find, test, or implement this issue or feature?
No.
