### PR TITLE
SPU: Speed up DMA

### DIFF
--- a/pcsx2/SPU2/Dma.cpp
+++ b/pcsx2/SPU2/Dma.cpp
@@ -9,6 +9,8 @@
 #include "IopHw.h"
 #include "Config.h"
 
+static constexpr int CYCLES_PER_WORD = 24;
+
 #ifdef PCSX2_DEVBUILD
 
 #define safe_fclose(ptr) \
@@ -163,7 +165,7 @@ void V_Core::StartADMAWrite(u16* pMem, u32 sz)
 	if ((AutoDMACtrl & (Index + 1)) == 0)
 	{
 		ActiveTSA = 0x2000 + (Index << 10);
-		DMAICounter = size * 48;
+		DMAICounter = size * CYCLES_PER_WORD;
 		LastClock = psxRegs.cycle;
 	}
 	else if (size >= 256)
@@ -191,7 +193,7 @@ void V_Core::StartADMAWrite(u16* pMem, u32 sz)
 		if (SPU2::MsgToConsole())
 			SPU2::ConLog("ADMA%c Error Size of %x too small\n", GetDmaIndexChar(), size);
 		InputDataLeft = 0;
-		DMAICounter = size * 48;
+		DMAICounter = size * CYCLES_PER_WORD;
 		LastClock = psxRegs.cycle;
 	}
 }
@@ -248,7 +250,7 @@ void V_Core::FinishDMAwrite()
 		DMA7LogWrite(DMAPtr, ReadSize << 1);
 #endif
 
-	u32 buff1end = ActiveTSA + std::min(ReadSize, (u32)0x100 + std::abs(DMAICounter / 48));
+	u32 buff1end = ActiveTSA + std::min(ReadSize, (u32)0x100 + std::abs(DMAICounter / CYCLES_PER_WORD));
 	u32 buff2end = 0;
 	if (buff1end > 0x100000)
 	{
@@ -343,7 +345,7 @@ void V_Core::FinishDMAwrite()
 	DMAPtr += TDA - ActiveTSA;
 	ReadSize -= TDA - ActiveTSA;
 
-	DMAICounter = (DMAICounter - ReadSize) * 48;
+	DMAICounter = (DMAICounter - ReadSize) * CYCLES_PER_WORD;
 
 	CounterUpdate(DMAICounter);
 
@@ -354,7 +356,7 @@ void V_Core::FinishDMAwrite()
 
 void V_Core::FinishDMAread()
 {
-	u32 buff1end = ActiveTSA + std::min(ReadSize, (u32)0x100 + std::abs(DMAICounter / 48));
+	u32 buff1end = ActiveTSA + std::min(ReadSize, (u32)0x100 + std::abs(DMAICounter / CYCLES_PER_WORD));
 	u32 buff2end = 0;
 
 	if (buff1end > 0x100000)
@@ -426,9 +428,9 @@ void V_Core::FinishDMAread()
 
 	// DMA Reads are done AFTER the delay, so to get the timing right we need to scheule one last DMA to catch IRQ's
 	if (ReadSize)
-		DMAICounter = std::min(ReadSize, (u32)0x100) * 48;
+		DMAICounter = std::min(ReadSize, (u32)0x100) * CYCLES_PER_WORD;
 	else
-		DMAICounter = 48;
+		DMAICounter = CYCLES_PER_WORD;
 
 	CounterUpdate(DMAICounter);
 
@@ -446,7 +448,7 @@ void V_Core::DoDMAread(u16* pMem, u32 size)
 	ReadSize = size;
 	IsDMARead = true;
 	LastClock = psxRegs.cycle;
-	DMAICounter = (std::min(ReadSize, (u32)0x100) * 48);
+	DMAICounter = (std::min(ReadSize, (u32)0x100) * CYCLES_PER_WORD);
 	Regs.STATX &= ~0x80;
 	Regs.STATX |= 0x400;
 	//Regs.ATTR |= 0x30;
@@ -470,7 +472,7 @@ void V_Core::DoDMAwrite(u16* pMem, u32 size)
 	{
 		Regs.STATX &= ~0x80;
 		//Regs.ATTR |= 0x30;
-		DMAICounter = 1 * 48;
+		DMAICounter = 1 * CYCLES_PER_WORD;
 		LastClock = psxRegs.cycle;
 		return;
 	}


### PR DESCRIPTION
### Description of Changes
Speeds up SPU DMA from 48 cycles per word to 24.

### Rationale behind Changes
Games keep breaking with accurate timings because everything else is too fast.
Fixes #14056
Fixes #14022
Fixes #14063 

### Suggested Testing Steps
Testing the recent regressions would be good.

### Did you use AI to help find, test, or implement this issue or feature?
No
