### PR TITLE
Deps: Use vswhere to find Visual Studio

### DIFF
--- a/.github/workflows/scripts/windows/build-dependencies-arm64.bat
+++ b/.github/workflows/scripts/windows/build-dependencies-arm64.bat
@@ -2,10 +2,15 @@
 setlocal enabledelayedexpansion
 
 echo Setting environment...
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsamd64_arm64.bat" (
-  call "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsamd64_arm64.bat"
-) else if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsamd64_arm64.bat" (
-  call "%ProgramFiles%\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsamd64_arm64.bat"
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" (
+  for /f "usebackq tokens=*" %%i in (`call "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -version "[17, 18)" -latest -property installationPath`) do set "VSINSTPATH=%%i"
+  if defined VSINSTPATH (
+    echo VSINSTPATH=!VSINSTPATH!
+    call "!VSINSTPATH!\VC\Auxiliary\Build\vcvarsamd64_arm64.bat" || goto error
+  ) else (
+    echo Visual Studio 2022 not found.
+    goto error
+  )
 ) else (
   echo Visual Studio 2022 not found.
   goto error

--- a/.github/workflows/scripts/windows/build-dependencies.bat
+++ b/.github/workflows/scripts/windows/build-dependencies.bat
@@ -2,10 +2,15 @@
 setlocal enabledelayedexpansion
 
 echo Setting environment...
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat" (
-  call "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-) else if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat" (
-  call "%ProgramFiles%\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" (
+  for /f "usebackq tokens=*" %%i in (`call "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -version "[17, 18)" -latest -property installationPath`) do set "VSINSTPATH=%%i"
+  if defined VSINSTPATH (
+    echo VSINSTPATH=!VSINSTPATH!
+    call "!VSINSTPATH!\VC\Auxiliary\Build\vcvars64.bat" || goto error
+  ) else (
+    echo Visual Studio 2022 not found.
+    goto error
+  )
 ) else (
   echo Visual Studio 2022 not found.
   goto error


### PR DESCRIPTION
### Description of Changes
Replaces the hardcoded paths in the build script with one that fetches paths from vswhere

### Rationale behind Changes
vswhere is always installed in a fixed location by the Visual Studio Installer.
Visual studio itself, can have the installation path changed during install (such as installing it on a HDD when the system has a smaller SSD boot drive).

The build script still targets only Visual studio 2022, this may need to be adjusted if VS 2026 makes its way onto the Windows runners we use.

### Suggested Testing Steps
Test the build script locally.
Test CI still works

### Did you use AI to help find, test, or implement this issue or feature?
No
