### PR TITLE
GHActions: Run arm64 build in Release

### DIFF
--- a/.github/workflows/release_cut_new.yml
+++ b/.github/workflows/release_cut_new.yml
@@ -151,6 +151,19 @@ jobs:
       sign_and_notarize: true
     secrets: inherit
 
+  # We don't use the artifacts, but we need this for the cache it generates
+  build_macos_qt_arm:
+    if: github.repository == 'PCSX2/pcsx2'
+    needs:
+      - cut-release
+    name: "MacOS"
+    uses: ./.github/workflows/macos_build.yml
+    with:
+      jobName: "Generate arm64 Caches"
+      artifactPrefixName: "PCSX2-macos-Qt-arm64"
+      arch: arm64
+    secrets: inherit
+
   # Upload the Artifacts
   upload_artifacts:
     if: github.repository == 'PCSX2/pcsx2'


### PR DESCRIPTION
### Description of Changes
Runs an arm64 build on the release pipeline

### Rationale behind Changes
If we don't, no arm64 caches are ever generated on the master branch, so each new PR starts with no caches available to it

### Suggested Testing Steps
Pray it works (the action won't run in PRs)

### Did you use AI to help find, test, or implement this issue or feature?
No
