### PR TITLE
GS: Further improve copy area hieratics for feedback loops(sw blending/fbmask/date).

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -1016,6 +1016,9 @@ public:
 	/// Generates a fixed index buffer for expanding points and sprites. Buffer is assumed to be at least EXPAND_BUFFER_SIZE in size.
 	static void GenerateExpansionIndexBuffer(void* buffer);
 
+	// Process copy area for sw blend copies.
+	GSVector4i ProcessCopyArea(const GSVector4i& rtsize, const GSVector4i& drawarea);
+
 	/// Reads the specified shader source file.
 	static std::optional<std::string> ReadShaderSource(const char* filename);
 

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -1323,7 +1323,7 @@ void GSDevice11::DoStretchRect(GSTexture* sTex, const GSVector4& sRect, GSTextur
 	GSVector2i ds;
 	if (dTex)
 	{
-		// preemptively bind svr if possible
+		// preemptively bind srv if possible
 		if (m_state.cached_rt_view != sTex && m_state.cached_dsv != sTex)
 			PSSetShaderResource(0, sTex);
 
@@ -1394,7 +1394,7 @@ void GSDevice11::PresentRect(GSTexture* sTex, const GSVector4& sRect, GSTexture*
 	GSVector2i ds;
 	if (dTex)
 	{
-		// preemptively bind svr if possible
+		// preemptively bind srv if possible
 		if (m_state.cached_rt_view != sTex && m_state.cached_dsv != sTex)
 			PSSetShaderResource(0, sTex);
 
@@ -2203,7 +2203,7 @@ void GSDevice11::SetupDATE(GSTexture* rt, GSTexture* ds, SetDATM datm, const GSV
 
 	m_ctx->ClearDepthStencilView(*static_cast<GSTexture11*>(ds), D3D11_CLEAR_STENCIL, 0.0f, 0);
 
-	// preemptively bind svr if possible
+	// preemptively bind srv if possible
 
 	if (m_state.cached_rt_view != rt && m_state.cached_dsv != rt)
 		PSSetShaderResource(0, rt);
@@ -2752,7 +2752,7 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 	if (config.tex && config.tex == config.ds)
 		read_only_dsv = static_cast<GSTexture11*>(config.ds)->ReadOnlyDepthStencilView();
 
-	// Preemptively bind svr if possible.
+	// Preemptively bind srv if possible.
 	// We update the local state, then if there are srv conflicts PSUnbindConflictingSRVs will update the gpu state.
 	if (config.tex)
 	{
@@ -2899,11 +2899,12 @@ void GSDevice11::SendHWDraw(const GSHWDrawConfig& config, GSTexture* draw_rt_clo
 				PSSetShaderResource(0, draw_rt_clone);
 		};
 
+		const GSVector4i rtsize(0, 0, draw_rt->GetWidth(), draw_rt->GetHeight());
+
 		if (m_features.multidraw_fb_copy && full_barrier)
 		{
 			const u32 draw_list_size = static_cast<u32>(config.drawlist->size());
 			const u32 indices_per_prim = config.indices_per_prim;
-			const GSVector4i rtsize(0, 0, draw_rt->GetWidth(), draw_rt->GetHeight());
 
 			pxAssert(config.drawlist && !config.drawlist->empty());
 			pxAssert(config.drawlist_bbox && static_cast<u32>(config.drawlist_bbox->size()) == draw_list_size);
@@ -2913,27 +2914,7 @@ void GSDevice11::SendHWDraw(const GSHWDrawConfig& config, GSTexture* draw_rt_clo
 				const u32 count = (*config.drawlist)[n] * indices_per_prim;
 
 				const GSVector4i original_bbox = (*config.drawlist_bbox)[n].rintersect(config.drawarea);
-				GSVector4i snapped_bbox = original_bbox;
-
-				// We don't want the snapped box adjustments when the rect is empty as it might make the copy to pass.
-				// The empty rect itself needs to be handled in renderer properly.
-				if (!snapped_bbox.rempty())
-				{
-					// Aligning bbox to 4 pixel boundaries so copies will be faster using Direct Memory Access,
-					// otherwise it may stall as more commands need to be issued.
-					snapped_bbox.left &= ~3;
-					snapped_bbox.top &= ~3;
-					snapped_bbox.right = (snapped_bbox.right + 3) & ~3;
-					snapped_bbox.bottom = (snapped_bbox.bottom + 3) & ~3;
-
-					// Ensure the new sizes are within bounds.
-					snapped_bbox.left = std::max(0, snapped_bbox.left);
-					snapped_bbox.top = std::max(0, snapped_bbox.top);
-					snapped_bbox.right = std::min(snapped_bbox.right, rtsize.right);
-					snapped_bbox.bottom = std::min(snapped_bbox.bottom, rtsize.bottom);
-				}
-
-				CopyAndBind(snapped_bbox);
+				CopyAndBind(ProcessCopyArea(rtsize, original_bbox));
 
 				DrawIndexedPrimitive(p, count);
 				p += count;
@@ -2944,7 +2925,7 @@ void GSDevice11::SendHWDraw(const GSHWDrawConfig& config, GSTexture* draw_rt_clo
 
 		// Optimization: For alpha second pass we can reuse the copy snapshot from the first pass.
 		if (!skip_first_barrier)
-			CopyAndBind(config.drawarea);
+			CopyAndBind(ProcessCopyArea(rtsize, config.drawarea));
 	}
 
 	DrawIndexedPrimitive();

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -4234,7 +4234,8 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 				config.drawarea.left, config.drawarea.top,
 				config.drawarea.width(), config.drawarea.height());
 			EndRenderPass();
-			CopyRect(draw_rt, draw_rt_clone, config.drawarea, config.drawarea.left, config.drawarea.top);
+			const GSVector4i snapped_drawarea = ProcessCopyArea(GSVector4i(0, 0, rtsize.x, rtsize.y), config.drawarea);
+			CopyRect(draw_rt, draw_rt_clone, snapped_drawarea, snapped_drawarea.left, snapped_drawarea.top);
 			if (config.require_one_barrier)
 				PSSetShaderResource(2, draw_rt_clone, true);
 			if (config.tex && config.tex == config.rt)

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -2681,7 +2681,8 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 			GL_PUSH("GL: Copy RT to temp texture {%d,%d %dx%d}",
 				config.drawarea.left, config.drawarea.top,
 				config.drawarea.width(), config.drawarea.height());
-			CopyRect(draw_rt, draw_rt_clone, config.drawarea, config.drawarea.left, config.drawarea.top);
+			const GSVector4i snapped_drawarea = ProcessCopyArea(GSVector4i(0, 0, rtsize.x, rtsize.y), config.drawarea);
+			CopyRect(draw_rt, draw_rt_clone, snapped_drawarea, snapped_drawarea.left, snapped_drawarea.top);
 			if (config.require_one_barrier)
 				PSSetShaderResource(2, draw_rt_clone);
 			if (config.tex && config.tex == config.rt)

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -5794,7 +5794,8 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 				config.drawarea.left, config.drawarea.top,
 				config.drawarea.width(), config.drawarea.height());
 			EndRenderPass();
-			CopyRect(draw_rt, draw_rt_clone, config.drawarea, config.drawarea.left, config.drawarea.top);
+			const GSVector4i snapped_drawarea = ProcessCopyArea(GSVector4i(0, 0, rtsize.x, rtsize.y), config.drawarea);
+			CopyRect(draw_rt, draw_rt_clone, snapped_drawarea, snapped_drawarea.left, snapped_drawarea.top);
 			if (config.require_one_barrier)
 				PSSetShaderResource(2, draw_rt_clone, true);
 			if (config.tex && config.tex == config.rt)


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS: Further improve copy area hieratics for feedback loops(sw blending/fbmask/date).
1. Expand 4 pixel boundaries correction to non overlapping draws.

2. If the copy area covers 95% or more of the render target size switch to full copies using CopyResource instead of CopySubresourceRegion.
At this size using full copies should be faster.
Currently it is only used when texture barriers are disabled but can be used when Depth testing/Afail copies are implemented.

3. Backport to other renderers DX12/GL/VK.

Currently it is only used when texture barriers are disabled but can be used when Depth testing/Afail copies are implemented.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Optimization.
Expanding upon https://github.com/PCSX2/pcsx2/pull/13917

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
A lot of games are affected so test variety of games.
Dump run didn't show anything broken except a difference in Cat Woman, but it looks like this is a different issue with drawarea being wrong to begin with, other renderers just mask this issue because they don't issue copies.

For other renderers smoke test a few games with barriers disabled to make sure nothing broke.
Can also bench Sly 2 and a few others with barriers disabled just to make sure performance isn't worse on gl/vk/dx12.

To test some games that use full RT copies here's a list:
[full RT copy expansion.txt](https://github.com/user-attachments/files/25025922/full.RT.copy.expansion.txt)

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
Yes Gemini for the idea, needs to be verified and tested if it helps.