### PR TITLE
Qt: Explicitly include source files generated by moc

### DIFF
--- a/pcsx2-qt/AboutDialog.cpp
+++ b/pcsx2-qt/AboutDialog.cpp
@@ -153,3 +153,5 @@ void AboutDialog::showHTMLDialog(QWidget* parent, const QString& title, const QS
 
 	dialog.exec();
 }
+
+#include "moc_AboutDialog.cpp"

--- a/pcsx2-qt/AutoUpdaterDialog.cpp
+++ b/pcsx2-qt/AutoUpdaterDialog.cpp
@@ -913,3 +913,5 @@ void AutoUpdaterDialog::cleanupAfterUpdate()
 }
 
 #endif
+
+#include "moc_AutoUpdaterDialog.cpp"

--- a/pcsx2-qt/ColorPickerButton.cpp
+++ b/pcsx2-qt/ColorPickerButton.cpp
@@ -51,3 +51,5 @@ void ColorPickerButton::onClicked()
 	updateBackgroundColor();
 	emit colorChanged(new_rgb);
 }
+
+#include "moc_ColorPickerButton.cpp"

--- a/pcsx2-qt/CoverDownloadDialog.cpp
+++ b/pcsx2-qt/CoverDownloadDialog.cpp
@@ -125,3 +125,5 @@ void CoverDownloadDialog::CoverDownloadThread::runAsync()
 {
 	GameList::DownloadCovers(m_urls, m_use_serials, this);
 }
+
+#include "moc_CoverDownloadDialog.cpp"

--- a/pcsx2-qt/Debugger/AnalysisOptionsDialog.cpp
+++ b/pcsx2-qt/Debugger/AnalysisOptionsDialog.cpp
@@ -33,3 +33,5 @@ void AnalysisOptionsDialog::analyse()
 	if (m_ui.closeCheckBox->isChecked())
 		accept();
 }
+
+#include "moc_AnalysisOptionsDialog.cpp"

--- a/pcsx2-qt/Debugger/Breakpoints/BreakpointDialog.cpp
+++ b/pcsx2-qt/Debugger/Breakpoints/BreakpointDialog.cpp
@@ -200,3 +200,5 @@ void BreakpointDialog::accept()
 
 	QDialog::accept();
 }
+
+#include "moc_BreakpointDialog.cpp"

--- a/pcsx2-qt/Debugger/Breakpoints/BreakpointModel.cpp
+++ b/pcsx2-qt/Debugger/Breakpoints/BreakpointModel.cpp
@@ -699,3 +699,5 @@ void BreakpointModel::clear()
 	m_breakpoints.clear();
 	endResetModel();
 }
+
+#include "moc_BreakpointModel.cpp"

--- a/pcsx2-qt/Debugger/Breakpoints/BreakpointView.cpp
+++ b/pcsx2-qt/Debugger/Breakpoints/BreakpointView.cpp
@@ -180,3 +180,5 @@ void BreakpointView::resizeColumns()
 		i++;
 	}
 }
+
+#include "moc_BreakpointView.cpp"

--- a/pcsx2-qt/Debugger/DebuggerView.cpp
+++ b/pcsx2-qt/Debugger/DebuggerView.cpp
@@ -310,3 +310,5 @@ std::vector<QAction*> DebuggerView::createEventActionsImplementation(
 
 	return actions;
 }
+
+#include "moc_DebuggerView.cpp"

--- a/pcsx2-qt/Debugger/DebuggerWindow.cpp
+++ b/pcsx2-qt/Debugger/DebuggerWindow.cpp
@@ -573,3 +573,5 @@ DebugInterface* DebuggerWindow::currentCPU()
 
 	return &DebugInterface::get(*maybe_cpu);
 }
+
+#include "moc_DebuggerWindow.cpp"

--- a/pcsx2-qt/Debugger/DisassemblyView.cpp
+++ b/pcsx2-qt/Debugger/DisassemblyView.cpp
@@ -1089,3 +1089,5 @@ bool DisassemblyView::FunctionCanRestore(u32 address)
 
 	return m_stubbedFunctions.find(address) != m_stubbedFunctions.end();
 }
+
+#include "moc_DisassemblyView.cpp"

--- a/pcsx2-qt/Debugger/Docking/DockManager.cpp
+++ b/pcsx2-qt/Debugger/Docking/DockManager.cpp
@@ -894,3 +894,5 @@ bool DockManager::dragAboutToStart(KDDockWidgets::Core::Draggable* draggable)
 
 	return !locked;
 }
+
+#include "moc_DockManager.cpp"

--- a/pcsx2-qt/Debugger/Docking/DockMenuBar.cpp
+++ b/pcsx2-qt/Debugger/Docking/DockMenuBar.cpp
@@ -319,3 +319,5 @@ QSize DockMenuBarStyle::sizeFromContents(
 
 	return size;
 }
+
+#include "moc_DockMenuBar.cpp"

--- a/pcsx2-qt/Debugger/Docking/DockViews.cpp
+++ b/pcsx2-qt/Debugger/Docking/DockViews.cpp
@@ -307,3 +307,5 @@ void DockTabBar::mouseDoubleClickEvent(QMouseEvent* event)
 	else
 		event->ignore();
 }
+
+#include "moc_DockViews.cpp"

--- a/pcsx2-qt/Debugger/Docking/DropIndicators.cpp
+++ b/pcsx2-qt/Debugger/Docking/DropIndicators.cpp
@@ -571,3 +571,5 @@ void DockSegmentedDropIndicatorOverlay::drawMinimalistic()
 		painter.drawRect(segment->second.boundingRect());
 	}
 }
+
+#include "moc_DropIndicators.cpp"

--- a/pcsx2-qt/Debugger/Docking/LayoutEditorDialog.cpp
+++ b/pcsx2-qt/Debugger/Docking/LayoutEditorDialog.cpp
@@ -105,3 +105,5 @@ void LayoutEditorDialog::onNameChanged()
 	m_ui.buttonBox->button(QDialogButtonBox::Ok)->setEnabled(error_message.isEmpty());
 	m_ui.errorMessage->setText(error_message);
 }
+
+#include "moc_LayoutEditorDialog.cpp"

--- a/pcsx2-qt/Debugger/Docking/NoLayoutsWidget.cpp
+++ b/pcsx2-qt/Debugger/Docking/NoLayoutsWidget.cpp
@@ -13,3 +13,5 @@ QPushButton* NoLayoutsWidget::createDefaultLayoutsButton()
 {
 	return m_ui.createDefaultLayoutsButton;
 }
+
+#include "moc_NoLayoutsWidget.cpp"

--- a/pcsx2-qt/Debugger/Memory/MemorySearchView.cpp
+++ b/pcsx2-qt/Debugger/Memory/MemorySearchView.cpp
@@ -753,3 +753,5 @@ std::vector<SearchComparison> MemorySearchView::getValidSearchComparisonsForStat
 
 	return comparisons;
 }
+
+#include "moc_MemorySearchView.cpp"

--- a/pcsx2-qt/Debugger/Memory/MemoryView.cpp
+++ b/pcsx2-qt/Debugger/Memory/MemoryView.cpp
@@ -965,3 +965,5 @@ void MemoryView::gotoAddress(u32 address)
 	this->repaint();
 	this->setFocus();
 }
+
+#include "moc_MemoryView.cpp"

--- a/pcsx2-qt/Debugger/Memory/SavedAddressesModel.cpp
+++ b/pcsx2-qt/Debugger/Memory/SavedAddressesModel.cpp
@@ -219,3 +219,5 @@ void SavedAddressesModel::clear()
 	m_savedAddresses.clear();
 	endResetModel();
 }
+
+#include "moc_SavedAddressesModel.cpp"

--- a/pcsx2-qt/Debugger/Memory/SavedAddressesView.cpp
+++ b/pcsx2-qt/Debugger/Memory/SavedAddressesView.cpp
@@ -166,3 +166,5 @@ void SavedAddressesView::saveToDebuggerSettings()
 {
 	DebuggerSettingsManager::saveGameSettings(m_model);
 }
+
+#include "moc_SavedAddressesView.cpp"

--- a/pcsx2-qt/Debugger/ModuleModel.cpp
+++ b/pcsx2-qt/Debugger/ModuleModel.cpp
@@ -131,3 +131,5 @@ void ModuleModel::refreshData()
 	m_modules = m_cpu.GetModuleList();
 	endResetModel();
 }
+
+#include "moc_ModuleModel.cpp"

--- a/pcsx2-qt/Debugger/ModuleView.cpp
+++ b/pcsx2-qt/Debugger/ModuleView.cpp
@@ -105,3 +105,5 @@ void ModuleView::onDoubleClick(const QModelIndex& index)
 		}
 	}
 }
+
+#include "moc_ModuleView.cpp"

--- a/pcsx2-qt/Debugger/RegisterView.cpp
+++ b/pcsx2-qt/Debugger/RegisterView.cpp
@@ -473,3 +473,5 @@ std::optional<DebuggerEvents::GoToAddress> RegisterView::contextCreateGotoEvent(
 	event.address = addr;
 	return event;
 }
+
+#include "moc_RegisterView.cpp"

--- a/pcsx2-qt/Debugger/StackModel.cpp
+++ b/pcsx2-qt/Debugger/StackModel.cpp
@@ -118,3 +118,5 @@ void StackModel::refreshData()
 	}
 	endResetModel();
 }
+
+#include "moc_StackModel.cpp"

--- a/pcsx2-qt/Debugger/StackView.cpp
+++ b/pcsx2-qt/Debugger/StackView.cpp
@@ -83,3 +83,5 @@ void StackView::onDoubleClick(const QModelIndex& index)
 		}
 	}
 }
+
+#include "moc_StackView.cpp"

--- a/pcsx2-qt/Debugger/SymbolTree/NewSymbolDialogs.cpp
+++ b/pcsx2-qt/Debugger/SymbolTree/NewSymbolDialogs.cpp
@@ -651,3 +651,5 @@ void NewParameterVariableDialog::createSymbol()
 	if (!error_message.isEmpty())
 		AsyncDialogs::warning(g_debugger_window, tr("Cannot Create Parameter Variable"), error_message);
 }
+
+#include "moc_NewSymbolDialogs.cpp"

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeDelegates.cpp
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeDelegates.cpp
@@ -527,3 +527,5 @@ void SymbolTreeIntegerLineEdit::setSignedValue(s64 value)
 {
 	setText(m_display_options.signedIntegerToString(value, m_size_bits));
 }
+
+#include "moc_SymbolTreeDelegates.cpp"

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeModel.cpp
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeModel.cpp
@@ -528,3 +528,5 @@ bool SymbolTreeModel::nodeHasChildren(const ccc::ast::Node& logical_type, const 
 
 	return result;
 }
+
+#include "moc_SymbolTreeModel.cpp"

--- a/pcsx2-qt/Debugger/SymbolTree/SymbolTreeViews.cpp
+++ b/pcsx2-qt/Debugger/SymbolTree/SymbolTreeViews.cpp
@@ -1272,3 +1272,5 @@ static bool testName(const QString& name, const QString& filter)
 {
 	return filter.isEmpty() || name.contains(filter, Qt::CaseInsensitive);
 }
+
+#include "moc_SymbolTreeViews.cpp"

--- a/pcsx2-qt/Debugger/ThreadModel.cpp
+++ b/pcsx2-qt/Debugger/ThreadModel.cpp
@@ -129,3 +129,5 @@ void ThreadModel::refreshData()
 	m_threads = m_cpu.GetThreadList();
 	endResetModel();
 }
+
+#include "moc_ThreadModel.cpp"

--- a/pcsx2-qt/Debugger/ThreadView.cpp
+++ b/pcsx2-qt/Debugger/ThreadView.cpp
@@ -90,3 +90,5 @@ void ThreadView::onDoubleClick(const QModelIndex& index)
 		}
 	}
 }
+
+#include "moc_ThreadView.cpp"

--- a/pcsx2-qt/DisplayWidget.cpp
+++ b/pcsx2-qt/DisplayWidget.cpp
@@ -493,3 +493,5 @@ bool DisplaySurface::eventFilter(QObject* object, QEvent* event)
 			return false;
 	}
 }
+
+#include "moc_DisplayWidget.cpp"

--- a/pcsx2-qt/GameList/GameListModel.cpp
+++ b/pcsx2-qt/GameList/GameListModel.cpp
@@ -519,3 +519,5 @@ void GameListModel::setColumnDisplayNames()
 	m_column_display_names[Column_Region] = tr("Region");
 	m_column_display_names[Column_Compatibility] = tr("Compatibility");
 }
+
+#include "moc_GameListModel.cpp"

--- a/pcsx2-qt/GameList/GameListRefreshThread.cpp
+++ b/pcsx2-qt/GameList/GameListRefreshThread.cpp
@@ -121,3 +121,5 @@ void GameListRefreshThread::run()
 	GameList::Refresh(m_invalidate_cache, false, &m_progress);
 	emit refreshComplete();
 }
+
+#include "moc_GameListRefreshThread.cpp"

--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -985,3 +985,5 @@ void GameListGridListView::wheelEvent(QWheelEvent* e)
 
 	QListView::wheelEvent(e);
 }
+
+#include "moc_GameListWidget.cpp"

--- a/pcsx2-qt/LogWindow.cpp
+++ b/pcsx2-qt/LogWindow.cpp
@@ -461,3 +461,5 @@ void LogWindow::restoreSize()
 	const int height = Host::GetBaseIntSettingValue("UI", "LogWindowHeight", DEFAULT_HEIGHT);
 	resize(width, height);
 }
+
+#include "moc_LogWindow.cpp"

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -3551,3 +3551,5 @@ const QString& QtHost::GetCurrentGamePath()
 {
 	return s_current_disc_path;
 }
+
+#include "moc_MainWindow.cpp"

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -2489,3 +2489,5 @@ shutdown_and_exit:
 
 	return result;
 }
+
+#include "moc_QtHost.cpp"

--- a/pcsx2-qt/QtProgressCallback.cpp
+++ b/pcsx2-qt/QtProgressCallback.cpp
@@ -232,3 +232,5 @@ QWidget* QtAsyncProgressThread::parentWidget() const
 {
 	return qobject_cast<QWidget*>(parent());
 }
+
+#include "moc_QtProgressCallback.cpp"

--- a/pcsx2-qt/Settings/AchievementLoginDialog.cpp
+++ b/pcsx2-qt/Settings/AchievementLoginDialog.cpp
@@ -171,3 +171,5 @@ bool AchievementLoginDialog::canEnableLoginButton() const
 {
 	return !m_ui.userName->text().isEmpty() && !m_ui.password->text().isEmpty();
 }
+
+#include "moc_AchievementLoginDialog.cpp"

--- a/pcsx2-qt/Settings/AchievementSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AchievementSettingsWidget.cpp
@@ -273,3 +273,5 @@ void AchievementSettingsWidget::onAchievementsRefreshed(quint32 id, const QStrin
 {
 	m_ui.gameInfo->setText(game_info_string);
 }
+
+#include "moc_AchievementSettingsWidget.cpp"

--- a/pcsx2-qt/Settings/AdvancedSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AdvancedSettingsWidget.cpp
@@ -225,3 +225,5 @@ void AdvancedSettingsWidget::onSavestateCompressionTypeChanged()
 							   static_cast<int>(SavestateCompressionMethod::Uncompressed));
 	m_ui.savestateCompressionLevel->setDisabled(uncompressed);
 }
+
+#include "moc_AdvancedSettingsWidget.cpp"

--- a/pcsx2-qt/Settings/AudioSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.cpp
@@ -503,3 +503,5 @@ void AudioSettingsWidget::resetVolume(const bool fast_forward)
 		slider->setValue(100);
 	}
 }
+
+#include "moc_AudioSettingsWidget.cpp"

--- a/pcsx2-qt/Settings/BIOSSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/BIOSSettingsWidget.cpp
@@ -145,3 +145,5 @@ void BIOSSettingsWidget::fastBootChanged()
 	const bool enabled = dialog()->getEffectiveBoolValue("EmuCore", "EnableFastBoot", true);
 	m_ui.fastBootFastForward->setEnabled(enabled);
 }
+
+#include "moc_BIOSSettingsWidget.cpp"

--- a/pcsx2-qt/Settings/ControllerBindingWidget.cpp
+++ b/pcsx2-qt/Settings/ControllerBindingWidget.cpp
@@ -1449,3 +1449,5 @@ USBBindingWidget* USBBindingWidget::createInstance(
 
 	return widget;
 }
+
+#include "moc_ControllerBindingWidget.cpp"

--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
@@ -213,3 +213,5 @@ ControllerMappingSettingsDialog::ControllerMappingSettingsDialog(ControllerSetti
 	connect(m_ui.buttonBox->button(QDialogButtonBox::Close), &QPushButton::clicked, this, &QDialog::accept);
 }
 ControllerMappingSettingsDialog::~ControllerMappingSettingsDialog() = default;
+
+#include "moc_ControllerGlobalSettingsWidget.cpp"

--- a/pcsx2-qt/Settings/ControllerSettingsWindow.cpp
+++ b/pcsx2-qt/Settings/ControllerSettingsWindow.cpp
@@ -600,3 +600,5 @@ void ControllerSettingsWindow::switchProfile(const QString& name)
 	m_profile_name = name;
 	createWidgets();
 }
+
+#include "moc_ControllerSettingsWindow.cpp"

--- a/pcsx2-qt/Settings/DEV9DnsHostDialog.cpp
+++ b/pcsx2-qt/Settings/DEV9DnsHostDialog.cpp
@@ -130,3 +130,5 @@ bool DEV9DnsHostDialog::eventFilter(QObject* object, QEvent* event)
 }
 
 DEV9DnsHostDialog::~DEV9DnsHostDialog() = default;
+
+#include "moc_DEV9DnsHostDialog.cpp"

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
@@ -1083,3 +1083,5 @@ void DEV9SettingsWidget::DeleteHostConfig(int index)
 }
 
 DEV9SettingsWidget::~DEV9SettingsWidget() = default;
+
+#include "moc_DEV9SettingsWidget.cpp"

--- a/pcsx2-qt/Settings/DEV9UiCommon.cpp
+++ b/pcsx2-qt/Settings/DEV9UiCommon.cpp
@@ -68,3 +68,5 @@ void IPItemDelegate::updateEditorGeometry(QWidget* editor, const QStyleOptionVie
 {
 	editor->setGeometry(option.rect);
 }
+
+#include "moc_DEV9UiCommon.cpp"

--- a/pcsx2-qt/Settings/DebugAnalysisSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DebugAnalysisSettingsWidget.cpp
@@ -517,3 +517,5 @@ int DebugAnalysisSettingsWidget::getIntSettingValue(
 
 	return Host::GetIntSettingValue(section, key, default_value);
 }
+
+#include "moc_DebugAnalysisSettingsWidget.cpp"

--- a/pcsx2-qt/Settings/DebugSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DebugSettingsWidget.cpp
@@ -276,3 +276,5 @@ void DebugSettingsWidget::onLoggingEnableChanged()
 	g_emu_thread->applySettings();
 }
 #endif
+
+#include "moc_DebugSettingsWidget.cpp"

--- a/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
@@ -334,3 +334,5 @@ void EmulationSettingsWidget::onUseSystemLocaleFormatChanged()
 	const bool enabled = dialog()->getEffectiveBoolValue("EmuCore", "UseSystemLocaleFormat", false);
 	m_ui.rtcDateTime->setDisplayFormat(enabled ? QLocale::system().dateTimeFormat(QLocale::ShortFormat) : "yyyy-MM-dd HH:mm:ss");
 }
+
+#include "moc_EmulationSettingsWidget.cpp"

--- a/pcsx2-qt/Settings/FolderSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/FolderSettingsWidget.cpp
@@ -29,3 +29,5 @@ FolderSettingsWidget::FolderSettingsWidget(SettingsWindow* settings_dialog, QWid
 }
 
 FolderSettingsWidget::~FolderSettingsWidget() = default;
+
+#include "moc_FolderSettingsWidget.cpp"

--- a/pcsx2-qt/Settings/GameCheatSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GameCheatSettingsWidget.cpp
@@ -346,3 +346,5 @@ QList<QStandardItem*> GameCheatSettingsWidget::populateTreeViewRow(const Patch::
 	items.push_back(descriptionItem);
 	return items;
 }
+
+#include "moc_GameCheatSettingsWidget.cpp"

--- a/pcsx2-qt/Settings/GameFixSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GameFixSettingsWidget.cpp
@@ -57,3 +57,5 @@ GameFixSettingsWidget::GameFixSettingsWidget(SettingsWindow* settings_dialog, QW
 }
 
 GameFixSettingsWidget::~GameFixSettingsWidget() = default;
+
+#include "moc_GameFixSettingsWidget.cpp"

--- a/pcsx2-qt/Settings/GameListSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GameListSettingsWidget.cpp
@@ -278,3 +278,5 @@ void GameListSettingsWidget::onScanForNewGamesClicked()
 {
 	g_main_window->refreshGameList(false, true);
 }
+
+#include "moc_GameListSettingsWidget.cpp"

--- a/pcsx2-qt/Settings/GamePatchSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GamePatchSettingsWidget.cpp
@@ -211,3 +211,5 @@ void GamePatchSettingsWidget::setGlobalNiPatchNoteVisibility(bool visible)
 {
 	m_ui.globalNiPatchState->setVisible(visible);
 }
+
+#include "moc_GamePatchSettingsWidget.cpp"

--- a/pcsx2-qt/Settings/GameSummaryWidget.cpp
+++ b/pcsx2-qt/Settings/GameSummaryWidget.cpp
@@ -418,3 +418,5 @@ void GameSummaryWidget::setCustomRegion(int region)
 	GameList::SaveCustomRegionForPath(m_entry_path, region);
 	repopulateCurrentDetails();
 }
+
+#include "moc_GameSummaryWidget.cpp"

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -1316,3 +1316,5 @@ void GraphicsSettingsWidget::onUpscaleMultiplierChanged()
 	dialog()->setFloatSettingValue("EmuCore/GS", "upscale_multiplier",
 		data.isValid() ? std::optional<float>(data.toFloat()) : std::optional<float>());
 }
+
+#include "moc_GraphicsSettingsWidget.cpp"

--- a/pcsx2-qt/Settings/HotkeySettingsWidget.cpp
+++ b/pcsx2-qt/Settings/HotkeySettingsWidget.cpp
@@ -93,3 +93,5 @@ void HotkeySettingsWidget::createButtons()
 	// Fill remaining space.
 	m_layout->addStretch(1);
 }
+
+#include "moc_HotkeySettingsWidget.cpp"

--- a/pcsx2-qt/Settings/InputBindingDialog.cpp
+++ b/pcsx2-qt/Settings/InputBindingDialog.cpp
@@ -384,3 +384,5 @@ void InputBindingDialog::ReloadBindNames()
 
 	updateList();
 }
+
+#include "moc_InputBindingDialog.cpp"

--- a/pcsx2-qt/Settings/InputBindingWidget.cpp
+++ b/pcsx2-qt/Settings/InputBindingWidget.cpp
@@ -527,3 +527,5 @@ void InputVibrationBindingWidget::mouseReleaseEvent(QMouseEvent* e)
 
 	QPushButton::mouseReleaseEvent(e);
 }
+
+#include "moc_InputBindingWidget.cpp"

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -294,3 +294,5 @@ void InterfaceSettingsWidget::onClearGameListBackgroundTriggered()
 	Host::CommitBaseSettingChanges();
 	emit backgroundChanged();
 }
+
+#include "moc_InterfaceSettingsWidget.cpp"

--- a/pcsx2-qt/Settings/MemoryCardConvertDialog.cpp
+++ b/pcsx2-qt/Settings/MemoryCardConvertDialog.cpp
@@ -321,3 +321,5 @@ void MemoryCardConvertDialog::FileOpenError(const QString errmsg)
 {
 	QMessageBox::critical(this, tr("Cannot Convert Memory Card"), tr("There was an error when accessing the memory card directory. Error message: %0").arg(errmsg));
 }
+
+#include "moc_MemoryCardConvertDialog.cpp"

--- a/pcsx2-qt/Settings/MemoryCardCreateDialog.cpp
+++ b/pcsx2-qt/Settings/MemoryCardCreateDialog.cpp
@@ -133,3 +133,5 @@ void MemoryCardCreateDialog::createCard()
 	QMessageBox::information(this, tr("Create Memory Card"), tr("Memory Card '%1' created.").arg(name));
 	accept();
 }
+
+#include "moc_MemoryCardCreateDialog.cpp"

--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
@@ -523,3 +523,5 @@ void MemoryCardSlotWidget::setCard(const std::optional<std::string>& name, bool 
 
 	item->setToolTip(item->text());
 }
+
+#include "moc_MemoryCardSettingsWidget.cpp"

--- a/pcsx2-qt/Settings/SettingsWidget.cpp
+++ b/pcsx2-qt/Settings/SettingsWidget.cpp
@@ -114,3 +114,5 @@ void SettingsWidget::updateTabMargins(QScrollArea* scroll_area)
 		scroll_area->widget()->layout()->setContentsMargins(-1, -1, -1, -1);
 	}
 }
+
+#include "moc_SettingsWidget.cpp"

--- a/pcsx2-qt/Settings/SettingsWindow.cpp
+++ b/pcsx2-qt/Settings/SettingsWindow.cpp
@@ -693,3 +693,5 @@ void SettingsWindow::closeGamePropertiesDialogs()
 		dialog->deleteLater();
 	}
 }
+
+#include "moc_SettingsWindow.cpp"

--- a/pcsx2-qt/SetupWizardDialog.cpp
+++ b/pcsx2-qt/SetupWizardDialog.cpp
@@ -479,3 +479,5 @@ void SetupWizardDialog::onInputDeviceDisconnected(const QString& identifier)
 		}
 	}
 }
+
+#include "moc_SetupWizardDialog.cpp"

--- a/pcsx2-qt/ShortcutCreationDialog.cpp
+++ b/pcsx2-qt/ShortcutCreationDialog.cpp
@@ -542,3 +542,5 @@ bool ShortcutCreationDialog::EscapeShortcutCommandLine(std::string* arg)
 	return lossless;
 #endif
 }
+
+#include "moc_ShortcutCreationDialog.cpp"

--- a/pcsx2-qt/Tools/InputRecording/InputRecordingViewer.cpp
+++ b/pcsx2-qt/Tools/InputRecording/InputRecordingViewer.cpp
@@ -118,3 +118,5 @@ void InputRecordingViewer::closeFile()
 	} // TODO else error
 	m_ui.actionClose->setEnabled(m_file_open);
 }
+
+#include "moc_InputRecordingViewer.cpp"

--- a/pcsx2-qt/Tools/InputRecording/NewInputRecordingDlg.cpp
+++ b/pcsx2-qt/Tools/InputRecording/NewInputRecordingDlg.cpp
@@ -92,3 +92,5 @@ void NewInputRecordingDlg::updateFormStatus()
 {
 	m_ui.m_dlgBtns->button(QDialogButtonBox::Ok)->setEnabled(isFormValid());
 }
+
+#include "moc_NewInputRecordingDlg.cpp"

--- a/pcsx2-qt/pcsx2-qt.vcxproj
+++ b/pcsx2-qt/pcsx2-qt.vcxproj
@@ -50,7 +50,7 @@
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SolutionDir)3rdparty\rapidjson\include</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SolutionDir)pcsx2</AdditionalIncludeDirectories>
       <!-- Needed for moc pch -->
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(ProjectDir)\Settings;$(ProjectDir)\GameList;$(ProjectDir)\Tools\InputRecording;$(ProjectDir)\Debugger;$(ProjectDir)\Debugger\Breakpoints;$(ProjectDir)\Debugger\Docking;$(ProjectDir)\Debugger\Memory;$(ProjectDir)\Debugger\SymbolTree</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(ProjectDir)Settings;$(ProjectDir)GameList;$(ProjectDir)Tools\InputRecording;$(ProjectDir)Debugger;$(ProjectDir)Debugger\Breakpoints;$(ProjectDir)\Debugger\Docking;$(ProjectDir)Debugger\Memory;$(ProjectDir)Debugger\SymbolTree;$(IntDir)Settings;$(IntDir)GameList;$(IntDir)Tools\InputRecording;$(IntDir)Debugger;$(IntDir)Debugger\Breakpoints;$(IntDir)\Debugger\Docking;$(IntDir)Debugger\Memory;$(IntDir)Debugger\SymbolTree</AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>PrecompiledHeader.h</PrecompiledHeaderFile>
       <ForcedIncludeFiles>PrecompiledHeader.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
@@ -280,83 +280,6 @@
     </QtResource>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="$(IntDir)Settings\moc_BIOSSettingsWidget.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_ControllerBindingWidget.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_ControllerGlobalSettingsWidget.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_ControllerSettingsWindow.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_MemoryCardCreateDialog.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_EmulationSettingsWidget.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_GameListSettingsWidget.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_GraphicsSettingsWidget.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_InterfaceSettingsWidget.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_SettingsWidget.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_SettingsWindow.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_AdvancedSettingsWidget.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_GameCheatSettingsWidget.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_GameFixSettingsWidget.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_GamePatchSettingsWidget.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_HotkeySettingsWidget.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_InputBindingDialog.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_InputBindingWidget.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_AudioSettingsWidget.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_MemoryCardConvertDialog.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_MemoryCardSettingsWidget.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_FolderSettingsWidget.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_DEV9DnsHostDialog.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_DEV9SettingsWidget.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_DEV9UiCommon.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_GameSummaryWidget.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_AchievementLoginDialog.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_AchievementSettingsWidget.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_DebugAnalysisSettingsWidget.cpp" />
-    <ClCompile Include="$(IntDir)Settings\moc_DebugSettingsWidget.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\moc_AnalysisOptionsDialog.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\moc_DebuggerView.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\moc_DebuggerWindow.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\moc_DisassemblyView.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\moc_RegisterView.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\moc_StackModel.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\moc_StackView.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\moc_ModuleModel.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\moc_ModuleView.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\moc_ThreadModel.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\moc_ThreadView.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\Breakpoints\moc_BreakpointDialog.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\Breakpoints\moc_BreakpointModel.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\Breakpoints\moc_BreakpointView.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\Docking\moc_DockManager.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\Docking\moc_DockMenuBar.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\Docking\moc_DockViews.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\Docking\moc_DropIndicators.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\Docking\moc_LayoutEditorDialog.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\Docking\moc_NoLayoutsWidget.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\Memory\moc_MemorySearchView.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\Memory\moc_MemoryView.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\Memory\moc_SavedAddressesModel.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\Memory\moc_SavedAddressesView.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\SymbolTree\moc_NewSymbolDialogs.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\SymbolTree\moc_SymbolTreeDelegates.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\SymbolTree\moc_SymbolTreeLocation.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\SymbolTree\moc_SymbolTreeModel.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\SymbolTree\moc_SymbolTreeNode.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\SymbolTree\moc_SymbolTreeViews.cpp" />
-    <ClCompile Include="$(IntDir)Debugger\SymbolTree\moc_TypeString.cpp" />
-    <ClCompile Include="$(IntDir)GameList\moc_GameListModel.cpp" />
-    <ClCompile Include="$(IntDir)GameList\moc_GameListRefreshThread.cpp" />
-    <ClCompile Include="$(IntDir)GameList\moc_GameListWidget.cpp" />
-    <ClCompile Include="$(IntDir)moc_AboutDialog.cpp" />
-    <ClCompile Include="$(IntDir)moc_AutoUpdaterDialog.cpp" />
-    <ClCompile Include="$(IntDir)moc_ColorPickerButton.cpp" />
-    <ClCompile Include="$(IntDir)moc_CoverDownloadDialog.cpp" />
-    <ClCompile Include="$(IntDir)moc_DisplayWidget.cpp" />
-    <ClCompile Include="$(IntDir)moc_LogWindow.cpp" />
-    <ClCompile Include="$(IntDir)moc_MainWindow.cpp" />
-    <ClCompile Include="$(IntDir)moc_QtHost.cpp" />
-    <ClCompile Include="$(IntDir)moc_QtProgressCallback.cpp" />
-    <ClCompile Include="$(IntDir)moc_SetupWizardDialog.cpp" />
-    <ClCompile Include="$(IntDir)moc_ShortcutCreationDialog.cpp" />
-    <ClCompile Include="$(IntDir)Tools\InputRecording\moc_NewInputRecordingDlg.cpp" />
-    <ClCompile Include="$(IntDir)Tools\InputRecording\moc_InputRecordingViewer.cpp" />
     <ClCompile Include="$(IntDir)qrc_resources.cpp">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>

--- a/pcsx2-qt/pcsx2-qt.vcxproj.filters
+++ b/pcsx2-qt/pcsx2-qt.vcxproj.filters
@@ -4,9 +4,6 @@
     <Filter Include="Resources">
       <UniqueIdentifier>{1f18feb4-85f0-455d-927a-d4d6b226d8a5}</UniqueIdentifier>
     </Filter>
-    <Filter Include="moc">
-      <UniqueIdentifier>{1ab68559-2163-40b5-818b-d2a7ff210c12}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Settings">
       <UniqueIdentifier>{11eec1ee-70c1-42ad-8cd1-e7f72f4c8673}</UniqueIdentifier>
     </Filter>
@@ -46,20 +43,11 @@
     <ClCompile Include="AsyncDialogs.cpp" />
     <ClCompile Include="QtHost.cpp" />
     <ClCompile Include="MainWindow.cpp" />
-    <ClCompile Include="$(IntDir)moc_MainWindow.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
     <ClCompile Include="$(IntDir)qrc_resources.cpp">
       <Filter>Resources</Filter>
     </ClCompile>
     <ClCompile Include="DisplayWidget.cpp" />
-    <ClCompile Include="$(IntDir)moc_DisplayWidget.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
     <ClCompile Include="QtUtils.cpp" />
-    <ClCompile Include="$(IntDir)moc_QtHost.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
     <ClCompile Include="QtKeyCodes.cpp" />
     <ClCompile Include="Settings\BIOSSettingsWidget.cpp">
       <Filter>Settings</Filter>
@@ -79,44 +67,11 @@
     <ClCompile Include="Settings\SettingsWindow.cpp">
       <Filter>Settings</Filter>
     </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_BIOSSettingsWidget.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_EmulationSettingsWidget.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_GameListSettingsWidget.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_GraphicsSettingsWidget.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_InterfaceSettingsWidget.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_SettingsWindow.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_AdvancedSettingsWidget.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
     <ClCompile Include="Settings\AdvancedSettingsWidget.cpp">
       <Filter>Settings</Filter>
     </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_GameFixSettingsWidget.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
     <ClCompile Include="Settings\GameFixSettingsWidget.cpp">
       <Filter>Settings</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_HotkeySettingsWidget.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_InputBindingDialog.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_InputBindingWidget.cpp">
-      <Filter>moc</Filter>
     </ClCompile>
     <ClCompile Include="Settings\InputBindingWidget.cpp">
       <Filter>Settings</Filter>
@@ -137,56 +92,14 @@
     <ClCompile Include="GameList\GameListModel.cpp">
       <Filter>GameList</Filter>
     </ClCompile>
-    <ClCompile Include="$(IntDir)moc_AboutDialog.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_ControllerSettingsWindow.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)GameList\moc_GameListModel.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)GameList\moc_GameListRefreshThread.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)GameList\moc_GameListWidget.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
     <ClCompile Include="Settings\ControllerSettingsWindow.cpp">
       <Filter>Settings</Filter>
     </ClCompile>
     <ClCompile Include="Settings\ControllerBindingWidget.cpp">
       <Filter>Settings</Filter>
     </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_ControllerBindingWidget.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
     <ClCompile Include="Settings\ControllerGlobalSettingsWidget.cpp">
       <Filter>Settings</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_MemoryCardConvertDialog.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_MemoryCardSettingsWidget.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_ControllerGlobalSettingsWidget.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_GameSummaryWidget.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_AudioSettingsWidget.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_DEV9DnsHostDialog.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_DEV9SettingsWidget.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_DEV9UiCommon.cpp">
-      <Filter>moc</Filter>
     </ClCompile>
     <ClCompile Include="Settings\GameSummaryWidget.cpp">
       <Filter>Settings</Filter>
@@ -199,9 +112,6 @@
     </ClCompile>
     <ClCompile Include="Settings\AudioSettingsWidget.cpp">
       <Filter>Settings</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_MemoryCardCreateDialog.cpp">
-      <Filter>moc</Filter>
     </ClCompile>
     <ClCompile Include="Settings\MemoryCardCreateDialog.cpp">
       <Filter>Settings</Filter>
@@ -219,15 +129,6 @@
       <Filter>Settings</Filter>
     </ClCompile>
     <ClCompile Include="AutoUpdaterDialog.cpp" />
-    <ClCompile Include="$(IntDir)moc_AutoUpdaterDialog.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Tools\InputRecording\moc_NewInputRecordingDlg.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Tools\InputRecording\moc_InputRecordingViewer.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
     <ClCompile Include="Tools\InputRecording\NewInputRecordingDlg.cpp">
       <Filter>Tools\Input Recording</Filter>
     </ClCompile>
@@ -235,32 +136,14 @@
     <ClCompile Include="Settings\FolderSettingsWidget.cpp">
       <Filter>Settings</Filter>
     </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_FolderSettingsWidget.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)moc_CoverDownloadDialog.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)moc_ShortcutCreationDialog.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
     <ClCompile Include="CoverDownloadDialog.cpp" />
     <ClCompile Include="ShortcutCreationDialog.cpp" />
     <ClCompile Include="QtProgressCallback.cpp" />
-    <ClCompile Include="$(IntDir)moc_QtProgressCallback.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
     <ClCompile Include="Settings\AchievementSettingsWidget.cpp">
       <Filter>Settings</Filter>
     </ClCompile>
     <ClCompile Include="Settings\AchievementLoginDialog.cpp">
       <Filter>Settings</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_AchievementSettingsWidget.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_AchievementLoginDialog.cpp">
-      <Filter>moc</Filter>
     </ClCompile>
     <ClCompile Include="Settings\MemoryCardConvertWorker.cpp">
       <Filter>Settings</Filter>
@@ -271,14 +154,8 @@
     <ClCompile Include="Settings\DebugAnalysisSettingsWidget.cpp">
       <Filter>Settings</Filter>
     </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_DebugAnalysisSettingsWidget.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
     <ClCompile Include="Settings\DebugSettingsWidget.cpp">
       <Filter>Settings</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_DebugSettingsWidget.cpp">
-      <Filter>moc</Filter>
     </ClCompile>
     <ClCompile Include="Debugger\AnalysisOptionsDialog.cpp">
       <Filter>Debugger</Filter>
@@ -295,61 +172,7 @@
     <ClCompile Include="Debugger\ThreadModel.cpp">
       <Filter>Debugger</Filter>
     </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\moc_AnalysisOptionsDialog.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\moc_DebuggerView.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\moc_DebuggerWindow.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\moc_StackModel.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\moc_ThreadModel.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\Breakpoints\moc_BreakpointDialog.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\Breakpoints\moc_BreakpointModel.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\Breakpoints\moc_BreakpointView.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\Docking\moc_DockManager.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\Docking\moc_DockViews.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\Docking\moc_DropIndicators.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\Docking\moc_LayoutEditorDialog.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\Docking\moc_NoLayoutsWidget.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\Memory\moc_MemorySearchView.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\Memory\moc_MemoryView.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\Memory\moc_SavedAddressesModel.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\Memory\moc_SavedAddressesView.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
     <ClCompile Include="ColorPickerButton.cpp" />
-    <ClCompile Include="$(IntDir)moc_ColorPickerButton.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
     <ClCompile Include="Themes.cpp" />
     <ClCompile Include="Settings\GamePatchSettingsWidget.cpp">
       <Filter>Settings</Filter>
@@ -357,21 +180,8 @@
     <ClCompile Include="Settings\GameCheatSettingsWidget.cpp">
       <Filter>Settings</Filter>
     </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_GamePatchSettingsWidget.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_GameCheatSettingsWidget.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
     <ClCompile Include="Translations.cpp" />
     <ClCompile Include="SetupWizardDialog.cpp" />
-    <ClCompile Include="$(IntDir)moc_SetupWizardDialog.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="LogWindow.cpp" />
-    <ClCompile Include="$(IntDir)moc_LogWindow.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
     <ClCompile Include="Debugger\DebuggerSettingsManager.cpp">
       <Filter>Debugger</Filter>
     </ClCompile>
@@ -439,27 +249,6 @@
     <ClCompile Include="Debugger\Docking\NoLayoutsWidget.cpp">
       <Filter>Debugger\Docking</Filter>
     </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\SymbolTree\moc_NewSymbolDialogs.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\SymbolTree\moc_SymbolTreeDelegates.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\SymbolTree\moc_SymbolTreeLocation.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\SymbolTree\moc_SymbolTreeModel.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\SymbolTree\moc_SymbolTreeNode.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\SymbolTree\moc_TypeString.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\Docking\moc_DockMenuBar.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
     <ClCompile Include="Debugger\Docking\DockMenuBar.cpp">
       <Filter>Debugger\Docking</Filter>
     </ClCompile>
@@ -469,21 +258,6 @@
     <ClCompile Include="Debugger\SymbolTree\SymbolTreeViews.cpp">
       <Filter>Debugger\SymbolTree</Filter>
     </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\moc_DisassemblyView.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\moc_RegisterView.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\moc_StackView.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\SymbolTree\moc_SymbolTreeViews.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\moc_ThreadView.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
     <ClCompile Include="Debugger\DisassemblyView.cpp">
       <Filter>Debugger</Filter>
     </ClCompile>
@@ -492,15 +266,6 @@
     </ClCompile>
     <ClCompile Include="Debugger\ThreadView.cpp">
       <Filter>Debugger</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\moc_ModuleModel.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Debugger\moc_ModuleView.cpp">
-      <Filter>moc</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntDir)Settings\moc_SettingsWidget.cpp">
-      <Filter>moc</Filter>
     </ClCompile>
     <ClCompile Include="Settings\SettingsWidget.cpp">
       <Filter>Settings</Filter>


### PR DESCRIPTION
### Description of Changes
Explicitly include the source files generated by `moc` in the corresponding `.cpp` source files instead of letting automoc add them all to a unity build.

### Rationale behind Changes
While using clang's `-ftime-trace` option I observed that when compiling with a high number of threads, since all the files generated by moc are compiled as a single translation unit, said translation unit ends up on the critical path.

Incremental build:
<img width="1622" height="894" alt="Screenshot 2026-03-03 at 16-06-48 before_single_header json (1 MB) - Perfetto UI" src="https://github.com/user-attachments/assets/22e4ad1b-457d-45d4-a6e8-74d657e7985a" />

Recompiling the whole UI:
<img width="1614" height="896" alt="Screenshot 2026-03-03 at 16-06-19 before_whole_ui json (1 MB) - Perfetto UI" src="https://github.com/user-attachments/assets/ace40630-4414-43f4-b46e-2890f08e08e6" />

I searched online for a solution and found that manually including source files generated by moc is a popular choice. This is recommended by [people from the KDE project](https://planet.kde.org/friedrich-kossebau-2023-06-28-include-also-moc-files-of-headers/), [KDAB](https://www.youtube.com/watch?v=Cx_m-qVnEjo), [a CMake maintainer](https://gitlab.kitware.com/cmake/cmake/-/issues/22338), and the Qt developers themselves (who do this for Qt itself).

I've timed how long the build takes before and after these changes on my 9950X3D, using CMake under Linux. Here are the results:

| Operation               | Threads | Time Before (s) | Time After (s) |
| ----------------------- | ------- | --------------- | -------------- |
| Modifying AboutDialog.h | 32      | 5.87            | 4.45           |
|                         | 16      | 5.84            | 4.40           |
|                         | 8       | 6.15            | 5.26           |
| Rebuilding the whole UI | 32      | 10.97           | 9.69           |
|                         | 16      | 11.10           | 11.11          |
|                         | 8       | 16.78           | 16.67          |

These results show that a full rebuild of the UI (everything in the pcsx2-qt directory) is faster when building with a high number of threads, and that incremental builds are faster even with lower numbers of threads. For good measure, every result in the above table is the average of two runs.

I expect this will scale even more favourably when more files are added to the project, and when building on a CPU with even more cores.

[KDAB have a handy script to add these includes automatically (although be warned that passing no arguments to it will make it run on the current directory).](https://github.com/KDABLabs/KDToolBox/tree/master/qt/includemocs)

I decided to add the includes at the end as that seems to avoid problems with conflicting declarations. This appears to be a common practice.

One quirk of this is that I've had to add more include directories for msbuild, so it can find the generated moc files. I'm not sure if there's a better solution.

### Suggested Testing Steps
Try timing builds on your own machine. Someone more familiar with msbuild than me could also double check that msbuild's dependency tracking is all still working as expected.

### Did you use AI to help find, test, or implement this issue or feature?
No.
