### PR TITLE
GS/HW: Enable non recursive sw blending on minimum level.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5932,13 +5932,15 @@ void GSRendererHW::EmulateBlending(int rt_alpha_min, int rt_alpha_max, const boo
 			accumulation_blend &= !prefer_sw_blend;
 			// Enable sw blending for barriers.
 			sw_blending |= blend_requires_barrier || prefer_sw_blend;
-			// Enable sw blending for free blending.
+			// Enable sw blending for free blending (non recursive, accumulation).
 			sw_blending |= free_blend;
 			// Do not run BLEND MIX if sw blending is already present, it's less accurate.
 			blend_mix &= !sw_blending;
 			sw_blending |= blend_mix;
 			[[fallthrough]];
 		case AccBlendLevel::Minimum:
+			// Enable sw blending for non recursive mode.
+			sw_blending |= blend_non_recursive;
 			break;
 	}
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/HW: Enable non recursive sw blending on minimum level.
Blending is free, no barriers/copies, doesn't require reading the fb.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Minimum blend better accuracy.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
A lot of changes but with small diffs, notable change is SW Battlefront 2. Test variety of games on minimum blend, also smoke test basic blend that I didn't break anything.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.

Some diffs on minimum blend:
Sniper Elite
Master
<img width="597" height="448" alt="image" src="https://github.com/user-attachments/assets/572ae067-ffec-4205-81fd-638e31255dc9" />

PR
<img width="597" height="448" alt="image" src="https://github.com/user-attachments/assets/21cc0fa8-f13a-4f5d-9310-292e69adf1df" />

Star Wars Battlefront 2
Master
<img width="596" height="447" alt="image" src="https://github.com/user-attachments/assets/f63fdddc-df23-4973-83ea-e2ef58ac1de7" />

PR
<img width="596" height="447" alt="image" src="https://github.com/user-attachments/assets/1dbedeb0-56d8-4353-8a67-a37324066524" />
