### PR TITLE
SmallString: Improve self-assignment behaviour

### DIFF
--- a/common/SmallString.cpp
+++ b/common/SmallString.cpp
@@ -392,7 +392,8 @@ void SmallStringBase::vsprintf(const char* format, va_list ap)
 
 void SmallStringBase::assign(const SmallStringBase& copy)
 {
-	assign(copy.c_str(), copy.length());
+	if (this != &copy)
+		assign(copy.c_str(), copy.length());
 }
 
 void SmallStringBase::assign(const char* str)

--- a/tests/ctest/common/CMakeLists.txt
+++ b/tests/ctest/common/CMakeLists.txt
@@ -2,6 +2,7 @@ add_pcsx2_test(common_test
 	byteswap_tests.cpp
 	filesystem_tests.cpp
 	path_tests.cpp
+	small_string_tests.cpp
 	string_util_tests.cpp
 )
 

--- a/tests/ctest/common/small_string_tests.cpp
+++ b/tests/ctest/common/small_string_tests.cpp
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "common/SmallString.h"
+#include <gtest/gtest.h>
+
+TEST(StackString, SelfAssignment)
+{
+	SmallStackString<6> string("Hello");
+	string = string;
+	ASSERT_STREQ(string.c_str(), "Hello");
+}


### PR DESCRIPTION
### Description of Changes
Add a self-assignment check to SmallStringBase::assign.

### Rationale behind Changes
Minor improvement: Make it so `str = str;` is a no-op instead of having it clear the string, and prevent it from calling `memcpy` with the same source and destination pointer.

### Suggested Testing Steps
N/A

### Did you use AI to help find, test, or implement this issue or feature?
No.
