### PR TITLE
Actions: Check if PR commit messages have a prefix

### DIFF
--- a/.github/workflows/check_pr_commits.yml
+++ b/.github/workflows/check_pr_commits.yml
@@ -1,0 +1,22 @@
+name: 'Commit Message Check'
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+jobs:
+  check-commit-message:
+    name: Check Commit Message
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for a commit prefix 
+        uses: gsactions/commit-message-checker@16fa2d5de096ae0d35626443bcd24f1e756cafee
+        with:
+          pattern: '^[A-Z][A-Za-z0-9 \[]+:.+'
+          excludeTitle: true
+          excludeDescription: true
+          checkAllCommitMessages: true
+          error: 'Commit messages should be capitalized, start with a prefix, delimited by a colon. Example: "Debugger: Add a paste bytes option to the memory view"'


### PR DESCRIPTION
More of a RFQ, is this more annoying than helpful?

### Description of Changes
Adds a quick check to see if a commit message is capitalized, and if it has a prefix.

### Rationale behind Changes
I sometimes forget to check the commit name when reviewing PRs, this should hopefully help me.
The capitalization isn't necessary, just included it because I figured why not.

### Suggested Testing Steps
I tried testing on my fork but it wouldn't work there.

### Did you use AI to help find, test, or implement this issue or feature?
Quickly tossed the regex to an AI to make sure I didn't make a huge mistake.