### PR TITLE
Qt: Save cover downloader URLs

### DIFF
--- a/pcsx2-qt/CoverDownloadDialog.cpp
+++ b/pcsx2-qt/CoverDownloadDialog.cpp
@@ -5,8 +5,10 @@
 #include "QtUtils.h"
 
 #include "pcsx2/GameList.h"
+#include "pcsx2/Host.h"
 
 #include "common/Assertions.h"
+#include "common/SettingsInterface.h"
 
 CoverDownloadDialog::CoverDownloadDialog(QWidget* parent /*= nullptr*/)
 	: QDialog(parent)
@@ -18,11 +20,15 @@ CoverDownloadDialog::CoverDownloadDialog(QWidget* parent /*= nullptr*/)
 	connect(m_ui.start, &QPushButton::clicked, this, &CoverDownloadDialog::onStartClicked);
 	connect(m_ui.close, &QPushButton::clicked, this, &CoverDownloadDialog::onCloseClicked);
 	connect(m_ui.urls, &QTextEdit::textChanged, this, &CoverDownloadDialog::updateEnabled);
+
+	loadCoverURLs();
 }
 
 CoverDownloadDialog::~CoverDownloadDialog()
 {
 	pxAssert(!m_thread);
+
+	saveCoverURLs();
 }
 
 void CoverDownloadDialog::closeEvent(QCloseEvent* ev)
@@ -109,6 +115,52 @@ void CoverDownloadDialog::cancelThread()
 	m_thread->requestInterruption();
 	m_thread->join();
 	m_thread.reset();
+}
+
+void CoverDownloadDialog::loadCoverURLs()
+{
+	auto lock = Host::GetSecretsSettingsLock();
+	SettingsInterface* secrets = Host::Internal::GetSecretsSettingsLayer();
+
+	QString text;
+
+	int count = secrets->GetIntValue("UI/CoverURLs", "Count", 0);
+	for (int i = 0; i < count; i++)
+	{
+		std::string key = std::to_string(i);
+
+		std::string url;
+		if (!secrets->GetStringValue("UI/CoverURLs", key.c_str(), &url))
+			break;
+
+		text += QString::fromStdString(url);
+		text += '\n';
+	}
+
+	m_ui.urls->setPlainText(text);
+}
+
+void CoverDownloadDialog::saveCoverURLs()
+{
+	auto lock = Host::GetSecretsSettingsLock();
+	SettingsInterface* secrets = Host::Internal::GetSecretsSettingsLayer();
+
+	secrets->RemoveSection("UI/CoverURLs");
+
+	QStringList urls = m_ui.urls->toPlainText().trimmed().split('\n');
+	if (urls.count() == 1 && urls[0].isEmpty())
+		urls = QStringList();
+
+	secrets->SetIntValue("UI/CoverURLs", "Count", static_cast<int>(urls.count()));
+
+	for (qsizetype i = 0; i < urls.count(); i++)
+	{
+		std::string key = std::to_string(i);
+		std::string url = urls[i].toStdString();
+		secrets->SetStringValue("UI/CoverURLs", key.c_str(), url.c_str());
+	}
+
+	secrets->Save();
 }
 
 CoverDownloadDialog::CoverDownloadThread::CoverDownloadThread(QWidget* parent, const QString& urls, bool use_serials)

--- a/pcsx2-qt/CoverDownloadDialog.h
+++ b/pcsx2-qt/CoverDownloadDialog.h
@@ -51,6 +51,9 @@ private:
 	void startThread();
 	void cancelThread();
 
+	void loadCoverURLs();
+	void saveCoverURLs();
+
 	Ui::CoverDownloadDialog m_ui;
 	std::unique_ptr<CoverDownloadThread> m_thread;
 	Common::Timer m_last_refresh_time;

--- a/pcsx2-qt/CoverDownloadDialog.ui
+++ b/pcsx2-qt/CoverDownloadDialog.ui
@@ -67,7 +67,11 @@
     </widget>
    </item>
    <item>
-    <widget class="QTextEdit" name="urls"/>
+    <widget class="QTextEdit" name="urls">
+      <property name="acceptRichText">
+        <bool>false</bool>
+      </property>
+    </widget>
    </item>
    <item>
     <widget class="QLabel" name="label_2">


### PR DESCRIPTION
### Description of Changes
Add logic to the cover downloader to save cover URLs to the config file and load them back.

### Rationale behind Changes
This wasn't originally going to be added in, but after a discussion we decided it should be okay.

I've decided to open a new PR instead of getting the existing one reopened because that one was buggy.

I'm storing the cover URLs as an array of keys-value pairs within their own INI section. I think this makes more sense as it's conceptually more of an array of strings rather than a single multiline string (even through we're currently using a multiline QTextEdit in the GUI).

Moreover, this way we can avoid relying on SimpleIni's multiline string support, which isn't standardized among the different INI libraries. So this way the files should be more portable.

While I was at it I set the acceptRichText property of the QTextEdit for the cover URLs to false, since I don't think putting rich text in it makes sense.

### Suggested Testing Steps
Put some URLs in the cover downloader dialog, restart the application, and make sure they're still there.

### Did you use AI to help find, test, or implement this issue or feature?
No.
