### PR TITLE
Qt: Make sure the game list table view cover column remains hidden

### DIFF
--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -294,11 +294,6 @@ void GameListWidget::initialize()
 	if (Host::ContainsBaseSettingValue("GameListTableView", "HeaderState"))
 	{
 		loadTableHeaderState();
-		// Enforce at least one column is visible immediately after loading.
-		// This handles cases where a config (perhaps from an older version) has 0 columns and
-		// no games are visible to be changed (such as per-game config) or played as you can't click on any.
-		// Will automatically repair a broken header state from config (PCSX2.ini) file.
-		ensureMinimumOneColumnVisible();
 	}
 	else
 	{
@@ -806,6 +801,14 @@ void GameListWidget::loadTableHeaderState()
 
 	QSignalBlocker blocker(header);
 	header->restoreState(QByteArray::fromBase64(QByteArray::fromStdString(state_setting)));
+
+	header->setSectionHidden(GameListModel::Column_Cover, true);
+
+	// Enforce at least one column is visible immediately after loading.
+	// This handles cases where a config (perhaps from an older version) has 0 columns and
+	// no games are visible to be changed (such as per-game config) or played as you can't click on any.
+	// Will automatically repair a broken header state from config (PCSX2.ini) file.
+	ensureMinimumOneColumnVisible();
 }
 
 void GameListWidget::ensureMinimumOneColumnVisible()


### PR DESCRIPTION
### Description of Changes
Make sure the cover column remains hidden when loading the game list table view state.

### Rationale behind Changes
Somehow I got it into a state where the cover column was visible. This shouldn't be possible.

### Suggested Testing Steps
This happens with the following config value (in the GameListTableView section):

```
HeaderState = AAAA/wAAAAAAAAABAAAAAAAAAAkBAAAAAAAAAAAAAAALCAAAAAABAAAAAwAAATUAAAXuAAAACwEBAAAAAAAAAAAAAAAAAABk/////wAAAIQAAAAAAAAACwAAADcAAAABAAAAAAAAAFUAAAABAAAAAAAAAl4AAAABAAAAAAAAAAAAAAABAAAAAAAAAEsAAAABAAAAAAAAAF8AAAABAAAAAAAAAFoAAAABAAAAAAAAAFAAAAABAAAAAAAAADwAAAABAAAAAAAAAHgAAAABAAAAAAAAAPwAAAABAAAAAAAAA+gAAAAAAAAAAAAAAAAAAAAAAAAAAAE=
```

### Did you use AI to help find, test, or implement this issue or feature?
No.
