### PR TITLE
Update pcsx2-qt_it-IT.ts

### DIFF
--- a/pcsx2-qt/Translations/pcsx2-qt_it-IT.ts
+++ b/pcsx2-qt/Translations/pcsx2-qt_it-IT.ts
@@ -100,8 +100,8 @@ AboutDialog['File non trovato: %1']</translation>
     <message>
       <location filename="../Settings/AchievementLoginDialog.cpp" line="28"/>
       <source>&lt;strong&gt;Your RetroAchievements login token is no longer valid.&lt;/strong&gt; You must re-enter your credentials for achievements to be tracked. Your password will not be saved in PCSX2, an access token will be generated and used instead.</source>
-      <translation>&lt;strong&gt;Il tuo gettone di accesso RetroAchievements non è più valido.&lt;/strong&gt; È necessario reinserire le credenziali affinché i risultati vengano monitorati. La tua password non verrà salvata in PCSX2, ma verrà generato e utilizzato un token di accesso.
-AchievementLoginDialog['&lt;strong&gt;Il tuo gettone di accesso RetroAchievements non è più valido.&lt;/strong&gt; È necessario reinserire le credenziali affinché i risultati vengano monitorati. La tua password non verrà salvata in PCSX2, ma verrà generato e utilizzato un token di accesso.']</translation>
+      <translation>&lt;strong&gt;Il tuo token di accesso RetroAchievements non è più valido.&lt;/strong&gt; È necessario reinserire le credenziali affinché i risultati vengano monitorati. La tua password non verrà salvata in PCSX2, ma verrà generato e utilizzato un token di accesso.
+AchievementLoginDialog['&lt;strong&gt;Il tuo token di accesso RetroAchievements non è più valido.&lt;/strong&gt; È necessario reinserire le credenziali affinché i risultati vengano monitorati. La tua password non verrà salvata in PCSX2, ma verrà generato e utilizzato un token di accesso.']</translation>
     </message>
     <message>
       <location filename="../Settings/AchievementLoginDialog.cpp" line="33"/>


### PR DESCRIPTION
### Description of Changes
Replaced "gettone" with "token".

### Rationale behind Changes
The italian word "gettone" actually means "coin". In this case, it's more correct to leave "token" as it is. The word "token" is also already used in previous lines in the same file.

### Suggested Testing Steps
None, probably, since this is a simple translation fix.

### Did you use AI to help find, test, or implement this issue or feature?
No, I did not.
