### PR TITLE
Patch: Fix MemoryInterface::CompareBytes functions

### DIFF
--- a/pcsx2/IopMem.cpp
+++ b/pcsx2/IopMem.cpp
@@ -614,5 +614,5 @@ bool IOPMemoryInterface::WriteBytes(u32 address, void* src, u32 size)
 
 bool IOPMemoryInterface::CompareBytes(u32 address, void* src, u32 size)
 {
-	return iopMemSafeCmpBytes(address, src, size) != 0;
+	return iopMemSafeCmpBytes(address, src, size) == 0;
 }

--- a/pcsx2/Memory.cpp
+++ b/pcsx2/Memory.cpp
@@ -1333,5 +1333,5 @@ bool EEMemoryInterface::WriteBytes(u32 address, void* src, u32 size)
 
 bool EEMemoryInterface::CompareBytes(u32 address, void* src, u32 size)
 {
-	return vtlb_memSafeCmpBytes(address, src, size) != 0;
+	return vtlb_memSafeCmpBytes(address, src, size) == 0;
 }


### PR DESCRIPTION
### Description of Changes
Fix the EEMemoryInterface::CompareBytes and IOPMemoryInterface::CompareBytes functions.

### Rationale behind Changes
This fixes the `bytes` patch type. Regression from #13952, whoops.

### Suggested Testing Steps
Make sure the WRC 4 patch works.

### Did you use AI to help find, test, or implement this issue or feature?
No.
