### PR TITLE
GS: Pick zero based framebuffer for anti-blur offset

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -6112,7 +6112,7 @@ void GSState::GSPCRTCRegs::CalculateFramebufferOffset(bool scanmask, GSRegDISPFB
 
 	if (GSConfig.PCRTCAntiBlur && PCRTCSameSrc && !scanmask && abs(fb1.y - fb0.y) <= 1)
 	{
-		if (framebuffer0Reg.DBY != PCRTCDisplays[0].prevFramebufferReg.DBY)
+		if (framebuffer0Reg.DBY != PCRTCDisplays[0].prevFramebufferReg.DBY || fb1.y == 0)
 		{
 			PCRTCDisplays[0].framebufferRect.y = PCRTCDisplays[1].framebufferRect.y;
 			PCRTCDisplays[0].framebufferRect.w = PCRTCDisplays[1].framebufferRect.w;


### PR DESCRIPTION
### Description of Changes
Pickes the zero offset framebuffer rect in the PCRTC

### Rationale behind Changes
Regression from #13806 causing MLB 11 The Show to have vertical lines. I have no idea why this does it, and I don't want to think about it, this fixes it and makes more sense anyways.

### Suggested Testing Steps
test MLB The Show upscaled (yes Native doesn't show it)

### Did you use AI to help find, test, or implement this issue or feature?
No
