### PR TITLE
GHActions: Clean up old caches

### DIFF
--- a/.github/workflows/linux_build_flatpak.yml
+++ b/.github/workflows/linux_build_flatpak.yml
@@ -91,6 +91,12 @@ jobs:
         run: |
           flatpak-builder-lint manifest .github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
 
+      - name: Clean Caches
+        uses: PCSX2/cache-clean-action@v1.0.0
+        with:
+          items: '[{"key": " flatpak", "count": 1}]'
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build Flatpak (beta)
         if: ${{ inputs.stableBuild == false || inputs.stableBuild == 'false' }}
         uses: flatpak/flatpak-github-actions/flatpak-builder@92ae9851ad316786193b1fd3f40c4b51eb5cb101

--- a/.github/workflows/linux_build_qt.yml
+++ b/.github/workflows/linux_build_qt.yml
@@ -27,10 +27,6 @@ on:
         required: false
         type: boolean
         default: false
-      detail:
-        required: false
-        type: string
-        default: ""
       patchesUrl:
         required: false
         type: string
@@ -86,6 +82,12 @@ jobs:
           PR_SHA: ${{ github.event.pull_request.head.sha }}
         run: ./.github/workflows/scripts/common/name-artifacts.sh
 
+      - name: Clean Caches
+        uses: PCSX2/cache-clean-action@v1.0.0
+        with:
+          items: '[{"key": " deps", "count": 4}, {"key": " ccache", "count": 1}]'
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       # -- SETUP CCACHE - https://cristianadam.eu/20200113/speeding-up-c-plus-plus-github-actions-using-ccache/
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
@@ -95,8 +97,8 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .ccache
-          key: ${{ inputs.os }} ${{ inputs.platform }} ${{ inputs.compiler }} ${{ inputs.detail }} ccache ${{ steps.ccache_cache_timestamp.outputs.timestamp }}
-          restore-keys: ${{ inputs.os }} ${{ inputs.platform }} ${{ inputs.compiler }} ${{ inputs.detail }} ccache
+          key: ${{ inputs.os }} ${{ inputs.platform }} ${{ inputs.compiler }} ccache ${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          restore-keys: ${{ inputs.os }} ${{ inputs.platform }} ${{ inputs.compiler }} ccache
 
       - name: Install Packages
         run: |

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -89,6 +89,12 @@ jobs:
             brew install ccache nasm
           fi
 
+      - name: Clean Caches
+        uses: PCSX2/cache-clean-action@v1.0.0
+        with:
+          items: '[{"key": " deps", "count": 4}, {"key": " ccache", "count": 1}]'
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Cache Dependencies
         id: cache-deps
         uses: actions/cache@v5


### PR DESCRIPTION
### Description of Changes
Adds an action to clean up old caches at the end of builds

### Rationale behind Changes
GH Actions is great and has no way to make a new cache entry supersede a previous one.  For ccache, this means a new cache file for every build.  All the ccache caches pile up and evict other more important caches.  This will clean up all but the newest cache of each type, ensuring that we're not wasting our cache storage on caches that will never be used.

### Suggested Testing Steps
You won't be able to see much without merging it

### Did you use AI to help find, test, or implement this issue or feature?
No
