### PR TITLE
GS/HW: Add new method of rounding sprites

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -3560,7 +3560,7 @@ __forceinline bool AreTrianglesQuad(const GSVertex* RESTRICT vin, const u16* RES
 	return are_quad;
 }
 
-__forceinline bool AreTrianglesQuadNonAA(const GSVertex* RESTRICT vin, const u16* RESTRICT index0, const u16* RESTRICT index1)
+bool GSState::AreTrianglesQuadNonAA(const GSVertex* RESTRICT vin, const u16* RESTRICT index0, const u16* RESTRICT index1)
 {
 	u32 v0[3] = {
 		vin[index0[0]].XYZ.U32[0],

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -478,6 +478,7 @@ public:
 	
 	template<bool shuffle_check>
 	bool TrianglesAreQuadsImpl();
+	bool AreTrianglesQuadNonAA(const GSVertex* RESTRICT vin, const u16* RESTRICT index0, const u16* RESTRICT index1);
 	bool TrianglesAreQuads(bool shuffle_check = false);
 	template <u32 primclass>
 	PRIM_OVERLAP GetPrimitiveOverlapDrawlistImpl(bool save_drawlist = false, bool save_bbox = false, float bbox_scale = 1.0f);


### PR DESCRIPTION
### Description of Changes
Add new method of sprite/quad rounding.  It attempts to turn off Bilinear filtering if there's no gradient to the sprite (as would happen on hardware), also does a bunch of taking off half pixels.

### Rationale behind Changes
A lot of games have text problems (and need preround) and this improves a bunch of them.

### Suggested Testing Steps
Test games with text issues or UI with rogue lines (except armored core or ridge racer 5)

### Did you use AI to help find, test, or implement this issue or feature?
No

### How to use
For now it's gated behind "Align Sprite", so enable that fix to test it out.

Area 51:
Master:
<img width="1471" height="1294" alt="image" src="https://github.com/user-attachments/assets/12444ec6-96fc-4dec-aa5d-8eb5c34fb218" />
PR:
<img width="1471" height="1294" alt="image" src="https://github.com/user-attachments/assets/80df21fd-3c78-4538-bb9f-7165ada887fa" />

True Crime NYC:
Master:
<img width="1471" height="1294" alt="image" src="https://github.com/user-attachments/assets/d619a00f-a899-401e-a4d9-48f9d2e6da99" />
PR:
<img width="1471" height="1294" alt="image" src="https://github.com/user-attachments/assets/06855e6f-5a2e-4b40-bc80-6276a684b942" />

Singstar:
Master:
<img width="1471" height="1294" alt="image" src="https://github.com/user-attachments/assets/ce3e37ea-41ec-4f63-bdcb-5c2954282670" />
PR:
<img width="1471" height="1294" alt="image" src="https://github.com/user-attachments/assets/b38e665c-7125-407f-bf70-c3570d34c8ae" />

Persona 3 (not sure how it works in movement):
Master:
<img width="1471" height="1294" alt="image" src="https://github.com/user-attachments/assets/10cc6301-b587-4271-b9db-bfee17c58429" />
PR:
<img width="1471" height="1294" alt="image" src="https://github.com/user-attachments/assets/0c3b2e73-2ea5-4c04-9694-3d79492b126f" />

Raw Danger:
Master:
<img width="1471" height="1294" alt="image" src="https://github.com/user-attachments/assets/8a72776e-8210-4cd8-bbb7-2d1ccff560fa" />
PR:
<img width="1471" height="1294" alt="image" src="https://github.com/user-attachments/assets/535d81a0-2c09-41fd-be61-f565cd1ffc22" />

Final Fantasy X:
Master:
<img width="1471" height="1294" alt="image" src="https://github.com/user-attachments/assets/1586b27c-b6c6-4cb2-b86a-ad1478f0f071" />
PR:
<img width="1471" height="1294" alt="image" src="https://github.com/user-attachments/assets/3c49ea30-6694-4f42-9555-71293ed10225" />

Final Fantasy 10 subtitles:
Master:
<img width="1472" height="1294" alt="image" src="https://github.com/user-attachments/assets/1575c3ad-d15e-44bb-a7fe-116831319819" />
PR:
<img width="1466" height="1294" alt="image" src="https://github.com/user-attachments/assets/4a93ae0b-4a8f-4cb4-b51d-550ae7b6d267" />


Dragonball Z BT 3:
Master:
<img width="1471" height="1294" alt="image" src="https://github.com/user-attachments/assets/87cc6e6d-46c0-4647-b825-3f8f7fa30133" />
PR:
<img width="1471" height="1294" alt="image" src="https://github.com/user-attachments/assets/136a0f7e-0f26-46d2-8481-335f2d8ddd25" />
