### PR TITLE
GS/TC: Recycle instead of delete targets involved in native scaling

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2837,7 +2837,7 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVe
 			m_target_memory_usage = (m_target_memory_usage - dst->m_texture->GetMemUsage()) + tex->GetMemUsage();
 
 			// If we're changing resolution scale, just toss the texture, it's not going to get reused.
-			if ((!GSConfig.UserHacks_NativePaletteDraw && !dst->m_downscaled) || (dst->m_scale != 1.0f && scale != 1.0f))
+			if ((!GSConfig.UserHacks_NativePaletteDraw && !dst->m_downscaled && scale != 1.0f) || (dst->m_scale != 1.0f && scale != 1.0f))
 				delete dst->m_texture;
 			else
 				g_gs_device->Recycle(dst->m_texture);


### PR DESCRIPTION
### Description of Changes
Recycles rather than deletes targets associated with native scaling

### Rationale behind Changes
Constantly deleting targets is really bad for performance, and it was causing some wicked bad frametimes when Native Scaling was enabled, quite evident in Shadow of Rome.

### Suggested Testing Steps
Test Shadow of Rome and other native scaling games. I suggest checking the frametimes on the OSD, could also impact maximum framerates.

### Did you use AI to help find, test, or implement this issue or feature?
No