### PR TITLE
Qt: Disallow writing to EE SIF RX FIFO while hardcore mode is active and fix race

### DIFF
--- a/pcsx2-qt/LogWindow.cpp
+++ b/pcsx2-qt/LogWindow.cpp
@@ -2,10 +2,13 @@
 // SPDX-License-Identifier: GPL-3.0+
 
 #include "LogWindow.h"
-#include "Host.h"
+
 #include "MainWindow.h"
 #include "QtHost.h"
 #include "SettingWidgetBinder.h"
+
+#include "Achievements.h"
+#include "Host.h"
 #include "VMManager.h"
 
 #include <QtCore/QLatin1StringView>
@@ -428,7 +431,22 @@ void LogWindow::onInputEntered()
 	std::string str = text.toUtf8().toStdString();
 
 	Host::RunOnCPUThread([str = std::move(str), focus, window]() {
-		bool success = VMManager::WriteBytesToEESIORXFIFO({reinterpret_cast<const u8*>(str.data()), str.size()});
+		bool success = true;
+
+		if (!VMManager::HasValidVM())
+		{
+			Console.Warning("Cannot write to EE SIO RX FIFO while there is no virtual machine running.");
+			success = false;
+		}
+
+		if (success && Achievements::IsHardcoreModeActive())
+		{
+			Console.Warning("Cannot write to EE SIO RX FIFO while RetroAchievements hardcore mode is active.");
+			success = false;
+		}
+
+		if (success)
+			success = VMManager::WriteBytesToEESIORXFIFO({reinterpret_cast<const u8*>(str.data()), str.size()});
 
 		QtHost::RunOnUIThread([success, str = std::move(str), focus, window]() {
 			if (!window)


### PR DESCRIPTION
### Description of Changes
- Disallow writing to the EE SIF RX FIFO while hardcore mode is enabled.
- Don't write to ee_sio_rx_fifo from multiple threads, or when we don't have a VM.

### Rationale behind Changes
I don't think it was really practical to use this for cheating, since if you've got a debugger running in the VM hardcore mode is already broken, but it still really seems like this should be disabled.

### Suggested Testing Steps
Check that the EE SIF RX FIFO input box still works.

### Did you use AI to help find, test, or implement this issue or feature?
No.
