### PR TITLE
IPU: Reset dc dct precision on soft reset

### DIFF
--- a/pcsx2/IPU/IPU.cpp
+++ b/pcsx2/IPU/IPU.cpp
@@ -314,6 +314,13 @@ void ipuSoftReset()
 	g_ipu_thresh[0] = 0;
 	g_ipu_thresh[1] = 0;
 
+	if (!decoder.intra_dc_precision)
+	{
+		decoder.dc_dct_pred[0] =
+		decoder.dc_dct_pred[1] =
+		decoder.dc_dct_pred[2] = 128 << decoder.intra_dc_precision;
+	}
+
 	ipuRegs.ctrl.reset();
 	ipuRegs.top = 0;
 	ipu_cmd.clear();


### PR DESCRIPTION
### Description of Changes
Resets DC DCT precision on soft reset

### Rationale behind Changes
I don't know if this is 100% correct, but it seems logically correct and fixes Critical Velocity so you no longer have a seizure playing the game, and hopefully doesn't mess up any other videos, but that will need testing. 

### Suggested Testing Steps
Test many FMV's, make sure they work fine, including Critical Velocity

### Did you use AI to help find, test, or implement this issue or feature?
No

Thanks to Goatman13 for the suggestion on the fix

Fixes #9842
  
