### PR TITLE
GS: Split and round sprites to emulate UV rounding error.

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -4319,6 +4319,220 @@ bool GSState::SpriteDrawWithoutGaps()
 	return false;
 }
 
+// Emulate UV rounding error when UVs fall exactly on texel boundaries (i.e. UVs being rounded down instead of up,
+// likely due to internal precision of GS). Rounding error may impact triangles and lines also, but this is only
+// implemented for sprites at the moment.
+// Return true if the sprites were split (and thus vertices were quadrupled), otherwise false.
+bool GSState::SplitSprites4xAndRound()
+{
+	// The following rules are suggested by hardware tests and applies to cases where UVs should fall exactly on a texel boundary
+	// at pixel centers (at least if we do mathematically correct interpolation without rounding errors):
+	// - The top-most and/or left-most pixels never seem to have rounding error (since the GS likely rasterizes top-left to bottom-right).
+	// - When the width is not power of 2, the Us other than the left-most seem to round down (when on a texel boundary).
+	// - When the height is not power of 2, the Vs other than the top-most seem to round down (when on a texel boundary).
+	// - If the width and/or height is a power of 2, the UVs always round up (when on a texel boundary).
+	// To emulate this behavior, each sprite is split into 4 new sprites for the top, left, top-left, and bottom-right pixels,
+	// and the UVs are adjusted.
+	
+	// Side note: The reason for this behavior might be due to the GS fixed-point precision for computing gradients,
+	// since power-of-2 and non-power-of-2 denominators have different behavior. However, this pattern only seems to
+	// hold when the width or height is <= 512 pixels. At > 512 pixels, the rounding seems to be sporadically up/down,
+	// suggesting that reciprocals < 1/ 512 are somehow treated differently. Fortunately, a width or height of 640
+	// rounds down the UVs, so no changes are needed to the below code (640 is likely the most common size > 512).
+
+	if (m_vt.m_primclass == GS_SPRITE_CLASS && PRIM->FST && !m_vt.IsRealLinear())
+	{
+		while (m_vertex.maxcount < 4 * m_index.tail)
+			GrowVertexBuffer();
+
+		const GSVector4i xyof = m_context->scissor.xyof.xyxy();
+
+		GSVertex* RESTRICT vtx = m_vertex.buff;
+		GSVertex* RESTRICT vtx_out = m_vertex.buff_copy;
+
+		u32 i_out = 0;
+		for (u32 i = 0; i < m_index.tail; i += 2, i_out += 8)
+		{
+			GSVertex v0 = vtx[i + 0];
+			GSVertex v1 = vtx[i + 1];
+
+			// Make sure flat attributes are the same.
+			v0.RGBAQ = v1.RGBAQ;
+			v0.FOG = v1.FOG;
+			v0.XYZ.Z = v1.XYZ.Z;
+
+			// Make sure vertices are top-left and bottom-right.
+			if (v0.XYZ.X > v1.XYZ.X)
+			{
+				std::swap(v0.XYZ.X, v1.XYZ.X);
+				std::swap(v0.U, v1.U);
+			}
+
+			if (v0.XYZ.Y > v1.XYZ.Y)
+			{
+				std::swap(v0.XYZ.Y, v1.XYZ.Y);
+				std::swap(v0.V, v1.V);
+			}
+
+			const int X0 = static_cast<int>(v0.XYZ.X) - xyof.x;
+			const int Y0 = static_cast<int>(v0.XYZ.Y) - xyof.y;
+			const int X1 = static_cast<int>(v1.XYZ.X) - xyof.x;
+			const int Y1 = static_cast<int>(v1.XYZ.Y) - xyof.y;
+			const int U0 = static_cast<int>(v0.U);
+			const int V0 = static_cast<int>(v0.V);
+			const int U1 = static_cast<int>(v1.U);
+			const int V1 = static_cast<int>(v1.V);
+
+			const int dX = X1 - X0;
+			const int dY = Y1 - Y0;
+			const int dU = U1 - U0;
+			const int dV = V1 - V0;
+
+			const bool int_dx = (dX & 0xF) == 0;
+			const bool int_dy = (dY & 0xF) == 0;
+			const bool int_scale_u = (dU % dX) == 0;
+			const bool int_scale_v = (dV % dY) == 0;
+			const int scale_u = dU / dX;
+			const int scale_v = dV / dY;
+
+			// Whether pixel centers in X, Y correspond to texel boundaries in U, V.
+			const bool half_u = int_dx && int_scale_u && ((U0 + scale_u * (16 - (X0 & 0xF))) & 0xF) == 0;
+			const bool half_v = int_dy && int_scale_v && ((V0 + scale_v * (16 - (Y0 & 0xF))) & 0xF) == 0;
+
+			const auto IsPow2 = [](int i) { return (i & (i - 1)) == 0; };
+			
+			// Whether U, V will round down at pixel centers in X, Y.
+			const bool round_down_u = half_u && (U1 > U0) && !IsPow2(dX);
+			const bool round_down_v = half_v && (V1 > V0) && !IsPow2(dY);
+
+			// Round up X if on texel boundary (rounding down handled later).
+			if (half_u)
+			{
+				v0.U += 8;
+				v1.U += 8;
+			}
+
+			// Round up Y if on texel boundary (rounding down handled later).
+			if (half_v)
+			{
+				v0.V += 8;
+				v1.V += 8;
+			}
+
+			// Get references to new vertices.
+			GSVertex& vtl0 = vtx_out[i_out + 0];
+			GSVertex& vtl1 = vtx_out[i_out + 1];
+			GSVertex& vt0 = vtx_out[i_out + 2];
+			GSVertex& vt1 = vtx_out[i_out + 3];
+			GSVertex& vl0 = vtx_out[i_out + 4];
+			GSVertex& vl1 = vtx_out[i_out + 5];
+			GSVertex& vbr0 = vtx_out[i_out + 6];
+			GSVertex& vbr1 = vtx_out[i_out + 7];
+
+			// Indices for sprites.
+			m_index.buff[i_out + 0] = i_out + 0;
+			m_index.buff[i_out + 1] = i_out + 1;
+			m_index.buff[i_out + 2] = i_out + 2;
+			m_index.buff[i_out + 3] = i_out + 3;
+			m_index.buff[i_out + 4] = i_out + 4;
+			m_index.buff[i_out + 5] = i_out + 5;
+			m_index.buff[i_out + 6] = i_out + 6;
+			m_index.buff[i_out + 7] = i_out + 7;
+
+			// Top left pixel. Empty unless splitting both X and Y.
+			vtl0 = v0;
+			vtl1 = v0;
+			if (round_down_u && round_down_v)
+			{
+				vtl1.XYZ.X += 16;
+				vtl1.XYZ.Y += 16;
+				vtl1.U += 16 * scale_u;
+				vtl1.V += 16 * scale_v;
+			}
+
+			// Left vertical strip. Empty unless splitting X.
+			vl0 = v0;
+			vl1 = v0;
+			vl1.XYZ.Y = v1.XYZ.Y;
+			vl1.V = v1.V;
+			if (round_down_u)
+			{
+				vl1.XYZ.X += 16;
+				vl1.U += 16 * scale_u;
+			}
+			if (round_down_v)
+			{
+				vl0.XYZ.Y += 16;
+				vl0.V += 16 * scale_v;
+			}
+
+			// Top horizontal strip. Empty unless splitting Y.
+			vt0 = v0;
+			vt1 = v0;
+			vt1.XYZ.X = v1.XYZ.X;
+			vt1.U = v1.U;
+			if (round_down_v)
+			{
+				vt1.XYZ.Y += 16;
+				vt1.V += 16 * scale_v;
+			}
+			if (round_down_u)
+			{
+				vt0.XYZ.X += 16;
+				vt0.U += 16 * scale_u;
+			}
+
+			// Bottom right rectangle. Whole sprite if not splitting X nor Y.
+			vbr0 = v0;
+			vbr1 = v1;
+			if (round_down_u)
+			{
+				vbr0.XYZ.X += 16;
+				vbr0.U += 16 * scale_u;
+			}
+			if (round_down_v)
+			{
+				vbr0.XYZ.Y += 16;
+				vbr0.V += 16 * scale_v;
+			}
+
+			// Round down X if needed.
+			if (round_down_u)
+			{
+				vt0.U -= 16;
+				vt1.U -= 16;
+				vbr0.U -= 16;
+				vbr1.U -= 16;
+			}
+
+			// Round down Y if needed.
+			if (round_down_v)
+			{
+				vl0.V -= 16;
+				vl1.V -= 16;
+				vbr0.V -= 16;
+				vbr1.V -= 16;
+			}
+		}
+
+		// Replace old sprites with new split sprites.
+		std::swap(m_vertex.buff, m_vertex.buff_copy);
+		m_vertex.head = m_vertex.next = m_vertex.tail = m_index.tail = i_out;
+
+		// Dump vertices for debugging.
+		if (GSConfig.ShouldDump(s_n, g_perfmon.GetFrame()) && GSConfig.SaveInfo)
+		{
+			DumpVertices(GetDrawDumpPath("%05d_vertex_sprite_split.txt", s_n));
+		}
+
+		return true;
+	}
+	else
+	{
+		return false;
+	}
+}
+
 void GSState::CalculatePrimitiveCoversWithoutGaps()
 {
 	m_primitive_covers_without_gaps = FullCover;

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -486,6 +486,7 @@ public:
 	bool SpriteDrawWithoutGaps();
 	void CalculatePrimitiveCoversWithoutGaps();
 	GIFRegTEX0 GetTex0Layer(u32 lod);
+	bool SplitSprites4xAndRound();
 };
 
 // We put this in the header because of Multi-ISA.

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -8118,6 +8118,20 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 		m_conf.drawlist_bbox = &m_drawlist_bbox;
 	}
 
+	// Sprite splitting/rounding to emulate UV rounding error on GS.
+	// Only implemented for native resolution currently.
+	if (GetUpscaleMultiplier() == 1.0f)
+	{
+		if (SplitSprites4xAndRound())
+		{
+			// Need to adjust drawlist counts since each sprite becomes 4 sprites.
+			for (u32 i = 0; i < m_drawlist.size(); i++)
+			{
+				m_drawlist[i] *= 4;
+			}
+		}
+	}
+
 	HandleProvokingVertexFirst();
 
 	SetupIA(rtscale, sx, sy, m_channel_shuffle_width != 0);

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -446,6 +446,9 @@ void GSRendererSW::Draw()
 			pxFailRel("Unknown primitive class.");
 			break;
 	}
+
+	// Sprite splitting/rounding to emulate UV rounding error on GS.
+	SplitSprites4xAndRound();
 	
 	auto data = m_vertex_heap.make_shared<SharedData>().cast<GSRasterizerData>();
 	SharedData* sd = static_cast<SharedData*>(data.get());


### PR DESCRIPTION
### Description of Changes
Some games draws point-sampled sprites that should sample exactly at texel boundaries. For such cases, it seems that the GS rounds texels coordinates to the nearest texel. However, in many cases there appears to interpolation error in UVs so that the GS rounds down to the nearest texel instead (details on hardware tests below). This PR attempts to detect such cases, and split and round sprites to account for this.

Credits: This is built on ideas and work by refraction (see https://github.com/PCSX2/pcsx2/pull/6553).

### Rationale behind Changes
Fixes accuracy issues in games that rely on accurate rounding. The initial intention was to fix the Beyond Good and Evil water reflections (see https://github.com/PCSX2/pcsx2/issues/1986).

Appears to fix https://github.com/PCSX2/pcsx2/issues/14002.

Caveats:
- There are some cases where text appears to be slightly blurrier by 1 pixel in the PR. However, I've checked a few examples by hand and they seem to appear on the PS2 also (examples below).
- Future work: This PR is conservative in choosing which sprites to modify, so it might not fix all cases. For instance, only sprites whose X/Y dimensions are pixel multiples and such that the gradient dU/dX or dV/dY is an integer are modified.
- Future work: This could probably be extended to axis-aligned triangles also, but for now it handles sprites only.
- Future work: Upscaling is not considered in this PR, but it may require modifications to work correctly.
- Performance: For any draws where sprites are split, the number of polys will be quadrupled (though number of pixels should be the same). This may have a performance impact, though I suspect it will be small since it only applies to point-sampled sprites.

### Comparisons

bge.gs.xz (note, red strip that looks like a bug on left occurs on both PS2 and PR)

PS2
<img width="640" height="448" alt="bge-frame-2" src="https://github.com/user-attachments/assets/073cf3d0-fa27-4e50-aa53-da1316ad64ce" />

Master SW
<img width="641" height="448" alt="01432_f00002_fr-1_00dc0_C_32_master_sw" src="https://github.com/user-attachments/assets/101cd927-a149-4a23-8795-64a54e7341c4" />

PR SW
<img width="641" height="448" alt="01432_f00002_fr-1_00dc0_C_32_pr_sw" src="https://github.com/user-attachments/assets/79297293-670a-4f15-840a-0dbc6372acc3" />

---

Gallop Racer Inbreed_SLPS-25701.gs.xz (UI elements)

PS2
<img width="640" height="448" alt="gallop-frame-3" src="https://github.com/user-attachments/assets/3857a24e-fa64-444d-849f-93a9b9853ee2" />

Master SW
<img width="640" height="448" alt="00436_f00003_fr-1_01180_C_24_master_sw" src="https://github.com/user-attachments/assets/b8bd5a7e-9d67-40fa-8c0c-db31a22b73e8" />

PR SW
<img width="640" height="448" alt="00436_f00003_fr-1_01180_C_24_pr_sw" src="https://github.com/user-attachments/assets/9d935d1f-edac-4ae4-a9d0-1bdc4f72b8e5" />

---

Dragon Ball Z - Budokai Tenkaichi 3_SLUS-21678_20221208223633.gs.xz (character outlines, some might still be a bit off in PR)

PS2
<img width="512" height="448" alt="dbz-frame-1" src="https://github.com/user-attachments/assets/f9a3c97b-ab12-4075-af4d-56f7e0370e33" />

Master SW
<img width="512" height="448" alt="04254_f00001_fr-1_00e00_C_32_master_sw" src="https://github.com/user-attachments/assets/5ace969e-68a8-4a41-abab-3c27d3bc78dc" />

PR SW
<img width="512" height="448" alt="04254_f00001_fr-1_00e00_C_32_pr_sw" src="https://github.com/user-attachments/assets/b989c1e5-e37b-4152-8a11-6e03b262557c" />

---

Ace Combat - Squadron Leader_SCES-52424_20250401050853.gs.xz (example where PS2 and PR look slightly worse, "Edge" in HUD looks a bit squished compared to master)

PS2
<img width="512" height="256" alt="ace-combat-frame-1" src="https://github.com/user-attachments/assets/66d840f4-e883-44c6-8ade-01f200dadce4" />

Master SW
<img width="512" height="256" alt="04461_f00001_fr1_00e00_C_24_master_sw" src="https://github.com/user-attachments/assets/666b030b-46ea-434f-9d55-fb2288d203cd" />

PR SW
<img width="512" height="256" alt="04461_f00001_fr1_00e00_C_24_pr_sw" src="https://github.com/user-attachments/assets/9f6e4aaf-0e5b-4508-b343-b380bec4f182" />

---

Wild_ARMs_3_SCUS-97203.gs.xz (see borders of UI elements)

PS2
<img width="640" height="224" alt="wild-arms-frame-1" src="https://github.com/user-attachments/assets/7ea18cd8-06b1-4ee4-83a0-189d3f888362" />

Master SW
<img width="640" height="224" alt="00762_f00001_fr1_00000_C_32_master_sw" src="https://github.com/user-attachments/assets/49e04ed5-3b39-4226-85ae-04bedf5f7744" />

PR SW
<img width="640" height="224" alt="00762_f00001_fr1_00000_C_32_pr_sw" src="https://github.com/user-attachments/assets/676f34f2-0bd9-4b51-93fb-a38e7b6dd38c" />

---

roguegalaxytext.gs.xz (black line at top in both PS2 and PR, though alignment of circle UI elements is a bit more centered compared to master)

PS2
<img width="512" height="448" alt="rogue-frame-1" src="https://github.com/user-attachments/assets/6678cc02-0ab8-4024-88a3-f803e3980687" />

Master SW
<img width="512" height="448" alt="00048_f00001_fr-1_00e00_C_24_master_sw" src="https://github.com/user-attachments/assets/31731321-bff1-4c62-b593-ebfc388f4a44" />

PR SW
<img width="512" height="448" alt="00048_f00001_fr-1_00e00_C_24_pr_sw" src="https://github.com/user-attachments/assets/8ad09db6-2423-4536-acbe-f2dae9fc4aca" />

---

Dragon Quest VIII - Journey of the Cursed King_SLES-53974_20230321134214.gs.xz ("HP" and "MP" in PS2 and PR are a bit more stretched and may look slightly worse than master)

PS2
<img width="512" height="512" alt="dquest-frame-1" src="https://github.com/user-attachments/assets/c5ee815d-cd6b-4c5c-90d6-16531e741b1c" />

Master SW
<img width="512" height="509" alt="00112_f00001_fr-1_00e00_C_24_master_sw" src="https://github.com/user-attachments/assets/9ed55318-5163-46bf-8fa1-374479041ef8" />

PR SW
<img width="512" height="509" alt="00112_f00001_fr-1_00e00_C_24_pr_sw" src="https://github.com/user-attachments/assets/2c07f28c-68be-4a98-8af0-cb41254e7f75" />

### Suggested Testing Steps
Use any renderer, as both SW or HW are affected. Many games may not have not visual differences (although a large number of pixel might have tiny differences), or have subtle changes (UI alignment changes or single black line at edge of frame changed, etc.).

### Hardware Tests/Details

Based on hardware tests the following rounding rules seems to apply when UVs are should ("should" means if the interpolation was mathematically exact) be on texel boundaries for sprites (similar conditions may apply to triangles and lines):
- The top-most and/or left-most pixels never seems to have rounding error (since the GS likely rasterizes top-left to bottom-right). They are always rounded up.
- When the width is not power of 2, the interpolated Us other than the left-most pixels seem to round down.
- When the height is not power of 2, the interpolated Vs other than the top-most pixels seem to round down.
- If the width and/or height is a power of 2, the interpolated UVs seem to round up.
- If the directions of U and X (or Y and V) is opposite, the error seems to cause the UVs to round up instead of down (meaning that all UVs are rounded as if there is no error).
- The above rules apply to the horizontal and vertical axes separately (e.g. we can have U round down and V round up).
- There is an exception to these rules for heights or widths > 512 pixels (see below), which was not emulated here.
Note: The default behavior on the PCSX2 SW and HW renderers appears to be to round up at texel boundaries, hence the inaccuracies.

Additional details:
- Shifting the sprite by any amount (including fractional) does not seem to affect the rounding rules above (as long as pixel centers map to texel boundaries).
- The same rules seem to apply even if dU / dX (or dY / dV) is not exactly 1 (however this PR only modifies sprites where the ratio is an integer >= 1).
- When the sprite dimensions are a power of 2, there appears to be no interpolation error. This may be caused by accuracy of the gradients during interpolation (I think this was suggested to me by TellowKrinkle).
- For heights or widths > 512 pixels, there is sporadic round up/down behavior that I couldn't find a simple pattern for. Again this may have to do with the precision for computing gradients or reciprocals. Seemingly by chance, sprites with 640 width or height round UVs down, which is partly the cause of the Beyond Good and Evil water issue.

The hardware tests were straightforward: draw some sprites and lines with different dimensions and choose UVs in such a way that the sampling values should fall on texel boundaries. No tests were done for triangles, though I'd assume the results would be the same for axis-aligned triangles.

### Did you use AI to help find, test, or implement this issue or feature?
I asked AI on advice for types of hardware tests to use to reverse GS internal precision. However, this did not end up being necessary to fix the rounding issues.