### PR TITLE
OSD: Use standard font for input overlay

### DIFF
--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -908,7 +908,7 @@ __ri void ImGuiManager::DrawInputsOverlay(float scale, float margin, float spaci
 		return;
 
 	const float shadow_offset = std::ceil(scale);
-	ImFont* const font = ImGuiManager::GetOSDFont();
+	ImFont* const font = ImGuiManager::GetStandardFont();
 	const float font_size = ImGuiManager::GetFontSizeStandard();
 	const float line_height = ImGuiFullscreen::GetLineHeight({ font, font_size });
 


### PR DESCRIPTION
### Description of Changes
Switched the input overlay back to the standard font instead of the OSD font.

### Rationale behind Changes
Custom OSD font changes should not affect the input overlay.

### Suggested Testing Steps
- Enable input overlay and make sure it shows correctly.
- Set a custom OSD font and make sure input overlay font does not change.

### Did you use AI to help find, test, or implement this issue or feature?
No