### PR TITLE
Qt: Don't set a layout for the log window central widget twice

### DIFF
--- a/pcsx2-qt/LogWindow.cpp
+++ b/pcsx2-qt/LogWindow.cpp
@@ -243,7 +243,6 @@ void LogWindow::createUi()
 	vlayout->addWidget(m_text);
 	vlayout->addWidget(m_input_widget);
 
-	central_widget->setLayout(vlayout);
 	setCentralWidget(central_widget);
 }
 


### PR DESCRIPTION
### Description of Changes
Don't set central\_widget's layout twice.

### Rationale behind Changes
Silences a warning at runtime. The layout's constructor already sets it.

### Suggested Testing Steps
N/A

### Did you use AI to help find, test, or implement this issue or feature?
No.
