### PR TITLE
Qt: Add display monitor selector

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -3235,6 +3235,11 @@ void MainWindow::doSettings(const char* category /* = nullptr */)
 	if (!dlg->isVisible())
 	{
 		dlg->show();
+		if (dlg->screen() != screen())
+		{
+			const QRect screenGeo = screen()->availableGeometry();
+			dlg->move(screenGeo.center() - QPoint(dlg->frameGeometry().width() / 2, dlg->frameGeometry().height() / 2));
+		}
 	}
 	else
 	{

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -2837,6 +2837,18 @@ void MainWindow::createDisplayWidget(bool fullscreen, bool render_to_main)
 	}
 
 	m_display_surface = new DisplaySurface();
+
+	const int monitor_index = Host::GetBaseIntSettingValue("UI", "DisplayMonitor", 0);
+	const QList<QScreen*> screens = QGuiApplication::screens();
+	QScreen* target_screen;
+	if (monitor_index == 1)
+		target_screen = QGuiApplication::primaryScreen();
+	//Separator from UI takes up index 2
+	else if (monitor_index >= 3 && (monitor_index - 3) < screens.size())
+		target_screen = screens[monitor_index - 3];
+	else
+		target_screen = screen();
+
 	if (fullscreen || !render_to_main)
 	{
 #ifdef DISPLAY_SURFACE_WINDOW
@@ -2860,19 +2872,20 @@ void MainWindow::createDisplayWidget(bool fullscreen, bool render_to_main)
 
 #ifdef DISPLAY_SURFACE_WINDOW
 		if (isVisible() && g_emu_thread->shouldRenderToMain())
-			m_display_surface->setGeometry(screen()->geometry());
+			m_display_surface->setGeometry(target_screen->geometry());
 		else
-			restoreDisplayWindowGeometryFromConfig();
+			restoreDisplayWindowGeometryFromConfig(target_screen);
 
 		if (fullscreen)
 			m_display_surface->showFullScreen();
 		else
 			m_display_surface->showNormal();
 #else
+		m_display_container->setScreen(target_screen);
 		if (isVisible() && g_emu_thread->shouldRenderToMain())
-			m_display_container->move(screen()->availableGeometry().topLeft());
+			m_display_container->move(target_screen->availableGeometry().topLeft());
 		else
-			restoreDisplayWindowGeometryFromConfig();
+			restoreDisplayWindowGeometryFromConfig(target_screen);
 
 		if (fullscreen)
 			m_display_container->showFullScreen();
@@ -2886,18 +2899,34 @@ void MainWindow::createDisplayWidget(bool fullscreen, bool render_to_main)
 		if (m_is_temporarily_windowed && g_emu_thread->shouldRenderToMain())
 			m_display_surface->setGeometry(geometry());
 		else
-			restoreDisplayWindowGeometryFromConfig();
+			restoreDisplayWindowGeometryFromConfig(target_screen);
 		m_display_surface->showNormal();
 #else
+		m_display_container->setScreen(target_screen);
 		if (m_is_temporarily_windowed && g_emu_thread->shouldRenderToMain())
 			m_display_container->setGeometry(geometry());
 		else
-			restoreDisplayWindowGeometryFromConfig();
+			restoreDisplayWindowGeometryFromConfig(target_screen);
 		m_display_container->showNormal();
 #endif
 	}
 	else
 	{
+		if (screen() != target_screen)
+		{
+			m_pre_game_main_window_geometry = saveGeometry();
+
+			if (!m_target_screen_main_window_geometry.isEmpty())
+				restoreGeometry(m_target_screen_main_window_geometry);
+
+			if (m_target_screen_main_window_geometry.isEmpty() ||
+				!target_screen->availableGeometry().contains(geometry().center()))
+			{
+				const QRect screenGeo = target_screen->availableGeometry();
+				move(screenGeo.x() + (screenGeo.width() - width()) / 2,
+					screenGeo.y() + (screenGeo.height() - height()) / 2);
+			}
+		}
 		pxAssertRel(m_ui.mainContainer->count() == 1, "Has no display widget");
 		m_ui.mainContainer->addWidget(m_display_container);
 		m_ui.mainContainer->setCurrentIndex(1);
@@ -3005,6 +3034,24 @@ void MainWindow::destroyDisplayWidget(bool show_game_list)
 	{
 		pxAssertRel(m_ui.mainContainer->indexOf(m_display_container) == 1, "Display widget in stack");
 		m_ui.mainContainer->removeWidget(m_display_container);
+		if (!m_pre_game_main_window_geometry.isEmpty())
+		{
+			const int monitor_index = Host::GetBaseIntSettingValue("UI", "DisplayMonitor", 0);
+			const QList<QScreen*> screens = QGuiApplication::screens();
+			QScreen* target_screen;
+			if (monitor_index == 1)
+				target_screen = QGuiApplication::primaryScreen();
+			else if (monitor_index >= 3 && (monitor_index - 3) < screens.size())
+				target_screen = screens[monitor_index - 3];
+			else
+				target_screen = nullptr;
+			if (target_screen && screen() == target_screen)
+				m_target_screen_main_window_geometry = saveGeometry();
+			else
+				m_target_screen_main_window_geometry.clear();
+			restoreGeometry(m_pre_game_main_window_geometry);
+			m_pre_game_main_window_geometry.clear();
+		}
 		if (show_game_list)
 		{
 			m_ui.mainContainer->setCurrentIndex(0);
@@ -3116,10 +3163,11 @@ void MainWindow::saveDisplayWindowGeometryToConfig()
 	}
 }
 
-void MainWindow::restoreDisplayWindowGeometryFromConfig()
+void MainWindow::restoreDisplayWindowGeometryFromConfig(QScreen* target_screen)
 {
 	const std::string geometry_b64 = Host::GetBaseStringSettingValue("UI", "DisplayWindowGeometry");
 	const QByteArray geometry = QByteArray::fromBase64(QByteArray::fromStdString(geometry_b64));
+
 	if (!geometry.isEmpty())
 	{
 		m_display_surface->restoreGeometry(geometry);
@@ -3138,6 +3186,28 @@ void MainWindow::restoreDisplayWindowGeometryFromConfig()
 		m_display_surface->resize(640, 480);
 #else
 		m_display_container->resize(640, 480);
+#endif
+	}
+
+	// if a target screen is specified and the window is not on it, center on it
+	if (target_screen)
+	{
+#ifdef DISPLAY_SURFACE_WINDOW
+		if (!target_screen->availableGeometry().contains(m_display_surface->geometry()))
+		{
+			const QRect screenGeo = target_screen->availableGeometry();
+			const QPoint center(screenGeo.x() + (screenGeo.width() - m_display_surface->width()) / 2,
+				screenGeo.y() + (screenGeo.height() - m_display_surface->height()) / 2);
+			m_display_surface->setGeometry(QRect(center, m_display_surface->size()));
+		}
+#else
+		if (!target_screen->availableGeometry().contains(m_display_container->geometry()))
+		{
+			const QRect screenGeo = target_screen->availableGeometry();
+			const QPoint center(screenGeo.x() + (screenGeo.width() - m_display_container->width()) / 2,
+				screenGeo.y() + (screenGeo.height() - m_display_container->height()) / 2);
+			m_display_container->setGeometry(QRect(center, m_display_container->size()));
+		}
 #endif
 	}
 }

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -2846,6 +2846,22 @@ QScreen* MainWindow::getTargetScreenForWindow() {
 	return screens[monitor];
 }
 
+static QRect centeredGeometry(const QRect& frameGeo, const QRect& geo, const QScreen* screen)
+{
+	const QRect screenGeo = screen->availableGeometry();
+	const QPoint frameOffset = geo.topLeft() - frameGeo.topLeft();
+	const QSize frameBorder(frameGeo.width() - geo.width(), frameGeo.height() - geo.height());
+
+	// Shrink frame to fit within screen, then center it
+	const int newFrameW = qMin(frameGeo.width(), screenGeo.width());
+	const int newFrameH = qMin(frameGeo.height(), screenGeo.height());
+
+	const int frameX = qBound(screenGeo.left(), screenGeo.x() + (screenGeo.width() - newFrameW) / 2, screenGeo.x() + screenGeo.width() - newFrameW);
+	const int frameY = qBound(screenGeo.top(), screenGeo.y() + (screenGeo.height() - newFrameH) / 2, screenGeo.y() + screenGeo.height() - newFrameH);
+
+	return QRect(frameX + frameOffset.x(), frameY + frameOffset.y(), newFrameW - frameBorder.width(), newFrameH - frameBorder.height());
+}
+
 void MainWindow::createDisplayWidget(bool fullscreen, bool render_to_main)
 {
 	// If we're rendering to main and were hidden (e.g. coming back from fullscreen),
@@ -2909,18 +2925,18 @@ void MainWindow::createDisplayWidget(bool fullscreen, bool render_to_main)
 	else if (!render_to_main)
 	{
 #ifdef DISPLAY_SURFACE_WINDOW
+		m_display_surface->showNormal();
 		if (m_is_temporarily_windowed && g_emu_thread->shouldRenderToMain())
 			m_display_surface->setGeometry(geometry());
 		else
 			restoreDisplayWindowGeometryFromConfig(target_screen);
-		m_display_surface->showNormal();
 #else
 		m_display_container->setScreen(target_screen);
+		m_display_container->showNormal();
 		if (m_is_temporarily_windowed && g_emu_thread->shouldRenderToMain())
 			m_display_container->setGeometry(geometry());
 		else
 			restoreDisplayWindowGeometryFromConfig(target_screen);
-		m_display_container->showNormal();
 #endif
 	}
 	else
@@ -2935,9 +2951,7 @@ void MainWindow::createDisplayWidget(bool fullscreen, bool render_to_main)
 			if (m_target_screen_main_window_geometry.isEmpty() ||
 				!target_screen->availableGeometry().contains(geometry().center()))
 			{
-				const QRect screenGeo = target_screen->availableGeometry();
-				move(screenGeo.x() + (screenGeo.width() - width()) / 2,
-					screenGeo.y() + (screenGeo.height() - height()) / 2);
+				setGeometry(centeredGeometry(frameGeometry(), geometry(), target_screen));
 			}
 		}
 		pxAssertRel(m_ui.mainContainer->count() == 1, "Has no display widget");
@@ -3194,25 +3208,15 @@ void MainWindow::restoreDisplayWindowGeometryFromConfig(QScreen* target_screen)
 #endif
 	}
 
-	// if a target screen is specified and the window is not on it, center on it
+	// if a target screen is specified and the window is not on it, center and resize to fit
 	if (target_screen)
 	{
 #ifdef DISPLAY_SURFACE_WINDOW
 		if (!target_screen->availableGeometry().contains(m_display_surface->geometry()))
-		{
-			const QRect screenGeo = target_screen->availableGeometry();
-			const QPoint center(screenGeo.x() + (screenGeo.width() - m_display_surface->width()) / 2,
-				screenGeo.y() + (screenGeo.height() - m_display_surface->height()) / 2);
-			m_display_surface->setGeometry(QRect(center, m_display_surface->size()));
-		}
+			m_display_surface->setGeometry(centeredGeometry(m_display_surface->frameGeometry(), m_display_surface->geometry(), target_screen));
 #else
 		if (!target_screen->availableGeometry().contains(m_display_container->geometry()))
-		{
-			const QRect screenGeo = target_screen->availableGeometry();
-			const QPoint center(screenGeo.x() + (screenGeo.width() - m_display_container->width()) / 2,
-				screenGeo.y() + (screenGeo.height() - m_display_container->height()) / 2);
-			m_display_container->setGeometry(QRect(center, m_display_container->size()));
-		}
+			m_display_container->setGeometry(centeredGeometry(m_display_container->frameGeometry(), m_display_container->geometry(), target_screen));
 #endif
 	}
 }

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -2826,6 +2826,26 @@ std::optional<WindowInfo> MainWindow::acquireRenderWindow(bool recreate_window, 
 	return wi;
 }
 
+QScreen* MainWindow::getTargetScreenForWindow() {
+	const int monitor = Host::GetBaseIntSettingValue("UI", "DisplayMonitor", -1);
+
+	if (monitor == -1)
+		return screen();
+	if (monitor == -2)
+		return QGuiApplication::primaryScreen();
+
+	QList<QScreen*> screens = QGuiApplication::screens();
+	std::sort(screens.begin(), screens.end(), [](QScreen* a, QScreen* b) {
+		const QRect ga = a->geometry();
+		const QRect gb = b->geometry();
+		return ga.x() != gb.x() ? ga.x() < gb.x() : ga.y() < gb.y();
+	});
+
+	if (monitor >= screens.size())
+		return nullptr;
+	return screens[monitor];
+}
+
 void MainWindow::createDisplayWidget(bool fullscreen, bool render_to_main)
 {
 	// If we're rendering to main and were hidden (e.g. coming back from fullscreen),
@@ -2838,15 +2858,8 @@ void MainWindow::createDisplayWidget(bool fullscreen, bool render_to_main)
 
 	m_display_surface = new DisplaySurface();
 
-	const int monitor_index = Host::GetBaseIntSettingValue("UI", "DisplayMonitor", 0);
-	const QList<QScreen*> screens = QGuiApplication::screens();
-	QScreen* target_screen;
-	if (monitor_index == 1)
-		target_screen = QGuiApplication::primaryScreen();
-	//Separator from UI takes up index 2
-	else if (monitor_index >= 3 && (monitor_index - 3) < screens.size())
-		target_screen = screens[monitor_index - 3];
-	else
+	QScreen* target_screen = getTargetScreenForWindow();
+	if (!target_screen)
 		target_screen = screen();
 
 	if (fullscreen || !render_to_main)
@@ -3036,15 +3049,7 @@ void MainWindow::destroyDisplayWidget(bool show_game_list)
 		m_ui.mainContainer->removeWidget(m_display_container);
 		if (!m_pre_game_main_window_geometry.isEmpty())
 		{
-			const int monitor_index = Host::GetBaseIntSettingValue("UI", "DisplayMonitor", 0);
-			const QList<QScreen*> screens = QGuiApplication::screens();
-			QScreen* target_screen;
-			if (monitor_index == 1)
-				target_screen = QGuiApplication::primaryScreen();
-			else if (monitor_index >= 3 && (monitor_index - 3) < screens.size())
-				target_screen = screens[monitor_index - 3];
-			else
-				target_screen = nullptr;
+			QScreen* target_screen = getTargetScreenForWindow();
 			if (target_screen && screen() == target_screen)
 				m_target_screen_main_window_geometry = saveGeometry();
 			else

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -281,6 +281,7 @@ private:
 	void restoreDisplayWindowGeometryFromConfig(QScreen* target_screen = nullptr);
 	void createDisplayWidget(bool fullscreen, bool render_to_main);
 	void destroyDisplayWidget(bool show_game_list);
+	QScreen* getTargetScreenForWindow();
 	void updateDisplayWidgetCursor();
 
 	SettingsWindow* getSettingsWindow();

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -278,7 +278,7 @@ private:
 
 	QWidget* getContentParent();
 	void saveDisplayWindowGeometryToConfig();
-	void restoreDisplayWindowGeometryFromConfig();
+	void restoreDisplayWindowGeometryFromConfig(QScreen* target_screen = nullptr);
 	void createDisplayWidget(bool fullscreen, bool render_to_main);
 	void destroyDisplayWidget(bool show_game_list);
 	void updateDisplayWidgetCursor();
@@ -348,6 +348,8 @@ private:
 	bool m_was_disc_change_request = false;
 	bool m_is_closing = false;
 	bool m_is_temporarily_windowed = false;
+	QByteArray m_pre_game_main_window_geometry;
+	QByteArray m_target_screen_main_window_geometry;
 
 	QString m_last_fps_status;
 

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -124,17 +124,13 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsWindow* settings_dialog
 	{
 		m_ui.mouseLock->setEnabled(false);
 	}
-	m_ui.displayMonitor->addItem(tr("Current Monitor"));
-	m_ui.displayMonitor->addItem(tr("Primary Monitor"));
-	m_ui.displayMonitor->insertSeparator(m_ui.displayMonitor->count());
-	const QList<QScreen*> screens = QGuiApplication::screens();
-	for (int i = 0; i < screens.size(); i++)
-		m_ui.displayMonitor->addItem(tr("Monitor %1: %2").arg(i + 1).arg(screens[i]->name()));
-	m_ui.displayMonitor->setCurrentIndex(Host::GetBaseIntSettingValue("UI", "DisplayMonitor", 0));
-	connect(m_ui.displayMonitor, &QComboBox::currentIndexChanged, this, [](int index) {
-		Host::SetBaseIntSettingValue("UI", "DisplayMonitor", index);
+	connect(qGuiApp, &QGuiApplication::screenAdded, this, &InterfaceSettingsWidget::populateMonitors);
+	connect(qGuiApp, &QGuiApplication::screenRemoved, this, &InterfaceSettingsWidget::populateMonitors);
+	connect(m_ui.displayMonitor, &QComboBox::currentIndexChanged, this, [this]() {
+		Host::SetBaseIntSettingValue("UI", "DisplayMonitor", m_ui.displayMonitor->currentData().toInt());
 		Host::CommitBaseSettingChanges();
 	});
+	populateMonitors();
 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.startFullscreen, "UI", "StartFullscreen", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.doubleClickTogglesFullscreen, "UI", "DoubleClickTogglesFullscreen", true);
@@ -293,6 +289,32 @@ void InterfaceSettingsWidget::populateLanguages()
 		else
 			m_ui.language->addItem(it.first, it.second);
 	}
+}
+
+void InterfaceSettingsWidget::populateMonitors()
+{
+	QSignalBlocker blocker(m_ui.displayMonitor);
+	m_ui.displayMonitor->clear();
+	m_ui.displayMonitor->addItem(tr("Current Monitor"), -1);
+	m_ui.displayMonitor->addItem(tr("Primary Monitor"), -2);
+	m_ui.displayMonitor->insertSeparator(m_ui.displayMonitor->count());
+
+	QList<QScreen*> screens = QGuiApplication::screens();
+	std::sort(screens.begin(), screens.end(), [](QScreen* a, QScreen* b) {
+		const QRect ga = a->geometry();
+		const QRect gb = b->geometry();
+		return ga.x() != gb.x() ? ga.x() < gb.x() : ga.y() < gb.y();
+	});
+	for (int i = 0; i < screens.size(); i++)
+		m_ui.displayMonitor->addItem(tr("Monitor %1: %2").arg(i + 1).arg(screens[i]->name()), i);
+
+	const int current_value = Host::GetBaseIntSettingValue("UI", "DisplayMonitor", -1);
+	int current_index = 0;
+	if (current_value == -2)
+		current_index = 1;
+	else if (current_value >= 0 && current_value < screens.size())
+		current_index = current_value + 3; // 0=Current, 1=Primary, 2=separator
+	m_ui.displayMonitor->setCurrentIndex(current_index);
 }
 
 void InterfaceSettingsWidget::onSetGameListBackgroundTriggered()

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -12,6 +12,7 @@
 #include "QtHost.h"
 
 #include <QtCore/QLocale>
+#include <QtGui/QScreen>
 
 const char* InterfaceSettingsWidget::THEME_NAMES[] = {
 	QT_TRANSLATE_NOOP("InterfaceSettingsWidget", "Native"),
@@ -123,6 +124,17 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsWindow* settings_dialog
 	{
 		m_ui.mouseLock->setEnabled(false);
 	}
+	m_ui.displayMonitor->addItem(tr("Current Monitor"));
+	m_ui.displayMonitor->addItem(tr("Primary Monitor"));
+	m_ui.displayMonitor->insertSeparator(m_ui.displayMonitor->count());
+	const QList<QScreen*> screens = QGuiApplication::screens();
+	for (int i = 0; i < screens.size(); i++)
+		m_ui.displayMonitor->addItem(tr("Monitor %1: %2").arg(i + 1).arg(screens[i]->name()));
+	m_ui.displayMonitor->setCurrentIndex(Host::GetBaseIntSettingValue("UI", "DisplayMonitor", 0));
+	connect(m_ui.displayMonitor, &QComboBox::currentIndexChanged, this, [](int index) {
+		Host::SetBaseIntSettingValue("UI", "DisplayMonitor", index);
+		Host::CommitBaseSettingChanges();
+	});
 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.startFullscreen, "UI", "StartFullscreen", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.doubleClickTogglesFullscreen, "UI", "DoubleClickTogglesFullscreen", true);

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -215,6 +215,10 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsWindow* settings_dialog
 		tr("Checked"), tr("Displays a modal dialog when a save state load/save operation fails."));
 	dialog()->registerWidgetHelp(m_ui.preferEnglishGameList, tr("Prefer English Game Titles"), tr("Unchecked"),
 		tr("For games with both a title in the game's native language and one in English, prefer the English title. Affects how game titles are displayed on the game list, window title and Discord Presence"));
+	dialog()->registerWidgetHelp(
+		m_ui.displayMonitor, tr("Display Monitor"), tr("Current Monitor"),
+		tr("Selects which monitor the PCSX2 game window will be displayed on when launching."
+		   "<br><b>On Linux Wayland, this setting only takes effect when Start Fullscreen is enabled.</b>"));
 	dialog()->registerWidgetHelp(m_ui.startFullscreen, tr("Start Fullscreen"), tr("Unchecked"),
 		tr("Automatically switches to fullscreen mode when a game is started."));
 	dialog()->registerWidgetHelp(m_ui.hideMouseCursor, tr("Hide Cursor In Fullscreen"), tr("Unchecked"),

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.h
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.h
@@ -31,6 +31,7 @@ private Q_SLOTS:
 
 private:
 	void populateLanguages();
+	void populateMonitors();
 
 	Ui::InterfaceSettingsWidget m_ui;
 

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
@@ -157,6 +157,19 @@
         </property>
        </widget>
       </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="displayMonitorLabel">
+        <property name="text">
+         <string>Display Monitor:</string>
+        </property>
+        <property name="buddy">
+         <cstring>displayMonitor</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QComboBox" name="displayMonitor"/>
+      </item>
      </layout>
     </widget>
    </item>
@@ -411,6 +424,7 @@
   <tabstop>disableWindowResizing</tabstop>
   <tabstop>hideMouseCursor</tabstop>
   <tabstop>startFullscreenUI</tabstop>
+  <tabstop>displayMonitor</tabstop>
   <tabstop>language</tabstop>
   <tabstop>theme</tabstop>
   <tabstop>backgroundBrowse</tabstop>


### PR DESCRIPTION
### Description of Changes
Adds a display monitor selector to the Qt frontend, allowing users to choose which monitor PCSX2 opens on. Also restores the main window position when a game shuts down.

### Rationale Behind Changes
Users with multi-monitor setups previously had no control over which display PCSX2 opened on. This change provides explicit control and ensures the window position is remembered per monitor.

### Suggested Testing Steps
- Open PCSX2 with multiple monitors connected
- Go to Display Settings and select a monitor from the new selector
- Verify the window opens on or moves to the selected monitor
- Launch a game, then close it
- Verify the main window restores to the original monitor

### Did you use AI to help find, test, or implement this issue or feature?
Yes. I am unfamiliar with Qt, so I used AI to help learn it during implementation.