### PR TITLE
GameDB: fix minor Psychonauts upscaling issues

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -24845,7 +24845,7 @@ SLES-53830:
   name: "Psychonauts"
   region: "PAL-M3"
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Fixes misaligned bloom.
 SLES-53831:
   name: "BloodRayne 2"
   region: "PAL-M5"
@@ -69902,7 +69902,7 @@ SLUS-21120:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 1 # Fixes misaligned bloom.
+    halfPixelOffset: 4 # Fixes misaligned bloom.
 SLUS-21122:
   name: "Taito Legends"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
fixes slightly misaligned bloom and pixel-wide gaps in subtitle boxes in Psychonauts, by changing halfPixelOffset from 1 ”Normal (Vertex)" to 4 "Align to Native".

### Rationale behind Changes
it was slightly annoying me (at 2x upscaling on my steam deck) so i tried changing it. the first thing i tried worked perfectly.

### Suggested Testing Steps
start a new game, skip the intro, turn subtitles on and see the dialog boxes, and look at a character/item in the game and see their bloom highlighting.

### Did you use AI to help find, test, or implement this issue or feature?
no. never