### PR TITLE
Qt: Add a bunch of Open XXX Folder for Game List Entries

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1566,8 +1566,18 @@ void MainWindow::onGameListEntryContextMenuRequested(const QPoint& point)
 		if (!entry->serial.empty())
 			connect(menu.addAction(tr("Check Wiki Page")), &QAction::triggered, [this, entry]() { goToWikiPage(*entry); });
 
+		menu.addSeparator();
+		action = menu.addAction(tr("Open Memory Card Folder"));
+		connect(action, &QAction::triggered, [this, entry]() { openMemoryCardFolder(); });
+
 		action = menu.addAction(tr("Open Snapshots Folder"));
 		connect(action, &QAction::triggered, [this, entry]() { openSnapshotsFolderForGame(*entry); });
+
+		action = menu.addAction(tr("Open Texture Dump/Replacement Folder"));
+		connect(action, &QAction::triggered, [this, entry]() { openTextureFolderForGame(*entry); });
+
+		action = menu.addAction(tr("Open Video Capture Folder"));
+		connect(action, &QAction::triggered, [this, entry]() { openVideoCaptureFolder(*entry); });
 		menu.addSeparator();
 
 		if (!s_vm_valid)
@@ -3095,7 +3105,8 @@ void MainWindow::openSnapshotsFolderForGame(const GameList::Entry& entry)
 	// Go to top-level snapshots directory if not organizing by game.
 	if (EmuConfig.GS.OrganizeSnapshotsByGame && !entry.title.empty())
 	{
-		std::string game_name = entry.title;
+		const bool prefer_english = Host::GetBaseBoolSettingValue("UI", "PreferEnglishGameList", false);
+		std::string game_name =  (prefer_english && !entry.title_en.empty()) ? entry.title_en : entry.title;
 		Path::SanitizeFileName(&game_name);
 
 		const std::string game_dir = Path::Combine(EmuFolders::Snapshots, game_name);
@@ -3112,6 +3123,64 @@ void MainWindow::openSnapshotsFolderForGame(const GameList::Entry& entry)
 	}
 
 	QtUtils::OpenURL(this, QUrl::fromLocalFile(QString::fromStdString(EmuFolders::Snapshots)));
+}
+
+void MainWindow::openTextureFolderForGame(const GameList::Entry& entry)
+{
+	const std::string serial = entry.serial;
+	const std::string game_texture_dir = Path::Combine(EmuFolders::Textures, serial);
+
+	// Make sure the per-game directory exists or that we can successfully create it.
+	if (FileSystem::DirectoryExists(game_texture_dir.c_str()) || FileSystem::CreateDirectoryPath(game_texture_dir.c_str(), false))
+	{
+		const QFileInfo fi(QString::fromStdString(game_texture_dir));
+		QtUtils::OpenURL(this, QUrl::fromLocalFile(fi.absoluteFilePath()));
+		return;
+	}
+
+	QMessageBox::critical(this, tr("Error"), tr("Failed to create game texture directory '%1'\n\nOpening default directory.").arg(QString::fromStdString(game_texture_dir)));
+
+	QtUtils::OpenURL(this, QUrl::fromLocalFile(QString::fromStdString(EmuFolders::Textures)));
+}
+
+void MainWindow::openMemoryCardFolder()
+{
+	const std::string memcard_dir = EmuFolders::MemoryCards;
+
+	// Make sure directory exists or that we can successfully create it.
+	if (FileSystem::DirectoryExists(memcard_dir.c_str()) || FileSystem::CreateDirectoryPath(memcard_dir.c_str(), false))
+	{
+		const QFileInfo fi(QString::fromStdString(memcard_dir));
+		QtUtils::OpenURL(this, QUrl::fromLocalFile(fi.absoluteFilePath()));
+		return;
+	}
+
+	QMessageBox::critical(this, tr("Error"), tr("Failed to open memory card directory."));
+}
+
+void MainWindow::openVideoCaptureFolder(const GameList::Entry& entry)
+{
+	// Go to top-level video directory if not organizing by game.
+	if (EmuConfig.GS.OrganizeVideoCaptureByGame && !entry.title.empty())
+	{
+		const bool prefer_english = Host::GetBaseBoolSettingValue("UI", "PreferEnglishGameList", false);
+		std::string game_name =  (prefer_english && !entry.title_en.empty()) ? entry.title_en : entry.title;
+		Path::SanitizeFileName(&game_name);
+
+		const std::string game_dir = Path::Combine(EmuFolders::Videos, game_name);
+
+		// Make sure the per-game directory exists or that we can successfully create it.
+		if (FileSystem::DirectoryExists(game_dir.c_str()) || FileSystem::CreateDirectoryPath(game_dir.c_str(), false))
+		{
+			const QFileInfo fi(QString::fromStdString(game_dir));
+			QtUtils::OpenURL(this, QUrl::fromLocalFile(fi.absoluteFilePath()));
+			return;
+		}
+
+		QMessageBox::critical(this, tr("Error"), tr("Failed to create game video capture directory '%1'\n\nOpening default directory.").arg(QString::fromStdString(game_dir)));
+	}
+
+	QtUtils::OpenURL(this, QUrl::fromLocalFile(QString::fromStdString(EmuFolders::Videos)));
 }
 
 std::optional<bool> MainWindow::promptForResumeState(const QString& save_state_path)

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -282,7 +282,10 @@ private:
 	void setGameListEntryCoverImage(const GameList::Entry& entry);
 	void clearGameListEntryPlayTime(const GameList::Entry& entry, const time_t entry_played_time);
 	void goToWikiPage(const GameList::Entry& entry);
+	void openMemoryCardFolder();
 	void openSnapshotsFolderForGame(const GameList::Entry& entry);
+	void openTextureFolderForGame(const GameList::Entry& entry);
+	void openVideoCaptureFolder(const GameList::Entry& entry);
 
 	std::optional<bool> promptForResumeState(const QString& save_state_path);
 	void loadSaveStateSlot(s32 slot, bool load_backup = false);

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
@@ -402,6 +402,8 @@
   <tabstop>pauseOnControllerDisconnection</tabstop>
   <tabstop>savestateSelector</tabstop>
   <tabstop>promptOnStateLoadSaveFailure</tabstop>
+  <tabstop>preferEnglishGameList</tabstop>
+  <tabstop>mouseLock</tabstop>
   <tabstop>startFullscreen</tabstop>
   <tabstop>doubleClickTogglesFullscreen</tabstop>
   <tabstop>renderToSeparateWindow</tabstop>


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

# NOTE: This PR are rebased on top of https://github.com/PCSX2/pcsx2/pull/14191. Please merge it first before this.

This PR adds a number of nice frequently used per-game folders to the game list such as:
- Memory Cards
- Texture Dumps/Replacements
- Video Capture

Preview:
<img width="373" height="161" alt="image" src="https://github.com/user-attachments/assets/74b8cd19-d611-425a-a212-731a3a41ae8c" />

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
QoL improvements.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test each folder and see if it brings you to the correct path.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
Nada.