### PR TITLE
CMake: Remove dead link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,14 +84,10 @@ endif()
 if(_M_ARM64)
 	message(WARNING "
 *************** UNSUPPORTED CONFIGURATION ***************
-
 Apple Silicon support in PCSX2 is INCOMPLETE. There are
 currently no EE/VU/IOP recompilers, and games will run
 VERY slow. There is no date for completion yet, you
 should set -DCMAKE_OSX_ARCHITECTURES=x86_64 for now,
 unless you want to work on the recompilers.
-
-We also ask that you read https://dont-ship.it/.
-
 *********************************************************")
 endif()


### PR DESCRIPTION
### Description of Changes
Remove the link to https://dont-ship.it/.

### Rationale behind Changes
The site is dead.

### Suggested Testing Steps
N/A

### Did you use AI to help find, test, or implement this issue or feature?
No.
