### PR TITLE
GS: Remove OpenGL/CL compat check

### DIFF
--- a/pcsx2/GS/Renderers/DX11/D3D.cpp
+++ b/pcsx2/GS/Renderers/DX11/D3D.cpp
@@ -17,7 +17,6 @@
 
 #include "IconsFontAwesome.h"
 
-#include <appmodel.h>
 #include <array>
 #include <d3d11.h>
 #include <d3d12.h>
@@ -382,29 +381,7 @@ GSRendererType D3D::GetPreferredRenderer()
 		return device;
 	};
 #ifdef ENABLE_VULKAN
-	static constexpr auto check_for_mapping_layers = []() {
-		PCWSTR familyName = L"Microsoft.D3DMappingLayers_8wekyb3d8bbwe";
-		UINT32 numPackages = 0, bufferLength = 0;
-		const DWORD error = GetPackagesByPackageFamily(familyName, &numPackages, nullptr, &bufferLength, nullptr);
-		if (error == ERROR_INSUFFICIENT_BUFFER || numPackages > 0)
-		{
-			Host::AddIconOSDMessage("VKDriverUnsupported", ICON_FA_TV,
-				TRANSLATE_STR("GS",
-					"Your system has the \"OpenCL, OpenGL, and Vulkan Compatibility Pack\" installed.\n"
-					"This Vulkan driver crashes PCSX2 on some GPUs.\n"
-					"To use the Vulkan renderer, you should remove this app package."),
-				Host::OSD_WARNING_DURATION);
-			return true;
-		}
-
-		return false;
-	};
 	static constexpr auto check_vulkan_supported = []() {
-		// Don't try to enumerate Vulkan devices if the DX12 Vulkan driver is present.
-		// It crashes on AMD GPUs.
-		if (check_for_mapping_layers())
-			return false;
-
 		if (!GSDeviceVK::EnumerateGPUs().empty())
 			return true;
 


### PR DESCRIPTION
### Description of Changes
Removes check for OpenGL/CL compat pack that blocked Vulkan selection.

### Rationale behind Changes
The crash has been fixed for a fair bit now and all this does is block systems that otherwise would be using Vulkan.

### Suggested Testing Steps
Make sure auto still works and nothing else breaks.

### Did you use AI to help find, test, or implement this issue or feature?
No
