### PR TITLE
GS/DX12: Check for typed casting support

### DIFF
--- a/pcsx2/GS/Renderers/DX12/GSDevice12.h
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.h
@@ -315,6 +315,7 @@ private:
 	bool m_using_allow_tearing = false;
 	bool m_is_exclusive_fullscreen = false;
 	bool m_enhanced_barriers = false;
+	bool m_typed_casting_supported = false;
 	bool m_device_lost = false;
 
 	ComPtr<ID3D12RootSignature> m_tfx_root_signature;


### PR DESCRIPTION
### Description of Changes
Check for fully typed casting support, and use a typeless format for depth if typed casting is unsupported.
Also init the enhanced barriers support flag to false, to be consistent with other feature check flags.

### Rationale behind Changes
Skylake iGPUs (and older) lack this feature and would crash pretty quickly if we didn't check for it.
Fully typed potentially allow hardware optimisations, so retain it for supported GPUs (such as literally everything else).

Pre Skylake intel iGPUs remain unsupported and blocked via a feature level check.

### Suggested Testing Steps
Test and make sure nothing explodes.

### Did you use AI to help find, test, or implement this issue or feature?
AI was asked about the impact of using TYPELESS formats, it stating that typed formats can allow for more optimisations from the driver/hardware.
