### PR TITLE
GS/HW: Add maximum number clamping to prevent integer conversion overflow.

### DIFF
--- a/bin/resources/shaders/dx11/convert.fx
+++ b/bin/resources/shaders/dx11/convert.fx
@@ -166,7 +166,7 @@ PS_OUTPUT ps_colclip_resolve(PS_INPUT input)
 uint ps_convert_float32_32bits(PS_INPUT input) : SV_Target0
 {
 	// Convert a FLOAT32 depth texture into a 32 bits UINT texture
-	return uint(exp2(32.0f) * sample_c(input.t).r);
+	return uint(min(exp2(32.0f) * sample_c(input.t).r, 4294967280.0f));
 }
 
 PS_OUTPUT ps_convert_float32_rgba8(PS_INPUT input)
@@ -174,7 +174,7 @@ PS_OUTPUT ps_convert_float32_rgba8(PS_INPUT input)
 	PS_OUTPUT output;
 
 	// Convert a FLOAT32 depth texture into a RGBA color texture
-	uint d = uint(sample_c(input.t).r * exp2(32.0f));
+	uint d = uint(min(sample_c(input.t).r * exp2(32.0f), 4294967280.0f));
 	output.c = float4(uint4((d & 0xFFu), ((d >> 8) & 0xFFu), ((d >> 16) & 0xFFu), (d >> 24))) / 255.0f;
 
 	return output;
@@ -185,7 +185,7 @@ PS_OUTPUT ps_convert_float16_rgb5a1(PS_INPUT input)
 	PS_OUTPUT output;
 
 	// Convert a FLOAT32 (only 16 lsb) depth into a RGB5A1 color texture
-	uint d = uint(sample_c(input.t).r * exp2(32.0f));
+	uint d = uint(min(sample_c(input.t).r * exp2(32.0f), 4294967280.0f));
 	output.c = float4(uint4(d << 3, d >> 2, d >> 7, d >> 8) & uint4(0xf8, 0xf8, 0xf8, 0x80)) / 255.0f;
 	return output;
 }
@@ -217,7 +217,7 @@ float rgb5a1_to_depth16(float4 val)
 float ps_convert_float32_float24(PS_INPUT input) : SV_Depth
 {
 	// Truncates depth value to 24bits
-	uint d = uint(sample_c(input.t).r * exp2(32.0f)) & 0xFFFFFFu;
+	uint d = uint(min(sample_c(input.t).r * exp2(32.0f), 4294967280.0f)) & 0xFFFFFFu;
 	return float(d) * exp2(-32.0f);
 }
 

--- a/bin/resources/shaders/opengl/convert.glsl
+++ b/bin/resources/shaders/opengl/convert.glsl
@@ -99,7 +99,7 @@ void ps_convert_rgba8_16bits()
 void ps_convert_float32_32bits()
 {
 	// Convert a GL_FLOAT32 depth texture into a 32 bits UINT texture
-	SV_Target1 = uint(exp2(32.0f) * sample_c().r);
+	SV_Target1 = uint(min(exp2(32.0f) * sample_c().r, 4294967280.0f));
 }
 #endif
 
@@ -107,7 +107,7 @@ void ps_convert_float32_32bits()
 void ps_convert_float32_rgba8()
 {
 	// Convert a GL_FLOAT32 depth texture into a RGBA color texture
-	uint d = uint(sample_c().r * exp2(32.0f));
+	uint d = uint(min(sample_c().r * exp2(32.0f), 4294967280.0f));
 	SV_Target0 = vec4(uvec4((d & 0xFFu), ((d >> 8) & 0xFFu), ((d >> 16) & 0xFFu), (d >> 24))) / vec4(255.0);
 }
 #endif
@@ -116,7 +116,7 @@ void ps_convert_float32_rgba8()
 void ps_convert_float16_rgb5a1()
 {
 	// Convert a GL_FLOAT32 (only 16 lsb) depth into a RGB5A1 color texture
-	uint d = uint(sample_c().r * exp2(32.0f));
+	uint d = uint(min(sample_c().r * exp2(32.0f), 4294967280.0f));
 	SV_Target0 = vec4(uvec4(d << 3, d >> 2, d >> 7, d >> 8) & uvec4(0xf8, 0xf8, 0xf8, 0x80)) / 255.0f;
 }
 #endif
@@ -149,7 +149,7 @@ float rgb5a1_to_depth16(vec4 unorm)
 void ps_convert_float32_float24()
 {
 	// Truncates depth value to 24bits
-	uint d = uint(sample_c().r * exp2(32.0f)) & 0xFFFFFFu;
+	uint d = uint(min(sample_c().r * exp2(32.0f), 4294967280.0f)) & 0xFFFFFFu;
 	gl_FragDepth = float(d) * exp2(-32.0f);
 }
 #endif

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -421,13 +421,13 @@ vec4 sample_depth(vec2 st)
 #elif PS_DEPTH_FMT == 1
 	// Based on ps_convert_float32_rgba8 of convert
 	// Convert a GL_FLOAT32 depth texture into a RGBA color texture
-	uint d = uint(fetch_c(uv).r * exp2(32.0f));
+	uint d = uint(min(fetch_c(uv).r * exp2(32.0f), 4294967280.0f));
 	t = vec4(uvec4((d & 0xFFu), ((d >> 8) & 0xFFu), ((d >> 16) & 0xFFu), (d >> 24)));
 
 #elif PS_DEPTH_FMT == 2
 	// Based on ps_convert_float16_rgb5a1 of convert
 	// Convert a GL_FLOAT32 (only 16 lsb) depth into a RGB5A1 color texture
-	uint d = uint(fetch_c(uv).r * exp2(32.0f));
+	uint d = uint(min(fetch_c(uv).r * exp2(32.0f), 4294967280.0f));
 	t = vec4(uvec4((d & 0x1Fu), ((d >> 5) & 0x1Fu), ((d >> 10) & 0x1Fu), (d >> 15) & 0x01u)) * vec4(8.0f, 8.0f, 8.0f, 128.0f);
 
 #elif PS_DEPTH_FMT == 3

--- a/bin/resources/shaders/vulkan/convert.glsl
+++ b/bin/resources/shaders/vulkan/convert.glsl
@@ -170,7 +170,7 @@ void ps_colclip_resolve()
 void ps_convert_float32_32bits()
 {
 	// Convert a vec32 depth texture into a 32 bits UINT texture
-	o_col0 = uint(exp2(32.0f) * sample_c(v_tex).r);
+	o_col0 = uint(min(exp2(32.0f) * sample_c(v_tex).r, 4294967280.0f));
 }
 #endif
 
@@ -178,7 +178,7 @@ void ps_convert_float32_32bits()
 void ps_convert_float32_rgba8()
 {
 	// Convert a vec32 depth texture into a RGBA color texture
-	uint d = uint(sample_c(v_tex).r * exp2(32.0f));
+	uint d = uint(min(sample_c(v_tex).r * exp2(32.0f), 4294967280.0f));
 	o_col0 = vec4(uvec4((d & 0xFFu), ((d >> 8) & 0xFFu), ((d >> 16) & 0xFFu), (d >> 24))) / vec4(255.0);
 }
 #endif
@@ -187,7 +187,7 @@ void ps_convert_float32_rgba8()
 void ps_convert_float16_rgb5a1()
 {
 	// Convert a vec32 (only 16 lsb) depth into a RGB5A1 color texture
-	uint d = uint(sample_c(v_tex).r * exp2(32.0f));
+	uint d = uint(min(sample_c(v_tex).r * exp2(32.0f), 4294967280.0f));
 	o_col0 = vec4(uvec4(d << 3, d >> 2, d >> 7, d >> 8) & uvec4(0xf8, 0xf8, 0xf8, 0x80)) / 255.0f;
 }
 #endif
@@ -220,7 +220,7 @@ float rgb5a1_to_depth16(vec4 unorm)
 void ps_convert_float32_float24()
 {
 	// Truncates depth value to 24bits
-	uint d = uint(sample_c(v_tex).r * exp2(32.0f)) & 0xFFFFFFu;
+	uint d = uint(min(sample_c(v_tex).r * exp2(32.0f), 4294967280.0f)) & 0xFFFFFFu;
 	gl_FragDepth = float(d) * exp2(-32.0f);
 }
 #endif

--- a/pcsx2/GS/Renderers/Metal/GSMTLShaderCommon.h
+++ b/pcsx2/GS/Renderers/Metal/GSMTLShaderCommon.h
@@ -39,13 +39,13 @@ struct ConvertPSDepthRes
 
 static inline float4 convert_depth32_rgba8(float value)
 {
-	uint val = uint(value * 0x1p32);
+	uint val = uint(min(value * 0x1p32, 4294967280.0f));
 	return float4(as_type<uchar4>(val));
 }
 
 static inline float4 convert_depth16_rgba8(float value)
 {
-	uint val = uint(value * 0x1p32);
+	uint val = uint(min(value * 0x1p32, 4294967280.0f));
 	return float4(uint4(val << 3, val >> 2, val >> 7, val >> 8) & uint4(0xf8, 0xf8, 0xf8, 0x80));
 }
 

--- a/pcsx2/GS/Renderers/Metal/convert.metal
+++ b/pcsx2/GS/Renderers/Metal/convert.metal
@@ -158,7 +158,7 @@ fragment float4 ps_filter_transparency(ConvertShaderData data [[stage_in]], Conv
 
 fragment uint ps_convert_float32_32bits(ConvertShaderData data [[stage_in]], ConvertPSDepthRes res)
 {
-	return uint(0x1p32 * res.sample(data.t));
+	return uint(min(0x1p32 * res.sample(data.t), 4294967280.0f));
 }
 
 fragment float4 ps_convert_float32_rgba8(ConvertShaderData data [[stage_in]], ConvertPSDepthRes res)
@@ -252,7 +252,7 @@ struct ConvertToDepthRes
 fragment DepthOut ps_convert_float32_float24(ConvertShaderData data [[stage_in]], ConvertPSDepthRes res)
 {
 	// Truncates depth value to 24bits
-	uint val = uint(res.sample(data.t) * 0x1p32) & 0xFFFFFF;
+	uint val = uint(min(res.sample(data.t) * 0x1p32, 4294967280.0f)) & 0xFFFFFF;
 	return float(val) * 0x1p-32f;
 }
 

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -509,7 +509,7 @@ struct PSMain
 
 	uint fetch_raw_depth()
 	{
-		return tex_depth.read(ushort2(in.p.xy + cb.channel_shuffle_offset)) * 0x1p32f;
+		return uint(min(tex_depth.read(ushort2(in.p.xy + cb.channel_shuffle_offset)) * 0x1p32f, 4294967280.0f));
 	}
 
 	float4 fetch_raw_color()


### PR DESCRIPTION
The floating-point value 4294967296.0f causes a numeric overflow when converted to a 32-bit unsigned integer, as it exceeds the maximum value of uint (4294967295).

Use 4294967280.0f for clamping to prevent unpredictable behavior across different compilers on different platforms.

Additionally, fix  two int() conversion to uint() .

### Description of Changes
Add maximum number clamping to all integer conversion functions

### Rationale behind Changes
Prevent overflow

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

### Did you use AI to help find, test, or implement this issue or feature?
No, it's just a simple clamping;  no need to use AI.
