### PR TITLE
GS/HW: Don't bind source tex when using tex is fb hle.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -9947,8 +9947,9 @@ void GSRendererHW::EndHLEHardwareDraw(bool force_copy_on_hazard /* = false */)
 		if (!force_copy_on_hazard && config.tex == config.rt)
 		{
 			// Sample RT 1:1.
-			config.require_one_barrier = !features.framebuffer_fetch;
+			config.tex = nullptr;
 			config.ps.tex_is_fb = true;
+			config.require_one_barrier = !features.framebuffer_fetch;
 		}
 		else if (!force_copy_on_hazard && config.tex == config.ds && !config.depth.zwe &&
 				 features.test_and_sample_depth)


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/HW: Don't bind source tex when using tex is fb hle.
Slot 2 will be used for fb read instead of slot 0, don't bind it when it's not needed.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Bugfix, less hazard checks, optimization.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test Final Fantasy XII, GT3/4/Tourist Trophy games.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.