### PR TITLE
HeapArray: Fix comparison operators and self-assignment behaviour

### DIFF
--- a/common/HeapArray.h
+++ b/common/HeapArray.h
@@ -87,24 +87,15 @@ public:
 		return *this;
 	}
 
-#define RELATIONAL_OPERATOR(op) \
-	bool operator op(const this_type& rhs) const \
-	{ \
-		for (size_type i = 0; i < SIZE; i++) \
-		{ \
-			if (!(m_data[i] op rhs.m_data[i])) \
-				return false; \
-		} \
+	bool operator==(const this_type& rhs) const
+	{
+		return std::equal(m_data, m_data + SIZE, rhs.m_data, rhs.m_data + SIZE);
 	}
 
-	RELATIONAL_OPERATOR(==);
-	RELATIONAL_OPERATOR(!=);
-	RELATIONAL_OPERATOR(<);
-	RELATIONAL_OPERATOR(<=);
-	RELATIONAL_OPERATOR(>);
-	RELATIONAL_OPERATOR(>=);
-
-#undef RELATIONAL_OPERATOR
+	auto operator<=>(const this_type& rhs) const
+	{
+		return std::lexicographical_compare_three_way(m_data, m_data + SIZE, rhs.m_data, rhs.m_data + SIZE);
+	}
 
 private:
 	void allocate()
@@ -337,26 +328,17 @@ public:
 		return *this;
 	}
 
-#define RELATIONAL_OPERATOR(op, size_op) \
-	bool operator op(const this_type& rhs) const \
-	{ \
-		if (m_size != rhs.m_size) \
-			return m_size size_op rhs.m_size; \
-		for (size_type i = 0; i < m_size; i++) \
-		{ \
-			if (!(m_data[i] op rhs.m_data[i])) \
-				return false; \
-		} \
+	bool operator==(const this_type& rhs) const
+	{
+		return std::equal(m_data, m_data + m_size, rhs.m_data, rhs.m_data + rhs.m_size);
 	}
 
-	RELATIONAL_OPERATOR(==, !=);
-	RELATIONAL_OPERATOR(!=, ==);
-	RELATIONAL_OPERATOR(<, <);
-	RELATIONAL_OPERATOR(<=, <=);
-	RELATIONAL_OPERATOR(>, >);
-	RELATIONAL_OPERATOR(>=, >=);
-
-#undef RELATIONAL_OPERATOR
+	auto operator<=>(const this_type& rhs) const
+	{
+		return std::lexicographical_compare_three_way(
+			m_data, m_data + m_size,
+			rhs.m_data, rhs.m_data + rhs.m_size);
+	}
 
 private:
 	void internal_resize(size_t size, T* prev_ptr, size_t prev_size)


### PR DESCRIPTION
### Description of Changes
Rewrite the comparison operators for FixedHeapArray and DynamicHeapArray, and add a case for self-assignment to DynamicHeapArray.

### Rationale behind Changes
The comparison operators I'm replacing were broken: They were missing return statements at the end, and operator== would always return true if the input arrays had different sizes (among other problems).

Also avoid a `memcpy` with equal source and destination pointers for DynamicHeapArray.

### Suggested Testing Steps
N/A

### Did you use AI to help find, test, or implement this issue or feature?
No.
