### PR TITLE
Achievements: Add game cache

### DIFF
--- a/common/FileSystem.cpp
+++ b/common/FileSystem.cpp
@@ -279,7 +279,7 @@ bool Path::IsAbsolute(const std::string_view path)
 #ifdef _WIN32
 	return (path.length() >= 3 && ((path[0] >= 'A' && path[0] <= 'Z') || (path[0] >= 'a' && path[0] <= 'z')) &&
 			   path[1] == ':' && (path[2] == '/' || path[2] == '\\')) ||
-		   (path.length() >= 3 && path[0] == '\\' && path[1] == '\\');
+	       (path.length() >= 3 && path[0] == '\\' && path[1] == '\\');
 #else
 	return (path.length() >= 1 && path[0] == '/');
 #endif
@@ -2725,3 +2725,53 @@ FileSystem::POSIXLock::~POSIXLock()
 }
 
 #endif
+
+bool FileSystem::ReadString(std::FILE* file, std::string* dest)
+{
+	u32 size;
+	if (std::fread(&size, sizeof(size), 1, file) != 1)
+		return false;
+
+	dest->resize(size);
+	if (size > 0 && std::fread(dest->data(), size, 1, file) != 1)
+		return false;
+
+	return true;
+}
+
+bool FileSystem::ReadU8(std::FILE* file, u8* dest)
+{
+	return std::fread(dest, sizeof(u8), 1, file) == 1;
+}
+
+bool FileSystem::ReadU32(std::FILE* file, u32* dest)
+{
+	return std::fread(dest, sizeof(u32), 1, file) == 1;
+}
+
+bool FileSystem::ReadU64(std::FILE* file, u64* dest)
+{
+	return std::fread(dest, sizeof(u64), 1, file) == 1;
+}
+
+bool FileSystem::WriteString(std::FILE* file, const std::string& str)
+{
+	const u32 size = static_cast<u32>(str.size());
+	return (std::fwrite(&size, sizeof(size), 1, file) == 1 &&
+			(size == 0 || std::fwrite(str.data(), size, 1, file) == 1));
+}
+
+bool FileSystem::WriteU8(std::FILE* file, u8 dest)
+{
+	return std::fwrite(&dest, sizeof(u8), 1, file) == 1;
+}
+
+bool FileSystem::WriteU32(std::FILE* file, u32 dest)
+{
+	return std::fwrite(&dest, sizeof(u32), 1, file) == 1;
+}
+
+bool FileSystem::WriteU64(std::FILE* file, u64 dest)
+{
+	return std::fwrite(&dest, sizeof(u64), 1, file) == 1;
+}

--- a/common/FileSystem.h
+++ b/common/FileSystem.h
@@ -197,6 +197,22 @@ namespace FileSystem
 	/// Deletes a symbolic link (either a file or directory).
 	bool DeleteSymbolicLink(const char* path, Error* error = nullptr);
 
+	/// Read a length-prefixed string from a file.
+	bool ReadString(std::FILE* file, std::string* dest);
+
+	/// Read an integer from a file.
+	bool ReadU8(std::FILE* file, u8* dest);
+	bool ReadU32(std::FILE* file, u32* dest);
+	bool ReadU64(std::FILE* file, u64* dest);
+
+	/// Write a length-prefixed string to a file.
+	bool WriteString(std::FILE* file, const std::string& str);
+
+	/// Write an integer to a file.
+	bool WriteU8(std::FILE* file, u8 dest);
+	bool WriteU32(std::FILE* file, u32 dest);
+	bool WriteU64(std::FILE* file, u64 dest);
+
 #ifdef _WIN32
 	// Path limit remover, but also converts to a wide string at the same time.
 	bool GetWin32Path(std::wstring* dest, std::string_view str);

--- a/pcsx2-qt/GameList/GameListModel.cpp
+++ b/pcsx2-qt/GameList/GameListModel.cpp
@@ -4,9 +4,13 @@
 #include "GameListModel.h"
 #include "QtHost.h"
 #include "QtUtils.h"
+
+#include "Achievements.h"
+
 #include "common/FileSystem.h"
 #include "common/Path.h"
 #include "common/StringUtil.h"
+
 #include "fmt/format.h"
 #include <QtCore/QDate>
 #include <QtCore/QDateTime>
@@ -18,7 +22,7 @@
 #include <QtGui/QPainter>
 
 static constexpr std::array<const char*, GameListModel::Column_Count> s_column_names = {
-	{"Type", "Code", "Title", "File Title", "CRC", "Time Played", "Last Played", "Size", "Region", "Compatibility", "Cover"}};
+	{"Type", "Code", "Title", "File Title", "CRC", "Time Played", "Last Played", "Size", "Region", "Compatibility", "Achievements", "Cover"}};
 
 static constexpr int COVER_ART_WIDTH = 350;
 static constexpr int COVER_ART_HEIGHT = 512;
@@ -270,6 +274,20 @@ QVariant GameListModel::data(const QModelIndex& index, const int role) const
 				case Column_Size:
 					return QString("%1 MB").arg(static_cast<double>(ge->total_size) / 1048576.0, 0, 'f', 2);
 
+				case Column_Achivements:
+				{
+					std::optional<Achievements::CacheEntry> achievements = Achievements::LookupCacheEntry(ge->crc);
+					if (!achievements.has_value())
+						return tr("Unknown");
+
+					if (!achievements->supported)
+						return tr("Unsupported");
+
+					return tr("%1 / %2")
+					    .arg(achievements->num_unlocked_achievements)
+					    .arg(achievements->num_core_achievements);
+				}
+
 				case Column_Cover:
 					return m_show_titles_for_covers ? QString::fromStdString(ge->GetTitle(m_prefer_english_titles)) : QVariant();
 
@@ -456,6 +474,23 @@ bool GameListModel::lessThan(const QModelIndex& left_index, const QModelIndex& r
 			return (left->last_played_time < right->last_played_time);
 		}
 
+		case Column_Achivements:
+		{
+			std::optional<Achievements::CacheEntry> achievements_left = Achievements::LookupCacheEntry(left->crc);
+			std::optional<Achievements::CacheEntry> achievements_right = Achievements::LookupCacheEntry(right->crc);
+			if (!achievements_left.has_value() || !achievements_right.has_value())
+				return false;
+
+			float completion_left =
+				static_cast<float>(achievements_left->num_unlocked_achievements) /
+				achievements_left->num_unlocked_achievements;
+			float completion_right =
+				static_cast<float>(achievements_right->num_unlocked_achievements) /
+				achievements_right->num_unlocked_achievements;
+
+			return completion_left < completion_right;
+		}
+
 		default:
 			return false;
 	}
@@ -518,6 +553,7 @@ void GameListModel::setColumnDisplayNames()
 	m_column_display_names[Column_Size] = tr("Size");
 	m_column_display_names[Column_Region] = tr("Region");
 	m_column_display_names[Column_Compatibility] = tr("Compatibility");
+	m_column_display_names[Column_Achivements] = tr("Achievements");
 }
 
 #include "moc_GameListModel.cpp"

--- a/pcsx2-qt/GameList/GameListModel.h
+++ b/pcsx2-qt/GameList/GameListModel.h
@@ -32,6 +32,7 @@ public:
 		Column_Size,
 		Column_Region,
 		Column_Compatibility,
+		Column_Achivements,
 		Column_Cover,
 
 		Column_Count

--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -59,10 +59,10 @@ static constexpr std::array<int, GameListModel::Column_Count> DEFAULT_COLUMN_WID
 	90, // last played
 	80, // size
 	60, // region
-	120 // compatibility
+	120, // compatibility
+	120, // achievements
+	0, // cover
 }};
-static_assert(static_cast<int>(DEFAULT_COLUMN_WIDTHS.size()) <= GameListModel::Column_Count,
-	"Game List: More default column widths than column types.");
 
 class GameListSortModel final : public QSortFilterProxyModel
 {
@@ -790,6 +790,7 @@ void GameListWidget::resizeTableViewColumnsToFit()
 														 DEFAULT_COLUMN_WIDTHS[GameListModel::Column_Size],
 														 DEFAULT_COLUMN_WIDTHS[GameListModel::Column_Region],
 														 DEFAULT_COLUMN_WIDTHS[GameListModel::Column_Compatibility],
+														 DEFAULT_COLUMN_WIDTHS[GameListModel::Column_Achivements],
 													 });
 }
 

--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -455,9 +455,9 @@ bool Achievements::Initialize()
 		SettingsInterface* secretsInterface = Host::Internal::GetSecretsSettingsLayer();
 		secretsInterface->SetStringValue("Achievements", "Token", oldToken.c_str());
 		secretsInterface->Save();
-		
+
 		oldToken.clear();
-		
+
 		auto baseLock = Host::GetSettingsLock();
 		SettingsInterface* baseInterface = Host::Internal::GetBaseSettingsLayer();
 		baseInterface->DeleteValue("Achievements", "Token");
@@ -540,7 +540,7 @@ void Achievements::UpdateNotificationPosition()
 {
 	// Set notification position based on achievement settings
 	float horizontal_position, vertical_position, direction;
-	
+
 	// Determine horizontal alignment
 	switch (EmuConfig.Achievements.NotificationPosition)
 	{
@@ -549,13 +549,13 @@ void Achievements::UpdateNotificationPosition()
 		case OsdOverlayPos::BottomLeft:
 			horizontal_position = 0.0f; // Left
 			break;
-			
+
 		case OsdOverlayPos::TopCenter:
 		case OsdOverlayPos::Center:
 		case OsdOverlayPos::BottomCenter:
 			horizontal_position = 0.5f; // Center
 			break;
-			
+
 		case OsdOverlayPos::TopRight:
 		case OsdOverlayPos::CenterRight:
 		case OsdOverlayPos::BottomRight:
@@ -563,7 +563,7 @@ void Achievements::UpdateNotificationPosition()
 			horizontal_position = 1.0f; // Right
 			break;
 	}
-	
+
 	// Determine vertical alignment and stacking direction
 	switch (EmuConfig.Achievements.NotificationPosition)
 	{
@@ -573,14 +573,14 @@ void Achievements::UpdateNotificationPosition()
 			vertical_position = 0.15f; // Top area
 			direction = 1.0f; // Stack downward
 			break;
-			
+
 		case OsdOverlayPos::CenterLeft:
 		case OsdOverlayPos::Center:
 		case OsdOverlayPos::CenterRight:
 			vertical_position = 0.5f; // Center
 			direction = 1.0f; // Stack downward
 			break;
-			
+
 		case OsdOverlayPos::BottomLeft:
 		case OsdOverlayPos::BottomCenter:
 		case OsdOverlayPos::BottomRight:
@@ -589,7 +589,7 @@ void Achievements::UpdateNotificationPosition()
 			direction = -1.0f; // Stack upward
 			break;
 	}
-	
+
 	ImGuiFullscreen::SetNotificationPosition(horizontal_position, vertical_position, direction);
 }
 
@@ -739,13 +739,19 @@ uint32_t Achievements::ClientReadMemory(uint32_t address, uint8_t* buffer, uint3
 void Achievements::ClientServerCall(
 	const rc_api_request_t* request, rc_client_server_callback_t callback, void* callback_data, rc_client_t* client)
 {
-	HTTPDownloader::Request::Callback hd_callback = [callback, callback_data](s32 status_code, const std::string& content_type, HTTPDownloader::Request::Data data)
-	{
+	HTTPDownloader::Request::Callback hd_callback = [callback, callback_data](s32 status_code, const std::string& content_type, HTTPDownloader::Request::Data data) {
 		rc_api_server_response_t rr;
-		rr.http_status_code = (status_code <= 0) ? (status_code == HTTPDownloader::HTTP_STATUS_CANCELLED ?
-		                                                   RC_API_SERVER_RESPONSE_CLIENT_ERROR :
-		                                                   RC_API_SERVER_RESPONSE_RETRYABLE_CLIENT_ERROR)
-		                                         : status_code;
+		if (status_code <= 0)
+		{
+			if (status_code == HTTPDownloader::HTTP_STATUS_CANCELLED)
+				rr.http_status_code = RC_API_SERVER_RESPONSE_CLIENT_ERROR;
+			else
+				rr.http_status_code = RC_API_SERVER_RESPONSE_RETRYABLE_CLIENT_ERROR;
+		}
+		else
+		{
+			rr.http_status_code = status_code;
+		}
 		rr.body_length = data.size();
 		rr.body = reinterpret_cast<const char*>(data.data());
 
@@ -1833,7 +1839,7 @@ void Achievements::ClientLoginWithPasswordCallback(int result, const char* error
 	Host::SetBaseStringSettingValue("Achievements", "Username", params->username);
 	Host::SetBaseStringSettingValue("Achievements", "LoginTimestamp", fmt::format("{}", std::time(nullptr)).c_str());
 	Host::CommitBaseSettingChanges();
-	
+
 	SettingsInterface* secretsInterface = Host::Internal::GetSecretsSettingsLayer();
 	secretsInterface->SetStringValue("Achievements", "Token", user->token);
 	secretsInterface->Save();
@@ -2032,7 +2038,7 @@ static ImVec2 CalculateOverlayPosition(const ImGuiIO& io, float padding, Achieve
 static ImVec2 AdjustPositionForAlignment(const ImVec2& base_position, const ImVec2& element_size, AchievementOverlayPosition alignment)
 {
 	ImVec2 adjusted = base_position;
-	
+
 	// Adjust for horizontal alignment
 	switch (alignment)
 	{
@@ -2041,14 +2047,14 @@ static ImVec2 AdjustPositionForAlignment(const ImVec2& base_position, const ImVe
 		case AchievementOverlayPosition::BottomLeft:
 			// Left aligned no adjustment needed for x
 			break;
-			
+
 		case AchievementOverlayPosition::TopCenter:
 		case AchievementOverlayPosition::Center:
 		case AchievementOverlayPosition::BottomCenter:
 			// Center aligned offset by half element width
 			adjusted.x -= element_size.x * 0.5f;
 			break;
-			
+
 		case AchievementOverlayPosition::TopRight:
 		case AchievementOverlayPosition::CenterRight:
 		case AchievementOverlayPosition::BottomRight:
@@ -2057,7 +2063,7 @@ static ImVec2 AdjustPositionForAlignment(const ImVec2& base_position, const ImVe
 			adjusted.x -= element_size.x;
 			break;
 	}
-	
+
 	// Adjust for vertical alignment
 	switch (alignment)
 	{
@@ -2066,14 +2072,14 @@ static ImVec2 AdjustPositionForAlignment(const ImVec2& base_position, const ImVe
 		case AchievementOverlayPosition::TopRight:
 			// Top aligned no adjustment needed for y
 			break;
-			
+
 		case AchievementOverlayPosition::CenterLeft:
 		case AchievementOverlayPosition::Center:
 		case AchievementOverlayPosition::CenterRight:
 			// Center aligned offset by half element height
 			adjusted.y -= element_size.y * 0.5f;
 			break;
-			
+
 		case AchievementOverlayPosition::BottomLeft:
 		case AchievementOverlayPosition::BottomCenter:
 		case AchievementOverlayPosition::BottomRight:
@@ -2082,7 +2088,7 @@ static ImVec2 AdjustPositionForAlignment(const ImVec2& base_position, const ImVe
 			adjusted.y -= element_size.y;
 			break;
 	}
-	
+
 	return adjusted;
 }
 
@@ -2094,19 +2100,19 @@ static ImVec2 GetStackingDirection(AchievementOverlayPosition alignment)
 		case AchievementOverlayPosition::TopCenter:
 		case AchievementOverlayPosition::TopRight:
 			return ImVec2(0.0f, 1.0f); // Stack downward
-			
+
 		case AchievementOverlayPosition::BottomLeft:
 		case AchievementOverlayPosition::BottomCenter:
 		case AchievementOverlayPosition::BottomRight:
 		default:
 			return ImVec2(0.0f, -1.0f); // Stack upward
-			
+
 		case AchievementOverlayPosition::CenterLeft:
 			return ImVec2(1.0f, 0.0f); // Stack rightward
-			
+
 		case AchievementOverlayPosition::CenterRight:
 			return ImVec2(-1.0f, 0.0f); // Stack leftward
-			
+
 		case AchievementOverlayPosition::Center:
 			return ImVec2(0.0f, -1.0f); // Stack upward for center
 	}
@@ -2147,7 +2153,7 @@ void Achievements::DrawGameOverlays()
 			{
 				dl->AddImage(reinterpret_cast<ImTextureID>(badge->GetNativeHandle()),
 					current_position, current_position + image_size, ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f), col);
-				
+
 				// For horizontal layouts, go horizontally for vertical layouts, stay in the same row
 				if (std::abs(stack_direction.x) > 0.0f)
 				{
@@ -2198,7 +2204,7 @@ void Achievements::DrawGameOverlays()
 		const ImVec2 progress_box_size = ImVec2(image_size.x + text_size.x + spacing + padding * 2.0f, image_size.y + padding * 2.0f);
 		const ImVec2 stack_direction = GetStackingDirection(EmuConfig.Achievements.OverlayPosition);
 		const ImVec2 box_position = AdjustPositionForAlignment(position, progress_box_size, EmuConfig.Achievements.OverlayPosition);
-		
+
 		const ImVec2 box_min = box_position;
 		const ImVec2 box_max = box_position + progress_box_size;
 		const float box_rounding = LayoutScale(1.0f);
@@ -2232,7 +2238,7 @@ void Achievements::DrawGameOverlays()
 	if (!s_active_leaderboard_trackers.empty() && EmuConfig.Achievements.LBOverlays)
 	{
 		const ImVec2 stack_direction = GetStackingDirection(EmuConfig.Achievements.OverlayPosition);
-		
+
 		for (auto it = s_active_leaderboard_trackers.begin(); it != s_active_leaderboard_trackers.end();)
 		{
 			const LeaderboardTrackerIndicator& indicator = *it;
@@ -2247,7 +2253,7 @@ void Achievements::DrawGameOverlays()
 
 			const ImVec2 tracker_box_size = ImVec2(size.x + padding * 2.0f, size.y + padding * 2.0f);
 			const ImVec2 box_position = AdjustPositionForAlignment(position, tracker_box_size, EmuConfig.Achievements.OverlayPosition);
-			
+
 			const ImVec2 box_min = box_position;
 			const ImVec2 box_max = box_position + tracker_box_size;
 			const float box_rounding = LayoutScale(1.0f);
@@ -3053,7 +3059,7 @@ void Achievements::DrawLeaderboardsWindow()
 			{
 				const bool wants_to_go_back = ImGuiFullscreen::FloatingButton(
 												  ICON_FA_SQUARE_CARET_LEFT, 10.0f, 10.0f, -1.0f, -1.0f, 1.0f, 0.0f, true, g_large_font) ||
-												ImGuiFullscreen::WantsToCloseMenu();
+				                              ImGuiFullscreen::WantsToCloseMenu();
 				if (wants_to_go_back)
 				{
 					close_leaderboard_on_exit = true;

--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -4,6 +4,7 @@
 #include "Achievements.h"
 #include "BuildVersion.h"
 #include "CDVD/CDVD.h"
+#include "Config.h"
 #include "Elfheader.h"
 #include "Host.h"
 #include "GS/Renderers/Common/GSTexture.h"
@@ -74,6 +75,10 @@ namespace Achievements
 	// Chrome uses 10 server calls per domain, seems reasonable.
 	static constexpr u32 MAX_CONCURRENT_SERVER_CALLS = 10;
 
+	static constexpr u32 ACHIEVEMENTS_CACHE_SIGNATURE = 0x43413250; // "P2AC"
+	static constexpr u32 ACHIEVEMENTS_CACHE_VERSION = 1;
+	static constexpr u32 ACHIEVEMENTS_CACHE_ENTRY_SIZE = 30;
+
 	namespace
 	{
 		struct LoginWithPasswordParameters
@@ -119,7 +124,7 @@ namespace Achievements
 	static void BeginLoadingScreen(const char* text, bool* was_running_idle);
 	static void EndLoadingScreen(bool was_running_idle);
 	static std::string_view GetELFNameForHash(const std::string& elf_path);
-	static std::string GetGameHash(const std::string& elf_path);
+	static std::optional<Achievements::GameHash> GetGameHash(const std::string& elf_path);
 	static void SetHardcoreMode(bool enabled, bool force_display_message);
 	static bool IsLoggedInOrLoggingIn();
 	static bool CanEnableHardcoreMode();
@@ -188,6 +193,19 @@ namespace Achievements
 	static void CloseLeaderboard();
 	static void CloseSubset();
 
+	static void UpdateCacheEntry(bool supported);
+	static void ReadCacheFile();
+	static bool AppendCacheEntry(u32 crc, const CacheEntry& entry);
+	static bool OverwriteCacheEntry(std::multimap<u32, CacheEntry>::iterator iterator, const CacheEntry& entry);
+	static bool WriteEntireCacheFile();
+	static bool ReadCacheFileHeader(std::FILE* file, u32* entry_count);
+	static bool WriteCacheFileHeader(std::FILE* file, u32 entry_count);
+	static bool ReadCacheEntryFirstPart(std::FILE* file, u32* crc, GameHash* hash);
+	static bool ReadCacheEntrySecondPart(std::FILE* file, CacheEntry* entry);
+	static bool WriteCacheEntryFirstPart(std::FILE* file, u32 crc, const GameHash& hash);
+	static bool WriteCacheEntrySecondPart(std::FILE* file, const CacheEntry& entry);
+	static std::string GetCacheFilePath();
+
 	static bool s_hardcore_mode = false;
 
 #ifdef ENABLE_RAINTEGRATION
@@ -199,7 +217,7 @@ namespace Achievements
 	static std::string s_image_directory;
 	static std::unique_ptr<HTTPDownloader> s_http_downloader;
 
-	static std::string s_game_hash;
+	static std::optional<GameHash> s_game_hash;
 	static std::string s_game_title;
 	static std::string s_game_icon;
 	static std::string s_game_icon_url;
@@ -236,6 +254,10 @@ namespace Achievements
 	static std::vector<LeaderboardTrackerIndicator> s_active_leaderboard_trackers;
 	static std::vector<AchievementChallengeIndicator> s_active_challenge_indicators;
 	static std::optional<AchievementProgressIndicator> s_active_progress_indicator;
+
+	/// Map from game CRCs to cache entries. This gets stored on disk so that
+	/// we know whether to enable hardcore mode or not when booting a game.
+	static std::multimap<u32, CacheEntry> s_game_cache;
 } // namespace Achievements
 
 
@@ -297,19 +319,19 @@ std::string_view Achievements::GetELFNameForHash(const std::string& elf_path)
 	return std::string_view(elf_path).substr(start, end - start);
 }
 
-std::string Achievements::GetGameHash(const std::string& elf_path)
+std::optional<Achievements::GameHash> Achievements::GetGameHash(const std::string& elf_path)
 {
 	// this.. really shouldn't be invalid
 	const std::string_view name_for_hash = GetELFNameForHash(elf_path);
 	if (name_for_hash.empty())
-		return {};
+		return std::nullopt;
 
 	ElfObject elfo;
 	Error error;
 	if (!cdvdLoadElf(&elfo, elf_path, false, &error))
 	{
 		Console.Error(fmt::format("Achievements: Failed to read ELF '{}' on disc: {}", elf_path, error.GetDescription()));
-		return {};
+		return std::nullopt;
 	}
 
 	// See rcheevos hash.c - rc_hash_ps2().
@@ -323,15 +345,12 @@ std::string Achievements::GetGameHash(const std::string& elf_path)
 	if (hash_size > 0)
 		digest.Update(elfo.GetData().data(), hash_size);
 
-	u8 hash[16];
-	digest.Final(hash);
+	GameHash hash;
+	digest.Final(hash.bytes.data());
 
-	const std::string hash_str =
-		StringUtil::StdStringFromFormat("%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x", hash[0], hash[1], hash[2],
-			hash[3], hash[4], hash[5], hash[6], hash[7], hash[8], hash[9], hash[10], hash[11], hash[12], hash[13], hash[14], hash[15]);
-
-	Console.WriteLn(fmt::format("Hash for '{}' ({} bytes, {} bytes hashed): {}", name_for_hash, elfo.GetSize(), hash_size, hash_str));
-	return hash_str;
+	std::string hash_str = hash.ToString();
+	Console.WriteLnFmt("Hash for '{}' ({} bytes, {} bytes hashed): {}", name_for_hash, elfo.GetSize(), hash_size, hash_str);
+	return hash;
 }
 
 
@@ -950,7 +969,8 @@ void Achievements::IdentifyGame(u32 disc_crc, u32 crc)
 	if (s_game_crc == crc_to_use)
 		return;
 
-	const std::string game_hash = GetGameHash(booted_elf ? VMManager::GetCurrentELF() : VMManager::GetDiscELF());
+	const std::string elf_path = booted_elf ? VMManager::GetCurrentELF() : VMManager::GetDiscELF();
+	const std::optional<GameHash> game_hash = GetGameHash(elf_path);
 	if (s_game_hash == game_hash)
 		return;
 
@@ -991,7 +1011,7 @@ void Achievements::BeginLoadGame()
 
 	ClearGameInfo();
 
-	if (s_game_hash.empty())
+	if (!s_game_hash.has_value())
 	{
 		// when we're booting the bios, or shutting down, this will fail
 		if (s_game_crc != 0)
@@ -1005,7 +1025,8 @@ void Achievements::BeginLoadGame()
 		return;
 	}
 
-	s_load_game_request = rc_client_begin_load_game(s_client, s_game_hash.c_str(), ClientLoadGameCallback, nullptr);
+	std::string game_hash_str = s_game_hash.has_value() ? s_game_hash->ToString() : "";
+	s_load_game_request = rc_client_begin_load_game(s_client, game_hash_str.c_str(), ClientLoadGameCallback, nullptr);
 }
 
 void Achievements::ClientLoadGameCallback(int result, const char* error_message, rc_client_t* client, void* userdata)
@@ -1013,10 +1034,12 @@ void Achievements::ClientLoadGameCallback(int result, const char* error_message,
 	s_load_game_request = nullptr;
 
 	if (result == RC_NO_GAME_LOADED)
-	{
-		// Unknown game.
-		Console.WriteLn(Color_StrongYellow, "Achievements: Unknown game '%s', disabling achievements.", s_game_hash.c_str());
+	{ // Unknown game.
+		std::string game_hash_str = s_game_hash.has_value() ? s_game_hash->ToString() : "";
+		Console.WriteLn(Color_StrongYellow,
+			"Achievements: Unknown game '%s', disabling achievements.", game_hash_str.c_str());
 		DisableHardcoreMode();
+		UpdateCacheEntry(false);
 		return;
 	}
 	else if (result == RC_LOGIN_REQUIRED)
@@ -1072,6 +1095,7 @@ void Achievements::ClientLoadGameCallback(int result, const char* error_message,
 	}
 
 	UpdateGameSummary();
+	UpdateCacheEntry(true);
 	DisplayAchievementSummary();
 
 	Host::OnAchievementsRefreshed();
@@ -1108,7 +1132,7 @@ void Achievements::ClearGameInfo()
 void Achievements::ClearGameHash()
 {
 	s_game_crc = 0;
-	std::string().swap(s_game_hash);
+	s_game_hash.reset();
 }
 
 void Achievements::DisplayAchievementSummary()
@@ -1181,6 +1205,7 @@ void Achievements::HandleUnlockEvent(const rc_client_event_t* event)
 
 	Console.WriteLn("Achievements: Achievement %s (%u) for game %u unlocked", cheevo->title, cheevo->id, s_game_id);
 	UpdateGameSummary();
+	UpdateCacheEntry(true);
 
 	if (EmuConfig.Achievements.Notifications)
 	{
@@ -3573,6 +3598,330 @@ void Achievements::CloseSubset()
 	s_open_subset = nullptr;
 }
 
+std::optional<Achievements::CacheEntry> Achievements::LookupCacheEntry(u32 game_crc, const GameHash* game_hash)
+{
+	auto lock = GetLock();
+
+	if (s_game_cache.empty())
+		ReadCacheFile();
+
+	const auto range = s_game_cache.equal_range(game_crc);
+	if (range.first == range.second)
+		return std::nullopt;
+
+	if (game_hash)
+	{
+		// Check for CRC collisions.
+		for (auto iterator = range.first; iterator != range.second; iterator++)
+			if (iterator->second.game_hash == *game_hash)
+				return iterator->second;
+
+		return std::nullopt;
+	}
+
+	return range.first->second;
+}
+
+void Achievements::DeleteCacheFile()
+{
+	auto lock = GetLock();
+
+	s_game_cache.clear();
+
+	const std::string path = GetCacheFilePath();
+	FileSystem::DeleteFilePath(path.c_str());
+}
+
+static void Achievements::UpdateCacheEntry(bool supported)
+{
+	if (!s_game_hash.has_value())
+		return;
+
+	if (s_game_cache.empty())
+		ReadCacheFile();
+
+	CacheEntry entry;
+	entry.game_hash = *s_game_hash;
+	entry.supported = supported;
+	if (supported)
+	{
+		entry.has_achievements = rc_client_has_achievements(s_client);
+		entry.has_leaderboards = rc_client_has_leaderboards(s_client);
+		entry.num_core_achievements = s_game_summary.num_core_achievements;
+		entry.num_unlocked_achievements = s_game_summary.num_unlocked_achievements;
+	}
+
+	bool found = false;
+	bool success = false;
+
+	// Check if there's a pre-existing cache entry for this game.
+	const auto range = s_game_cache.equal_range(s_game_crc);
+	for (auto iterator = range.first; iterator != range.second; iterator++)
+	{
+		if (iterator->second.game_hash == *s_game_hash)
+		{
+			found = true;
+			success = iterator->second == entry || OverwriteCacheEntry(iterator, std::move(entry));
+			break;
+		}
+	}
+
+	if (!found)
+	{
+		// No existing entry was found, so create a new one.
+		success = AppendCacheEntry(s_game_crc, std::move(entry));
+	}
+
+	if (!success)
+	{
+		Console.Warning("Achievements cache couldn't be updated. Recreating...");
+		if (!WriteEntireCacheFile())
+		{
+			Console.Warning("Achievements cache couldn't be recreated.");
+			DeleteCacheFile();
+		}
+	}
+}
+
+static void Achievements::ReadCacheFile()
+{
+	const std::string path = GetCacheFilePath();
+	auto file = FileSystem::OpenManagedCFile(path.c_str(), "rb");
+	if (!file)
+		return;
+
+#ifndef _WIN32
+	FileSystem::POSIXLock lock(file.get());
+#endif
+
+	u32 entry_count;
+	if (!ReadCacheFileHeader(file.get(), &entry_count))
+		return;
+
+	for (u32 i = 0; i < entry_count; i++)
+	{
+		u32 crc;
+		CacheEntry entry;
+
+		entry.index_in_file = i;
+
+		if (!ReadCacheEntryFirstPart(file.get(), &crc, &entry.game_hash) ||
+			!ReadCacheEntrySecondPart(file.get(), &entry))
+		{
+			s_game_cache.clear();
+			return;
+		}
+
+		s_game_cache.emplace(crc, std::move(entry));
+	}
+}
+
+static bool Achievements::AppendCacheEntry(u32 crc, const CacheEntry& entry)
+{
+	auto iterator = s_game_cache.emplace(crc, entry);
+
+	const std::string path = GetCacheFilePath();
+	auto file = FileSystem::OpenManagedCFile(path.c_str(), "r+b");
+	if (!file)
+		return false;
+
+#ifndef _WIN32
+	FileSystem::POSIXLock lock(file.get());
+#endif
+
+	u32 entry_count;
+	if (!ReadCacheFileHeader(file.get(), &entry_count))
+		return false;
+
+	s64 offset = static_cast<s64>(entry_count) * ACHIEVEMENTS_CACHE_ENTRY_SIZE;
+	if (FileSystem::FSeek64(file.get(), offset, SEEK_CUR) != 0)
+		return false;
+
+	if (!WriteCacheEntryFirstPart(file.get(), crc, entry.game_hash) ||
+		!WriteCacheEntrySecondPart(file.get(), entry))
+		return false;
+
+	iterator->second.index_in_file = entry_count;
+
+	return true;
+}
+
+static bool Achievements::OverwriteCacheEntry(
+	std::multimap<u32, CacheEntry>::iterator iterator, const CacheEntry& entry)
+{
+	pxAssert(iterator->second.game_hash == entry.game_hash);
+
+	std::optional<u32> index_in_file = iterator->second.index_in_file;
+	if (!index_in_file.has_value())
+		return false;
+
+	iterator->second = entry;
+	iterator->second.index_in_file = index_in_file;
+
+	const std::string path = GetCacheFilePath();
+	auto file = FileSystem::OpenManagedCFile(path.c_str(), "r+b");
+	if (!file)
+		return false;
+
+#ifndef _WIN32
+	FileSystem::POSIXLock lock(file.get());
+#endif
+
+	u32 entry_count;
+	if (!ReadCacheFileHeader(file.get(), &entry_count))
+		return false;
+
+	if (*index_in_file >= entry_count)
+		return false;
+
+	s64 offset = static_cast<s64>(*index_in_file) * ACHIEVEMENTS_CACHE_ENTRY_SIZE;
+	if (FileSystem::FSeek64(file.get(), offset, SEEK_CUR) != 0)
+		return false;
+
+	u32 crc_on_disk;
+	GameHash hash_on_disk;
+	if (!ReadCacheEntryFirstPart(file.get(), &crc_on_disk, &hash_on_disk))
+		return false;
+
+	if (crc_on_disk != iterator->first || hash_on_disk != entry.game_hash)
+		return false;
+
+	if (!WriteCacheEntrySecondPart(file.get(), entry))
+		return false;
+
+	return true;
+}
+
+static bool Achievements::WriteEntireCacheFile()
+{
+	const std::string path = GetCacheFilePath();
+	auto file = FileSystem::OpenManagedCFile(path.c_str(), "wb");
+	if (!file)
+		return false;
+
+#ifndef _WIN32
+	FileSystem::POSIXLock lock(file.get());
+#endif
+
+	if (!WriteCacheFileHeader(file.get(), static_cast<u32>(s_game_cache.size())))
+		return false;
+
+	for (const auto& [crc, entry] : s_game_cache)
+		if (!WriteCacheEntryFirstPart(file.get(), crc, entry.game_hash) ||
+			!WriteCacheEntrySecondPart(file.get(), entry))
+			return false;
+
+	return true;
+}
+
+static bool Achievements::ReadCacheFileHeader(std::FILE* file, u32* entry_count)
+{
+	u32 signature;
+	u32 version;
+	if (!FileSystem::ReadU32(file, &signature) ||
+		signature != ACHIEVEMENTS_CACHE_SIGNATURE ||
+		!FileSystem::ReadU32(file, &version) ||
+		!FileSystem::ReadU32(file, entry_count))
+	{
+		Console.Warning("Failed to read achievements cache: Invalid file header.");
+		return false;
+	}
+
+	if (version != ACHIEVEMENTS_CACHE_VERSION)
+	{
+		Console.Warning("Failed to read achievements cache: Incompatible file version.");
+		return false;
+	}
+
+	return true;
+}
+
+
+static bool Achievements::WriteCacheFileHeader(std::FILE* file, u32 entry_count)
+{
+	if (!FileSystem::WriteU32(file, ACHIEVEMENTS_CACHE_SIGNATURE) ||
+		!FileSystem::WriteU32(file, ACHIEVEMENTS_CACHE_VERSION) ||
+		!FileSystem::WriteU32(file, static_cast<u32>(entry_count)))
+	{
+		Console.Warning("Failed to write achievements cache: Cannot write file header.");
+		return false;
+	}
+
+	return true;
+}
+
+static bool Achievements::ReadCacheEntryFirstPart(std::FILE* file, u32* crc, GameHash* hash)
+{
+	if (!FileSystem::ReadU32(file, crc) ||
+		std::fread(hash->bytes.data(), hash->bytes.size(), 1, file) != 1)
+	{
+		Console.Warning("Failed to read achievements cache entry (first part).");
+		return false;
+	}
+
+	return true;
+}
+
+static bool Achievements::ReadCacheEntrySecondPart(std::FILE* file, CacheEntry* entry)
+{
+	u8 supported;
+	u8 has_achievements;
+	u8 has_leaderboards;
+	if (!FileSystem::ReadU8(file, &supported) ||
+		!FileSystem::ReadU8(file, &has_achievements) ||
+		has_achievements > 1 ||
+		!FileSystem::ReadU8(file, &has_leaderboards) ||
+		has_leaderboards > 1 ||
+		!FileSystem::ReadU32(file, &entry->num_core_achievements) ||
+		!FileSystem::ReadU32(file, &entry->num_unlocked_achievements))
+	{
+		Console.Warning("Failed to read achievements cache entry (second part).");
+		return false;
+	}
+
+	entry->supported = static_cast<bool>(supported);
+	entry->has_achievements = static_cast<bool>(has_achievements);
+	entry->has_leaderboards = static_cast<bool>(has_leaderboards);
+
+	return true;
+}
+
+static bool Achievements::WriteCacheEntryFirstPart(std::FILE* file, u32 crc, const GameHash& hash)
+{
+	if (!FileSystem::WriteU32(file, crc) ||
+		std::fwrite(hash.bytes.data(), hash.bytes.size(), 1, file) != 1)
+	{
+		Console.Warning("Failed to write achievements cache entry (first part).");
+		return false;
+	}
+
+	return true;
+}
+
+static bool Achievements::WriteCacheEntrySecondPart(std::FILE* file, const CacheEntry& entry)
+{
+	const u8 supported = static_cast<u8>(entry.supported);
+	const u8 has_achievements = static_cast<u8>(entry.has_achievements);
+	const u8 has_leaderboards = static_cast<u8>(entry.has_leaderboards);
+
+	if (!FileSystem::WriteU8(file, supported) ||
+		!FileSystem::WriteU8(file, has_achievements) ||
+		!FileSystem::WriteU8(file, has_leaderboards) ||
+		!FileSystem::WriteU32(file, entry.num_core_achievements) ||
+		!FileSystem::WriteU32(file, entry.num_unlocked_achievements))
+	{
+		Console.Warning("Failed to write achievements cache entry (second part).");
+		return false;
+	}
+
+	return true;
+}
+
+static std::string Achievements::GetCacheFilePath()
+{
+	return Path::Combine(EmuFolders::Cache, "achievements.cache");
+}
+
 #ifdef ENABLE_RAINTEGRATION
 
 #include "RA_Consoles.h"
@@ -3640,7 +3989,15 @@ void Achievements::RAIntegration::MainWindowChanged(void* new_handle)
 
 void Achievements::RAIntegration::GameChanged()
 {
-	s_game_id = s_game_hash.empty() ? 0 : RA_IdentifyHash(s_game_hash.c_str());
+	if (s_game_hash.has_value())
+	{
+		std::string game_hash_str = s_game_hash->ToString();
+		s_game_id = RA_IdentifyHash(game_hash_str.c_str());
+	}
+	else
+	{
+		s_game_id = 0;
+	}
 	RA_ActivateGame(s_game_id);
 }
 

--- a/pcsx2/Achievements.h
+++ b/pcsx2/Achievements.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "common/Pcsx2Types.h"
+#include "common/StringUtil.h"
 
 #include "Config.h"
 
@@ -24,6 +25,39 @@ namespace Achievements
 	{
 		UserInitiated,
 		TokenInvalid,
+	};
+
+	struct GameHash
+	{
+		std::array<u8, 16> bytes;
+
+		std::string ToString() const
+		{
+			return StringUtil::StdStringFromFormat(
+				"%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
+				bytes[0], bytes[1], bytes[2], bytes[3],
+				bytes[4], bytes[5], bytes[6], bytes[7],
+				bytes[8], bytes[9], bytes[10], bytes[11],
+				bytes[12], bytes[13], bytes[14], bytes[15]);
+		}
+
+		friend auto operator<=>(const GameHash&, const GameHash&) = default;
+	};
+
+	struct CacheEntry
+	{
+		GameHash game_hash;
+
+		bool supported = false;
+		bool has_achievements = false;
+		bool has_leaderboards = false;
+
+		u32 num_core_achievements = 0;
+		u32 num_unlocked_achievements = 0;
+
+		std::optional<u32> index_in_file;
+
+		friend auto operator<=>(const CacheEntry&, const CacheEntry&) = default;
 	};
 
 	/// Acquires the achievements lock. Must be held when accessing any achievement state from another thread.
@@ -147,6 +181,14 @@ namespace Achievements
 
 	/// Renders the leaderboard list.
 	void DrawLeaderboardsWindow();
+
+	/// Lookup achievement information (unlocks, etc) for a given game based on
+	/// its CRC, and optionally the MD5 hash of its ELF file if you want to
+	/// gracefully handle CRC collisions.
+	std::optional<CacheEntry> LookupCacheEntry(u32 game_crc, const GameHash* game_hash = nullptr);
+
+	/// Delete the achievement game cache. This will clear
+	void DeleteCacheFile();
 
 #ifdef ENABLE_RAINTEGRATION
 	/// Prevents the internal implementation from being used. Instead, RAIntegration will be

--- a/pcsx2/GameList.cpp
+++ b/pcsx2/GameList.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
 // SPDX-License-Identifier: GPL-3.0+
 
+#include "Achievements.h"
 #include "CDVD/CDVD.h"
 #include "Elfheader.h"
 #include "GameList.h"
@@ -153,36 +154,36 @@ const char* GameList::RegionToString(Region region, bool translate)
 const char* GameList::RegionToFlagFilename(Region region)
 {
 	static constexpr std::array<const char*, static_cast<int>(Region::Count)> flag_names = {
-		"br",  // NTSC-B
-		"cn",  // NTSC-C
-		"hk",  // NTSC-HK
-		"jp",  // NTSC-J
-		"kr",  // NTSC-K
-		"tw",  // NTSC-T
-		"us",  // NTSC-U
-		"Other",  // Other
-		"au",  // PAL-A
-		"za",  // PAL-AF
-		"at",  // PAL-AU
-		"be",  // PAL-BE
-		"eu",  // PAL-E
-		"fr",  // PAL-F
-		"fi",  // PAL-FI
-		"de",  // PAL-G
-		"gr",  // PAL-GR
-		"it",  // PAL-I
-		"in",  // PAL-IN
-		"eu",  // PAL-M
-		"nl",  // PAL-NL
-		"no",  // PAL-NO
-		"pt",  // PAL-P
-		"pl",  // PAL-PL
-		"ru",  // PAL-R
-		"es",  // PAL-S
-		"scn",  // PAL-SC
-		"se",  // PAL-SW
-		"ch",  // PAL-SWI
-		"gb",  // PAL-UK
+		"br", // NTSC-B
+		"cn", // NTSC-C
+		"hk", // NTSC-HK
+		"jp", // NTSC-J
+		"kr", // NTSC-K
+		"tw", // NTSC-T
+		"us", // NTSC-U
+		"Other", // Other
+		"au", // PAL-A
+		"za", // PAL-AF
+		"at", // PAL-AU
+		"be", // PAL-BE
+		"eu", // PAL-E
+		"fr", // PAL-F
+		"fi", // PAL-FI
+		"de", // PAL-G
+		"gr", // PAL-GR
+		"it", // PAL-I
+		"in", // PAL-IN
+		"eu", // PAL-M
+		"nl", // PAL-NL
+		"no", // PAL-NO
+		"pt", // PAL-P
+		"pl", // PAL-PL
+		"ru", // PAL-R
+		"es", // PAL-S
+		"scn", // PAL-SC
+		"se", // PAL-SW
+		"ch", // PAL-SWI
+		"gb", // PAL-UK
 	};
 
 	return flag_names.at(static_cast<int>(region));
@@ -454,62 +455,17 @@ bool GameList::GetGameListEntryFromCache(const std::string& path, GameList::Entr
 	return true;
 }
 
-static bool ReadString(std::FILE* stream, std::string* dest)
-{
-	u32 size;
-	if (std::fread(&size, sizeof(size), 1, stream) != 1)
-		return false;
-
-	dest->resize(size);
-	if (size > 0 && std::fread(dest->data(), size, 1, stream) != 1)
-		return false;
-
-	return true;
-}
-
-static bool ReadU8(std::FILE* stream, u8* dest)
-{
-	return std::fread(dest, sizeof(u8), 1, stream) > 0;
-}
-
-static bool ReadU32(std::FILE* stream, u32* dest)
-{
-	return std::fread(dest, sizeof(u32), 1, stream) > 0;
-}
-
-static bool ReadU64(std::FILE* stream, u64* dest)
-{
-	return std::fread(dest, sizeof(u64), 1, stream) > 0;
-}
-
-static bool WriteString(std::FILE* stream, const std::string& str)
-{
-	const u32 size = static_cast<u32>(str.size());
-	return (std::fwrite(&size, sizeof(size), 1, stream) > 0 && (size == 0 || std::fwrite(str.data(), size, 1, stream) > 0));
-}
-
-static bool WriteU8(std::FILE* stream, u8 dest)
-{
-	return std::fwrite(&dest, sizeof(u8), 1, stream) > 0;
-}
-
-static bool WriteU32(std::FILE* stream, u32 dest)
-{
-	return std::fwrite(&dest, sizeof(u32), 1, stream) > 0;
-}
-
-static bool WriteU64(std::FILE* stream, u64 dest)
-{
-	return std::fwrite(&dest, sizeof(u64), 1, stream) > 0;
-}
-
 bool GameList::LoadEntriesFromCache(std::FILE* stream)
 {
 	u32 file_signature, file_version;
 	s64 start_pos, file_size;
-	if (!ReadU32(stream, &file_signature) || !ReadU32(stream, &file_version) || file_signature != GAME_LIST_CACHE_SIGNATURE ||
-		file_version != GAME_LIST_CACHE_VERSION || (start_pos = FileSystem::FTell64(stream)) < 0 ||
-		FileSystem::FSeek64(stream, 0, SEEK_END) != 0 || (file_size = FileSystem::FTell64(stream)) < 0 ||
+	if (!FileSystem::ReadU32(stream, &file_signature) ||
+		!FileSystem::ReadU32(stream, &file_version) ||
+		file_signature != GAME_LIST_CACHE_SIGNATURE ||
+		file_version != GAME_LIST_CACHE_VERSION ||
+		(start_pos = FileSystem::FTell64(stream)) < 0 ||
+		FileSystem::FSeek64(stream, 0, SEEK_END) != 0 ||
+		(file_size = FileSystem::FTell64(stream)) < 0 ||
 		FileSystem::FSeek64(stream, start_pos, SEEK_SET) != 0)
 	{
 		Console.Warning("Game list cache is corrupted");
@@ -526,10 +482,19 @@ bool GameList::LoadEntriesFromCache(std::FILE* stream)
 		u8 compatibility_rating;
 		u64 last_modified_time;
 
-		if (!ReadString(stream, &path) || !ReadString(stream, &ge.serial) || !ReadString(stream, &ge.title) || !ReadString(stream, &ge.title_sort) ||
-			!ReadString(stream, &ge.title_en) || !ReadU8(stream, &type) || !ReadU8(stream, &region) || !ReadU64(stream, &ge.total_size) ||
-			!ReadU64(stream, &last_modified_time) || !ReadU32(stream, &ge.crc) || !ReadU8(stream, &compatibility_rating) ||
-			region >= static_cast<u8>(Region::Count) || type >= static_cast<u8>(EntryType::Count) ||
+		if (!FileSystem::ReadString(stream, &path) ||
+			!FileSystem::ReadString(stream, &ge.serial) ||
+			!FileSystem::ReadString(stream, &ge.title) ||
+			!FileSystem::ReadString(stream, &ge.title_sort) ||
+			!FileSystem::ReadString(stream, &ge.title_en) ||
+			!FileSystem::ReadU8(stream, &type) ||
+			!FileSystem::ReadU8(stream, &region) ||
+			!FileSystem::ReadU64(stream, &ge.total_size) ||
+			!FileSystem::ReadU64(stream, &last_modified_time) ||
+			!FileSystem::ReadU32(stream, &ge.crc) ||
+			!FileSystem::ReadU8(stream, &compatibility_rating) ||
+			region >= static_cast<u8>(Region::Count) ||
+			type >= static_cast<u8>(EntryType::Count) ||
 			compatibility_rating > static_cast<u8>(CompatibilityRating::Perfect))
 		{
 			Console.Warning("Game list cache entry is corrupted");
@@ -586,8 +551,8 @@ bool GameList::OpenCacheForWriting()
 	{
 		// check the header
 		u32 signature, version;
-		if (ReadU32(s_cache_write_stream, &signature) && signature == GAME_LIST_CACHE_SIGNATURE &&
-			ReadU32(s_cache_write_stream, &version) && version == GAME_LIST_CACHE_VERSION &&
+		if (FileSystem::ReadU32(s_cache_write_stream, &signature) && signature == GAME_LIST_CACHE_SIGNATURE &&
+			FileSystem::ReadU32(s_cache_write_stream, &version) && version == GAME_LIST_CACHE_VERSION &&
 			FileSystem::FSeek64(s_cache_write_stream, 0, SEEK_END) == 0)
 		{
 			return true;
@@ -604,7 +569,8 @@ bool GameList::OpenCacheForWriting()
 
 
 	// new cache file, write header
-	if (!WriteU32(s_cache_write_stream, GAME_LIST_CACHE_SIGNATURE) || !WriteU32(s_cache_write_stream, GAME_LIST_CACHE_VERSION))
+	if (!FileSystem::WriteU32(s_cache_write_stream, GAME_LIST_CACHE_SIGNATURE) ||
+		!FileSystem::WriteU32(s_cache_write_stream, GAME_LIST_CACHE_VERSION))
 	{
 		Console.Error("Failed to write game list cache header");
 		std::fclose(s_cache_write_stream);
@@ -619,17 +585,17 @@ bool GameList::OpenCacheForWriting()
 bool GameList::WriteEntryToCache(const Entry* entry)
 {
 	bool result = true;
-	result &= WriteString(s_cache_write_stream, entry->path);
-	result &= WriteString(s_cache_write_stream, entry->serial);
-	result &= WriteString(s_cache_write_stream, entry->title);
-	result &= WriteString(s_cache_write_stream, entry->title_sort);
-	result &= WriteString(s_cache_write_stream, entry->title_en);
-	result &= WriteU8(s_cache_write_stream, static_cast<u8>(entry->type));
-	result &= WriteU8(s_cache_write_stream, static_cast<u8>(entry->region));
-	result &= WriteU64(s_cache_write_stream, entry->total_size);
-	result &= WriteU64(s_cache_write_stream, static_cast<u64>(entry->last_modified_time));
-	result &= WriteU32(s_cache_write_stream, entry->crc);
-	result &= WriteU8(s_cache_write_stream, static_cast<u8>(entry->compatibility_rating));
+	result &= FileSystem::WriteString(s_cache_write_stream, entry->path);
+	result &= FileSystem::WriteString(s_cache_write_stream, entry->serial);
+	result &= FileSystem::WriteString(s_cache_write_stream, entry->title);
+	result &= FileSystem::WriteString(s_cache_write_stream, entry->title_sort);
+	result &= FileSystem::WriteString(s_cache_write_stream, entry->title_en);
+	result &= FileSystem::WriteU8(s_cache_write_stream, static_cast<u8>(entry->type));
+	result &= FileSystem::WriteU8(s_cache_write_stream, static_cast<u8>(entry->region));
+	result &= FileSystem::WriteU64(s_cache_write_stream, entry->total_size);
+	result &= FileSystem::WriteU64(s_cache_write_stream, static_cast<u64>(entry->last_modified_time));
+	result &= FileSystem::WriteU32(s_cache_write_stream, entry->crc);
+	result &= FileSystem::WriteU8(s_cache_write_stream, static_cast<u8>(entry->compatibility_rating));
 
 	// flush after each entry, that way we don't end up with a corrupted file if we crash scanning.
 	if (result)
@@ -875,9 +841,14 @@ void GameList::Refresh(bool invalidate_cache, bool only_cache, ProgressCallback*
 	ScopedGuard unlock_cdvd = &cdvdUnlock;
 
 	if (invalidate_cache)
+	{
 		DeleteCacheFile();
+		Achievements::DeleteCacheFile();
+	}
 	else
+	{
 		LoadCache();
+	}
 
 	// don't delete the old entries, since the frontend might still access them
 	std::vector<Entry> old_entries;

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1141,7 +1141,7 @@ void VMManager::UpdateDiscDetails(bool booting)
 	UpdateGameSettingsLayer();
 	ApplySettings();
 
-	// Patches are game-dependent, thus should get applied after game settings ia loaded.
+	// Patches are game-dependent, thus should get applied after game settings are loaded.
 	Patch::ReloadPatches(s_disc_serial, HasBootedELF() ? s_current_crc : 0, true, true, false, false);
 
 	ReportGameChangeToHost();


### PR DESCRIPTION
### Description of Changes
- Add a achievements game cache that records whether each game is supported, and how many achievements are unlocked.
- Show the number of achievements that are unlocked in the game list table.

**This is not done.**

### Rationale behind Changes
This PR aims to fix the following issues:
- If you start a game that doesn't support achievements with hardcore mode enabled in the settings window, the first time hardcore mode will be disabled correctly, however on subsequent startups hardcore mode will remain enabled. This is because rcheevos caches the result of the load game request in memory so Achievements::ClientLoadGameCallback runs before Achievements::ResetHardcoreMode after the first time.
- If you start a game that doesn't support achievements with hardcore mode enabled in the settings window, boot patches and cheats will only be applied sometimes.
- If you try to start a game from a save state, it will prompt you to disable hardcore mode even if the game doesn't support achievements.

The last two issues stem from a fundamental problem: When the virtual machine starts booting it sends a request to the RetroAchievements server to figure out if the game being loaded supports achievements, however we don't want to have to block the boot process until the response comes back, as that would waste people's time.

The current behaviour is to assume that hardcore mode is enabled until the request comes back, which leads to the issues listed above. I think the most sensible solution is to remember which games support achievements and which do not.

The first time a game is launched the boot process will block until the response comes back from the RetroAchievements server, and on subsequent startups hardcore mode will be enabled or disabled depending on the state of the cache. If the response comes back and the cache turns out to be wrong, we can just prompt the user to reset the virtual machine (or, if the memory card is busy, just inform the user that there's a problem).

I'm not sure exactly when this all broke. Older builds don't seem to work with hardcore mode anymore, so I haven't bisected it.

Closes #12927.

### Suggested Testing Steps
Not yet ready for review.

### Did you use AI to help find, test, or implement this issue or feature?
No.
