### PR TITLE
GS: Add unsafe setting warnings for debug settings

### DIFF
--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -3266,6 +3266,11 @@ void VMManager::WarnAboutUnsafeSettings()
 			append(ICON_FA_IMAGES,
 				TRANSLATE_SV("VMManager", "Accurate Alpha Test is enabled, this may reduce performance."));
 		}
+		if (EmuConfig.GS.DepthFeedbackMode != GSDepthFeedbackMode::Auto)
+		{
+			append(ICON_FA_IMAGES,
+				TRANSLATE_SV("VMManager", "Overriding default depth feedback mode, this may break rendering in some games."));
+		}
 		if (EmuConfig.GS.UseDebugDevice)
 		{
 			append(ICON_FA_BUG,
@@ -3295,6 +3300,11 @@ void VMManager::WarnAboutUnsafeSettings()
 			append(ICON_FA_CIRCLE_EXCLAMATION,
 				TRANSLATE_SV("VMManager", "Graphics API is not set to Automatic. This may cause performance problems and graphical issues."));
 		}
+	}
+	if (EmuConfig.GS.DumpGSData)
+	{
+		const std::string& dir = is_sw_renderer ? EmuConfig.GS.SWDumpDirectory : EmuConfig.GS.HWDumpDirectory;
+		append(ICON_FA_LAYER_GROUP, fmt::format(TRANSLATE_FS("VMManager", "Dumping draw data to {}."), dir));
 	}
 	if (EmuConfig.GS.TextureFiltering != BiFiltering::PS2)
 	{


### PR DESCRIPTION
### Description of Changes
Adds unsafe setting warnings for some debug settings

### Rationale behind Changes
<img width="2048" height="1768" alt="Screenshot_20210721-1106042" src="https://github.com/user-attachments/assets/034a1059-ea1c-4ed1-a033-e5b046b5c584" />

### Suggested Testing Steps
Turn on draw dumping and see if you get a message

### Did you use AI to help find, test, or implement this issue or feature?
No