### PR TITLE
Build/EE: Omit declaration of SQC2 and LQC2 in iR5900LoadStore

### DIFF
--- a/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
+++ b/pcsx2/x86/ix86-32/iR5900LoadStore.cpp
@@ -50,9 +50,11 @@ REC_FUNC(SDR);
 REC_FUNC(SQ);
 REC_FUNC(LWC1);
 REC_FUNC(SWC1);
+/*
+These are technically COP2 so they are handled in microVU_Macro.inl
 REC_FUNC(LQC2);
 REC_FUNC(SQC2);
-
+*/
 #else
 
 using namespace Interpreter::OpcodeImpl;


### PR DESCRIPTION
### Description of Changes
Omit rec fallbacks for SQC2 and LQC2 from LoadStore functions.

### Rationale behind Changes
These are COP2 functions and are handled in microVU_macro.inl.  Came across this while trying to find what I thought was a recompiler bug and realised I couldn't disable certain combinations of instructions.

### Suggested Testing Steps
Shouldn't need to test anything, just make sure it still builds.

### Did you use AI to help find, test, or implement this issue or feature?
no
