### PR TITLE
Debugger: Prevent duplicate saved addresses from being loaded

### DIFF
--- a/pcsx2-qt/Debugger/Memory/SavedAddressesView.cpp
+++ b/pcsx2-qt/Debugger/Memory/SavedAddressesView.cpp
@@ -30,7 +30,8 @@ SavedAddressesView::SavedAddressesView(const DebuggerViewParameters& parameters)
 			DebuggerSettingsManager::loadGameSettings(m_model);
 	});
 
-	DebuggerSettingsManager::loadGameSettings(m_model);
+	if (m_model->rowCount() == 0)
+		DebuggerSettingsManager::loadGameSettings(m_model);
 
 	for (std::size_t i = 0; auto mode : SavedAddressesModel::HeaderResizeModes)
 	{


### PR DESCRIPTION
### Description of Changes
Prevent saved addresses from being loaded multiple times when reopening the debugger.

### Rationale behind Changes
Fixes #13859.

### Suggested Testing Steps
N/A

### Did you use AI to help find, test, or implement this issue or feature?
No.
