### PR TITLE
Qt: Adjust positioning of window for fullscreen

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -2570,7 +2570,7 @@ void MainWindow::createDisplayWidget(bool fullscreen, bool render_to_main)
 
 #ifdef DISPLAY_SURFACE_WINDOW
 		if (isVisible() && g_emu_thread->shouldRenderToMain())
-			m_display_surface->setFramePosition(pos());
+			m_display_surface->setPosition(screen()->availableGeometry().topLeft());
 		else
 			restoreDisplayWindowGeometryFromConfig();
 
@@ -2580,7 +2580,7 @@ void MainWindow::createDisplayWidget(bool fullscreen, bool render_to_main)
 			m_display_surface->showNormal();
 #else
 		if (isVisible() && g_emu_thread->shouldRenderToMain())
-			m_display_container->move(pos());
+			m_display_container->move(screen()->availableGeometry().topLeft());
 		else
 			restoreDisplayWindowGeometryFromConfig();
 


### PR DESCRIPTION
### Description of Changes
Use `setPosition` instead of `setFramePosition` on Windows.
Move windows to the top left of the screen instead of the window position.

### Rationale behind Changes
`setFramePosition` proved ineffective in positioning the window before fullscreening, 
As the window we fullscreen is created smaller than the main window we could fullscreen on the wrong window if the main window straddles two screens.

Fixes https://github.com/PCSX2/pcsx2/issues/14076

### Suggested Testing Steps
Test full screening on Windows and Unix

### Did you use AI to help find, test, or implement this issue or feature?
No
