### PR TITLE
SIO2: Rename registers

### DIFF
--- a/pcsx2/IopHw.h
+++ b/pcsx2/IopHw.h
@@ -64,14 +64,14 @@ static const u32
 
 	// SIO2 is a DMA interface for the SIO.
 
-	HW_SIO2_DATAIN		= 0x1F808260,
-	HW_SIO2_FIFO		= 0x1f808264,
+	HW_SIO2_TX		    = 0x1F808260,
+	HW_SIO2_RX		    = 0x1f808264,
 	HW_SIO2_CTRL		= 0x1f808268,
-	HW_SIO2_RECV1		= 0x1f80826c,
-	HW_SIO2_RECV2		= 0x1f808270,
-	HW_SIO2_RECV3		= 0x1f808274,
-	HW_SIO2_8278        = 0x1F808278, // May as well add defs
-	HW_SIO2_827C        = 0x1F80827C, // for these 2...
+	HW_SIO2_CMD_STAT	= 0x1f80826c,
+	HW_SIO2_PORT_STAT   = 0x1f808270,
+	HW_SIO2_FIFO_STAT	= 0x1f808274,
+	HW_SIO2_FIFO_TX     = 0x1F808278, // May as well add defs
+	HW_SIO2_FIFO_RX     = 0x1F80827C, // for these 2...
 	HW_SIO2_INTR		= 0x1f808280;
 
 enum DMAMadrAddresses

--- a/pcsx2/SIO/Sio2.h
+++ b/pcsx2/SIO/Sio2.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "common/Pcsx2Types.h"
+
 #include <array>
 #include <deque>
 
@@ -11,37 +13,33 @@ class StateWrapper;
 class Sio2
 {
 public:
-	std::array<u32, 16> send3; // 0x1f808200 - 0x1f80823f
-	// SEND1 and SEND2 are an unusual bunch. It's not entirely clear just from
-	// documentation but these registers almost seem like they are the same thing;
-	// when bit 2 is set, SEND2 is being read/written. When bit 2 isn't set, it is
-	// SEND1. Their use is not really known, either.
-	std::array<u32, 4> send1; // 0x1f808240 - 0x1f80825f
-	std::array<u32, 4> send2; // 0x1f808240 - 0x1f80825f
+	std::array<u32, 16> CmdQueue; // 0x1f808200 - 0x1f80823f
+	std::array<u32, 4> PortCtrl0; // 0x1f808240 - 0x1f80825f
+	std::array<u32, 4> PortCtrl1; // 0x1f808240 - 0x1f80825f
 	u32 dataIn; // 0x1f808260
 	u32 dataOut; // 0x1f808264
 	u32 ctrl; // 0x1f808268
-	u32 recv1; // 0x1f80826c
-	u32 recv2; // 0x1f808270
-	u32 recv3; // 0x1f808274
-	u32 unknown1; // 0x1f808278
-	u32 unknown2; // 0x1f80827c
+	u32 CmdStat; // 0x1f80826c
+	u32 PortStat; // 0x1f808270
+	u32 FifoStat; // 0x1f808274
+	u32 FifoTxPos; // 0x1f808278
+	u32 FifoRxPos; // 0x1f80827c
 	u32 iStat; // 0x1f808280
 
 	u8 port = 0;
 
-	// The current working index of SEND3. The SEND3 register is a 16 position
+	// The current working index of the command queue. The queue is a 16 position
 	// array of command descriptors. Each descriptor describes the port the command
 	// is targeting, as well as the length of the command in bytes.
-	bool send3Read = false;
-	size_t send3Position = 0;
+	bool queueRead = false;
+	size_t queuePosition = 0;
 	size_t commandLength = 0;
 	size_t processedLength = 0;
 	// Tracks the size of a single block of DMA11/DMA12 data. psxDma11 will set this prior
 	// to doing writes, and Sio2::SetSend3 will clear this to ensure a non-DMA write into SIO2
 	// does not accidentally use dmaBlockSize.
 	size_t dmaBlockSize = 0;
-	bool send3Complete = false;
+	bool queueComplete = false;
 
 	Sio2();
 	~Sio2();
@@ -55,8 +53,8 @@ public:
 	void Interrupt();
 
 	void SetCtrl(u32 value);
-	void SetSend3(size_t position, u32 value);
-	void SetRecv1(u32 value);
+	void SetCmd(size_t position, u32 value);
+	void SetCmdStat(u32 value);
 
 	void Pad();
 	void Multitap();

--- a/pcsx2/SIO/SioTypes.h
+++ b/pcsx2/SIO/SioTypes.h
@@ -103,7 +103,7 @@ namespace SIO0_CTRL
 	static constexpr u16 PORT = 0x2000;
 } // namespace SIO0_CTRL
 
-namespace Send3
+namespace Sio2Cmd
 {
 	static constexpr u32 PORT = 0x01;
 	static constexpr u16 COMMAND_LENGTH_MASK = 0x3ff;
@@ -119,7 +119,7 @@ namespace Sio2Ctrl
 } // namespace Sio2Ctrl
 
 // TODO: Remove deprecated options once memcards are no longer using them.
-namespace Recv1
+namespace CmdStat
 {
 	// Deprecated
 	static constexpr u32 DISCONNECTED = 0x1d100;
@@ -135,7 +135,7 @@ namespace Recv1
 
 } // namespace Recv1
 
-namespace Recv2
+namespace PortStat
 {
 	static constexpr u32 DEFAULT = 0xf;
 } // namespace Recv2
@@ -145,7 +145,7 @@ namespace Recv2
 // to use them. We're going to try and respect these where it seems like
 // it may make sense to do so, but these are still largely unknown and
 // tests suggest they are not even used at all.
-namespace Recv3
+namespace FifoStat
 {
 	static constexpr u32 DEFAULT = 0x0;
 	// Set when getting memcard specs

--- a/pcsx2/ps2/Iop/IopHwRead.cpp
+++ b/pcsx2/ps2/Iop/IopHwRead.cpp
@@ -119,7 +119,7 @@ mem8_t iopHwRead8_Page8( u32 addr )
 
 	mem8_t ret;
 
-	if (addr == HW_SIO2_FIFO)
+	if (addr == HW_SIO2_RX)
 	{
 		ret = g_Sio2.Read();
 	}
@@ -415,7 +415,7 @@ mem32_t iopHwRead32_Page8( u32 addr )
 		if( masked_addr < 0x240 )
 		{
 			const int parm = (masked_addr-0x200) / 4;
-			ret = g_Sio2.send3[parm];
+			ret = g_Sio2.CmdQueue[parm];
 			Sio2Log.WriteLn("%s(%08X) SIO2 SEND3 Read (%08X)", __FUNCTION__, addr, ret);
 		}
 		else if ( masked_addr < 0x260 )
@@ -423,18 +423,18 @@ mem32_t iopHwRead32_Page8( u32 addr )
 			// SIO2 Send commands alternate registers.  First reg maps to Send1, second
 			// to Send2, third to Send1, etc.  And the following clever code does this:
 			const int parm = (masked_addr-0x240) / 8;
-			ret = (masked_addr & 4) ? g_Sio2.send2[parm] : g_Sio2.send1[parm];
+			ret = (masked_addr & 4) ? g_Sio2.PortCtrl1[parm] : g_Sio2.PortCtrl0[parm];
 			Sio2Log.WriteLn("%s(%08X) SIO2 SEND1/2 Read (%08X)", __FUNCTION__, addr, ret);
 		}
 		else if ( masked_addr <= 0x280 )
 		{
 			switch( masked_addr )
 			{
-				case (HW_SIO2_DATAIN & 0x0fff):
+				case (HW_SIO2_TX & 0x0fff):
 					ret = psxHu32(addr);
 					Sio2Log.Warning("%s(%08X) Unexpected 32 bit read of HW_SIO2_DATAIN (%08X)", __FUNCTION__, addr, ret);
 					break;
-				case (HW_SIO2_FIFO & 0x0fff):
+				case (HW_SIO2_RX & 0x0fff):
 					ret = psxHu32(addr);
 					Sio2Log.Warning("%s(%08X) Unexpected 32 bit read of HW_SIO2_FIFO (%08X)", __FUNCTION__, addr, ret);
 					break;
@@ -442,24 +442,24 @@ mem32_t iopHwRead32_Page8( u32 addr )
 					ret = g_Sio2.ctrl;
 					Sio2Log.WriteLn("%s(%08X) SIO2 CTRL Read (%08X)", __FUNCTION__, addr, ret);
 					break;
-				case (HW_SIO2_RECV1 & 0xfff):
-					ret = g_Sio2.recv1;
+				case (HW_SIO2_CMD_STAT & 0xfff):
+					ret = g_Sio2.CmdStat;
 					Sio2Log.WriteLn("%s(%08X) SIO2 RECV1 Read (%08X)", __FUNCTION__, addr, ret);
 					break;
-				case (HW_SIO2_RECV2 & 0x0fff):
-					ret = g_Sio2.recv2;
+				case (HW_SIO2_PORT_STAT & 0x0fff):
+					ret = g_Sio2.PortStat;
 					Sio2Log.WriteLn("%s(%08X) SIO2 RECV2 Read (%08X)", __FUNCTION__, addr, ret);
 					break;
-				case (HW_SIO2_RECV3 & 0x0fff):
-					ret = g_Sio2.recv3;
+				case (HW_SIO2_FIFO_STAT & 0x0fff):
+					ret = g_Sio2.FifoStat;
 					Sio2Log.WriteLn("%s(%08X) SIO2 RECV3 Read (%08X)", __FUNCTION__, addr, ret);
 					break;
 				case (0x1f808278 & 0x0fff):
-					ret = g_Sio2.unknown1;
+					ret = g_Sio2.FifoTxPos;
 					Sio2Log.WriteLn("%s(%08X) SIO2 UNK1 Read (%08X)", __FUNCTION__, addr, ret);
 					break;
 				case (0x1f80827C & 0x0fff):
-					ret = g_Sio2.unknown2;
+					ret = g_Sio2.FifoRxPos;
 					Sio2Log.WriteLn("%s(%08X) SIO2 UNK2 Read (%08X)", __FUNCTION__, addr, ret);
 					break;
 				case (HW_SIO2_INTR & 0x0fff):

--- a/pcsx2/ps2/Iop/IopHwWrite.cpp
+++ b/pcsx2/ps2/Iop/IopHwWrite.cpp
@@ -162,7 +162,7 @@ void iopHwWrite8_Page8( u32 addr, mem8_t val )
 	// all addresses are assumed to be prefixed with 0x1f808xxx:
 	pxAssert( (addr >> 12) == 0x1f808 );
 
-	if (addr == HW_SIO2_DATAIN)
+	if (addr == HW_SIO2_TX)
 	{
 		g_Sio2.Write(val);
 	}
@@ -595,9 +595,9 @@ void iopHwWrite32_Page8( u32 addr, mem32_t val )
 	{
 		if( masked_addr < 0x240 )
 		{
-			Sio2Log.WriteLn("%s(%08X, %08X) SIO2 SEND3 Write (len = %d / %d) (port = %d)", __FUNCTION__, addr, val, (val >> 8) & Send3::COMMAND_LENGTH_MASK, (val >> 18) & Send3::COMMAND_LENGTH_MASK, val & 0x01);
+			Sio2Log.WriteLn("%s(%08X, %08X) SIO2 SEND3 Write (len = %d / %d) (port = %d)", __FUNCTION__, addr, val, (val >> 8) & Sio2Cmd::COMMAND_LENGTH_MASK, (val >> 18) & Sio2Cmd::COMMAND_LENGTH_MASK, val & 0x01);
 			const int parm = (masked_addr - 0x200) / 4;
-			g_Sio2.SetSend3(parm, val);
+			g_Sio2.SetCmd(parm, val);
 		}
 		else if ( masked_addr < 0x260 )
 		{
@@ -609,47 +609,47 @@ void iopHwWrite32_Page8( u32 addr, mem32_t val )
 			if (masked_addr & 4)
 			{
 				Sio2Log.WriteLn("%s(%08X, %08X) SIO2 SEND2 Write", __FUNCTION__, addr, val);
-				g_Sio2.send2[parm] = val;
+				g_Sio2.PortCtrl1[parm] = val;
 			}
 			else
 			{
 				Sio2Log.WriteLn("%s(%08X, %08X) SIO2 SEND1 Write", __FUNCTION__, addr, val);
-				g_Sio2.send1[parm] = val;
+				g_Sio2.PortCtrl0[parm] = val;
 			}
 		}
 		else if ( masked_addr <= 0x280 )
 		{
 			switch( masked_addr )
 			{
-				case (HW_SIO2_DATAIN & 0x0fff):
+				case (HW_SIO2_TX & 0x0fff):
 					Sio2Log.Warning("%s(%08X, %08X) Unexpected 32 bit write to HW_SIO2_DATAIN", __FUNCTION__, addr, val);
 					break;
-				case (HW_SIO2_FIFO & 0x0fff):
+				case (HW_SIO2_RX & 0x0fff):
 					Sio2Log.Warning("%s(%08X, %08X) Unexpected 32 bit write to HW_SIO2_FIFO", __FUNCTION__, addr, val);
 					break;
 				case (HW_SIO2_CTRL & 0x0fff):
 					Sio2Log.WriteLn("%s(%08X, %08X) SIO2 CTRL Write", __FUNCTION__, addr, val);
 					g_Sio2.SetCtrl(val);
 					break;
-				case (HW_SIO2_RECV1 & 0x0fff):
+				case (HW_SIO2_CMD_STAT & 0x0fff):
 					Sio2Log.WriteLn("%s(%08X, %08X) SIO2 RECV1 Write", __FUNCTION__, addr, val);
-					g_Sio2.recv1 = val;
+					g_Sio2.CmdStat = val;
 					break;
-				case (HW_SIO2_RECV2 & 0x0fff):
+				case (HW_SIO2_PORT_STAT & 0x0fff):
 					Sio2Log.WriteLn("%s(%08X, %08X) SIO2 RECV2 Write", __FUNCTION__, addr, val);
-					g_Sio2.recv2 = val;
+					g_Sio2.PortStat = val;
 					break;
-				case (HW_SIO2_RECV3 & 0x0fff):
+				case (HW_SIO2_FIFO_STAT & 0x0fff):
 					Sio2Log.WriteLn("%s(%08X, %08X) SIO2 RECV3 Write", __FUNCTION__, addr, val);
-					g_Sio2.recv3 = val;
+					g_Sio2.FifoStat = val;
 					break;
-				case (HW_SIO2_8278 & 0x0fff):
+				case (HW_SIO2_FIFO_TX & 0x0fff):
 					Sio2Log.WriteLn("%s(%08X, %08X) SIO2 UNK1 Write", __FUNCTION__, addr, val);
-					g_Sio2.unknown1 = val;
+					g_Sio2.FifoTxPos = val;
 					break;
-				case (HW_SIO2_827C & 0x0fff):
+				case (HW_SIO2_FIFO_RX & 0x0fff):
 					Sio2Log.WriteLn("%s(%08X, %08X) SIO2 UNK2 Write", __FUNCTION__, addr, val);
-					g_Sio2.unknown2 = val;
+					g_Sio2.FifoRxPos = val;
 					break;
 				case (HW_SIO2_INTR & 0x0fff):
 					Sio2Log.WriteLn("%s(%08X, %08X) SIO2 ISTAT Write", __FUNCTION__, addr, val);

--- a/pcsx2/ps2/Iop/IopHw_Internal.h
+++ b/pcsx2/ps2/Iop/IopHw_Internal.h
@@ -136,14 +136,14 @@ static __ri const char* _ioplog_GetHwName( u32 addr, T val )
 
 		// ------------------------------------------------------------------------
 
-		case HW_SIO2_FIFO:	return "SIO2 FIFO";
-		case HW_SIO2_CTRL:	return "SIO2 CTRL";
-		case HW_SIO2_RECV1:	return "SIO2 RECV1";
-		case HW_SIO2_RECV2:	return "SIO2 RECV2";
-		case HW_SIO2_RECV3:	return "SIO2 RECV3";
-		case HW_SIO2_INTR:	return "SIO2 INTR";
-		case 0x1f808278:	return "SIO2 8278";
-		case 0x1f80827C:	return "SIO2 827C";
+		case HW_SIO2_RX:	    return "SIO2 RX";
+		case HW_SIO2_CTRL:	    return "SIO2 CTRL";
+		case HW_SIO2_CMD_STAT:	return "SIO2 CMD_STAT";
+		case HW_SIO2_PORT_STAT:	return "SIO2 PORT_STAT";
+		case HW_SIO2_FIFO_STAT:	return "SIO2 FIFO_STAT";
+		case HW_SIO2_INTR:	    return "SIO2 INTR";
+		case HW_SIO2_FIFO_TX:   return "SIO2 FIFO_TX";
+		case HW_SIO2_FIFO_RX:   return "SIO2 FIFO_RX";
 
 		// ------------------------------------------------------------------------
 		// Check for "zoned" registers in the default case.


### PR DESCRIPTION
### Description of Changes
Renames SIO2 registers to match what frno7 has reverse engineered (https://github.com/frno7/iopmod/blob/gamepad/include/iopmod/sio2.h)

### Rationale behind Changes
These make way more sense than trying to remember which number is what.

### Suggested Testing Steps
Should not change any behavior.

### Did you use AI to help find, test, or implement this issue or feature?
no
