### PR TITLE
GS/HW: Add disable conservative depth setting.

### DIFF
--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -361,7 +361,7 @@ layout(set = 1, binding = 1) uniform texture2D Palette;
 layout(set = 1, binding = 3) uniform texture2D PrimMinTexture;
 #endif
 
-#if PS_ZFLOOR || PS_ZCLAMP
+#if PS_HAS_CONSERVATIVE_DEPTH && (PS_ZFLOOR || PS_ZCLAMP)
 layout(depth_less) out float gl_FragDepth;
 #endif
 

--- a/pcsx2-qt/Settings/GraphicsAdvancedSettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsAdvancedSettingsTab.ui
@@ -321,6 +321,13 @@
           </property>
          </widget>
         </item>
+        <item row="2" column="0">
+         <widget class="QCheckBox" name="disableConservativeDepth">
+          <property name="text">
+           <string>Disable Conservative Depth</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
      </layout>
@@ -358,6 +365,7 @@
   <tabstop>disableFramebufferFetch</tabstop>
   <tabstop>disableShaderCache</tabstop>
   <tabstop>disableVertexShaderExpand</tabstop>
+  <tabstop>disableConservativeDepth</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -259,6 +259,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_advanced.disableFramebufferFetch, "EmuCore/GS", "DisableFramebufferFetch", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_advanced.disableShaderCache, "EmuCore/GS", "DisableShaderCache", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_advanced.disableVertexShaderExpand, "EmuCore/GS", "DisableVertexShaderExpand", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_advanced.disableConservativeDepth, "EmuCore/GS", "DisableConservativeDepth", false);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_advanced.gsDownloadMode, "EmuCore/GS", "HWDownloadMode", static_cast<int>(GSHardwareDownloadMode::Enabled));
 	SettingWidgetBinder::BindWidgetToFloatSetting(sif, m_advanced.ntscFrameRate, "EmuCore/GS", "FrameRateNTSC", 59.94f);
 	SettingWidgetBinder::BindWidgetToFloatSetting(sif, m_advanced.palFrameRate, "EmuCore/GS", "FrameRatePAL", 50.00f);

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -739,6 +739,7 @@ struct Pcsx2Config
 					DisableShaderCache : 1,
 					DisableFramebufferFetch : 1,
 					DisableVertexShaderExpand : 1,
+					DisableConservativeDepth : 1,
 					SkipDuplicateFrames : 1,
 					OsdShowSpeed : 1,
 					OsdShowFPS : 1,

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -886,6 +886,7 @@ public:
 		bool stencil_buffer       : 1; ///< Supports stencil buffer, and can use for DATE.
 		bool cas_sharpening       : 1; ///< Supports sufficient functionality for contrast adaptive sharpening.
 		bool test_and_sample_depth: 1; ///< Supports concurrently binding the depth-stencil buffer for sampling and depth testing.
+		bool conservative_depth   : 1; ///< Supports conservative depth to use early Z optimization with shader Z write.
 		FeatureSupport()
 		{
 			memset(this, 0, sizeof(*this));

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -609,13 +609,13 @@ void GSDevice11::SetFeatures(IDXGIAdapter1* adapter)
 	                         D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION :
 	                         D3D10_REQ_TEXTURE2D_U_OR_V_DIMENSION;
 
-	m_conservative_depth = (m_feature_level >= D3D_FEATURE_LEVEL_11_0);
+	m_features.conservative_depth = !GSConfig.DisableConservativeDepth && (m_feature_level >= D3D_FEATURE_LEVEL_11_0);
 	m_rgba16_unorm_hw_blend = IsTextureFormatHWBlendable(m_dev.get(), DXGI_FORMAT_R16G16B16A16_UNORM);
 
 	// Let the user know if said features are available.
 	Console.WriteLnFmt("D3D11: DXTn Texture Compression: {}", m_features.dxt_textures ? "Supported" : "Not Supported");
 	Console.WriteLnFmt("D3D11: BC6/7 Texture Compression: {}", m_features.bptc_textures ? "Supported" : "Not Supported");
-	Console.WriteLnFmt("D3D11: Conservative Depth: {}", m_conservative_depth ? "Supported" : "Not Supported");
+	Console.WriteLnFmt("D3D11: Conservative Depth: {}", m_features.conservative_depth ? "Supported" : "Not Supported");
 	Console.WriteLnFmt("D3D11: RGBA16 UNORM Hardware Blending: {}", m_rgba16_unorm_hw_blend ? "Supported" : "Not Supported");
 }
 
@@ -1762,7 +1762,7 @@ void GSDevice11::SetupPS(const PSSelector& sel, const GSHWDrawConfig::PSConstant
 		ShaderMacro sm;
 
 		sm.AddMacro("PIXEL_SHADER", 1);
-		sm.AddMacro("PS_HAS_CONSERVATIVE_DEPTH", m_conservative_depth);
+		sm.AddMacro("PS_HAS_CONSERVATIVE_DEPTH", static_cast<int>(m_features.conservative_depth));
 		sm.AddMacro("PS_FST", sel.fst);
 		sm.AddMacro("PS_WMS", sel.wms);
 		sm.AddMacro("PS_WMT", sel.wmt);

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -136,7 +136,6 @@ private:
 	bool m_using_flip_model_swap_chain = true;
 	bool m_using_allow_tearing = false;
 	bool m_is_exclusive_fullscreen = false;
-	bool m_conservative_depth = false;
 	bool m_rgba16_unorm_hw_blend = false;
 
 	struct

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -1391,6 +1391,7 @@ bool GSDevice12::CheckFeatures(const u32& vendor_id)
 	m_features.cas_sharpening = true;
 	m_features.test_and_sample_depth = true;
 	m_features.vs_expand = !GSConfig.DisableVertexShaderExpand;
+	m_features.conservative_depth = !GSConfig.DisableConservativeDepth;
 
 	m_features.dxt_textures = SupportsTextureFormat(DXGI_FORMAT_BC1_UNORM) &&
 	                          SupportsTextureFormat(DXGI_FORMAT_BC2_UNORM) &&
@@ -3063,7 +3064,7 @@ const ID3DBlob* GSDevice12::GetTFXPixelShader(const GSHWDrawConfig::PSSelector& 
 
 	ShaderMacro sm;
 	sm.AddMacro("PIXEL_SHADER", 1);
-	sm.AddMacro("PS_HAS_CONSERVATIVE_DEPTH", 1);
+	sm.AddMacro("PS_HAS_CONSERVATIVE_DEPTH", static_cast<int>(m_features.conservative_depth));
 	sm.AddMacro("PS_FST", sel.fst);
 	sm.AddMacro("PS_WMS", sel.wms);
 	sm.AddMacro("PS_WMT", sel.wmt);

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -920,6 +920,7 @@ bool GSDeviceMTL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 
 	m_features.broken_point_sampler = false;
 	m_features.vs_expand = !GSConfig.DisableVertexShaderExpand;
+	m_features.conservative_depth = !GSConfig.DisableConservativeDepth;
 	m_features.primitive_id = m_dev.features.primid;
 	m_features.texture_barrier = true;
 	m_features.multidraw_fb_copy = false;
@@ -933,6 +934,7 @@ bool GSDeviceMTL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 	m_features.stencil_buffer = true;
 	m_features.cas_sharpening = true;
 	m_features.test_and_sample_depth = true;
+	m_features.conservative_depth = true;
 	m_max_texture_size = m_dev.features.max_texsize;
 
 	// Init metal stuff

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -772,7 +772,12 @@ bool GSDeviceOGL::CheckFeatures()
 
 	if (!GLAD_GL_ARB_conservative_depth)
 	{
+		m_features.conservative_depth = false;
 		Console.Warning("GLAD_GL_ARB_conservative_depth is not supported. This will reduce performance.");
+	}
+	else
+	{
+		m_features.conservative_depth = !GSConfig.DisableConservativeDepth;
 	}
 
 	return true;
@@ -1298,14 +1303,9 @@ std::string GSDeviceOGL::GenGlslHeader(const std::string_view entry, GLenum type
 	else
 		header += "#define HAS_FRAMEBUFFER_FETCH 0\n";
 
-	if (GLAD_GL_ARB_conservative_depth)
+	if (m_features.conservative_depth)
 	{
 		header += "#extension GL_ARB_conservative_depth : enable\n";
-		header += "#define PS_HAS_CONSERVATIVE_DEPTH 1\n";
-	}
-	else
-	{
-		header += "#define PS_HAS_CONSERVATIVE_DEPTH 0\n";
 	}
 
 	// Allow to puts several shader in 1 files
@@ -1356,7 +1356,9 @@ std::string GSDeviceOGL::GetPSSource(const PSSelector& sel)
 {
 	DevCon.WriteLn("GL: Compiling new pixel shader with selector 0x%" PRIX64 "%08X", sel.key_hi, sel.key_lo);
 
-	std::string macro = fmt::format("#define PS_FST {}\n", sel.fst)
+	std::string macro =
+		fmt::format("#define PS_HAS_CONSERVATIVE_DEPTH {}\n", static_cast<int>(m_features.conservative_depth))
+		+ fmt::format("#define PS_FST {}\n", sel.fst)
 		+ fmt::format("#define PS_WMS {}\n", sel.wms)
 		+ fmt::format("#define PS_WMT {}\n", sel.wmt)
 		+ fmt::format("#define PS_ADJS {}\n", sel.adjs)

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -2635,6 +2635,7 @@ bool GSDeviceVK::CheckFeatures()
 	m_features.prefer_new_textures = true;
 	m_features.provoking_vertex_last = m_optional_extensions.vk_ext_provoking_vertex;
 	m_features.vs_expand = !GSConfig.DisableVertexShaderExpand;
+	m_features.conservative_depth = !GSConfig.DisableConservativeDepth;
 
 	if (!m_features.texture_barrier)
 		Console.Warning("VK: Texture buffers are disabled. This may break some graphical effects.");
@@ -4722,6 +4723,7 @@ VkShaderModule GSDeviceVK::GetTFXFragmentShader(const GSHWDrawConfig::PSSelector
 	std::stringstream ss;
 	AddShaderHeader(ss);
 	AddShaderStageMacro(ss, false, false, true);
+	AddMacro(ss, "PS_HAS_CONSERVATIVE_DEPTH", static_cast<int>(m_features.conservative_depth));
 	AddMacro(ss, "PS_FST", sel.fst);
 	AddMacro(ss, "PS_WMS", sel.wms);
 	AddMacro(ss, "PS_WMT", sel.wmt);

--- a/pcsx2/ImGui/FullscreenUI_Settings.cpp
+++ b/pcsx2/ImGui/FullscreenUI_Settings.cpp
@@ -3231,6 +3231,8 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 			"EmuCore/GS", "DisableShaderCache", false);
 		DrawToggleSetting(bsi, FSUI_CSTR("Disable Vertex Shader Expand"), FSUI_CSTR("Falls back to the CPU for expanding sprites/lines."),
 			"EmuCore/GS", "DisableVertexShaderExpand", false);
+		DrawToggleSetting(bsi, FSUI_CSTR("Disable Conservative Depth"), FSUI_CSTR("Prevents usage of conservative depth optimization."),
+			"EmuCore/GS", "DisableConservativeDepth", false);
 		DrawIntListSetting(bsi, FSUI_CSTR("Texture Preloading"),
 			FSUI_CSTR(
 				"Uploads full textures to the GPU on use, rather than only the utilized regions. Can improve performance in some games."),

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -722,6 +722,7 @@ Pcsx2Config::GSOptions::GSOptions()
 	DisableShaderCache = false;
 	DisableFramebufferFetch = false;
 	DisableVertexShaderExpand = false;
+	DisableConservativeDepth = false;
 	SkipDuplicateFrames = false;
 	OsdMessagesPos = OsdOverlayPos::TopLeft;
 	OsdPerformancePos = OsdOverlayPos::TopRight;
@@ -901,6 +902,7 @@ bool Pcsx2Config::GSOptions::RestartOptionsAreEqual(const GSOptions& right) cons
 		   OpEqu(DisableShaderCache) &&
 		   OpEqu(DisableFramebufferFetch) &&
 		   OpEqu(DisableVertexShaderExpand) &&
+		   OpEqu(DisableConservativeDepth) &&
 		   OpEqu(OverrideTextureBarriers) &&
 		   OpEqu(ExclusiveFullscreenControl);
 }
@@ -946,6 +948,7 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitBool(DisableShaderCache);
 	SettingsWrapBitBool(DisableFramebufferFetch);
 	SettingsWrapBitBool(DisableVertexShaderExpand);
+	SettingsWrapBitBool(DisableConservativeDepth);
 	SettingsWrapBitBool(SkipDuplicateFrames);
 	SettingsWrapBitBool(OsdShowSpeed);
 	SettingsWrapBitBool(OsdShowFPS);


### PR DESCRIPTION
### Description of Changes
- Add a feature bit to determine if conservative depth is allowed (standardizes the bit across the APIs).
- Add a INI/GUI setting to allow disabling the conservative depth features

### Rationale behind Changes
Some systems/drivers may not work well with conservative depth (particularly older Intel GPUs on Windows/Vulkan), so this gives users an out if they have issues.

This is a more lightweight/flexible alternative to https://github.com/PCSX2/pcsx2/pull/13945.

### Suggested Testing Steps
On affected systems, use the setting to disable conservative depth and check if the issues are resolved.

### Did you use AI to help find, test, or implement this issue or feature?
No.
