### PR TITLE
GS/HW: Require 32 bit RT for accumulation blend on max blend.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5910,6 +5910,7 @@ void GSRendererHW::EmulateBlending(int rt_alpha_min, int rt_alpha_max, const boo
 	{
 		case AccBlendLevel::Maximum:
 			sw_blending |= true;
+			accumulation_blend &= (GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].bpp == 32);
 			[[fallthrough]];
 		case AccBlendLevel::Full:
 			sw_blending |= m_conf.ps.blend_a != m_conf.ps.blend_b && alpha_c0_high_max_one;


### PR DESCRIPTION
### Description of Changes
Allows accumulation blend to be used with max blend only if the RT is 32 bit.

### Rationale behind Changes
Accumulation blend can be quite inaccurate for 16 bit RTs since rounding is applied to the wrong quantity. For example, it's possible that accumulation blend results in 255 for RGB, although 240 should be the largest possible value. Sometimes the difference is not obvious, but since the goal of max blend is accuracy, this should be avoided.

### Example
Sonic_Riders_-_Zero_Gravity_SLES-54915_20221109094120.gs.xz (zoom in to see dither pattern)

Master VK
<img width="640" height="512" alt="00265_f00003_fr-1_00000_C_16" src="https://github.com/user-attachments/assets/10e6f524-233b-4c4f-ae1c-87cc4dfc4815" />

PR VK
<img width="640" height="512" alt="00265_f00003_fr-1_00000_C_16" src="https://github.com/user-attachments/assets/7f6e5f50-278b-46aa-b922-5ee14dc43bd8" />

Master SW (ground truth)
<img width="640" height="512" alt="00266_f00003_fr-1_00000_C_16" src="https://github.com/user-attachments/assets/f199bd95-f52d-4cdb-9d4a-0faf519c576b" />

### Suggested Testing Steps
Changes are transparent, since we are only disabling an optimization.

### Did you use AI to help find, test, or implement this issue or feature?
No.
