### PR TITLE
GHActions: Make commit message pattern compatible with reverts

### DIFF
--- a/.github/workflows/check_pr_commits.yml
+++ b/.github/workflows/check_pr_commits.yml
@@ -16,7 +16,7 @@ jobs:
         uses: gsactions/commit-message-checker@16fa2d5de096ae0d35626443bcd24f1e756cafee
         with:
           accessToken: ${{ secrets.GITHUB_TOKEN }}
-          pattern: '^[A-Z][A-Za-z0-9 \[]+:.+'
+          pattern: '^[A-Z][A-Za-z0-9 \["]+:.+'
           excludeTitle: true
           excludeDescription: true
           checkAllCommitMessages: true


### PR DESCRIPTION
### Description of Changes
Allows quotes in the prefix, because reverts take the form `Revert "Original Commit Message"`

### Rationale behind Changes
With this change, reverts of commits that pass the commit message test should also pass the commit message test

### Suggested Testing Steps
Test in prod

### Did you use AI to help find, test, or implement this issue or feature?
No