### PR TITLE
GameDB:Paddington Bear half right fix

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -27426,6 +27426,8 @@ SLES-54664:
 SLES-54665:
   name: "Paddington Bear"
   region: "PAL-M11"
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes half right.
 SLES-54666:
   name: "Mr. Bean"
   region: "PAL-M11"


### PR DESCRIPTION
### Description of Changes
Fixes half right issue using tex in rt.

Fixes #14139 

### Rationale behind Changes
Game broke bad.

### Suggested Testing Steps
N/A

### Did you use AI to help find, test, or implement this issue or feature?
No
