### PR TITLE
added localized titles for "Buzz! The Big Quiz" and "Buzz! The Sports Quiz"

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -6268,19 +6268,23 @@ SCES-53880:
   region: "PAL-E"
 SCES-53881:
   name: "Buzz! Le Grand Quiz"
+  name-en: "Buzz! The Big Quiz"
   region: "PAL-F"
 SCES-53882:
-  name: "Buzz! The Big Quiz"
+  name: "Buzz! Il Superquiz"
+  name-en: "Buzz! The Big Quiz"
   region: "PAL-I"
   gameFixes:
     - EETimingHack # Fixes freezes.
 SCES-53883:
-  name: "Buzz! The Big Quiz"
+  name: "Buzz! Das große Quiz"
+  name-en: "Buzz! The Big Quiz"
   region: "PAL-G"
   gameFixes:
     - EETimingHack # Fixes freezes.
 SCES-53884:
-  name: "Buzz! El GRAN Reto"
+  name: "Buzz! El Gran Reto"
+  name-en: "Buzz! The Big Quiz"
   region: "PAL-S"
   compat: 2
   gameFixes:
@@ -6317,10 +6321,12 @@ SCES-53926:
   name: "Buzz! The Big Quiz"
   region: "PAL-SC"
 SCES-53927:
-  name: "Buzz! The Big Quiz"
+  name: "Buzz! Suuri Tietovisa"
+  name-en: "Buzz! The Big Quiz"
   region: "PAL-FI"
 SCES-53929:
-  name: "Buzz! The Big Quiz"
+  name: "Buzz! O Grande Quiz"
+  name-en: "Buzz! The Big Quiz"
   region: "PAL-P"
 SCES-53931:
   name: "Shinobido - Way of the Ninja"
@@ -6436,19 +6442,23 @@ SCES-54258:
   name: "Buzz! The Sports Quiz"
   region: "PAL-E"
 SCES-54259:
-  name: "Buzz! The Sports Quiz"
+  name: "Buzz! Das Sport-Quiz"
+  name-en: "Buzz! The Sports Quiz"
   region: "PAL-G"
 SCES-54260:
   name: "Buzz! Le Quiz du Sport"
+  name-en: "Buzz! The Sports Quiz"
   region: "PAL-F"
 SCES-54261:
   name: "Buzz! The Sports Quiz"
   region: "PAL-I"
 SCES-54262:
-  name: "Buzz! - El Gran Concurso de Deportes"
+  name: "Buzz! El Gran Concurso de Deportes"
+  name-en: "Buzz! The Sports Quiz"
   region: "PAL-S"
 SCES-54263:
-  name: "Buzz! The Sports Quiz"
+  name: "Buzz! O Quiz Desportivo"
+  name-en: "Buzz! The Sports Quiz"
   region: "PAL-P"
 SCES-54264:
   name: "Buzz! The Sports Quiz"
@@ -6460,7 +6470,8 @@ SCES-54266:
   name: "Buzz! The Sports Quiz"
   region: "PAL-SC"
 SCES-54267:
-  name: "Buzz! The Sports Quiz"
+  name: "Buzz! Sporttivisa"
+  name-en: "Buzz! The Sports Quiz"
   region: "PAL-FI"
 SCES-54268:
   name: "Buzz! The Sports Quiz"
@@ -6496,24 +6507,29 @@ SCES-54496:
   region: "PAL-E"
 SCES-54497:
   name: "Buzz! Le Mega Quiz"
+  name-en: "Buzz! The Mega Quiz"
   region: "PAL-F"
 SCES-54498:
   name: "Buzz! The Mega Quiz"
   region: "PAL-I"
 SCES-54499:
   name: "Buzz! Das Mega-Quiz"
+  name-en: "Buzz! The Mega Quiz"
   region: "PAL-G"
 SCES-54500:
   name: "Buzz! El Mega Concurso"
+  name-en: "Buzz! The Mega Quiz"
   region: "PAL-S"
 SCES-54501:
   name: "Buzz! The Mega Quiz"
   region: "PAL-A"
 SCES-54503:
   name: "Buzz! Megavisa"
+  name-en: "Buzz! The Mega Quiz"
   region: "PAL-FI"
 SCES-54504:
   name: "Buzz! O Mega Quiz"
+  name-en: "Buzz! The Mega Quiz"
   region: "PAL-P"
 SCES-54505:
   name: "Buzz! The Mega Quiz"


### PR DESCRIPTION
### Description of Changes
Changed the titles for the serials:

#### _Buzz! The Big Quiz_:
SCES-53882, SCES-53883, SCES-53884 (this one I just changed the capitalization, to better match the other localized titles), SCES-53927, SCES-53929

#### _Buzz! The Sports Quiz_:
SCES-54259, SCES-54262 (this one I just removed an hyphen to better match the other localized titles), SCES-54263, SCES-54267

### Rationale behind Changes
The titles were missing their localized names. I got them through MobyGames and some images I found online:

#### _Buzz! The Big Quiz_
- [**MobyGames**](https://www.mobygames.com/game/21963/buzz-the-big-quiz/)
- [Finnish box](https://www.tori.fi/recommerce/forsale/item/33895936?)
- [German box](https://www.amazon.de/Sony-9672760-BUZZ-gro%C3%9Fe-Quiz/dp/B000E6G900?th=1)
- [Italian box](https://nerdpick.com/prodotto/videogiochi/playstation/playstation-2/giochi-playstation-2/buzz-il-superquiz-playstation-2-ps2-pal-ita/)
- [Portuguese box](https://www.playnplay.net/produto/buzz-o-grande-quiz-ps2-seminovo/)

#### _Buzz! The Sports Quiz_
- [**MobyGames**](https://www.mobygames.com/game/41613/buzz-the-sports-quiz/)
- [German box](https://www.ebay.de/itm/164084252266)
- [Finnish box](https://www.ebay.fr/itm/255742938625)
- [Portuguese box](https://www.playnplay.net/produto/buzz-quiz-desportivo-ps2-seminovo/)

### Did you use AI to help find, test, or implement this issue or feature?
Nope
