### PR TITLE
Qt: Fix clazy warnings

### DIFF
--- a/pcsx2-qt/AutoUpdaterDialog.cpp
+++ b/pcsx2-qt/AutoUpdaterDialog.cpp
@@ -419,7 +419,7 @@ void AutoUpdaterDialog::getChangesComplete(s32 status_code, std::vector<u8> data
 				if (!message.isEmpty())
 				{
 					changes_html +=
-						QStringLiteral("<li>%1 <i>(%2)</i></li>").arg(message.toHtmlEscaped()).arg(author.toHtmlEscaped());
+						QStringLiteral("<li>%1 <i>(%2)</i></li>").arg(message.toHtmlEscaped(), author.toHtmlEscaped());
 				}
 			}
 
@@ -564,8 +564,8 @@ void AutoUpdaterDialog::checkIfUpdateNeeded()
 		return;
 	}
 
-	m_ui.currentVersion->setText(tr("Current Version: %1 (%2)").arg(getCurrentVersion()).arg(getCurrentVersionDate()));
-	m_ui.newVersion->setText(tr("New Version: %1 (%2)").arg(m_latest_version).arg(m_latest_version_timestamp.toString()));
+	m_ui.currentVersion->setText(tr("Current Version: %1 (%2)").arg(getCurrentVersion(), getCurrentVersionDate()));
+	m_ui.newVersion->setText(tr("New Version: %1 (%2)").arg(m_latest_version, m_latest_version_timestamp.toString()));
 	m_ui.downloadSize->setText(tr("Download Size: %1 MB").arg(static_cast<double>(m_download_size) / 1048576.0, 0, 'f', 2));
 	m_ui.updateNotes->setText(tr("Loading..."));
 	queueGetChanges();

--- a/pcsx2-qt/Debugger/Breakpoints/BreakpointModel.cpp
+++ b/pcsx2-qt/Debugger/Breakpoints/BreakpointModel.cpp
@@ -638,7 +638,6 @@ void BreakpointModel::loadBreakpointFromFieldList(QStringList fields)
 		mc.memCond = static_cast<MemCheckCondition>(type);
 
 		// Address
-		QString test = fields[BreakpointColumns::OFFSET];
 		mc.start = fields[BreakpointColumns::OFFSET].toUInt(&ok, 16);
 		if (!ok)
 		{

--- a/pcsx2-qt/Debugger/Breakpoints/BreakpointView.cpp
+++ b/pcsx2-qt/Debugger/Breakpoints/BreakpointView.cpp
@@ -155,7 +155,7 @@ void BreakpointView::contextPasteCSV()
 		// In order to handle text with commas in them we must wrap values in quotes to mark
 		// where a value starts and end so that text commas aren't identified as delimiters.
 		// So matches each quote pair, parse it out, and removes the quotes to get the value.
-		QRegularExpression eachQuotePair(R"("([^"]|\\.)*")");
+		static QRegularExpression eachQuotePair(R"("([^"]|\\.)*")");
 		QRegularExpressionMatchIterator it = eachQuotePair.globalMatch(line);
 		while (it.hasNext())
 		{

--- a/pcsx2-qt/Debugger/DebuggerSettingsManager.cpp
+++ b/pcsx2-qt/Debugger/DebuggerSettingsManager.cpp
@@ -55,7 +55,6 @@ void DebuggerSettingsManager::loadGameSettings(BreakpointModel* bpModel)
 		return;
 
 	const QJsonValue breakpointsValue = loadGameSettingsJSON().value("Breakpoints");
-	const QString valueToLoad = breakpointsValue.toString();
 	if (breakpointsValue.isUndefined() || !breakpointsValue.isArray())
 	{
 		Console.WriteLnFmt("Debugger Settings Manager: Failed to read Breakpoints array from settings file: '{}'", path);
@@ -108,7 +107,6 @@ void DebuggerSettingsManager::loadGameSettings(SavedAddressesModel* savedAddress
 		return;
 
 	const QJsonValue savedAddressesValue = loadGameSettingsJSON().value("SavedAddresses");
-	QString valueToLoad = savedAddressesValue.toString();
 	if (savedAddressesValue.isUndefined() || !savedAddressesValue.isArray())
 	{
 		Console.WriteLnFmt("Debugger Settings Manager: Failed to read Saved Addresses array from settings file: '{}'", path);

--- a/pcsx2-qt/Debugger/Memory/MemorySearchView.cpp
+++ b/pcsx2-qt/Debugger/Memory/MemorySearchView.cpp
@@ -13,7 +13,7 @@
 #include <QtGui/QClipboard>
 #include <QtWidgets/QMenu>
 #include <QtWidgets/QScrollBar>
-#include <QtConcurrent/QtConcurrent>
+#include <QtConcurrent/QtConcurrentRun>
 #include <QtCore/QFutureWatcher>
 #include <QtGui/QPainter>
 

--- a/pcsx2-qt/Debugger/Memory/MemoryView.cpp
+++ b/pcsx2-qt/Debugger/Memory/MemoryView.cpp
@@ -939,7 +939,7 @@ void MemoryView::wheelEvent(QWheelEvent* event)
 
 void MemoryView::keyPressEvent(QKeyEvent* event)
 {
-	if (!m_table.KeyPress(event->key(), event->text().size() ? event->text()[0] : '\0', cpu()))
+	if (!m_table.KeyPress(event->key(), event->text().size() ? event->text().at(0) : '\0', cpu()))
 	{
 		switch (event->key())
 		{

--- a/pcsx2-qt/Debugger/Memory/SavedAddressesView.cpp
+++ b/pcsx2-qt/Debugger/Memory/SavedAddressesView.cpp
@@ -128,7 +128,7 @@ void SavedAddressesView::contextPasteCSV()
 		// In order to handle text with commas in them we must wrap values in quotes to mark
 		// where a value starts and end so that text commas aren't identified as delimiters.
 		// So matches each quote pair, parse it out, and removes the quotes to get the value.
-		QRegularExpression each_quote_pair(R"("([^"]|\\.)*")");
+		static QRegularExpression each_quote_pair(R"("([^"]|\\.)*")");
 		QRegularExpressionMatchIterator it = each_quote_pair.globalMatch(line);
 		while (it.hasNext())
 		{

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeNode.cpp
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeNode.cpp
@@ -452,7 +452,7 @@ QString SymbolTreeNode::generateDisplayString(
 					field_value = QString("(%1)").arg(ccc::ast::node_type_to_string(field_type));
 
 				QString field_name = QString::fromStdString(field.node->name);
-				result += QString(".%1=%2").arg(field_name).arg(field_value);
+				result += QString(".%1=%2").arg(field_name, field_value);
 
 				if (i + 1 != fields.size() || !all_fields)
 					result += ",";

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeViews.cpp
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeViews.cpp
@@ -919,9 +919,7 @@ std::vector<SymbolTreeView::SymbolWork> GlobalVariableTreeView::getSymbols(
 		else
 			function_name = tr("unknown function");
 
-		QString name = QString("%1 (%2)")
-		                   .arg(QString::fromStdString(local_variable.name()))
-		                   .arg(function_name);
+		QString name = QString("%1 (%2)").arg(QString::fromStdString(local_variable.name()), function_name);
 		if (!testName(name, filter))
 			continue;
 

--- a/pcsx2-qt/GameList/GameListModel.cpp
+++ b/pcsx2-qt/GameList/GameListModel.cpp
@@ -12,7 +12,7 @@
 #include <QtCore/QDateTime>
 #include <QtCore/QFuture>
 #include <QtCore/QFutureWatcher>
-#include <QtConcurrent/QtConcurrent>
+#include <QtConcurrent/QtConcurrentRun>
 #include <QtGui/QGuiApplication>
 #include <QtGui/QIcon>
 #include <QtGui/QPainter>

--- a/pcsx2-qt/LogWindow.cpp
+++ b/pcsx2-qt/LogWindow.cpp
@@ -122,7 +122,7 @@ void LogWindow::updateWindowTitle()
 	if (QtHost::IsVMValid() && !serial.isEmpty())
 	{
 		const QFileInfo fi(QtHost::GetCurrentGamePath());
-		title = tr("Log Window - %1 [%2]").arg(serial).arg(fi.fileName());
+		title = tr("Log Window - %1 [%2]").arg(serial, fi.fileName());
 	}
 	else
 	{
@@ -288,7 +288,7 @@ void LogWindow::logCallback(LOGLEVEL level, ConsoleColors color, std::string_vie
 	{
 		QMetaObject::invokeMethod(g_log_window, "appendMessage", Qt::QueuedConnection,
 			Q_ARG(quint32, static_cast<u32>(level)), Q_ARG(quint32, static_cast<u32>(color)),
-			Q_ARG(const QString&, qmessage));
+			Q_ARG(QString, qmessage));
 	}
 }
 

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -48,6 +48,7 @@
 
 #include <QtCore/QDateTime>
 #include <QtCore/QDir>
+#include <QtCore/QUrl>
 #include <QtGui/QCloseEvent>
 #include <QtWidgets/QFileDialog>
 #include <QtWidgets/QInputDialog>
@@ -740,9 +741,9 @@ void MainWindow::onVideoCaptureToggled(bool checked)
 			{
 				const QString container(QString::fromStdString(
 					Host::GetStringSettingValue("EmuCore/GS", "CaptureContainer", Pcsx2Config::GSOptions::DEFAULT_CAPTURE_CONTAINER)));
-				const QString filter(tr("%1 Files (*.%2)").arg(container.toUpper()).arg(container));
+				const QString filter(tr("%1 Files (*.%2)").arg(container.toUpper(), container));
 
-				const QString base_video_filename(QStringLiteral("%1.%2").arg(QString::fromStdString(GSGetBaseVideoFilename())).arg(container));
+				const QString base_video_filename(QStringLiteral("%1.%2").arg(QString::fromStdString(GSGetBaseVideoFilename()), container));
 				s_path_to_recording_for_record_on_start = QDir::toNativeSeparators(QFileDialog::getSaveFileName(this, tr("Video Capture"), base_video_filename, filter));
 				s_record_on_start = !s_path_to_recording_for_record_on_start.isEmpty();
 			}
@@ -780,9 +781,9 @@ void MainWindow::onVideoCaptureToggled(bool checked)
 	{
 		const QString container(QString::fromStdString(
 			Host::GetStringSettingValue("EmuCore/GS", "CaptureContainer", Pcsx2Config::GSOptions::DEFAULT_CAPTURE_CONTAINER)));
-		const QString filter(tr("%1 Files (*.%2)").arg(container.toUpper()).arg(container));
+		const QString filter(tr("%1 Files (*.%2)").arg(container.toUpper(), container));
 
-		QString path(QStringLiteral("%1.%2").arg(QString::fromStdString(GSGetBaseVideoFilename())).arg(container));
+		QString path(QStringLiteral("%1.%2").arg(QString::fromStdString(GSGetBaseVideoFilename()), container));
 		path = QDir::toNativeSeparators(QFileDialog::getSaveFileName(this, tr("Video Capture"), path, filter));
 		if (path.isEmpty())
 			return;
@@ -3027,7 +3028,7 @@ void MainWindow::setGameListEntryCoverImage(const GameList::Entry& entry)
 
 	if (!QFile::copy(filename, new_filename))
 	{
-		QMessageBox::critical(this, tr("Copy Error"), tr("Failed to copy '%1' to '%2'").arg(filename).arg(new_filename));
+		QMessageBox::critical(this, tr("Copy Error"), tr("Failed to copy '%1' to '%2'").arg(filename, new_filename));
 		return;
 	}
 

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -294,7 +294,7 @@ void EmuThread::loadState(const QString& filename)
 {
 	if (!isOnEmuThread())
 	{
-		QMetaObject::invokeMethod(this, "loadState", Qt::QueuedConnection, Q_ARG(const QString&, filename));
+		QMetaObject::invokeMethod(this, "loadState", Qt::QueuedConnection, Q_ARG(QString, filename));
 		return;
 	}
 
@@ -334,7 +334,7 @@ void EmuThread::saveState(const QString& filename)
 {
 	if (!isOnEmuThread())
 	{
-		QMetaObject::invokeMethod(this, "saveState", Qt::QueuedConnection, Q_ARG(const QString&, filename));
+		QMetaObject::invokeMethod(this, "saveState", Qt::QueuedConnection, Q_ARG(QString, filename));
 		return;
 	}
 
@@ -628,7 +628,7 @@ void EmuThread::changeDisc(CDVD_SourceType source, const QString& path)
 {
 	if (!isOnEmuThread())
 	{
-		QMetaObject::invokeMethod(this, "changeDisc", Qt::QueuedConnection, Q_ARG(CDVD_SourceType, source), Q_ARG(const QString&, path));
+		QMetaObject::invokeMethod(this, "changeDisc", Qt::QueuedConnection, Q_ARG(CDVD_SourceType, source), Q_ARG(QString, path));
 		return;
 	}
 
@@ -642,7 +642,7 @@ void EmuThread::setELFOverride(const QString& path)
 {
 	if (!isOnEmuThread())
 	{
-		QMetaObject::invokeMethod(this, "setELFOverride", Qt::QueuedConnection, Q_ARG(const QString&, path));
+		QMetaObject::invokeMethod(this, "setELFOverride", Qt::QueuedConnection, Q_ARG(QString, path));
 		return;
 	}
 
@@ -656,7 +656,7 @@ void EmuThread::changeGSDump(const QString& path)
 {
 	if (!isOnEmuThread())
 	{
-		QMetaObject::invokeMethod(this, "changeGSDump", Qt::QueuedConnection, Q_ARG(const QString&, path));
+		QMetaObject::invokeMethod(this, "changeGSDump", Qt::QueuedConnection, Q_ARG(QString, path));
 		return;
 	}
 
@@ -854,7 +854,7 @@ void EmuThread::beginCapture(const QString& path)
 {
 	if (!isOnEmuThread())
 	{
-		QMetaObject::invokeMethod(this, "beginCapture", Qt::QueuedConnection, Q_ARG(const QString&, path));
+		QMetaObject::invokeMethod(this, "beginCapture", Qt::QueuedConnection, Q_ARG(QString, path));
 		return;
 	}
 
@@ -996,7 +996,7 @@ void EmuThread::updatePerformanceMetrics(bool force)
 			}
 		}
 
-		QMetaObject::invokeMethod(g_main_window->getStatusVerboseWidget(), "setText", Qt::QueuedConnection, Q_ARG(const QString&, gs_stat));
+		QMetaObject::invokeMethod(g_main_window->getStatusVerboseWidget(), "setText", Qt::QueuedConnection, Q_ARG(QString, gs_stat));
 	}
 
 	const GSRendererType renderer = GSGetCurrentRenderer(); // Reading from GS thread, therefore racey, but it's just visual.
@@ -1012,7 +1012,7 @@ void EmuThread::updatePerformanceMetrics(bool force)
 		if (renderer != m_last_renderer || force)
 		{
 			QMetaObject::invokeMethod(g_main_window->getStatusRendererWidget(), "setText", Qt::QueuedConnection,
-				Q_ARG(const QString&, QString::fromUtf8(Pcsx2Config::GSOptions::GetRendererName(renderer))));
+				Q_ARG(QString, QString::fromUtf8(Pcsx2Config::GSOptions::GetRendererName(renderer))));
 			m_last_renderer = renderer;
 		}
 
@@ -1025,7 +1025,7 @@ void EmuThread::updatePerformanceMetrics(bool force)
 				text = tr("%1x%2").arg(iwidth).arg(iheight);
 
 			QMetaObject::invokeMethod(
-				g_main_window->getStatusResolutionWidget(), "setText", Qt::QueuedConnection, Q_ARG(const QString&, text));
+				g_main_window->getStatusResolutionWidget(), "setText", Qt::QueuedConnection, Q_ARG(QString, text));
 
 			m_last_internal_width = iwidth;
 			m_last_internal_height = iheight;
@@ -1040,20 +1040,20 @@ void EmuThread::updatePerformanceMetrics(bool force)
 				text = tr("FPS: %1").arg(gfps, 0, 'f', 0);
 
 			QMetaObject::invokeMethod(g_main_window->getStatusFPSWidget(), "setText", Qt::QueuedConnection,
-				Q_ARG(const QString&, text));
+				Q_ARG(QString, text));
 			m_last_game_fps = gfps;
 		}
 
 		if (vfps != m_last_video_fps || force)
 		{
 			QMetaObject::invokeMethod(g_main_window->getStatusVPSWidget(), "setText", Qt::QueuedConnection,
-				Q_ARG(const QString&, tr("VPS: %1 ").arg(vfps, 0, 'f', 0)));
+				Q_ARG(QString, tr("VPS: %1 ").arg(vfps, 0, 'f', 0)));
 			m_last_video_fps = vfps;
 
 			if (speed != m_last_speed || force)
 			{
 				QMetaObject::invokeMethod(g_main_window->getStatusSpeedWidget(), "setText", Qt::QueuedConnection,
-					Q_ARG(const QString&, tr("Speed: %1% ").arg(speed, 0, 'f', 0)));
+					Q_ARG(QString, tr("Speed: %1% ").arg(speed, 0, 'f', 0)));
 				m_last_speed = speed;
 			}
 		}
@@ -1166,8 +1166,8 @@ void Host::OpenHostFileSelectorAsync(std::string_view title, bool select_directo
 			filters_str.append(
 				QStringLiteral(";;%1 Files (%2)")
 					.arg(
-						QtUtils::StringViewToQString(std::string_view(filter).substr(filter.starts_with("*.") ? 2 : 0)).toUpper())
-					.arg(QString::fromStdString(filter)));
+						QtUtils::StringViewToQString(std::string_view(filter).substr(filter.starts_with("*.") ? 2 : 0)).toUpper(),
+						QString::fromStdString(filter)));
 		}
 	}
 
@@ -1209,7 +1209,7 @@ void Host::RunOnCPUThread(std::function<void()> function, bool block /* = false 
 	}
 
 	QMetaObject::invokeMethod(g_emu_thread, "runOnCPUThread", block ? Qt::BlockingQueuedConnection : Qt::QueuedConnection,
-		Q_ARG(const std::function<void()>&, std::move(function)));
+		Q_ARG(std::function<void()>, std::move(function)));
 }
 
 void Host::RefreshGameListAsync(bool invalidate_cache)
@@ -1300,8 +1300,8 @@ bool QtHost::InitializeConfig()
 						   "The error was: %2\n"
 						   "Please ensure this directory is writable. You can also try portable mode "
 						   "by creating portable.txt in the same directory you installed PCSX2 into.")
-				.arg(QString::fromStdString(EmuFolders::DataRoot))
-				.arg(QString::fromStdString(error.GetDescription())));
+				.arg(QString::fromStdString(EmuFolders::DataRoot),
+					QString::fromStdString(error.GetDescription())));
 		return false;
 	}
 
@@ -1339,8 +1339,8 @@ bool QtHost::InitializeConfig()
 				QStringLiteral(
 					"Failed to save configuration to\n\n%1\n\nThe error was: %2\n\nPlease ensure this directory is writable. You "
 					"can also try portable mode by creating portable.txt in the same directory you installed PCSX2 into.")
-					.arg(QString::fromStdString(s_base_settings_interface->GetFileName()))
-					.arg(QString::fromStdString(error.GetDescription())));
+					.arg(QString::fromStdString(s_base_settings_interface->GetFileName()),
+						QString::fromStdString(error.GetDescription())));
 			return false;
 		}
 
@@ -1365,8 +1365,8 @@ bool QtHost::InitializeConfig()
 				QStringLiteral(
 					"Failed to save secrets to\n\n%1\n\nThe error was: %2\n\nPlease ensure this directory is writable. You "
 					"can also try portable mode by creating portable.txt in the same directory you installed PCSX2 into.")
-					.arg(QString::fromStdString(s_secrets_settings_interface->GetFileName()))
-					.arg(QString::fromStdString(error.GetDescription())));
+					.arg(QString::fromStdString(s_secrets_settings_interface->GetFileName()),
+						QString::fromStdString(error.GetDescription())));
 			return false;
 		}
 	}
@@ -1470,7 +1470,7 @@ void QtHost::RunOnUIThread(const std::function<void()>& func, bool block /*= fal
 {
 	// main window always exists, so it's fine to attach it to that.
 	QMetaObject::invokeMethod(g_main_window, "runOnUIThread", block ? Qt::BlockingQueuedConnection : Qt::QueuedConnection,
-		Q_ARG(const std::function<void()>&, func));
+		Q_ARG(std::function<void()>, func));
 }
 
 bool Host::RequestResetSettings(bool folders, bool core, bool controllers, bool hotkeys, bool ui)
@@ -1640,8 +1640,8 @@ void Host::ReportInfoAsync(const std::string_view title, const std::string_view 
 		INFO_LOG("ReportInfoAsync: {}", message);
 
 	QMetaObject::invokeMethod(g_main_window, "reportInfo", Qt::QueuedConnection,
-		Q_ARG(const QString&, title.empty() ? QString() : QString::fromUtf8(title.data(), title.size())),
-		Q_ARG(const QString&, message.empty() ? QString() : QString::fromUtf8(message.data(), message.size())));
+		Q_ARG(QString, title.empty() ? QString() : QString::fromUtf8(title.data(), title.size())),
+		Q_ARG(QString, message.empty() ? QString() : QString::fromUtf8(message.data(), message.size())));
 }
 
 void Host::ReportErrorAsync(const std::string_view title, const std::string_view message)
@@ -1652,8 +1652,8 @@ void Host::ReportErrorAsync(const std::string_view title, const std::string_view
 		ERROR_LOG("ReportErrorAsync: {}", message);
 
 	QMetaObject::invokeMethod(g_main_window, "reportError", Qt::QueuedConnection,
-		Q_ARG(const QString&, title.empty() ? QString() : QString::fromUtf8(title.data(), title.size())),
-		Q_ARG(const QString&, message.empty() ? QString() : QString::fromUtf8(message.data(), message.size())));
+		Q_ARG(QString, title.empty() ? QString() : QString::fromUtf8(title.data(), title.size())),
+		Q_ARG(QString, message.empty() ? QString() : QString::fromUtf8(message.data(), message.size())));
 }
 
 void Host::OpenURL(const std::string_view url)
@@ -2287,8 +2287,8 @@ bool QtHost::ParseCommandLineOptions(const QStringList& args, std::shared_ptr<VM
 		Console.Warning("Skipping autoboot due to no boot parameters.");
 		autoboot.reset();
 	}
-	
-	if(autoboot && autoboot->start_turbo.value_or(false) && autoboot->start_unlimited.value_or(false))
+
+	if (autoboot && autoboot->start_turbo.value_or(false) && autoboot->start_unlimited.value_or(false))
 	{
 		Console.Warning("Both turbo and unlimited frame limit modes requested. Using unlimited.");
 		autoboot->start_turbo.reset();

--- a/pcsx2-qt/QtUtils.cpp
+++ b/pcsx2-qt/QtUtils.cpp
@@ -547,7 +547,7 @@ namespace QtUtils
 			country_code = QStringLiteral("RS");
 		}
 
-		const QString flag_path = QStringLiteral("%1/icons/flags/%2.svg").arg(QtHost::GetResourcesBasePath()).arg(country_code.toLower());
+		const QString flag_path = QStringLiteral("%1/icons/flags/%2.svg").arg(QtHost::GetResourcesBasePath(), country_code.toLower());
 		return QIcon(flag_path);
 	}
 } // namespace QtUtils

--- a/pcsx2-qt/SettingWidgetBinder.h
+++ b/pcsx2-qt/SettingWidgetBinder.h
@@ -6,7 +6,6 @@
 #include <optional>
 #include <type_traits>
 
-#include <QtCore/QtCore>
 #include <QtGui/QAction>
 #include <QtGui/QFont>
 #include <QtWidgets/QAbstractButton>

--- a/pcsx2-qt/Settings/AchievementSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AchievementSettingsWidget.cpp
@@ -214,8 +214,7 @@ void AchievementSettingsWidget::updateLoginState()
 			StringUtil::FromChars<u64>(Host::GetBaseStringSettingValue("Achievements", "LoginTimestamp", "0")).value_or(0);
 		const QDateTime login_timestamp(QDateTime::fromSecsSinceEpoch(static_cast<qint64>(login_unix_timestamp)));
 		m_ui.loginStatus->setText(tr("Username: %1\nLogin token generated on %2.")
-				.arg(QString::fromStdString(username))
-				.arg(login_timestamp.toString(Qt::TextDate)));
+				.arg(QString::fromStdString(username), login_timestamp.toString(Qt::TextDate)));
 		m_ui.loginButton->setText(tr("Logout"));
 	}
 	else

--- a/pcsx2-qt/Settings/ControllerBindingWidget.cpp
+++ b/pcsx2-qt/Settings/ControllerBindingWidget.cpp
@@ -206,7 +206,7 @@ void ControllerBindingWidget::onAutomaticBindingClicked()
 		if (dev.first.compare(dev.second, Qt::CaseInsensitive) == 0)
 			action = menu.addAction(dev.first);
 		else
-			action = menu.addAction(QStringLiteral("%1: %2").arg(dev.first).arg(dev.second));
+			action = menu.addAction(QStringLiteral("%1: %2").arg(dev.first, dev.second));
 		action->setData(dev.first);
 		connect(action, &QAction::triggered, this, [this, action]() { doDeviceAutomaticBinding(action->data().toString()); });
 		added = true;
@@ -537,7 +537,7 @@ ControllerCustomSettingsWidget::~ControllerCustomSettingsWidget() = default;
 static std::tuple<QString, QString> getPrefixAndSuffixForIntFormat(const QString& format)
 {
 	QString prefix, suffix;
-	QRegularExpression re(QStringLiteral("(.*)%.*d(.*)"));
+	static QRegularExpression re(QStringLiteral("(.*)%.*d(.*)"));
 	QRegularExpressionMatch match(re.match(format));
 	if (match.isValid())
 	{
@@ -553,7 +553,7 @@ static std::tuple<QString, QString, int> getPrefixAndSuffixForFloatFormat(const 
 	QString prefix, suffix;
 	int decimals = -1;
 
-	QRegularExpression re(QStringLiteral("(.*)%.*([0-9]+)f(.*)"));
+	static QRegularExpression re(QStringLiteral("(.*)%.*([0-9]+)f(.*)"));
 	QRegularExpressionMatch match(re.match(format));
 	if (match.isValid())
 	{
@@ -567,8 +567,8 @@ static std::tuple<QString, QString, int> getPrefixAndSuffixForFloatFormat(const 
 	}
 	else
 	{
-		re = QRegularExpression(QStringLiteral("(.*)%.*f(.*)"));
-		match = re.match(format);
+		static QRegularExpression re_fallback(QStringLiteral("(.*)%.*f(.*)"));
+		match = re_fallback.match(format);
 		prefix = match.captured(1).replace(QStringLiteral("%%"), QStringLiteral("%"));
 		suffix = match.captured(2).replace(QStringLiteral("%%"), QStringLiteral("%"));
 	}
@@ -739,8 +739,6 @@ void ControllerCustomSettingsWidget::restoreDefaults()
 {
 	for (const SettingInfo& si : m_settings)
 	{
-		const QString key(QString::fromStdString(si.name));
-
 		switch (si.type)
 		{
 			case SettingInfo::Type::Boolean:
@@ -1160,7 +1158,7 @@ void USBDeviceWidget::onAutomaticBindingClicked()
 		if (dev.first.compare(dev.second, Qt::CaseInsensitive) == 0)
 			action = menu.addAction(dev.first);
 		else
-			action = menu.addAction(QStringLiteral("%1: %2").arg(dev.first).arg(dev.second));
+			action = menu.addAction(QStringLiteral("%1: %2").arg(dev.first, dev.second));
 		action->setData(dev.first);
 		connect(action, &QAction::triggered, this, [this, action]() { doDeviceAutomaticBinding(action->data().toString()); });
 		added = true;

--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
@@ -91,7 +91,7 @@ void ControllerGlobalSettingsWidget::addDeviceToList(const QString& identifier, 
 	if (identifier.compare(name, Qt::CaseInsensitive) == 0)
 		item->setText(identifier);
 	else
-		item->setText(QStringLiteral("%1: %2").arg(identifier).arg(name));
+		item->setText(QStringLiteral("%1: %2").arg(identifier, name));
 
 	item->setData(Qt::UserRole, identifier);
 	m_ui.deviceList->addItem(item);

--- a/pcsx2-qt/Settings/ControllerSettingWidgetBinder.h
+++ b/pcsx2-qt/Settings/ControllerSettingWidgetBinder.h
@@ -11,7 +11,6 @@
 #include <optional>
 #include <type_traits>
 
-#include <QtCore/QtCore>
 #include <QtGui/QAction>
 #include <QtWidgets/QCheckBox>
 #include <QtWidgets/QComboBox>

--- a/pcsx2-qt/Settings/ControllerSettingsWindow.cpp
+++ b/pcsx2-qt/Settings/ControllerSettingsWindow.cpp
@@ -460,7 +460,7 @@ void ControllerSettingsWindow::createWidgets()
 		if (mtap_enabled[port])
 		{
 			//: Controller Port is an official term from Sony. Find the official translation for your language inside the console's manual.
-			item->setText(tr("Controller Port %1%2\n%3").arg(port + 1).arg(s_mtap_slot_names[slot]).arg(display_name));
+			item->setText(tr("Controller Port %1%2\n%3").arg(port + 1).arg(s_mtap_slot_names[slot], display_name));
 		}
 		else
 		{
@@ -522,7 +522,7 @@ void ControllerSettingsWindow::updateListDescription(u32 global_slot, Controller
 			if (mtap_enabled)
 			{
 				//: Controller Port is an official term from Sony. Find the official translation for your language inside the console's manual.
-				item->setText(tr("Controller Port %1%2\n%3").arg(port + 1).arg(s_mtap_slot_names[slot]).arg(display_name));
+				item->setText(tr("Controller Port %1%2\n%3").arg(port + 1).arg(s_mtap_slot_names[slot], display_name));
 			}
 			else
 			{

--- a/pcsx2-qt/Settings/GamePatchSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GamePatchSettingsWidget.cpp
@@ -29,9 +29,7 @@ GamePatchDetailsWidget::GamePatchDetailsWidget(const Patch::PatchInfo& info, boo
 	m_ui.name->setText(name);
 	m_ui.description->setText(
 		tr("<strong>Author:</strong> %1<br><strong>Applied:</strong> %2<br>%3")
-			.arg(author)
-			.arg(place)
-			.arg(description));
+			.arg(author, place, description));
 
 	pxAssert(dialog->getSettingsInterface());
 	m_ui.enabled->setTristate(tristate);

--- a/pcsx2-qt/Settings/GameSummaryWidget.cpp
+++ b/pcsx2-qt/Settings/GameSummaryWidget.cpp
@@ -83,7 +83,9 @@ void GameSummaryWidget::populateDetails(const GameList::Entry* entry)
 
 				const qsizetype compatibility_value = static_cast<qsizetype>(entry->compatibility_rating);
 				//: First arg is filled-in stars for game compatibility; second is empty stars; should be swapped for RTL languages
-				return tr(" %0%1").arg(QStringLiteral("★").repeated(compatibility_value - 1)).arg(QStringLiteral("☆").repeated(6 - compatibility_value));
+				return tr(" %0%1").arg(
+					QStringLiteral("★").repeated(compatibility_value - 1),
+					QStringLiteral("☆").repeated(6 - compatibility_value));
 			}()));
 
 	int row = 0;
@@ -342,15 +344,15 @@ void GameSummaryWidget::onVerifyClicked()
 		if (!hentry->version.empty())
 		{
 			setVerifyResult(tr("Verified as %1 [%2] (Version %3).")
-					.arg(QString::fromStdString(hentry->name))
-					.arg(QString::fromStdString(hentry->serial))
-					.arg(QString::fromStdString(hentry->version)));
+					.arg(QString::fromStdString(hentry->name),
+						QString::fromStdString(hentry->serial),
+						QString::fromStdString(hentry->version)));
 		}
 		else
 		{
 			setVerifyResult(tr("Verified as %1 [%2].")
-					.arg(QString::fromStdString(hentry->name))
-					.arg(QString::fromStdString(hentry->serial)));
+					.arg(QString::fromStdString(hentry->name),
+						QString::fromStdString(hentry->serial)));
 		}
 	}
 	else

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -994,7 +994,7 @@ void GraphicsSettingsWidget::onCaptureContainerChanged()
 	{
 		const QString qformat(QString::fromStdString(format));
 		const QString qname(QString::fromStdString(name));
-		m_capture.videoCaptureCodec->addItem(QStringLiteral("%1 [%2]").arg(qformat).arg(qname), qformat);
+		m_capture.videoCaptureCodec->addItem(QStringLiteral("%1 [%2]").arg(qformat, qname), qformat);
 	}
 
 	SettingWidgetBinder::BindWidgetToStringSetting(
@@ -1008,7 +1008,7 @@ void GraphicsSettingsWidget::onCaptureContainerChanged()
 	{
 		const QString qformat(QString::fromStdString(format));
 		const QString qname(QString::fromStdString(name));
-		m_capture.audioCaptureCodec->addItem(QStringLiteral("%1 [%2]").arg(qformat).arg(qname), qformat);
+		m_capture.audioCaptureCodec->addItem(QStringLiteral("%1 [%2]").arg(qformat, qname), qformat);
 	}
 
 	SettingWidgetBinder::BindWidgetToStringSetting(

--- a/pcsx2-qt/Settings/InputBindingDialog.cpp
+++ b/pcsx2-qt/Settings/InputBindingDialog.cpp
@@ -26,7 +26,7 @@ InputBindingDialog::InputBindingDialog(SettingsInterface* sif, InputBindingInfo:
 	, m_bindings_ui(std::move(bindings_ui))
 {
 	m_ui.setupUi(this);
-	m_ui.title->setText(tr("Bindings for %1 %2").arg(QString::fromStdString(m_section_name)).arg(QString::fromStdString(m_key_name)));
+	m_ui.title->setText(tr("Bindings for %1 %2").arg(QString::fromStdString(m_section_name), QString::fromStdString(m_key_name)));
 	m_ui.buttonBox->button(QDialogButtonBox::Close)->setText(tr("Close"));
 
 	connect(m_ui.addBinding, &QPushButton::clicked, this, &InputBindingDialog::onAddBindingButtonClicked);

--- a/pcsx2-qt/Settings/InputBindingWidget.cpp
+++ b/pcsx2-qt/Settings/InputBindingWidget.cpp
@@ -467,7 +467,7 @@ void InputVibrationBindingWidget::onClicked()
 {
 	QInputDialog dialog(QtUtils::GetRootWidget(this));
 
-	const QString full_key(QStringLiteral("%1/%2").arg(QString::fromStdString(m_section_name)).arg(QString::fromStdString(m_key_name)));
+	const QString full_key(QStringLiteral("%1/%2").arg(QString::fromStdString(m_section_name), QString::fromStdString(m_key_name)));
 	const QString current(QString::fromStdString(m_binding));
 	QStringList input_setting_options(m_dialog->getVibrationMotors());
 	QStringList input_ui_options;

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -164,7 +164,7 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsWindow* settings_dialog
 			AutoUpdaterDialog::getDefaultTag());
 
 		//: Variable %1 shows the version number and variable %2 shows a timestamp.
-		m_ui.autoUpdateCurrentVersion->setText(tr("%1 (%2)").arg(AutoUpdaterDialog::getCurrentVersion()).arg(AutoUpdaterDialog::getCurrentVersionDate()));
+		m_ui.autoUpdateCurrentVersion->setText(tr("%1 (%2)").arg(AutoUpdaterDialog::getCurrentVersion(), AutoUpdaterDialog::getCurrentVersionDate()));
 		connect(m_ui.checkForUpdates, &QPushButton::clicked, this, []() { g_main_window->checkForUpdates(true, true); });
 	}
 	else

--- a/pcsx2-qt/Settings/MemoryCardConvertDialog.cpp
+++ b/pcsx2-qt/Settings/MemoryCardConvertDialog.cpp
@@ -96,7 +96,7 @@ void MemoryCardConvertDialog::onProgressUpdated(int value, int range)
 
 void MemoryCardConvertDialog::onThreadFinished()
 {
-	QMessageBox::information(this, tr("Conversion Complete"), tr("Memory Card \"%1\" converted to \"%2\"").arg(m_selectedCard).arg(m_destCardName));
+	QMessageBox::information(this, tr("Conversion Complete"), tr("Memory Card \"%1\" converted to \"%2\"").arg(m_selectedCard, m_destCardName));
 	accept();
 }
 

--- a/pcsx2-qt/Settings/MemoryCardConvertWorker.h
+++ b/pcsx2-qt/Settings/MemoryCardConvertWorker.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <QtCore/QtCore>
 #include <QtWidgets/QMessageBox>
 #include <QtWidgets/QProgressDialog>
 

--- a/pcsx2-qt/Settings/MemoryCardCreateDialog.cpp
+++ b/pcsx2-qt/Settings/MemoryCardCreateDialog.cpp
@@ -100,7 +100,7 @@ void MemoryCardCreateDialog::createCard()
 {
 	const QString name = m_ui.name->text();
 	const QString type = (m_fileType == MemoryCardFileType::PS1) ? QStringLiteral("mcr") : QStringLiteral("ps2");
-	const std::string name_str = QStringLiteral("%1.%2").arg(name).arg(type).toStdString();
+	const std::string name_str = QStringLiteral("%1.%2").arg(name, type).toStdString();
 	if (!Path::IsValidFileName(name_str, false))
 	{
 		QMessageBox::critical(this, tr("Create Memory Card"),

--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
@@ -504,7 +504,7 @@ void MemoryCardSlotWidget::setCard(const std::optional<std::string>& name, bool 
 	if (mcd.has_value())
 	{
 		item->setIcon(getCardIcon(mcd.value()));
-		item->setText(tr("%1 [%2]").arg(QString::fromStdString(mcd->name)).arg(getSizeSummary(mcd.value())));
+		item->setText(tr("%1 [%2]").arg(QString::fromStdString(mcd->name), getSizeSummary(mcd.value())));
 	}
 	else
 	{

--- a/pcsx2-qt/Settings/SettingsWindow.cpp
+++ b/pcsx2-qt/Settings/SettingsWindow.cpp
@@ -393,7 +393,7 @@ bool SettingsWindow::eventFilter(QObject* object, QEvent* event)
 	if (event->type() == QEvent::Enter)
 	{
 		auto iter = m_widget_help_text_map.constFind(object);
-		if (iter != m_widget_help_text_map.end())
+		if (iter != m_widget_help_text_map.constEnd())
 		{
 			m_current_help_widget = object;
 			m_ui.helpText->setText(iter.value());

--- a/pcsx2-qt/SetupWizardDialog.cpp
+++ b/pcsx2-qt/SetupWizardDialog.cpp
@@ -415,7 +415,7 @@ void SetupWizardDialog::openAutomaticMappingMenu(u32 port, QLabel* update_label)
 	for (const QPair<QString, QString>& dev : m_device_list)
 	{
 		// we set it as data, because the device list could get invalidated while the menu is up
-		QAction* action = menu.addAction(QStringLiteral("%1 (%2)").arg(dev.first).arg(dev.second));
+		QAction* action = menu.addAction(QStringLiteral("%1 (%2)").arg(dev.first, dev.second));
 		action->setData(dev.first);
 		connect(action, &QAction::triggered, this, [this, port, update_label, action]() {
 			doDeviceAutomaticBinding(port, update_label, action->data().toString());

--- a/pcsx2-qt/Themes.cpp
+++ b/pcsx2-qt/Themes.cpp
@@ -612,12 +612,12 @@ void QtHost::SetStyleFromSettings()
 		//Additional Theme option than loads .qss from main PCSX2 Directory
 		qApp->setStyle(QStyleFactory::create("Fusion"));
 
-		QString sheet_content;
 		QFile sheets(QString::fromStdString(Path::Combine(EmuFolders::DataRoot, "custom.qss")));
 
 		if (sheets.open(QFile::ReadOnly))
 		{
-			QString sheet_content = QString::fromUtf8(sheets.readAll().data());
+			QByteArray bytes = sheets.readAll();
+			QString sheet_content = QString::fromUtf8(bytes.data());
 			qApp->setStyleSheet(sheet_content);
 		}
 		else

--- a/pcsx2-qt/Translations.cpp
+++ b/pcsx2-qt/Translations.cpp
@@ -128,7 +128,7 @@ void QtHost::InstallTranslator(QWidget* dialog_parent)
 
 	// Qt base uses underscores instead of hyphens.
 	const QString qt_language = QString(language).replace(QChar('-'), QChar('_'));
-	QString base_path = QStringLiteral("%1/qt_%2.qm").arg(base_dir).arg(qt_language);
+	QString base_path = QStringLiteral("%1/qt_%2.qm").arg(base_dir, qt_language);
 	bool has_base_ts = QFile::exists(base_path);
 	if (!has_base_ts)
 	{
@@ -136,7 +136,7 @@ void QtHost::InstallTranslator(QWidget* dialog_parent)
 		const qsizetype index = language.lastIndexOf('-');
 		if (index > 0)
 		{
-			base_path = QStringLiteral("%1/qt_%2.qm").arg(base_dir).arg(language.left(index));
+			base_path = QStringLiteral("%1/qt_%2.qm").arg(base_dir, language.left(index));
 			has_base_ts = QFile::exists(base_path);
 		}
 	}
@@ -147,7 +147,7 @@ void QtHost::InstallTranslator(QWidget* dialog_parent)
 		if (!base_translator->load(base_path))
 		{
 			QMessageBox::warning(nullptr, QStringLiteral("Translation Error"),
-				QStringLiteral("Failed to find load base translation file for '%1':\n%2").arg(language).arg(base_path));
+				QStringLiteral("Failed to find load base translation file for '%1':\n%2").arg(language, base_path));
 			delete base_translator;
 		}
 		else
@@ -157,7 +157,7 @@ void QtHost::InstallTranslator(QWidget* dialog_parent)
 		}
 	}
 
-	const QString path = QStringLiteral("%1/pcsx2-qt_%3.qm").arg(base_dir).arg(language);
+	const QString path = QStringLiteral("%1/pcsx2-qt_%3.qm").arg(base_dir, language);
 	QTranslator* translator = nullptr;
 	if (QFile::exists(path))
 	{
@@ -170,7 +170,7 @@ void QtHost::InstallTranslator(QWidget* dialog_parent)
 		else
 		{
 			QMessageBox::warning(nullptr, QStringLiteral("Translation Error"),
-				QStringLiteral("Failed to load translation file for language '%1':\n%2").arg(language).arg(path));
+				QStringLiteral("Failed to load translation file for language '%1':\n%2").arg(language, path));
 			delete translator;
 			translator = nullptr;
 		}
@@ -180,7 +180,7 @@ void QtHost::InstallTranslator(QWidget* dialog_parent)
 #ifdef PCSX2_DEVBUILD
 		// For now, until we're sure this works on all platforms, we won't block users from starting if they're missing.
 		QMessageBox::warning(nullptr, QStringLiteral("Translation Error"),
-			QStringLiteral("Failed to find translation file for language '%1':\n%2").arg(language).arg(path));
+			QStringLiteral("Failed to find translation file for language '%1':\n%2").arg(language, path));
 #endif
 	}
 


### PR DESCRIPTION
### Description of Changes
- Combine QString::arg calls.
- Normalize Q_ARG signatures.
- Make QRegularExpression objects static.

### Rationale behind Changes
- [If Q_ARG signatures are not normalized, Qt will do it for you at runtime.
](https://marcmutz.wordpress.com/effective-qt/prefer-to-use-normalised-signalslot-signatures/)

### Suggested Testing Steps
Use it casually for a little bit and see if you notice anything is broken.

### Did you use AI to help find, test, or implement this issue or feature?
I used the super-intelligent AGI known as [Clazy](https://github.com/KDE/clazy).
