### PR TITLE
IOP: Fix IRQ edges for SIO2 and CDVD and SIO2 ISTAT usage

### DIFF
--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -102,10 +102,16 @@ static void CDVD_INT(int eCycle)
 // test (which will cause the exception to be handled).
 static void cdvdSetIrq(uint id = (1 << Irq_CommandComplete))
 {
+	if (!(cdvd.IntrStat & id))
+	{
+		iopIntcIrq(2);
+		psxSetNextBranchDelta(20);
+	}
+	else
+		DevCon.Warning("CDVD trying to double issue IRQ %x", id);
+
 	cdvd.IntrStat |= id;
 	cdvd.AbortRequested = false;
-	iopIntcIrq(2);
-	psxSetNextBranchDelta(20);
 }
 
 static int mg_BIToffset(u8* buffer)

--- a/pcsx2/IopCounters.cpp
+++ b/pcsx2/IopCounters.cpp
@@ -782,8 +782,8 @@ void psxRcntSetNewIntrMode(int index)
 	psxCounters[index].mode.overflowFlag = false;
 	psxCounters[index].mode.intrEnable = true;
 
-	if (psxCounters[index].mode.repeatIntr != psxCounters[index].currentIrqMode.repeatInterrupt || psxCounters[index].mode.toggleIntr != psxCounters[index].currentIrqMode.toggleInterrupt)
-		DevCon.Warning("Updating psxCounter[%d] mode old repeat %d new %d old toggle %d new %d", index, psxCounters[index].mode.repeatIntr, psxCounters[index].currentIrqMode.repeatInterrupt, psxCounters[index].mode.toggleIntr, psxCounters[index].currentIrqMode.toggleInterrupt);
+	//if (psxCounters[index].mode.repeatIntr != psxCounters[index].currentIrqMode.repeatInterrupt || psxCounters[index].mode.toggleIntr != psxCounters[index].currentIrqMode.toggleInterrupt)
+	//	DevCon.Warning("Updating psxCounter[%d] mode old repeat %d new %d old toggle %d new %d", index, psxCounters[index].mode.repeatIntr, psxCounters[index].currentIrqMode.repeatInterrupt, psxCounters[index].mode.toggleIntr, psxCounters[index].currentIrqMode.toggleInterrupt);
 	
 	psxCounters[index].currentIrqMode.repeatInterrupt = psxCounters[index].mode.repeatIntr;
 	psxCounters[index].currentIrqMode.toggleInterrupt = psxCounters[index].mode.toggleIntr;

--- a/pcsx2/SIO/Sio2.cpp
+++ b/pcsx2/SIO/Sio2.cpp
@@ -100,7 +100,12 @@ void Sio2::SoftReset()
 
 void Sio2::Interrupt()
 {
-	iopIntcIrq(17);
+	if (!iStat)
+		iopIntcIrq(17);
+	else
+		DevCon.Warning("Nearly sent double SIO2 IRQ");
+
+	iStat |= 1;
 }
 
 void Sio2::SetCtrl(u32 value)

--- a/pcsx2/ps2/Iop/IopHwWrite.cpp
+++ b/pcsx2/ps2/Iop/IopHwWrite.cpp
@@ -653,7 +653,7 @@ void iopHwWrite32_Page8( u32 addr, mem32_t val )
 					break;
 				case (HW_SIO2_INTR & 0x0fff):
 					Sio2Log.WriteLn("%s(%08X, %08X) SIO2 ISTAT Write", __FUNCTION__, addr, val);
-					g_Sio2.iStat = val;
+					g_Sio2.iStat &= ~val;
 					break;
 				// Other SIO2 registers are read-only, no-ops on write.
 				default:


### PR DESCRIPTION
### Description of Changes
Fixes edge triggering of IRQ's on SIO2 and CDVD, though I couldn't find anything that triggers them.
Also fixes SIO2 ISTAT usage

### Rationale behind Changes
These IRQ's should be edge triggered, hopefully it doesn't break anything.

ISTAT handling was also incorrect, the only usage of it is to read it and immediately write the same bits back to itself to clear it, but we were just setting it to the value written, which is incorrect, so it at least fixes that.

### Suggested Testing Steps
Test games with possible CDVD sensitivity issues (No it doesn't make Jimmy Neutron better, sorry), saving games, loading saved games, fancy pad stuff (if any)

### Did you use AI to help find, test, or implement this issue or feature?
No

## Be sure to backup your memorycard before testing!