### PR TITLE
Debugger: Prevent menu items from moving slightly when clicked

### DIFF
--- a/pcsx2-qt/Debugger/Docking/DockMenuBar.cpp
+++ b/pcsx2-qt/Debugger/Docking/DockMenuBar.cpp
@@ -275,9 +275,17 @@ void DockMenuBarStyle::drawControl(
 			// false, QFusionStyle will try to draw a border along the bottom.
 			bool act = opt->state & State_Selected && opt->state & State_Sunken;
 			if (act)
-				break;
+			{
+				// Cancel out an unwanted adjustment that QFusionStyle does.
+				QStyleOptionMenuItem item = *opt;
+				item.rect = opt->rect.adjusted(0, -1, 0, 3);
 
-			QCommonStyle::drawControl(element, option, painter, widget);
+				QProxyStyle::drawControl(element, &item, painter, widget);
+			}
+			else
+			{
+				QCommonStyle::drawControl(element, opt, painter, widget);
+			}
 
 			return;
 		}


### PR DESCRIPTION
### Description of Changes
Cancel out an adjustment made to menu item rectangles by QFusionStyle. This won't affect any other style.

### Rationale behind Changes
This prevents menu items from moving slightly when clicked. I'm not sure how I didn't notice this before.

### Suggested Testing Steps
Click on menus in the debugger while using the fusion style.

### Did you use AI to help find, test, or implement this issue or feature?
No.
