### PR TITLE
GS: Anti-Blur takes lowest offset if neither display are alternating

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -6378,7 +6378,10 @@ void GSState::GSPCRTCRegs::CalculateFramebufferOffset(bool scanmask, GSRegDISPFB
 		}
 		else // Only one rect is alternating
 		{
-			const int index = alternating_1 ? 1 : 0;
+			// A lot of ternary operating going on here.
+			// Basically if display 1 is alternating, use that, otherwise use 0 if display 0 is alternating
+			// if neither are alternating, pick the one with the lowest offset.
+			const int index = alternating_1 ? 1 : (alternating_0 ? 0 : ((static_cast<u32>(PCRTCDisplays[1].framebufferRect.y) < static_cast<u32>(PCRTCDisplays[0].framebufferRect.y)) ? 0 : 1));
 			const int offset = PCRTCDisplays[1 - index].framebufferRect.y - PCRTCDisplays[index].framebufferRect.y;
 
 			if (std::abs(offset) <= 4)


### PR DESCRIPTION
### Description of Changes
Picks the lowest offset if neither is alternating.

### Rationale behind Changes
Sometimes games will stop updating the offsets, especially during busy moments, and with the current Anti-Blur changes it can cause a bit of jumping. This should deal with that

### Suggested Testing Steps
Try Spongebob - The Movie, Nascar games, thrillville, random games, just to make sure nothing is broken.

### Did you use AI to help find, test, or implement this issue or feature?
no

Fixes #14039