### PR TITLE
Qt: Don't steal focus when a modal dialog is open

### DIFF
--- a/pcsx2-qt/DisplayWidget.cpp
+++ b/pcsx2-qt/DisplayWidget.cpp
@@ -479,8 +479,15 @@ bool DisplaySurface::eventFilter(QObject* object, QEvent* event)
 			// macOS: When we (the display window) get focus from another window with a toolbar we update to the MainWindow toolbar.
 			// This is because we are a different native window from our MainWindow. So, whenever we get focus, focus our MainWindow.
 			// That way macOS will show the MainWindow toolbar when you click from the debugger / log window to the game.
-			if (auto* w = qobject_cast<QWidget*>(object))
+
+			// Don't try to steal focus when we're showing a modal dialog
+			// We end up ping ponging focus in a feedback loop
+			if (QApplication::activeModalWidget() != nullptr)
+				return false;
+
+			if (const auto* w = qobject_cast<QWidget*>(object))
 				w->window()->activateWindow();
+
 			return false;
 		default:
 			return false;


### PR DESCRIPTION
### Description of Changes
Fixes #13941 

If this doesn't really fix anything, I can make the original change macOS only. Assuming that the bug doesn't happen there, haven't tested.

### Rationale behind Changes
Broken dialog boxes are bad

### Suggested Testing Steps
Run a game

Try to close pcsx2 while the game is running. The confirm close dialog should show up normally.

Run a game

Drag and drop a game on to the game window, the disc change dialog should show up normally.

Finally, make sure that this didn't break #13853

### Did you use AI to help find, test, or implement this issue or feature?
No