### PR TITLE
Qt: Add controller navigation for the game list

### DIFF
--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -531,6 +531,7 @@ void GameListWidget::onRefreshComplete()
 		m_ui.stack->setCurrentIndex(2);
 		setFocusProxy(nullptr);
 	}
+
 }
 
 void GameListWidget::onSelectionModelCurrentChanged(const QModelIndex& current, const QModelIndex& previous)
@@ -655,24 +656,49 @@ void GameListWidget::refreshGridCovers()
 
 void GameListWidget::handleControllerNavigation(int qtKey)
 {
+	// If a modal dialog is active (e.g. the resume-state prompt), redirect navigation there
+	// instead of the game list. Map directional inputs to Tab/Shift+Tab since that is how
+	// focus moves between dialog buttons.
+	if (QApplication::activeModalWidget())
+	{
+		QWidget* target = QApplication::focusWidget();
+		if (!target)
+			target = QApplication::activeModalWidget();
+
+		int nav_key = qtKey;
+		Qt::KeyboardModifiers mods = Qt::NoModifier;
+		if (qtKey == Qt::Key_Up || qtKey == Qt::Key_Left)
+		{
+			nav_key = Qt::Key_Tab;
+			mods = Qt::ShiftModifier;
+		}
+		else if (qtKey == Qt::Key_Down || qtKey == Qt::Key_Right)
+		{
+			nav_key = Qt::Key_Tab;
+		}
+
+		QApplication::postEvent(target, new QKeyEvent(QEvent::KeyPress, nav_key, mods));
+		QApplication::postEvent(target, new QKeyEvent(QEvent::KeyRelease, nav_key, mods));
+		return;
+	}
+
 	// Only route to visible game views; ignore if showing the empty-game-directory widget.
 	if (!isShowingGameList() && !isShowingGameGrid())
 		return;
 
 	QAbstractItemView* view = isShowingGameGrid() ? static_cast<QAbstractItemView*>(m_list_view) : static_cast<QAbstractItemView*>(m_table_view);
 
-	// If nothing is selected yet, pick the first item so navigation has somewhere to start.
-	if (!view->currentIndex().isValid())
+	// Nothing is visually highlighted yet (currentIndex may exist but not be selected).
+	// Snap to item #1 and consume this input so the user sees it highlighted first.
+	if (!view->selectionModel()->hasSelection())
 	{
 		const QModelIndex first = view->model()->index(0, 0);
 		if (!first.isValid())
 			return;
+		view->setFocus();
 		view->setCurrentIndex(first);
-		if (qtKey == Qt::Key_Return)
-		{
-			// Treat confirm on an unselected list as just selecting the first item.
-			return;
-		}
+		view->selectionModel()->select(first, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
+		return;
 	}
 
 	QApplication::postEvent(view, new QKeyEvent(QEvent::KeyPress, qtKey, Qt::NoModifier));

--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -698,6 +698,7 @@ void GameListWidget::handleControllerNavigation(int qtKey)
 		view->setFocus();
 		view->setCurrentIndex(first);
 		view->selectionModel()->select(first, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
+		view->scrollToTop();
 		return;
 	}
 

--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -22,6 +22,7 @@
 #include <QtCore/QSortFilterProxyModel>
 #include <QtCore/QDir>
 #include <QtCore/QString>
+#include <QtGui/QKeyEvent>
 #include <QtGui/QPainter>
 #include <QtGui/QPixmap>
 #include <QtGui/QPixmapCache>
@@ -650,6 +651,32 @@ void GameListWidget::gridIntScale(int int_scale)
 void GameListWidget::refreshGridCovers()
 {
 	m_model->refreshCovers();
+}
+
+void GameListWidget::handleControllerNavigation(int qtKey)
+{
+	// Only route to visible game views; ignore if showing the empty-game-directory widget.
+	if (!isShowingGameList() && !isShowingGameGrid())
+		return;
+
+	QAbstractItemView* view = isShowingGameGrid() ? static_cast<QAbstractItemView*>(m_list_view) : static_cast<QAbstractItemView*>(m_table_view);
+
+	// If nothing is selected yet, pick the first item so navigation has somewhere to start.
+	if (!view->currentIndex().isValid())
+	{
+		const QModelIndex first = view->model()->index(0, 0);
+		if (!first.isValid())
+			return;
+		view->setCurrentIndex(first);
+		if (qtKey == Qt::Key_Return)
+		{
+			// Treat confirm on an unselected list as just selecting the first item.
+			return;
+		}
+	}
+
+	QApplication::postEvent(view, new QKeyEvent(QEvent::KeyPress, qtKey, Qt::NoModifier));
+	QApplication::postEvent(view, new QKeyEvent(QEvent::KeyRelease, qtKey, Qt::NoModifier));
 }
 
 void GameListWidget::showGameList()

--- a/pcsx2-qt/GameList/GameListWidget.h
+++ b/pcsx2-qt/GameList/GameListWidget.h
@@ -97,6 +97,7 @@ public Q_SLOTS:
 	void gridZoomOut();
 	void gridIntScale(int int_scale);
 	void refreshGridCovers();
+	void handleControllerNavigation(int qtKey);
 
 protected:
 	void showEvent(QShowEvent* event) override;

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -456,6 +456,7 @@ void MainWindow::connectVMThreadSignals(EmuThread* thread)
 	connect(thread, &EmuThread::onAchievementsHardcoreModeChanged, this, &MainWindow::onAchievementsHardcoreModeChanged);
 	connect(thread, &EmuThread::onCoverDownloaderOpenRequested, this, &MainWindow::onToolsCoverDownloaderTriggered);
 	connect(thread, &EmuThread::onCreateMemoryCardOpenRequested, this, &MainWindow::onCreateMemoryCardOpenRequested);
+	connect(thread, &EmuThread::navigationKeyPressed, m_game_list_widget, &GameListWidget::handleControllerNavigation);
 
 	connect(m_ui.actionReset, &QAction::triggered, this, &MainWindow::requestReset);
 	connect(m_ui.actionPause, &QAction::toggled, thread, &EmuThread::setVMPaused);

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -391,7 +391,7 @@ void EmuThread::run()
 			return false;
 
 		static constexpr float NAV_THRESHOLD = 0.5f;
-		static u8 s_nav_state = 0; // bitmask per direction to debounce analog stick
+		static u8 s_nav_state = 0;
 
 		u8 bit = 0;
 		int qt_key = -1;
@@ -440,7 +440,10 @@ void EmuThread::run()
 			s_nav_state &= ~bit;
 		}
 
-		return false;
+		// Consume the event so it doesn't reach InvokeEvents/pad bindings.
+		// If it were forwarded, the pad plugin would buffer the button state
+		// and the game would see a spurious press on launch.
+		return true;
 	});
 
 	// Main CPU thread loop.

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -385,6 +385,64 @@ void EmuThread::run()
 	createBackgroundControllerPollTimer();
 	startBackgroundControllerPollTimer();
 
+	// Install controller navigation callback so D-pad/analog stick can navigate the game list.
+	InputManager::SetUINavigationCallback([](GenericInputBinding key, float value) -> bool {
+		if (VMManager::HasValidVM())
+			return false;
+
+		static constexpr float NAV_THRESHOLD = 0.5f;
+		static u8 s_nav_state = 0; // bitmask per direction to debounce analog stick
+
+		u8 bit = 0;
+		int qt_key = -1;
+
+		switch (key)
+		{
+			case GenericInputBinding::DPadUp:
+			case GenericInputBinding::LeftStickUp:
+				bit = (1 << 0);
+				qt_key = Qt::Key_Up;
+				break;
+			case GenericInputBinding::DPadDown:
+			case GenericInputBinding::LeftStickDown:
+				bit = (1 << 1);
+				qt_key = Qt::Key_Down;
+				break;
+			case GenericInputBinding::DPadLeft:
+			case GenericInputBinding::LeftStickLeft:
+				bit = (1 << 2);
+				qt_key = Qt::Key_Left;
+				break;
+			case GenericInputBinding::DPadRight:
+			case GenericInputBinding::LeftStickRight:
+				bit = (1 << 3);
+				qt_key = Qt::Key_Right;
+				break;
+			case GenericInputBinding::Cross:
+			case GenericInputBinding::Start:
+				bit = (1 << 4);
+				qt_key = Qt::Key_Return;
+				break;
+			default:
+				return false;
+		}
+
+		const bool pressed = (value >= NAV_THRESHOLD);
+		const bool was_pressed = (s_nav_state & bit) != 0;
+
+		if (pressed && !was_pressed)
+		{
+			s_nav_state |= bit;
+			emit g_emu_thread->navigationKeyPressed(qt_key);
+		}
+		else if (!pressed && was_pressed)
+		{
+			s_nav_state &= ~bit;
+		}
+
+		return false;
+	});
+
 	// Main CPU thread loop.
 	while (!m_shutdown_flag.load())
 	{
@@ -418,6 +476,7 @@ void EmuThread::run()
 	}
 
 	// Teardown in reverse order.
+	InputManager::RemoveUINavigationCallback();
 	stopBackgroundControllerPollTimer();
 	destroyBackgroundControllerPollTimer();
 	VMManager::Internal::CPUThreadShutdown();

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -434,10 +434,17 @@ void EmuThread::run()
 		{
 			s_nav_state |= bit;
 			emit g_emu_thread->navigationKeyPressed(qt_key);
+			g_emu_thread->m_nav_held_key.store(qt_key, std::memory_order_release);
+			QMetaObject::invokeMethod(g_emu_thread, &EmuThread::startNavRepeatTimer, Qt::QueuedConnection);
 		}
 		else if (!pressed && was_pressed)
 		{
 			s_nav_state &= ~bit;
+			if (g_emu_thread->m_nav_held_key.load(std::memory_order_acquire) == qt_key)
+			{
+				g_emu_thread->m_nav_held_key.store(-1, std::memory_order_release);
+				QMetaObject::invokeMethod(g_emu_thread, &EmuThread::stopNavRepeatTimer, Qt::QueuedConnection);
+			}
 		}
 
 		// Consume the event so it doesn't reach InvokeEvents/pad bindings.
@@ -508,12 +515,19 @@ void EmuThread::createBackgroundControllerPollTimer()
 	m_background_controller_polling_timer->setSingleShot(false);
 	m_background_controller_polling_timer->setTimerType(Qt::CoarseTimer);
 	connect(m_background_controller_polling_timer, &QTimer::timeout, this, &EmuThread::doBackgroundControllerPoll);
+
+	m_nav_repeat_timer = new QTimer(this);
+	m_nav_repeat_timer->setSingleShot(false);
+	connect(m_nav_repeat_timer, &QTimer::timeout, this, &EmuThread::onNavRepeatTimeout);
 }
 
 void EmuThread::destroyBackgroundControllerPollTimer()
 {
 	delete m_background_controller_polling_timer;
 	m_background_controller_polling_timer = nullptr;
+
+	delete m_nav_repeat_timer;
+	m_nav_repeat_timer = nullptr;
 }
 
 void EmuThread::startBackgroundControllerPollTimer()
@@ -536,6 +550,31 @@ void EmuThread::stopBackgroundControllerPollTimer()
 void EmuThread::doBackgroundControllerPoll()
 {
 	VMManager::IdlePollUpdate();
+}
+
+void EmuThread::startNavRepeatTimer()
+{
+	m_nav_repeat_timer->setInterval(static_cast<int>(NAV_REPEAT_INITIAL_DELAY));
+	m_nav_repeat_timer->start();
+}
+
+void EmuThread::stopNavRepeatTimer()
+{
+	m_nav_repeat_timer->stop();
+}
+
+void EmuThread::onNavRepeatTimeout()
+{
+	const int key = m_nav_held_key.load(std::memory_order_acquire);
+	if (key < 0 || VMManager::HasValidVM() || FullscreenUI::IsInitialized())
+	{
+		m_nav_held_key.store(-1, std::memory_order_release);
+		m_nav_repeat_timer->stop();
+		return;
+	}
+	if (m_nav_repeat_timer->interval() != static_cast<int>(NAV_REPEAT_INTERVAL))
+		m_nav_repeat_timer->setInterval(static_cast<int>(NAV_REPEAT_INTERVAL));
+	emit navigationKeyPressed(key);
 }
 
 void EmuThread::toggleFullscreen()

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -387,7 +387,7 @@ void EmuThread::run()
 
 	// Install controller navigation callback so D-pad/analog stick can navigate the game list.
 	InputManager::SetUINavigationCallback([](GenericInputBinding key, float value) -> bool {
-		if (VMManager::HasValidVM())
+		if (VMManager::HasValidVM() || FullscreenUI::IsInitialized())
 			return false;
 
 		static constexpr float NAV_THRESHOLD = 0.5f;

--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -169,6 +169,9 @@ Q_SIGNALS:
 	void onCoverDownloaderOpenRequested();
 	void onCreateMemoryCardOpenRequested();
 
+	/// Emitted when a controller navigation event is received while no VM is running.
+	void navigationKeyPressed(int qtKey);
+
 	/// Called when video capture starts/stops.
 	void onCaptureStarted(const QString& filename);
 	void onCaptureStopped();

--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -186,6 +186,12 @@ private:
 	/// Poll at half the vsync rate for FSUI to reduce the chance of getting a press+release in the same frame.
 	static constexpr u32 FULLSCREEN_UI_CONTROLLER_POLLING_INTERVAL = 8;
 
+	/// Initial delay before auto-repeat begins (ms).
+	static constexpr u32 NAV_REPEAT_INITIAL_DELAY = 400;
+
+	/// Interval between repeated navigation events while a direction is held (ms).
+	static constexpr u32 NAV_REPEAT_INTERVAL = 100;
+
 	void destroyVM();
 
 	void createBackgroundControllerPollTimer();
@@ -198,12 +204,17 @@ private Q_SLOTS:
 	void onDisplayWindowResized(u32 width, u32 height, float scale);
 	void onApplicationStateChanged(Qt::ApplicationState state);
 	void redrawDisplayWindow();
+	void startNavRepeatTimer();
+	void stopNavRepeatTimer();
+	void onNavRepeatTimeout();
 
 private:
 	QThread* m_ui_thread;
 	QSemaphore m_started_semaphore;
 	QEventLoop* m_event_loop = nullptr;
 	QTimer* m_background_controller_polling_timer = nullptr;
+	QTimer* m_nav_repeat_timer = nullptr;
+	std::atomic<int> m_nav_held_key{-1};
 
 	std::atomic_bool m_shutdown_flag{false};
 	std::atomic_bool m_run_fullscreen_ui{false};

--- a/pcsx2/Input/InputManager.cpp
+++ b/pcsx2/Input/InputManager.cpp
@@ -136,6 +136,9 @@ static std::mutex s_binding_map_write_lock;
 static std::mutex m_event_intercept_mutex;
 static InputInterceptHook::Callback m_event_intercept_callback;
 
+// UI navigation callback (game list controller support)
+static InputManager::UINavigationCallback s_ui_nav_callback;
+
 // Input sources. Keyboard/mouse don't exist here.
 static std::array<std::unique_ptr<InputSource>, static_cast<u32>(InputSourceType::Count)> s_input_sources;
 
@@ -1279,6 +1282,9 @@ bool InputManager::PreprocessEvent(InputBindingKey key, float value, GenericInpu
 		InputLayout layout = s_input_sources[static_cast<u32>(InputSourceType::SDL)]->GetControllerLayout(key.source_index);
 		if (ImGuiManager::ProcessGenericInputEvent(generic_key, layout, value) && value != 0.0f)
 			return true;
+
+		if (s_ui_nav_callback && s_ui_nav_callback(generic_key, value))
+			return true;
 	}
 
 	return false;
@@ -1527,6 +1533,22 @@ bool InputManager::HasHook()
 {
 	std::unique_lock<std::mutex> lock(m_event_intercept_mutex);
 	return (bool)m_event_intercept_callback;
+}
+
+void InputManager::SetUINavigationCallback(UINavigationCallback callback)
+{
+	s_ui_nav_callback = std::move(callback);
+}
+
+void InputManager::RemoveUINavigationCallback()
+{
+	s_ui_nav_callback = {};
+}
+
+void InputManager::InvokeUINavigationEvent(GenericInputBinding key, float value)
+{
+	if (s_ui_nav_callback)
+		s_ui_nav_callback(key, value);
 }
 
 bool InputManager::DoEventHook(InputBindingKey key, float value)

--- a/pcsx2/Input/InputManager.h
+++ b/pcsx2/Input/InputManager.h
@@ -286,6 +286,17 @@ namespace InputManager
 	/// Returns true if there is an interception hook present.
 	bool HasHook();
 
+	/// Sets a callback to receive generic input events not consumed by ImGui or pad bindings.
+	/// Intended for UI navigation (e.g. controller-driven game list navigation) when no VM is running.
+	/// The callback is invoked on the EmuThread. Return true to consume the event.
+	using UINavigationCallback = std::function<bool(GenericInputBinding, float)>;
+	void SetUINavigationCallback(UINavigationCallback callback);
+	void RemoveUINavigationCallback();
+
+	/// Directly invokes the UI navigation callback with the given generic binding and value.
+	/// Used by input sources to fire directional axis events with proper unipolar magnitudes.
+	void InvokeUINavigationEvent(GenericInputBinding key, float value);
+
 	/// Internal method used by pads to dispatch vibration updates to input sources.
 	/// Intensity is normalized from 0 to 1.
 	void SetUSBVibrationIntensity(u32 port, float large_or_single_motor_intensity, float small_motor_intensity);

--- a/pcsx2/Input/SDLInputSource.cpp
+++ b/pcsx2/Input/SDLInputSource.cpp
@@ -1489,7 +1489,19 @@ bool SDLInputSource::HandleGamepadAxisEvent(const SDL_GamepadAxisEvent* ev)
 		return false;
 
 	const InputBindingKey key(MakeGenericControllerAxisKey(InputSourceType::SDL, it->player_id, ev->axis));
-	InputManager::InvokeEvents(key, NormalizeS16(ev->value));
+	const float value = NormalizeS16(ev->value);
+	InputManager::InvokeEvents(key, value);
+
+	// Fire directional generic events so UI navigation (game list) receives proper unipolar
+	// magnitudes for each direction — the bipolar raw value isn't usable for threshold checks.
+	if (ev->axis < std::size(s_sdl_generic_binding_axis_mapping))
+	{
+		InputManager::InvokeUINavigationEvent(s_sdl_generic_binding_axis_mapping[ev->axis][0],
+			(value < 0.0f) ? -value : 0.0f);
+		InputManager::InvokeUINavigationEvent(s_sdl_generic_binding_axis_mapping[ev->axis][1],
+			(value > 0.0f) ? value : 0.0f);
+	}
+
 	return true;
 }
 


### PR DESCRIPTION
### Description of Changes
Adds controller D-pad and left analog stick navigation to the game list and game grid. Pressing Cross/A or Start launches the selected game.

### Rationale behind Changes
Improves usability for users who prefer to navigate the game library with a controller without needing to switch to a mouse.

### Suggested Testing Steps
  - Use the D-pad or left analog stick to navigate between games in list or grid view
  - Verify the first controller input highlights the first game in the list
  - If a game has a suspended state, verify that the controller can navigate the pop dialogue options and is not still navigating the games on the list menu
  - Launch a game and verify no unintended button inputs carry over into the game (easier to verify with a suspended game since splash screen usually ignore input)
  - Guide Button enters and exits Big Picture Mode directly

### Did you use AI to help find, test, or implement this issue or feature?
Yes. I used AI to help implement the feature. Since Qt does not natively translate controller input, AI helped figure out how to hook into PCSX2's existing input pipeline to bridge controller events to Qt's navigation system.
