### PR TITLE
GS/HW: Merge together adjacent tristrips in drawlist.

### DIFF
--- a/pcsx2/GS/GSUtil.h
+++ b/pcsx2/GS/GSUtil.h
@@ -76,3 +76,89 @@ public:
 		return GetClassVertexCount(GetPrimClass(prim));
 	}
 };
+
+// Class that represents an octogonal bounding area with sides at 45 degree increments.
+class BoundingOct
+{
+private:
+	GSVector4i bbox0; // Standard bbox.
+	GSVector4i bbox1; // Bounding diamond (rotated 45 degrees axes and scaled, so (x, y) becomes (x + y, x - y)).
+
+	// Assumes that v is of the form { x, y, x, y }.
+	static GSVector4i Rotate45(const GSVector4i& v)
+	{
+		const GSVector4i swap = v.yxwz();
+		return (v + swap).blend32<0xa>(swap - v);
+	}
+
+	BoundingOct(const GSVector4i& bbox0, const GSVector4i& bbox1)
+		: bbox0(bbox0)
+		, bbox1(bbox1)
+	{
+	}
+
+public:
+	// Initialize to null bounding area.
+	BoundingOct()
+		: bbox0(GSVector4i(INT_MAX, INT_MAX, INT_MIN, INT_MIN))
+		, bbox1(GSVector4i(INT_MAX, INT_MAX, INT_MIN, INT_MIN))
+	{
+	}
+
+	static BoundingOct FromPoint(GSVector4i v)
+	{
+		v = v.xyxy();
+		return { v, Rotate45(v) };
+	}
+
+	// The two inputs are assumed to be diagonally opposite to each other in an axis-aligned quad (i.e. sprite).
+	static BoundingOct FromSprite(GSVector4i v0, GSVector4i v1)
+	{
+		const GSVector4i min = v0.min_i32(v1);
+		const GSVector4i max = v0.max_i32(v1);
+		const GSVector4i bbox = min.upl64(max);
+		// Rotate45(x, y) => (x + y, x - y), we want the (min, max) result for any pair of (x, y)
+		// Min: (min.x + min.y, min.x - max.y)
+		// Max: (max.x + max.y, max.x - min.y)
+		const GSVector4i x = GSVector4i::cast(GSVector4::cast(min).xxxx(GSVector4::cast(max))); // Don't use bbox immediately to help the compiler optimize.
+		const GSVector4i y = bbox.ywwy();
+		return {
+			bbox,
+			(x + y).blend32<0xa>(x - y),
+		};
+	}
+
+	BoundingOct Union(GSVector4i v) const
+	{
+		v = v.xyxy();
+		return { bbox0.runion(v), bbox1.runion(Rotate45(v)) };
+	}
+
+	BoundingOct Union(const BoundingOct& other) const
+	{
+		return { bbox0.runion(other.bbox0), bbox1.runion(other.bbox1) };
+	}
+
+	BoundingOct UnionSprite(GSVector4i pt0, GSVector4i pt1) const
+	{
+		return Union(FromSprite(pt0, pt1));
+	}
+
+	bool Intersects(const BoundingOct& other) const
+	{
+		return bbox0.rintersects(other.bbox0) && bbox1.rintersects(other.bbox1);
+	}
+
+	BoundingOct FixDegenerate() const
+	{
+		return {
+			bbox0.blend(bbox0 + GSVector4i(0, 0, 1, 1), bbox0.xyxy() == bbox0.zwzw()),
+			bbox1.blend(bbox1 + GSVector4i(0, 0, 1, 1), bbox1.xyxy() == bbox1.zwzw()),
+		};
+	}
+
+	const GSVector4i& ToBBox()
+	{
+		return bbox0;
+	}
+};


### PR DESCRIPTION
### Description of Changes
1. Fixes a bug in tristrip detection that prevented triangle strips with 2 triangles from being detected.
2. Try to merge together adjacent triangle strips if they appears to part of a non-overlapping grid (thanks ref for the initial idea).
3. Use bounding octagons (i.e. intersection of standard bbox with 45 degree rotated bbox) for overlap detection.

### Rationale behind Changes
Reduce barriers when full barriers are needed. In a dump run with max blend the median reduction was 9%.

Dumps with the largest reduction (31-84%):
```
Mark of Krik interlace.gs.xz
JonnyMoseleydebug.gs.xz
Psyvariar 2 - Ultimate Final_SLPM-62562_20240426200102.gs.xz
Counter_Terrorist_Special_Forces_-_Fire_for_Effect_SLES-53046_20230830195729.gs.xz
Spongebob_SquarePants_-_Revenge_of_the_Flying_Dutchman_SLUS-20425_20230603182758.gs.xz
gtasa_clut_dirt.gs.xz
Grand Theft Auto - San Andreas _PAL-M5__SLES-52541_20220518184229.gs.xz
Jak X - Combat Racing_SCES-53286_20250208235338.gs.xz
Grand_Theft_Auto_-_San_Andreas_SLUS-20946_20230710170720.gs.xz
Dead to Rights II_SLUS-20843_20240618142012.gs.xz
Pirates_-_The_Legend_of_Black_Kat_SLES-50680_20240523094526.gs.xz
Shadow_Hearts_SLUS-20347_20240611181634.gs.xz
Final_Fantasy_X_SCES-50490_20230222213741.gs.xz
UEFA_Champions_League_2006-2007_SLES-54511_20230207153203.gs.xz
Psyvariar 2 - Ultimate Final_SLPM-62562_20230731114621.gs.xz
WRC_3_SCES-51684_20231229001217.gs.xz
Armored Core 2_SLPS-25007_20231225155834.gs.xz
Naruto Shippuuden - Ultimate Ninja 5_SLES-55605_20220815130149.gs.xz
Onimusha_2_-_Samurais_Destiny_SLUS-20393_20230705221651.gs.xz
Grand Theft Auto - San Andreas_SLUS-20946_20240606125930.gs.xz
```

Dumps with no reductions but still a fairly high number of barrier (for possible regression testing):
```
Getaway, The_SLPM-65410_20231222221328.gs.xz
vampire_stalkers_garbledhw.gs.xz
Driving_Emotion_Type-S_SLUS-20113_20230715165053.gs.xz
Tekken 5_SLUS-21059_20220726202957.gs.xz
Malice_SLES-52413_20240617171243.gs.xz
Valkyrie Profile 2 - Silmeria _NTSC-U__SLUS-21452_20220415183722.gs.xz
Rozen Maiden Duellwalzer.gs.xz
WRC Rally Evolved_SCES-53247_20230625031903.gs.xz
Gran Turismo 4 _NTSC-U__SCUS-97328_20220410112130.gs.xz
drakengard_slow.gs.xz
TTP_koreanstage_intro.gs.xz
suikoden.gs.xz
Zatch Bell! Mamodo Fury_SLUS-21363_20230424185333.gs.xz
007AgentUnderFire.gs.xz
WWE SmackDown! vs. RAW 2006_SLUS-21286_20250523211551.gs.xz
WRC_Rally_Evolved_SCES-53247_20230315071723.gs.xz
pridefc-missingtext.gs.xz
Yu-Gi-Oh! The Duelists of the Roses_SLUS-20515_20250511091941.gs.xz
roguegalaxytext.gs.xz
SAvirtua2.gs.xz
```

### Misc. Details

1. There's at least one dump "gitarooman.gs.xz", where a triangle strip overlaps itself. Technically it's broken (in current master) though the difference is just a few pixels and color difference is small.
2. (**Edit:** No longer relevant as this was improved in a later iteration). ~~The reduction in barriers could have been improved more but it slightly breaks triangle strips in "Dr._Seuss_The_Cat_in_the_Hat_SLUS-20797_20240413181234.gs.xz" (zoom in on corkscrews):~~
3. There may be 1 pixel differences in line strips compared to master where consecutive lines meet. This is likely due to the line drawing rules of the graphics APIs being different from GS rules, so lines may overlap though they would not on a PS2.

### Suggested Testing Steps
Test the HW renderer with any API on higher blend levels. The majority of games may not have enough change in barriers to make a difference. However, we don't want to see any regressions as the GS thread usage will be higher with the new heuristics.

### Did you use AI to help find, test, or implement this issue or feature?
Yes, to get suggestions on how to implement 45 degree coordinate rotation on SSE and port to NEON.