### PR TITLE
GS: Don't try to anti-blur if both displays are alternating

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -6116,14 +6116,24 @@ void GSState::GSPCRTCRegs::CalculateFramebufferOffset(bool scanmask, GSRegDISPFB
 		{
 			if (framebuffer1Reg.DBY == PCRTCDisplays[1].prevFramebufferReg.DBY)
 			{
-				PCRTCDisplays[0].framebufferRect.y = PCRTCDisplays[1].framebufferRect.y;
-				PCRTCDisplays[0].framebufferRect.w = PCRTCDisplays[1].framebufferRect.w;
+				const int offset = PCRTCDisplays[1].framebufferRect.y - PCRTCDisplays[0].framebufferRect.y;
+
+				if (std::abs(offset) <= 4)
+				{
+					PCRTCDisplays[0].framebufferRect.y += offset;
+					PCRTCDisplays[0].framebufferRect.w += offset;
+				}
 			}
 		}
 		else
 		{
-			PCRTCDisplays[1].framebufferRect.y = PCRTCDisplays[0].framebufferRect.y;
-			PCRTCDisplays[1].framebufferRect.w = PCRTCDisplays[0].framebufferRect.w;
+			const int offset = PCRTCDisplays[0].framebufferRect.y - PCRTCDisplays[1].framebufferRect.y;
+
+			if (std::abs(offset) <= 4)
+			{
+				PCRTCDisplays[1].framebufferRect.y += offset;
+				PCRTCDisplays[1].framebufferRect.w += offset;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

### Rationale behind Changes
Regression from #13806 overlooked situation where both display outputs are switching, in which case copying one to the other to stop it isn't going to help, in fact it just made things worse for Spongebob, Squidward would not be happy (not that he ever is).  The offsets also could have different dimensions, not just different offsets.

### Suggested Testing Steps
Test a bunch of games to make sure they don't shake with Anti-Blur enabled, especially the Spongebob games

### Did you use AI to help find, test, or implement this issue or feature?
No

Fixes #13927
Fixes #14001
Fixes #14009

Also fixes Mobile Suit Gundam Climax bouncing with Anti-Blur enabled.
