### PR TITLE
GHActions: Bump microsoft/setup-msbuild

### DIFF
--- a/.github/workflows/windows_build_qt.yml
+++ b/.github/workflows/windows_build_qt.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Setup msbuild
         if: inputs.configuration != 'CMake'
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Download patches
         shell: cmd


### PR DESCRIPTION
### Description of Changes
Updates the setup-msbuild action to v3

### Rationale behind Changes
The setup-msbuild action was updated to use a newer version of Node.js, fixing the outdated Node warnings on CI.

### Suggested Testing Steps
Check CI still builds and Node,js warnings are gone.

### Did you use AI to help find, test, or implement this issue or feature?
No