### PR TITLE
GS: Fix missing GSVector4i constructor in GSVector4i::hsub32

### DIFF
--- a/pcsx2/GS/GSVector4i_arm64.h
+++ b/pcsx2/GS/GSVector4i_arm64.h
@@ -888,7 +888,7 @@ public:
 
 	__forceinline GSVector4i hsub32(const GSVector4i& v) const
 	{
-		return vsubq_u32(vuzp1q_u32(v4s, v.v4s), vuzp2q_u32(v4s, v.v4s));;
+		return GSVector4i(vsubq_u32(vuzp1q_u32(v4s, v.v4s), vuzp2q_u32(v4s, v.v4s)));
 	}
 
 	__forceinline GSVector4i subs8(const GSVector4i& v) const


### PR DESCRIPTION
### Description of Changes
Adds a missing constructor since there is no implicit uint32x4_t -> GSVector4i 

### Rationale behind Changes
It broke building ARM

### Suggested Testing Steps
Trust me and the fact that it works on my machine

### Did you use AI to help find, test, or implement this issue or feature?
no