### PR TITLE
Qt/GameList: Add click-and-drag scrolling to list and grid views

### DIFF
--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -31,6 +31,7 @@
 #include <QtWidgets/QHeaderView>
 #include <QtWidgets/QMenu>
 #include <QtWidgets/QScrollBar>
+#include <QtWidgets/QScroller>
 #include <QtWidgets/QStyledItemDelegate>
 #include <QShortcut>
 
@@ -270,6 +271,7 @@ void GameListWidget::initialize()
 	m_table_view->horizontalHeader()->setSectionsMovable(true);
 	m_table_view->verticalHeader()->hide();
 	m_table_view->setVerticalScrollMode(QAbstractItemView::ScrollMode::ScrollPerPixel);
+	QScroller::grabGesture(m_table_view->viewport(), QScroller::LeftMouseButtonGesture);
 
 	// Custom painter to center-align DisplayRoles (icons)
 	m_table_view->setItemDelegateForColumn(0, new GameListIconStyleDelegate(this));
@@ -327,6 +329,7 @@ void GameListWidget::initialize()
 	m_list_view->setFrameStyle(QFrame::NoFrame);
 	m_list_view->setVerticalScrollMode(QAbstractItemView::ScrollMode::ScrollPerPixel);
 	m_list_view->verticalScrollBar()->setSingleStep(15);
+	QScroller::grabGesture(m_list_view->viewport(), QScroller::LeftMouseButtonGesture);
 	onCoverScaleChanged();
 
 	connect(m_list_view->selectionModel(), &QItemSelectionModel::currentChanged, this,


### PR DESCRIPTION
 Enables click-and-drag scrolling in both the table view and
  the game grid view using Qt's built-in QScroller.

  Previously, scrolling was only possible via the mouse wheel or the
  scrollbar. Users can now click and drag anywhere in the game list area
  to scroll.