### PR TITLE
GameList: Add ability to favourite games

### DIFF
--- a/bin/resources/icons/star-fill.svg
+++ b/bin/resources/icons/star-fill.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><polygon points="8,1 10.5,6 15.5,6.5 11.5,10 13,15.5 8,12.5 3,15.5 4.5,10 0.5,6.5 5.5,6" fill="#FFFF00" stroke="#000000" stroke-width="0.3" stroke-linejoin="round"/></svg>

--- a/pcsx2-qt/GameList/GameListModel.cpp
+++ b/pcsx2-qt/GameList/GameListModel.cpp
@@ -282,6 +282,11 @@ QVariant GameListModel::data(const QModelIndex& index, const int role) const
 		{
 			switch (index.column())
 			{
+				case Column_Title:
+				case Column_FileTitle:
+					if (ge->is_favorite)
+						return m_favorite_pixmap;
+					return QVariant();
 				case Column_Type:
 					return m_type_pixmaps[static_cast<u32>(ge->type)];
 
@@ -308,6 +313,13 @@ QVariant GameListModel::data(const QModelIndex& index, const int role) const
 				default:
 					return QVariant();
 			}
+		}
+
+		case NeedsFavoriteBadgeRole:
+		{
+			if (index.column() == Column_Cover)
+				return ge->is_favorite;
+			return QVariant();
 		}
 
 		case Qt::SizeHintRole:
@@ -357,7 +369,7 @@ bool GameListModel::titlesLessThan(const int left_row, const int right_row) cons
 			   QString::fromStdString(right->GetTitleSort(m_prefer_english_titles))) < 0;
 }
 
-bool GameListModel::lessThan(const QModelIndex& left_index, const QModelIndex& right_index, const int column) const
+bool GameListModel::lessThan(const QModelIndex& left_index, const QModelIndex& right_index, const int column, Qt::SortOrder sort_order) const
 {
 	if (!left_index.isValid() || !right_index.isValid())
 		return false;
@@ -375,6 +387,10 @@ bool GameListModel::lessThan(const QModelIndex& left_index, const QModelIndex& r
 	const GameList::Entry* right = GameList::GetEntryByIndex(right_row);
 	if (!left || !right)
 		return false;
+
+	// Favorites always sort to the top regardless of column
+	if (left->is_favorite != right->is_favorite)
+		return sort_order == Qt::AscendingOrder ? left->is_favorite : right->is_favorite;
 
 	switch (column)
 	{
@@ -464,6 +480,7 @@ bool GameListModel::lessThan(const QModelIndex& left_index, const QModelIndex& r
 void GameListModel::loadSettings()
 {
 	m_prefer_english_titles = Host::GetBaseBoolSettingValue("UI", "PreferEnglishGameList", false);
+	m_show_titles_for_covers = Host::GetBaseBoolSettingValue("UI", "GameListShowCoverTitles", true);
 }
 
 QIcon GameListModel::getIconForType(const GameList::EntryType type)
@@ -504,6 +521,7 @@ void GameListModel::loadCommonImages()
 		m_compatibility_pixmaps[rating] = QIcon((QStringLiteral("%1/icons/star-%2.svg").arg(base_path).arg(rating - 1))).pixmap(QSize(88, 16), m_dpr);
 
 	m_placeholder_pixmap.load(QStringLiteral("%1/cover-placeholder.png").arg(base_path));
+	m_favorite_pixmap = QIcon(QStringLiteral("%1/icons/star-fill.svg").arg(base_path)).pixmap(QSize(16, 16), m_dpr);
 }
 
 void GameListModel::setColumnDisplayNames()

--- a/pcsx2-qt/GameList/GameListModel.h
+++ b/pcsx2-qt/GameList/GameListModel.h
@@ -37,6 +37,11 @@ public:
 		Column_Count
 	};
 
+	enum : int
+	{
+		NeedsFavoriteBadgeRole = Qt::UserRole
+	};
+
 	static std::optional<Column> getColumnIdForName(std::string_view name);
 	static const char* getColumnName(Column col);
 
@@ -58,10 +63,11 @@ public:
 
 	bool titlesLessThan(int left_row, int right_row) const;
 
-	bool lessThan(const QModelIndex& left_index, const QModelIndex& right_index, int column) const;
+	bool lessThan(const QModelIndex& left_index, const QModelIndex& right_index, int column, Qt::SortOrder sort_order) const;
 
 	bool getShowCoverTitles() const { return m_show_titles_for_covers; }
 	void setShowCoverTitles(bool enabled) { m_show_titles_for_covers = enabled; }
+	const QPixmap& getFavoritePixmap() const { return m_favorite_pixmap; }
 
 	float getCoverScale() const { return m_cover_scale; }
 	void setCoverScale(float scale);
@@ -99,5 +105,6 @@ private:
 	qreal m_dpr;
 
 	std::array<QPixmap, static_cast<int>(GameList::CompatibilityRatingCount)> m_compatibility_pixmaps;
+	QPixmap m_favorite_pixmap;
 	mutable LRUCache<std::string, QPixmap> m_cover_pixmap_cache;
 };

--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -50,16 +50,17 @@ static constexpr int DEFAULT_SORT_INDEX = static_cast<int>(DEFAULT_SORT_COLUMN);
 static constexpr Qt::SortOrder DEFAULT_SORT_ORDER = Qt::AscendingOrder;
 
 static constexpr std::array<int, GameListModel::Column_Count> DEFAULT_COLUMN_WIDTHS = {{
-	55, // type
-	85, // code
-	-1, // title
-	-1, // file title
-	75, // crc
-	95, // time played
-	90, // last played
-	80, // size
-	60, // region
-	120 // compatibility
+	55,  // type
+	85,  // code
+	-1,  // title
+	-1,  // file title
+	75,  // crc
+	95,  // time played
+	90,  // last played
+	80,  // size
+	60,  // region
+	120, // compatibility
+	-1,  // cover
 }};
 static_assert(static_cast<int>(DEFAULT_COLUMN_WIDTHS.size()) <= GameListModel::Column_Count,
 	"Game List: More default column widths than column types.");
@@ -117,7 +118,7 @@ public:
 
 	bool lessThan(const QModelIndex& source_left, const QModelIndex& source_right) const override
 	{
-		return m_model->lessThan(source_left, source_right, source_left.column());
+		return m_model->lessThan(source_left, source_right, source_left.column(), sortOrder());
 	}
 
 private:
@@ -133,6 +134,8 @@ namespace
 	class GameListIconStyleDelegate final : public QStyledItemDelegate
 	{
 	public:
+		static constexpr int STAR_MARGIN = 4;
+
 		GameListIconStyleDelegate(QWidget* parent)
 			: QStyledItemDelegate(parent)
 		{
@@ -145,7 +148,7 @@ namespace
 			Q_ASSERT(index.isValid());
 
 			// Draw highlight for cell.
-			QApplication::style()->drawControl(QStyle::CE_ItemViewItem, &option, painter, option.widget);
+			QStyledItemDelegate::paint(painter, option, index);
 
 			// Fetch icon pixmap and stop if no icon exists
 			const QPixmap icon = qvariant_cast<QPixmap>(index.data(Qt::DecorationRole));
@@ -153,51 +156,27 @@ namespace
 			if (icon.isNull())
 				return;
 
-			// Save painter state and restore later so clip setting doesn't persist across cell draws.
-			painter->save();
-
-			// Clip pixmap so it doesn't extend outside the cell.
-			const QRect rect = option.rect;
-			painter->setClipRect(rect);
-
-			// Determine starting location of icon (Qt uses top-left origin).
-			const int icon_width = static_cast<int>(static_cast<qreal>(icon.width()) / icon.devicePixelRatio());
-			const int icon_height = static_cast<int>(static_cast<qreal>(icon.height()) / icon.devicePixelRatio());
-			const QPoint icon_top_left = QPoint((rect.width() - icon_width) / 2, (rect.height() - icon_height) / 2);
-
-			// Change palette if the item is selected.
-			if (option.state & QStyle::State_Selected)
+			// Draw star overlay on bottom-right corner if game is favorited.
+			const bool is_favorite = index.data(GameListModel::NeedsFavoriteBadgeRole).toBool();
+			if (is_favorite)
 			{
-				// Set color based on whether cell is enabled.
-				const bool enabled = option.state & QStyle::State_Enabled;
-				QColor color = option.palette.color(enabled ? QPalette::Normal : QPalette::Disabled, QPalette::Highlight);
-				color.setAlphaF(0.3f);
+				painter->save();
 
-				// Fetch pixmap from cache or construct a new one.
-				const QString key = QString::fromStdString(fmt::format("{:016X}-{:d}-{:08X}", icon.cacheKey(), enabled, color.rgba()));
-				QPixmap highlighted_icon;
-				if (!QPixmapCache::find(key, &highlighted_icon))
-				{
-					QImage img = icon.toImage().convertToFormat(QImage::Format_ARGB32_Premultiplied);
+				const QRect rect = option.rect;
+				const int icon_width = static_cast<int>(static_cast<qreal>(icon.width()) / icon.devicePixelRatio());
+				const int icon_height = static_cast<int>(static_cast<qreal>(icon.height()) / icon.devicePixelRatio());
+				const QPoint icon_top_left = rect.topLeft() + QPoint((rect.width() - icon_width) / 2, 0);
 
-					QPainter tinted_painter(&img);
-					tinted_painter.setCompositionMode(QPainter::CompositionMode_SourceAtop);
-					tinted_painter.fillRect(0, 0, img.width(), img.height(), color);
-					tinted_painter.end();
+				const auto* sort_model = static_cast<const QSortFilterProxyModel*>(index.model());
+				const auto* game_model = static_cast<const GameListModel*>(sort_model->sourceModel());
+				const QPixmap& star = game_model->getFavoritePixmap();
+				const QPoint icon_bottom_right = icon_top_left + QPoint(icon_width, icon_height);
+				const QSizeF size = star.deviceIndependentSize();
+				const QPoint star_pos = icon_bottom_right - QPoint(size.width() + STAR_MARGIN, size.height() + STAR_MARGIN);
+				painter->drawPixmap(star_pos, star);
 
-					highlighted_icon = QPixmap(QPixmap::fromImage(img));
-					QPixmapCache::insert(key, highlighted_icon);
-				}
-
-				painter->drawPixmap(rect.topLeft() + icon_top_left, highlighted_icon);
+				painter->restore();
 			}
-			else
-			{
-				painter->drawPixmap(rect.topLeft() + icon_top_left, icon);
-			}
-
-			// Restore the old clip path.
-			painter->restore();
 		}
 	};
 } // namespace
@@ -272,9 +251,9 @@ void GameListWidget::initialize()
 	m_table_view->setVerticalScrollMode(QAbstractItemView::ScrollMode::ScrollPerPixel);
 
 	// Custom painter to center-align DisplayRoles (icons)
-	m_table_view->setItemDelegateForColumn(0, new GameListIconStyleDelegate(this));
-	m_table_view->setItemDelegateForColumn(8, new GameListIconStyleDelegate(this));
-	m_table_view->setItemDelegateForColumn(9, new GameListIconStyleDelegate(this));
+	m_table_view->setItemDelegateForColumn(static_cast<int>(GameListModel::Column_Type), new GameListIconStyleDelegate(this));
+	m_table_view->setItemDelegateForColumn(static_cast<int>(GameListModel::Column_Region), new GameListIconStyleDelegate(this));
+	m_table_view->setItemDelegateForColumn(static_cast<int>(GameListModel::Column_Compatibility), new GameListIconStyleDelegate(this));
 
 	connect(m_table_view->selectionModel(), &QItemSelectionModel::currentChanged, this,
 		&GameListWidget::onSelectionModelCurrentChanged);
@@ -313,6 +292,7 @@ void GameListWidget::initialize()
 	m_list_view = new GameListGridListView(m_ui.stack);
 	m_list_view->setModel(m_sort_model);
 	m_list_view->setModelColumn(GameListModel::Column_Cover);
+	m_list_view->setItemDelegate(new GameListIconStyleDelegate(this));
 	m_list_view->setSelectionMode(QAbstractItemView::SingleSelection);
 	m_list_view->setViewMode(QListView::IconMode);
 	m_list_view->setResizeMode(QListView::Adjust);

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1591,6 +1591,12 @@ void MainWindow::onGameListEntryContextMenuRequested(const QPoint& point)
 #if !defined(__APPLE__)
 		connect(menu.addAction(tr("Create Game Shortcut...")), &QAction::triggered, [this]() { MainWindow::onCreateGameShortcutTriggered(); });
 #endif
+		const bool is_favorite = entry->is_favorite;
+		action = menu.addAction(is_favorite ? tr("Remove from Favorites") : tr("Add to Favorites"));
+		connect(action, &QAction::triggered, [this, entry]() {
+			GameList::SaveFavoriteForPath(entry->path, !entry->is_favorite);
+			m_game_list_widget->refresh(false, false);
+		});
 
 		connect(menu.addAction(tr("Exclude From List")), &QAction::triggered,
 			[this, entry]() { getSettingsWindow()->getGameListSettingsWidget()->addExcludedPath(entry->path); });

--- a/pcsx2/GameList.cpp
+++ b/pcsx2/GameList.cpp
@@ -65,7 +65,7 @@ namespace GameList
 	static bool GetGameListEntryFromCache(const std::string& path, GameList::Entry* entry);
 	static void ScanDirectory(const char* path, bool recursive, bool only_cache, const std::vector<std::string>& excluded_paths,
 		const PlayedTimeMap& played_time_map, const INISettingsInterface& custom_attributes_ini, ProgressCallback* progress);
-	static bool AddFileFromCache(const std::string& path, std::time_t timestamp, const PlayedTimeMap& played_time_map);
+	static bool AddFileFromCache(const std::string& path, std::time_t timestamp, const PlayedTimeMap& played_time_map, const INISettingsInterface& custom_attributes_ini);
 	static bool ScanFile(std::string path, std::time_t timestamp, std::unique_lock<std::recursive_mutex>& lock,
 		const PlayedTimeMap& played_time_map, const INISettingsInterface& custom_attributes_ini);
 
@@ -716,7 +716,7 @@ void GameList::ScanDirectory(const char* path, bool recursive, bool only_cache, 
 		}
 
 		std::unique_lock lock(s_mutex);
-		if (GetEntryForPath(ffd.FileName.c_str()) || AddFileFromCache(ffd.FileName, ffd.ModificationTime, played_time_map) || only_cache)
+		if (GetEntryForPath(ffd.FileName.c_str()) || AddFileFromCache(ffd.FileName, ffd.ModificationTime, played_time_map, custom_attributes_ini) || only_cache)
 		{
 			continue;
 		}
@@ -731,7 +731,7 @@ void GameList::ScanDirectory(const char* path, bool recursive, bool only_cache, 
 	progress->PopState();
 }
 
-bool GameList::AddFileFromCache(const std::string& path, std::time_t timestamp, const PlayedTimeMap& played_time_map)
+bool GameList::AddFileFromCache(const std::string& path, std::time_t timestamp, const PlayedTimeMap& played_time_map, const INISettingsInterface& custom_attributes_ini)
 {
 	Entry entry;
 	if (!GetGameListEntryFromCache(path, &entry) || entry.last_modified_time != timestamp)
@@ -748,6 +748,7 @@ bool GameList::AddFileFromCache(const std::string& path, std::time_t timestamp, 
 		entry.total_played_time = iter->second.total_played_time;
 	}
 
+	entry.is_favorite = custom_attributes_ini.GetBoolValue(entry.path.c_str(), "Favorited", false);
 	s_entries.push_back(std::move(entry));
 	return true;
 }
@@ -786,8 +787,10 @@ bool GameList::ScanFile(std::string path, std::time_t timestamp, std::unique_loc
 		entry.total_played_time = iter->second.total_played_time;
 	}
 
-	auto custom_title = custom_attributes_ini.GetOptionalStringValue(EncodeIniKey(entry.path).c_str(), "Title");
-	if (custom_title)
+	entry.is_favorite = custom_attributes_ini.GetBoolValue(EncodeIniKey(entry.path).c_str(), "Favorited", false);
+
+	auto custom_title = custom_attributes_ini.GetOptionalStringValue(entry.path.c_str(), "Title");
+	if (custom_title && !custom_title.value().empty())
 	{
 		entry.title = std::move(custom_title.value());
 	}
@@ -1513,12 +1516,35 @@ void GameList::SaveCustomRegionForPath(const std::string& path, int custom_regio
 	}
 }
 
+void GameList::SaveFavoriteForPath(const std::string& path, bool favorite)
+{
+	INISettingsInterface custom_attributes(GetCustomPropertiesFile());
+	custom_attributes.Load();
+
+	if (favorite)
+	{
+		custom_attributes.SetBoolValue(path.c_str(), "Favorited", true);
+	}
+	else
+	{
+		custom_attributes.DeleteValue(path.c_str(), "Favorited");
+	}
+
+	if (custom_attributes.Save())
+	{
+		std::unique_lock lock(s_mutex);
+		GameList::Entry* entry = const_cast<GameList::Entry*>(GetEntryForPath(path.c_str()));
+		if (entry)
+			entry->is_favorite = favorite;
+	}
+}
+
 std::string GameList::GetCustomTitleForPath(const std::string& path)
 {
 	std::string ret;
 
 	std::unique_lock lock(s_mutex);
-	const GameList::Entry* entry = GetEntryForPath(EncodeIniKey(path).c_str());
+	const GameList::Entry* entry = GetEntryForPath(path.c_str());
 	if (entry)
 	{
 		ret = entry->title;

--- a/pcsx2/GameList.h
+++ b/pcsx2/GameList.h
@@ -100,6 +100,7 @@ namespace GameList
 		u32 crc = 0;
 
 		CompatibilityRating compatibility_rating = CompatibilityRating::Unknown;
+		bool is_favorite = false;
 
 		__fi bool IsDisc() const { return (type == EntryType::PS1Disc || type == EntryType::PS2Disc); }
 	};
@@ -160,5 +161,6 @@ namespace GameList
 	void CheckCustomAttributesForPath(const std::string& path, bool& has_custom_title, bool& has_custom_region);
 	void SaveCustomTitleForPath(const std::string& path, const std::string& custom_title);
 	void SaveCustomRegionForPath(const std::string& path, int custom_region);
+	void SaveFavoriteForPath(const std::string& path, bool favorite);
 	std::string GetCustomTitleForPath(const std::string& path);
 } // namespace GameList


### PR DESCRIPTION
### Description of Changes
Adds the ability to favourite games in the game list. Favourited games are persisted to a `favourites.ini` file in the settings directory and sorted to the top of the game list regardless of the active sort column.

- Added `is_favourite` field to `GameList::Entry`
- Added `GetFavouritesFile()`, `IsGameFavourited()` and `SetGameFavourite()` functions to `GameList`
- Favourites are loaded efficiently once per refresh, following the same pattern as `custom_attributes_ini`
- Added "Add to Favourites" / "Remove from Favourites" to the right-click context menu
- Favourited games sort to the top in `GameListModel::lessThan()`

#14107

### Rationale behind Changes
Searching for a specific game manually takes time, especially with large libraries. Favouriting allows users to pin frequently played games to the top of the list without scrolling or searching.

The implementation is kept flexible so it can be extended to a full groups system in the future (#11666), with "Favourites" acting as a special case of a group.

### Suggested Testing Steps
1. Right-click any game in the list -> select "Add to Favourites"
2. Verify the game sorts to the top of the list immediately
3. Close and reopen PCSX2 to verify the favourite persists
4. Right-click the favourited game -> verify it shows "Remove from Favourites"
5. Remove the favourite and verify the game returns to its normal sort position

### Did you use AI to help find, test, or implement this issue or feature?
Yes.  I did use Claude to understand the codebase and existing patterns such as how `custom_attributes_ini`and `PlayedTimeMap` are structured, and to guide the implementation. All code was reviewed and tested manually.
