### PR TITLE
GS/HW: Don't clamp negative coords to 0 in texture shuffle detection.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -386,7 +386,7 @@ void GSRendererHW::ConvertSpriteTextureShuffle(u32& process_rg, u32& process_ba,
 	const bool rev_pos = v[prim].XYZ.X > v[prim + 1].XYZ.X;
 	const GSVertex& first_vert = rev_pos ? v[prim + 1] : v[prim];
 	const GSVertex& second_vert = rev_pos ? v[prim] : v[prim + 1];
-	const int pos = std::max(static_cast<int>(first_vert.XYZ.X) - static_cast<int>(o.OFX), 0) & 0xFF;
+	const int pos = (static_cast<int>(first_vert.XYZ.X) - static_cast<int>(o.OFX)) & 0xFF;
 
 	// Read texture is 8 to 16 pixels (same as above)
 	const float tw = static_cast<float>(1u << m_cached_ctx.TEX0.TW);


### PR DESCRIPTION
### Description of Changes
Remove an unecessary coordinate clamp in shuffle detection code.

### Rationale behind Changes
Fixes https://github.com/PCSX2/pcsx2/issues/14157. Sprites with negative coordinates were being clamped to 0 and confusing the heuristic.

### Suggested Testing Steps
Test the dump in the issue above or any game with texture shuffles with any HW renderer.

### Did you use AI to help find, test, or implement this issue or feature?
No.
