### PR TITLE
Achievements: Fix Active Challenges bucket with subsets

### DIFF
--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -2652,7 +2652,7 @@ void Achievements::DrawAchievementsWindow()
 					if (bucket.bucket_type != bucket_type)
 						continue;
 
-					if (s_open_subset && bucket.subset_id != s_open_subset->id)
+					if (s_open_subset && bucket.subset_id != 0 && bucket.subset_id != s_open_subset->id)
 						continue;
 
 					pxAssert(bucket.bucket_type < NUM_RC_CLIENT_ACHIEVEMENT_BUCKETS);


### PR DESCRIPTION
### Description of Changes
Fixes active challenges bucket for subsets

### Rationale behind Changes
Fixes #13996

### Suggested Testing Steps
Test with a game that has subsets and active challenges and see if that bucket is there

### Did you use AI to help find, test, or implement this issue or feature?
No