### PR TITLE
IOP JIT: Prevent crashes in the dispatcher

### DIFF
--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -264,7 +264,10 @@ static void iopRecError(int err)
 	switch (err)
 	{
 		case 0:
-			Host::ReportErrorAsync("R3000A Exception", fmt::format("Jump to unmapped recLUT page"));
+			Host::ReportErrorAsync("R3000A Exception", fmt::format("Jump to unmapped recLUT page (PC: 0x{:08x})", psxRegs.pc));
+			break;
+		case 1:
+			Host::ReportErrorAsync("R3000A Exception", fmt::format("Jump to unaligned address (PC: 0x{:08x})", psxRegs.pc));
 			break;
 	}
 
@@ -1104,50 +1107,26 @@ static __fi void recClearIOP(u32 Addr, u32 Size)
 		pc += PSXREC_CLEARM(pc);
 }
 
-void psxSetBranchReg(u32 reg)
+void psxSetBranchReg()
 {
 	psxbranch = 1;
 
-	if (reg != 0xffffffff)
-	{
-		const bool swap = psxTrySwapDelaySlot(reg, 0, 0);
+	xMOV(ptr32[&psxRegs.pc], eax);
 
-		if (!swap)
-		{
-			const int wbreg = _allocX86reg(X86TYPE_PCWRITEBACK, 0, MODE_WRITE | MODE_CALLEESAVED);
-			_psxMoveGPRtoR(xRegister32(wbreg), reg);
-
-			psxRecompileNextInstruction(true, false);
-
-			if (x86regs[wbreg].inuse && x86regs[wbreg].type == X86TYPE_PCWRITEBACK)
-			{
-				xMOV(ptr32[&psxRegs.pc], xRegister32(wbreg));
-				x86regs[wbreg].inuse = 0;
-			}
-			else
-			{
-				xMOV(eax, ptr32[&psxRegs.pcWriteback]);
-				xMOV(ptr32[&psxRegs.pc], eax);
-			}
-		}
-		else
-		{
-			if (PSX_IS_DIRTY_CONST(reg) || _hasX86reg(X86TYPE_PSX, reg, 0))
-			{
-				const int x86reg = _allocX86reg(X86TYPE_PSX, reg, MODE_READ);
-				xMOV(ptr32[&psxRegs.pc], xRegister32(x86reg));
-			}
-			else
-			{
-				_psxMoveGPRtoM((uptr)&psxRegs.pc, reg);
-			}
-		}
-	}
+	xTEST(eax, 3);
+	xForwardJNZ32 unaligned;
 
 	_psxFlushCall(FLUSH_EVERYTHING);
 	iPsxBranchTest(0xffffffff, 1);
 
-	JMP32((uptr)iopDispatcherReg - ((uptr)x86Ptr + 5));
+	xJMP(iopDispatcherReg);
+
+	unaligned.SetTarget();
+
+	xFastCall(iopRecError, 1);
+	// Ideally iopRecERror should not return, but it might if the EE rec's
+	// ExitExecution deferred stopping until later
+	xJMP(iopExitRecompiledCode);
 }
 
 void psxSetBranchImm(u32 imm)

--- a/pcsx2/x86/iR3000A.h
+++ b/pcsx2/x86/iR3000A.h
@@ -41,7 +41,7 @@ extern u32 g_iopCyclePenalty;
 void psxSaveBranchState();
 void psxLoadBranchState();
 
-extern void psxSetBranchReg(u32 reg);
+extern void psxSetBranchReg();
 extern void psxSetBranchImm(u32 imm);
 extern void psxRecompileNextInstruction(bool delayslot, bool swapped_delayslot);
 

--- a/pcsx2/x86/iR3000Atables.cpp
+++ b/pcsx2/x86/iR3000Atables.cpp
@@ -1417,7 +1417,39 @@ static void rpsxJAL()
 
 static void rpsxJR()
 {
-	psxSetBranchReg(_Rs_);
+	const bool swap = psxTrySwapDelaySlot(_Rs_, 0, 0);
+
+	if (!swap)
+	{
+		const int wbreg = _allocX86reg(X86TYPE_PCWRITEBACK, 0, MODE_WRITE | MODE_CALLEESAVED);
+		_psxMoveGPRtoR(xRegister32(wbreg), _Rs_);
+
+		psxRecompileNextInstruction(true, false);
+
+		if (x86regs[wbreg].inuse && x86regs[wbreg].type == X86TYPE_PCWRITEBACK)
+		{
+			xMOV(eax, xRegister32(wbreg));
+			x86regs[wbreg].inuse = 0;
+		}
+		else
+		{
+			xMOV(eax, ptr32[&psxRegs.pcWriteback]);
+		}
+	}
+	else
+	{
+		if (PSX_IS_DIRTY_CONST(_Rs_) || _hasX86reg(X86TYPE_PSX, _Rs_, 0))
+		{
+			const int x86reg = _allocX86reg(X86TYPE_PSX, _Rs_, MODE_READ);
+			xMOV(eax, xRegister32(x86reg));
+		}
+		else
+		{
+			_psxMoveGPRtoR(eax, _Rs_);
+		}
+	}
+
+	psxSetBranchReg();
 }
 
 static void rpsxJALR()
@@ -1446,13 +1478,12 @@ static void rpsxJALR()
 
 		if (x86regs[wbreg].inuse && x86regs[wbreg].type == X86TYPE_PCWRITEBACK)
 		{
-			xMOV(ptr32[&psxRegs.pc], xRegister32(wbreg));
+			xMOV(eax, xRegister32(wbreg));
 			x86regs[wbreg].inuse = 0;
 		}
 		else
 		{
 			xMOV(eax, ptr32[&psxRegs.pcWriteback]);
-			xMOV(ptr32[&psxRegs.pc], eax);
 		}
 	}
 	else
@@ -1460,15 +1491,15 @@ static void rpsxJALR()
 		if (PSX_IS_DIRTY_CONST(_Rs_) || _hasX86reg(X86TYPE_PSX, _Rs_, 0))
 		{
 			const int x86reg = _allocX86reg(X86TYPE_PSX, _Rs_, MODE_READ);
-			xMOV(ptr32[&psxRegs.pc], xRegister32(x86reg));
+			xMOV(eax, xRegister32(x86reg));
 		}
 		else
 		{
-			_psxMoveGPRtoM((uptr)&psxRegs.pc, _Rs_);
+			_psxMoveGPRtoR(eax, _Rs_);
 		}
 	}
 
-	psxSetBranchReg(0xffffffff);
+	psxSetBranchReg();
 }
 
 //// BEQ


### PR DESCRIPTION
### Description of Changes
Same song and dance as #14061, but for the IOP this time.

### Rationale behind Changes
Stops buggy code from crashing pcsx2.

### Suggested Testing Steps
Nothing should change for anything that doesn't already hard-crash pcsx2.

### Did you use AI to help find, test, or implement this issue or feature?
No
