### PR TITLE
Qt: Only show "Applied" label for cheat tree items that are checkable

### DIFF
--- a/pcsx2-qt/Settings/GameCheatSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GameCheatSettingsWidget.cpp
@@ -118,9 +118,8 @@ void GameCheatSettingsWidget::onCheatListItemHovered(const QModelIndex& index)
 	const QModelIndex source_index = m_model_proxy->mapToSource(index);
 	const QModelIndex sibling_index = source_index.siblingAtColumn(0);
 	QStandardItem* item = m_model->itemFromIndex(sibling_index);
-	if (!item)
+	if (!item || !item->isCheckable())
 	{
-		// No item is selected.
 		m_ui.appliedLabel->clear();
 		return;
 	}


### PR DESCRIPTION
### Description of Changes
Only show the "Applied: ..." label on the cheats page for nodes that are checkable.

For example the label now won't be shown for this node:
<img width="345" height="42" alt="Screenshot_20260204_191701" src="https://github.com/user-attachments/assets/eeccf907-f7d4-4e37-a19c-baf01f73e29f" />

### Rationale behind Changes
It doesn't make sense to show that information for these nodes.

### Suggested Testing Steps
N/A

### Did you use AI to help find, test, or implement this issue or feature?
No.
