### PR TITLE
GS: Add some GSVector4i methods.

### DIFF
--- a/pcsx2/GS/GSVector4i.h
+++ b/pcsx2/GS/GSVector4i.h
@@ -494,6 +494,16 @@ public:
 		return GSVector4i(_mm_packus_epi32(m, m));
 	}
 
+	__forceinline GSVector4i pkl32(const GSVector4i& a) const
+	{
+		return GSVector4i(_mm_castps_si128(_mm_shuffle_ps(_mm_castsi128_ps(m), _mm_castsi128_ps(a.m), _MM_SHUFFLE(2, 0, 2, 0))));
+	}
+
+	__forceinline GSVector4i pku32(const GSVector4i& a) const
+	{
+		return GSVector4i(_mm_castps_si128(_mm_shuffle_ps(_mm_castsi128_ps(m), _mm_castsi128_ps(a.m), _MM_SHUFFLE(3, 1, 3, 1))));
+	}
+
 	__forceinline GSVector4i upl8(const GSVector4i& a) const
 	{
 		return GSVector4i(_mm_unpacklo_epi8(m, a));
@@ -840,6 +850,11 @@ public:
 		return GSVector4i(_mm_srli_epi64(m, i));
 	}
 
+	__forceinline GSVector4i abs32() const
+	{
+		return GSVector4i(_mm_abs_epi32(m));
+	}
+
 	__forceinline GSVector4i add8(const GSVector4i& v) const
 	{
 		return GSVector4i(_mm_add_epi8(m, v.m));
@@ -853,6 +868,11 @@ public:
 	__forceinline GSVector4i add32(const GSVector4i& v) const
 	{
 		return GSVector4i(_mm_add_epi32(m, v.m));
+	}
+
+	__forceinline GSVector4i hadd32(const GSVector4i& v) const
+	{
+		return GSVector4i(_mm_hadd_epi32(m, v.m));
 	}
 
 	__forceinline GSVector4i adds8(const GSVector4i& v) const
@@ -893,6 +913,11 @@ public:
 	__forceinline GSVector4i sub32(const GSVector4i& v) const
 	{
 		return GSVector4i(_mm_sub_epi32(m, v.m));
+	}
+
+	__forceinline GSVector4i hsub32(const GSVector4i& v) const
+	{
+		return GSVector4i(_mm_hsub_epi32(m, v.m));
 	}
 
 	__forceinline GSVector4i subs8(const GSVector4i& v) const
@@ -1965,6 +1990,11 @@ public:
 	__forceinline friend GSVector4i operator^(const GSVector4i& v, int i)
 	{
 		return v ^ GSVector4i(i);
+	}
+
+	__forceinline friend GSVector4i operator-(const GSVector4i& v)
+	{
+		return GSVector4i(_mm_sub_epi32(_mm_setzero_si128(), v));
 	}
 
 	__forceinline friend GSVector4i operator~(const GSVector4i& v)

--- a/pcsx2/GS/GSVector4i_arm64.h
+++ b/pcsx2/GS/GSVector4i_arm64.h
@@ -506,6 +506,16 @@ public:
 		return GSVector4i(vreinterpretq_s32_u16(vcombine_u16(vqmovun_s32(v4s), vqmovun_s32(v4s))));
 	}
 
+	__forceinline GSVector4i pkl32(const GSVector4i& a) const
+	{
+		return GSVector4i(vuzp1q_u32(v4s, a.v4s));
+	}
+
+	__forceinline GSVector4i pku32(const GSVector4i& a) const
+	{
+		return GSVector4i(vuzp2q_u32(v4s, a.v4s));
+	}
+
 	__forceinline GSVector4i upl8(const GSVector4i& a) const
 	{
 		return GSVector4i(vreinterpretq_s32_s8(vzip1q_s8(vreinterpretq_s8_s32(v4s), vreinterpretq_s8_s32(a.v4s))));
@@ -807,6 +817,11 @@ public:
 			vreinterpretq_s32_u64(vshlq_u64(vreinterpretq_u64_s32(v4s), vnegq_s64(vreinterpretq_s64_s32(v.v4s)))));
 	}
 
+	__forceinline GSVector4i abs32() const
+	{
+		return GSVector4i(vabsq_s32(v4s));
+	}
+
 	__forceinline GSVector4i add8(const GSVector4i& v) const
 	{
 		return GSVector4i(vreinterpretq_s32_s8(vaddq_s8(vreinterpretq_s8_s32(v4s), vreinterpretq_s8_s32(v.v4s))));
@@ -820,6 +835,11 @@ public:
 	__forceinline GSVector4i add32(const GSVector4i& v) const
 	{
 		return GSVector4i(vaddq_s32(v4s, v.v4s));
+	}
+
+	__forceinline GSVector4i hadd32(const GSVector4i& v) const
+	{
+		return GSVector4i(vpaddq_s32(v4s, v.v4s));
 	}
 
 	__forceinline GSVector4i adds8(const GSVector4i& v) const
@@ -864,6 +884,11 @@ public:
 	__forceinline GSVector4i sub32(const GSVector4i& v) const
 	{
 		return GSVector4i(vsubq_s32(v4s, v.v4s));
+	}
+
+	__forceinline GSVector4i hsub32(const GSVector4i& v) const
+	{
+		return vsubq_u32(vuzp1q_u32(v4s, v.v4s), vuzp2q_u32(v4s, v.v4s));;
 	}
 
 	__forceinline GSVector4i subs8(const GSVector4i& v) const
@@ -1918,6 +1943,11 @@ public:
 	__forceinline friend GSVector4i operator^(const GSVector4i& v, int i)
 	{
 		return v ^ GSVector4i(i);
+	}
+
+	__forceinline friend GSVector4i operator-(const GSVector4i& v)
+	{
+		return GSVector4i(vnegq_s32(v.v4s));
 	}
 
 	__forceinline friend GSVector4i operator~(const GSVector4i& v)


### PR DESCRIPTION
### Description of Changes
Adds some GSVector4i methods.

### Rationale behind Changes
To make GSVector4i slightly more convenient and efficient to use. The abs32() method is used in https://github.com/PCSX2/pcsx2/pull/13943.

### Suggested Testing Steps
Currently the methods not used in the codebase so they should just be checked for correctness.

@TellowKrinkle I named UZP1/2 to pkl32/pkh32 since it seemed complementary to upl32/uph32, though feel free to suggest an alternative.

I'm not 100% sure about the SSE port though I referred to https://docs.unity3d.com/Packages/com.unity.burst@1.7/api/Unity.Burst.Intrinsics.Arm.Neon.vuzp1q_u32.html.

### Did you use AI to help find, test, or implement this issue or feature?
Yes, to find out what instructions to use for some methods, though it told me that my SSE port of UZP1/2 was incorrect.