### PR TITLE
GHActions: Retry metal toolchain download

### DIFF
--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -66,7 +66,11 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_26.2.app
 
       - name: Install Metal Toolchain
-        run: xcodebuild -downloadComponent MetalToolchain
+        run: |
+          for i in {1..5}; do
+            if xcrun metal -v; then break; fi
+            xcodebuild -downloadComponent MetalToolchain
+          done
 
       - name: Prepare Artifact Metadata
         id: artifact-metadata


### PR DESCRIPTION
### Description of Changes
Retries metal toolchain download up to 5 times until it works

### Rationale behind Changes
Metal toolchain downloads keep breaking for some reason

### Suggested Testing Steps
Check CI

### Did you use AI to help find, test, or implement this issue or feature?
No
