### PR TITLE
Deps: Dependency download improvements

### DIFF
--- a/.github/workflows/scripts/linux/build-dependencies-qt.sh
+++ b/.github/workflows/scripts/linux/build-dependencies-qt.sh
@@ -110,7 +110,7 @@ if ! shasum -sa 256 --check SHASUMS 2> /dev/null; then
 		-O "https://github.com/sammycage/plutosvg/archive/v$PLUTOSVG/plutosvg-$PLUTOSVG.tar.gz"
 fi
 
-shasum -a 256 --check SHASUMS
+shasum -a 256 --check --strict SHASUMS
 
 if [ "$BUILD_FFMPEG" -ne 0 ]; then
 	echo "Installing vulkan headers..."

--- a/.github/workflows/scripts/linux/build-dependencies-runner.sh
+++ b/.github/workflows/scripts/linux/build-dependencies-runner.sh
@@ -70,7 +70,7 @@ if ! shasum -sa 256 --check SHASUMS 2> /dev/null; then
 		-O "https://github.com/sammycage/plutosvg/archive/v$PLUTOSVG/plutosvg-$PLUTOSVG.tar.gz"
 fi
 
-shasum -a 256 --check SHASUMS
+shasum -a 256 --check --strict SHASUMS
 
 echo "Building libbacktrace..."
 rm -fr "libbacktrace-$LIBBACKTRACE"

--- a/.github/workflows/scripts/macos/build-dependencies-universal.sh
+++ b/.github/workflows/scripts/macos/build-dependencies-universal.sh
@@ -140,7 +140,7 @@ if ! shasum -sa 256 --check SHASUMS 2> /dev/null; then
 		-O "https://github.com/sammycage/plutosvg/archive/v$PLUTOSVG/plutosvg-$PLUTOSVG.tar.gz"
 fi
 
-shasum -a 256 --check SHASUMS
+shasum -a 256 --check --strict SHASUMS
 
 echo "Installing SDL..."
 rm -fr "$SDL"

--- a/.github/workflows/scripts/macos/build-dependencies.sh
+++ b/.github/workflows/scripts/macos/build-dependencies.sh
@@ -116,7 +116,7 @@ if ! shasum -sa 256 --check SHASUMS 2> /dev/null; then
 		-O "https://github.com/sammycage/plutosvg/archive/v$PLUTOSVG/plutosvg-$PLUTOSVG.tar.gz"
 fi
 
-shasum -a 256 --check SHASUMS
+shasum -a 256 --check --strict SHASUMS
 
 echo "Installing SDL..."
 rm -fr "$SDL"


### PR DESCRIPTION
### Description of Changes
- Hash check existing files and only download if the check fails
- Clean up GitHub URLs

### Rationale behind Changes
- If you're working on the dependency build scripts locally and something fails, this way you don't have to redownload everything
- Slightly simpler lines in download list

### Suggested Testing Steps
Make sure CI works

### Did you use AI to help find, test, or implement this issue or feature?
No