### PR TITLE
GHActions: Fix cache clean permissions

### DIFF
--- a/.github/workflows/linux_build_flatpak.yml
+++ b/.github/workflows/linux_build_flatpak.yml
@@ -49,6 +49,9 @@ jobs:
       options: --privileged
     timeout-minutes: 60
 
+    permissions:
+      actions: write
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6

--- a/.github/workflows/linux_build_qt.yml
+++ b/.github/workflows/linux_build_qt.yml
@@ -53,6 +53,9 @@ jobs:
       CCACHE_COMPRESSLEVEL: 9
       CCACHE_MAXSIZE: 100M
 
+    permissions:
+      actions: write
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -46,6 +46,9 @@ jobs:
       # Only way to use a secret in an if statement
       SIGN_KEY: ${{ secrets.APPLE_SIGN_P12_B64 }}
 
+    permissions:
+      actions: write
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6


### PR DESCRIPTION
### Description of Changes
IDK why it worked fine when I tested on my fork, but apparently you need to give permission to delete caches.

### Rationale behind Changes
Make the cache clean action actually work

### Suggested Testing Steps
Wait while I run GH Actions twice to see if it can clean its old caches

### Did you use AI to help find, test, or implement this issue or feature?
No
