### PR TITLE
Qt: Add touch scrolling to game list and grid views

### DIFF
--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -31,6 +31,7 @@
 #include <QtWidgets/QHeaderView>
 #include <QtWidgets/QMenu>
 #include <QtWidgets/QScrollBar>
+#include <QtWidgets/QScroller>
 #include <QtWidgets/QStyledItemDelegate>
 #include <QShortcut>
 
@@ -270,6 +271,7 @@ void GameListWidget::initialize()
 	m_table_view->horizontalHeader()->setSectionsMovable(true);
 	m_table_view->verticalHeader()->hide();
 	m_table_view->setVerticalScrollMode(QAbstractItemView::ScrollMode::ScrollPerPixel);
+	QScroller::grabGesture(m_table_view->viewport(), QScroller::TouchGesture);
 
 	// Custom painter to center-align DisplayRoles (icons)
 	m_table_view->setItemDelegateForColumn(0, new GameListIconStyleDelegate(this));
@@ -328,6 +330,7 @@ void GameListWidget::initialize()
 	m_list_view->setVerticalScrollMode(QAbstractItemView::ScrollMode::ScrollPerPixel);
 	m_list_view->verticalScrollBar()->setSingleStep(15);
 	onCoverScaleChanged();
+	QScroller::grabGesture(m_list_view->viewport(), QScroller::TouchGesture);
 
 	connect(m_list_view->selectionModel(), &QItemSelectionModel::currentChanged, this,
 		&GameListWidget::onSelectionModelCurrentChanged);

--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -271,7 +271,9 @@ void GameListWidget::initialize()
 	m_table_view->horizontalHeader()->setSectionsMovable(true);
 	m_table_view->verticalHeader()->hide();
 	m_table_view->setVerticalScrollMode(QAbstractItemView::ScrollMode::ScrollPerPixel);
+#ifndef Q_OS_MACOS
 	QScroller::grabGesture(m_table_view->viewport(), QScroller::TouchGesture);
+#endif
 
 	// Custom painter to center-align DisplayRoles (icons)
 	m_table_view->setItemDelegateForColumn(0, new GameListIconStyleDelegate(this));
@@ -330,7 +332,9 @@ void GameListWidget::initialize()
 	m_list_view->setVerticalScrollMode(QAbstractItemView::ScrollMode::ScrollPerPixel);
 	m_list_view->verticalScrollBar()->setSingleStep(15);
 	onCoverScaleChanged();
+#ifndef Q_OS_MACOS
 	QScroller::grabGesture(m_list_view->viewport(), QScroller::TouchGesture);
+#endif
 
 	connect(m_list_view->selectionModel(), &QItemSelectionModel::currentChanged, this,
 		&GameListWidget::onSelectionModelCurrentChanged);


### PR DESCRIPTION
### Description of Changes
Adds touch scrolling to the game list table view and cover/grid view using Qt's QScroller with TouchGesture .

### Rationale Behind Changes
Improves navigating through the game library on touch-enabled devices.

### Suggested Testing Steps
- Open PCSX2 with a populated game library
- In list view, use touch to scroll through game titles.
- Switch to cover/grid view and repeat


### Did you use AI to help find, test, or implement this issue or feature?
Yes. I used AI to learn how Qt's QScroller API works.