### PR TITLE
Qt: cache cover download urls

### DIFF
--- a/pcsx2-qt/CoverDownloadDialog.cpp
+++ b/pcsx2-qt/CoverDownloadDialog.cpp
@@ -3,6 +3,7 @@
 
 #include "CoverDownloadDialog.h"
 #include "QtUtils.h"
+#include "QtHost.h"
 
 #include "pcsx2/GameList.h"
 
@@ -12,6 +13,13 @@ CoverDownloadDialog::CoverDownloadDialog(QWidget* parent /*= nullptr*/)
 	: QDialog(parent)
 {
 	m_ui.setupUi(this);
+
+	const std::string cached_urls = Host::GetBaseStringSettingValue("CoverDownload", "CoverDownloadURLs");
+	m_ui.urls->setPlainText(QString::fromStdString(cached_urls));
+
+	const bool use_titles = Host::GetBaseBoolSettingValue("CoverDownload", "useTitleFileNames", false);
+	m_ui.useTitleFileNames->setChecked(use_titles);
+
 	QtUtils::SetScalableIcon(m_ui.coverIcon, QIcon::fromTheme(QStringLiteral("artboard-2-line")), QSize(32, 32));
 	updateEnabled();
 
@@ -92,6 +100,11 @@ void CoverDownloadDialog::updateEnabled()
 
 void CoverDownloadDialog::startThread()
 {
+	std::string urls = m_ui.urls->toPlainText().toStdString();
+	Host::SetBaseStringSettingValue("CoverDownload", "CoverDownloadURLs", urls.c_str());
+	Host::SetBaseBoolSettingValue("CoverDownload", "useTitleFileNames", m_ui.useTitleFileNames->isChecked());
+	Host::CommitBaseSettingChanges();
+
 	m_thread = std::make_unique<CoverDownloadThread>(this, m_ui.urls->toPlainText(), !m_ui.useTitleFileNames->isChecked());
 	m_last_refresh_time.Reset();
 	connect(m_thread.get(), &CoverDownloadThread::statusUpdated, this, &CoverDownloadDialog::onDownloadStatus);


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Cache cover download URLs & the option to use title file names

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
When adding new games, the user usually wants to update the game's cover image. It is tedious to copy the cover download URLs from a site or notes over and over.

Hence, caching the download URLs is one (quick) solution without breaking the usual cover download flow. I personally prefer the covers to be automatically updated when a bunch of new game(s) is scanned.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
- Remove downloaded covers (if any)
- Open Tools > "Cover Downloader..."
- Download covers using your choice of URLs
- Close "Download Covers" dialog
- Open Tools > "Cover Downloader..."
- URLs and/or the option to "Use Title File Names" should be cached

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No