### PR TITLE
GS: Add new filtering mode to reduce UI blur.

### DIFF
--- a/pcsx2-qt/Settings/GraphicsHardwareRenderingSettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsHardwareRenderingSettingsTab.ui
@@ -121,6 +121,11 @@
        <string>Bilinear (Forced excluding sprite)</string>
       </property>
      </item>
+     <item>
+      <property name="text">
+       <string>Bilinear (PS2 except flat nearest)</string>
+      </property>
+     </item>
     </widget>
    </item>
    <item row="4" column="0">

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -497,7 +497,8 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 			   "Nearest: Makes no attempt to blend colors.<br> "
 			   "Bilinear (Forced): Will blend colors together to remove harsh edges between different colored pixels even if the game told the PS2 not to.<br> "
 			   "Bilinear (PS2): Will apply filtering to all surfaces that a game instructs the PS2 to filter.<br> "
-			   "Bilinear (Forced Excluding Sprites): Will apply filtering to all surfaces, even if the game told the PS2 not to, except sprites."));
+			   "Bilinear (Forced Excluding Sprites): Will apply filtering to all surfaces, even if the game told the PS2 not to, except sprites.<br>",
+			   "Bilinear (PS2 Except Flat Nearest): Will apply filtering to all surfaces that a game instructs the PS2 to filter, with the exception of flat draws that will be forced to nearest."));
 
 		dialog()->registerWidgetHelp(m_hw.trilinearFiltering, tr("Trilinear Filtering"), tr("Automatic (Default)"),
 			tr("Reduces blurriness of large textures applied to small, steeply angled surfaces by sampling colors from the two nearest Mipmaps. Requires Mipmapping to be 'on'.<br> "

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -317,6 +317,7 @@ enum class BiFiltering : u8
 	Forced,
 	PS2,
 	Forced_But_Sprite,
+	PS2_But_Flat_Nearest,
 };
 
 enum class TriFiltering : s8

--- a/pcsx2/GS/Renderers/Common/GSVertexTrace.cpp
+++ b/pcsx2/GS/Renderers/Common/GSVertexTrace.cpp
@@ -112,6 +112,11 @@ void GSVertexTrace::Update(const void* vertex, const u16* index, int v_count, in
 				m_filter.opt_linear = (m_primclass == GS_SPRITE_CLASS) ? m_filter.linear : 1;
 				break;
 
+			case BiFiltering::PS2_But_Flat_Nearest:
+				// Special case to reduce UI blurriness when upscaling is enabled
+				m_filter.opt_linear = (m_primclass == GS_SPRITE_CLASS || m_eq.z) ? 0 : m_filter.linear;
+				break;
+
 			case BiFiltering::Forced:
 				m_filter.opt_linear = 1;
 				break;


### PR DESCRIPTION
Status: currently for testing only.

### Description of Changes
Adds a new filtering setting that disables bilinear on flat draws (i.e. Z is constant).

### Rationale behind Changes
Reduce blur on UI elements that are drawn with sprites or flat triangles, while preserving bi/tri/AF filtering on 3D geometry.

Initial test to address https://github.com/PCSX2/pcsx2/issues/14165.

May have side effects such as breaking blur effects.

### Suggested Testing Steps
Test the dump in the issue above or other games that have a mix of 2D UI and 3D geometry. 

### Did you use AI to help find, test, or implement this issue or feature?
No.