### PR TITLE
FullscreenUI: Add analog control to big picture mode

### DIFF
--- a/pcsx2/ImGui/ImGuiManager.cpp
+++ b/pcsx2/ImGui/ImGuiManager.cpp
@@ -1205,11 +1205,11 @@ bool ImGuiManager::ProcessGenericInputEvent(GenericInputBinding key, InputLayout
 
 void ImGuiManager::ProcessGenericAxisEvent(GenericInputBinding negative_key, GenericInputBinding positive_key, InputLayout layout, float value)
 {
-	static constexpr float DEADZONE = 0.25f;
+	// Hysteresis prevents wobble: activate at 0.5, release at 0.2.
+	static constexpr float ACTIVATE_THRESHOLD = 0.5f;
+	static constexpr float RELEASE_THRESHOLD = 0.2f;
 
-	// Ignore diagonal analog stick input — neither axis fires when both exceed the deadzone.
-	// Also track last sent binary state per direction to avoid bursting duplicate events when
-	// the controller sends many axis updates in quick succession.
+	// Ignore diagonal input and track binary state per direction to suppress duplicate events.
 	struct AxisState
 	{
 		float x = 0.0f, y = 0.0f;
@@ -1249,7 +1249,7 @@ void ImGuiManager::ProcessGenericAxisEvent(GenericInputBinding negative_key, Gen
 	if (state)
 	{
 		const float other = is_x_axis ? state->y : state->x;
-		if (std::abs(other) > DEADZONE)
+		if (std::abs(other) > ACTIVATE_THRESHOLD)
 			suppressed_value = 0.0f;
 	}
 
@@ -1259,8 +1259,10 @@ void ImGuiManager::ProcessGenericAxisEvent(GenericInputBinding negative_key, Gen
 
 	if (negative_key != GenericInputBinding::Unknown)
 	{
-		const bool active = suppressed_value < -DEADZONE;
-		if (!neg_active_ptr || active != *neg_active_ptr)
+		const bool currently_active = neg_active_ptr ? *neg_active_ptr : false;
+		const float threshold = currently_active ? RELEASE_THRESHOLD : ACTIVATE_THRESHOLD;
+		const bool active = suppressed_value < -threshold;
+		if (!neg_active_ptr || active != currently_active)
 		{
 			if (neg_active_ptr)
 				*neg_active_ptr = active;
@@ -1269,8 +1271,10 @@ void ImGuiManager::ProcessGenericAxisEvent(GenericInputBinding negative_key, Gen
 	}
 	if (positive_key != GenericInputBinding::Unknown)
 	{
-		const bool active = suppressed_value > DEADZONE;
-		if (!pos_active_ptr || active != *pos_active_ptr)
+		const bool currently_active = pos_active_ptr ? *pos_active_ptr : false;
+		const float threshold = currently_active ? RELEASE_THRESHOLD : ACTIVATE_THRESHOLD;
+		const bool active = suppressed_value > threshold;
+		if (!pos_active_ptr || active != currently_active)
 		{
 			if (pos_active_ptr)
 				*pos_active_ptr = active;

--- a/pcsx2/ImGui/ImGuiManager.cpp
+++ b/pcsx2/ImGui/ImGuiManager.cpp
@@ -1142,15 +1142,15 @@ bool ImGuiManager::ProcessGenericInputEvent(GenericInputBinding key, InputLayout
 		ImGuiKey_GamepadDpadRight, // DPadRight
 		ImGuiKey_GamepadDpadLeft, // DPadLeft
 		ImGuiKey_GamepadDpadDown, // DPadDown
-		ImGuiKey_None, // LeftStickUp
-		ImGuiKey_None, // LeftStickRight
-		ImGuiKey_None, // LeftStickDown
-		ImGuiKey_None, // LeftStickLeft
+		ImGuiKey_GamepadDpadUp, // LeftStickUp
+		ImGuiKey_GamepadDpadRight, // LeftStickRight
+		ImGuiKey_GamepadDpadDown, // LeftStickDown
+		ImGuiKey_GamepadDpadLeft, // LeftStickLeft
 		ImGuiKey_GamepadL3, // L3
-		ImGuiKey_None, // RightStickUp
-		ImGuiKey_None, // RightStickRight
-		ImGuiKey_None, // RightStickDown
-		ImGuiKey_None, // RightStickLeft
+		ImGuiKey_GamepadDpadUp, // RightStickUp
+		ImGuiKey_GamepadDpadRight, // RightStickRight
+		ImGuiKey_GamepadDpadDown, // RightStickDown
+		ImGuiKey_GamepadDpadLeft, // RightStickLeft
 		ImGuiKey_GamepadR3, // R3
 		ImGuiKey_GamepadFaceUp, // Triangle
 		ImGuiKey_GamepadFaceRight, // Circle
@@ -1186,6 +1186,17 @@ bool ImGuiManager::ProcessGenericInputEvent(GenericInputBinding key, InputLayout
 		});
 
 	return s_imgui_wants_keyboard.load(std::memory_order_acquire);
+}
+
+void ImGuiManager::ProcessGenericAxisEvent(GenericInputBinding negative_key, GenericInputBinding positive_key, InputLayout layout, float value)
+{
+	static constexpr float DEADZONE = 0.25f;
+
+	// Treat as binary like the D-pad: either fully pressed or released, with a deadzone.
+	if (negative_key != GenericInputBinding::Unknown)
+		ProcessGenericInputEvent(negative_key, layout, (value < -DEADZONE) ? 1.0f : 0.0f);
+	if (positive_key != GenericInputBinding::Unknown)
+		ProcessGenericInputEvent(positive_key, layout, (value > DEADZONE) ? 1.0f : 0.0f);
 }
 
 void ImGuiManager::SwapGamepadNorthWest(bool value)

--- a/pcsx2/ImGui/ImGuiManager.cpp
+++ b/pcsx2/ImGui/ImGuiManager.cpp
@@ -1208,40 +1208,75 @@ void ImGuiManager::ProcessGenericAxisEvent(GenericInputBinding negative_key, Gen
 	static constexpr float DEADZONE = 0.25f;
 
 	// Ignore diagonal analog stick input — neither axis fires when both exceed the deadzone.
-	static float s_left_stick_x = 0.0f, s_left_stick_y = 0.0f;
-	static float s_right_stick_x = 0.0f, s_right_stick_y = 0.0f;
+	// Also track last sent binary state per direction to avoid bursting duplicate events when
+	// the controller sends many axis updates in quick succession.
+	struct AxisState
+	{
+		float x = 0.0f, y = 0.0f;
+		bool x_neg_active = false, x_pos_active = false;
+		bool y_neg_active = false, y_pos_active = false;
+	};
+	static AxisState s_left_stick, s_right_stick;
 
-	float suppressed_value = value;
+	AxisState* state = nullptr;
+	bool is_x_axis = false;
 	if (negative_key == GenericInputBinding::LeftStickLeft)
 	{
-		s_left_stick_x = value;
-		if (std::abs(s_left_stick_y) > DEADZONE)
-			suppressed_value = 0.0f;
+		state = &s_left_stick;
+		state->x = value;
+		is_x_axis = true;
 	}
 	else if (negative_key == GenericInputBinding::LeftStickUp)
 	{
-		s_left_stick_y = value;
-		if (std::abs(s_left_stick_x) > DEADZONE)
-			suppressed_value = 0.0f;
+		state = &s_left_stick;
+		state->y = value;
+		is_x_axis = false;
 	}
 	else if (negative_key == GenericInputBinding::RightStickLeft)
 	{
-		s_right_stick_x = value;
-		if (std::abs(s_right_stick_y) > DEADZONE)
-			suppressed_value = 0.0f;
+		state = &s_right_stick;
+		state->x = value;
+		is_x_axis = true;
 	}
 	else if (negative_key == GenericInputBinding::RightStickUp)
 	{
-		s_right_stick_y = value;
-		if (std::abs(s_right_stick_x) > DEADZONE)
+		state = &s_right_stick;
+		state->y = value;
+		is_x_axis = false;
+	}
+
+	float suppressed_value = value;
+	if (state)
+	{
+		const float other = is_x_axis ? state->y : state->x;
+		if (std::abs(other) > DEADZONE)
 			suppressed_value = 0.0f;
 	}
 
 	// Treat as binary like the D-pad: either fully pressed or released, with a deadzone.
+	bool* neg_active_ptr = state ? (is_x_axis ? &state->x_neg_active : &state->y_neg_active) : nullptr;
+	bool* pos_active_ptr = state ? (is_x_axis ? &state->x_pos_active : &state->y_pos_active) : nullptr;
+
 	if (negative_key != GenericInputBinding::Unknown)
-		ProcessGenericInputEvent(negative_key, layout, (suppressed_value < -DEADZONE) ? 1.0f : 0.0f);
+	{
+		const bool active = suppressed_value < -DEADZONE;
+		if (!neg_active_ptr || active != *neg_active_ptr)
+		{
+			if (neg_active_ptr)
+				*neg_active_ptr = active;
+			ProcessGenericInputEvent(negative_key, layout, active ? 1.0f : 0.0f);
+		}
+	}
 	if (positive_key != GenericInputBinding::Unknown)
-		ProcessGenericInputEvent(positive_key, layout, (suppressed_value > DEADZONE) ? 1.0f : 0.0f);
+	{
+		const bool active = suppressed_value > DEADZONE;
+		if (!pos_active_ptr || active != *pos_active_ptr)
+		{
+			if (pos_active_ptr)
+				*pos_active_ptr = active;
+			ProcessGenericInputEvent(positive_key, layout, active ? 1.0f : 0.0f);
+		}
+	}
 }
 
 void ImGuiManager::SwapGamepadNorthWest(bool value)

--- a/pcsx2/ImGui/ImGuiManager.cpp
+++ b/pcsx2/ImGui/ImGuiManager.cpp
@@ -100,6 +100,22 @@ static std::atomic_bool s_imgui_wants_text{false};
 
 static bool s_gamepad_swap_noth_west = false;
 
+struct ControllerNavState
+{
+	bool dpad_h_held = false;
+	bool dpad_v_held = false;
+
+	struct AxisState
+	{
+		float x = 0.0f, y = 0.0f;
+		bool x_neg_active = false, x_pos_active = false;
+		bool y_neg_active = false, y_pos_active = false;
+	};
+	AxisState left_stick;
+	AxisState right_stick;
+};
+static std::unordered_map<u32, ControllerNavState> s_controller_nav_states;
+
 // mapping of host key -> imgui key
 static std::unordered_map<u32, ImGuiKey> s_imgui_key_map;
 
@@ -1134,7 +1150,7 @@ bool ImGuiManager::ProcessHostKeyEvent(InputBindingKey key, float value)
 	return s_imgui_wants_keyboard.load(std::memory_order_acquire);
 }
 
-bool ImGuiManager::ProcessGenericInputEvent(GenericInputBinding key, InputLayout layout, float value)
+bool ImGuiManager::ProcessGenericInputEvent(GenericInputBinding key, InputLayout layout, float value, u32 controller_id)
 {
 	static constexpr ImGuiKey key_map[] = {
 		ImGuiKey_None, // Unknown,
@@ -1172,17 +1188,17 @@ bool ImGuiManager::ProcessGenericInputEvent(GenericInputBinding key, InputLayout
 		return false;
 
 	// Ignore diagonal D-pad input — neither direction fires when both axes are held simultaneously.
-	static bool s_dpad_h_held = false, s_dpad_v_held = false;
 	const bool is_dpad_h = (key == GenericInputBinding::DPadLeft || key == GenericInputBinding::DPadRight);
 	const bool is_dpad_v = (key == GenericInputBinding::DPadUp || key == GenericInputBinding::DPadDown);
 	if (is_dpad_h || is_dpad_v)
 	{
+		ControllerNavState& nav = s_controller_nav_states[controller_id];
 		if (is_dpad_h)
-			s_dpad_h_held = (value > 0.0f);
+			nav.dpad_h_held = (value > 0.0f);
 		else
-			s_dpad_v_held = (value > 0.0f);
+			nav.dpad_v_held = (value > 0.0f);
 
-		if (s_dpad_h_held && s_dpad_v_held)
+		if (nav.dpad_h_held && nav.dpad_v_held)
 			return false;
 	}
 
@@ -1203,44 +1219,39 @@ bool ImGuiManager::ProcessGenericInputEvent(GenericInputBinding key, InputLayout
 	return s_imgui_wants_keyboard.load(std::memory_order_acquire);
 }
 
-void ImGuiManager::ProcessGenericAxisEvent(GenericInputBinding negative_key, GenericInputBinding positive_key, InputLayout layout, float value)
+void ImGuiManager::ProcessGenericAxisEvent(GenericInputBinding negative_key, GenericInputBinding positive_key, InputLayout layout, float value, u32 controller_id)
 {
 	// Hysteresis prevents wobble: activate at 0.5, release at 0.2.
 	static constexpr float ACTIVATE_THRESHOLD = 0.5f;
 	static constexpr float RELEASE_THRESHOLD = 0.2f;
 
 	// Ignore diagonal input and track binary state per direction to suppress duplicate events.
-	struct AxisState
-	{
-		float x = 0.0f, y = 0.0f;
-		bool x_neg_active = false, x_pos_active = false;
-		bool y_neg_active = false, y_pos_active = false;
-	};
-	static AxisState s_left_stick, s_right_stick;
+	using AxisState = ControllerNavState::AxisState;
+	ControllerNavState& nav = s_controller_nav_states[controller_id];
 
 	AxisState* state = nullptr;
 	bool is_x_axis = false;
 	if (negative_key == GenericInputBinding::LeftStickLeft)
 	{
-		state = &s_left_stick;
+		state = &nav.left_stick;
 		state->x = value;
 		is_x_axis = true;
 	}
 	else if (negative_key == GenericInputBinding::LeftStickUp)
 	{
-		state = &s_left_stick;
+		state = &nav.left_stick;
 		state->y = value;
 		is_x_axis = false;
 	}
 	else if (negative_key == GenericInputBinding::RightStickLeft)
 	{
-		state = &s_right_stick;
+		state = &nav.right_stick;
 		state->x = value;
 		is_x_axis = true;
 	}
 	else if (negative_key == GenericInputBinding::RightStickUp)
 	{
-		state = &s_right_stick;
+		state = &nav.right_stick;
 		state->y = value;
 		is_x_axis = false;
 	}
@@ -1266,7 +1277,7 @@ void ImGuiManager::ProcessGenericAxisEvent(GenericInputBinding negative_key, Gen
 		{
 			if (neg_active_ptr)
 				*neg_active_ptr = active;
-			ProcessGenericInputEvent(negative_key, layout, active ? 1.0f : 0.0f);
+			ProcessGenericInputEvent(negative_key, layout, active ? 1.0f : 0.0f, controller_id);
 		}
 	}
 	if (positive_key != GenericInputBinding::Unknown)
@@ -1278,7 +1289,7 @@ void ImGuiManager::ProcessGenericAxisEvent(GenericInputBinding negative_key, Gen
 		{
 			if (pos_active_ptr)
 				*pos_active_ptr = active;
-			ProcessGenericInputEvent(positive_key, layout, active ? 1.0f : 0.0f);
+			ProcessGenericInputEvent(positive_key, layout, active ? 1.0f : 0.0f, controller_id);
 		}
 	}
 }

--- a/pcsx2/ImGui/ImGuiManager.cpp
+++ b/pcsx2/ImGui/ImGuiManager.cpp
@@ -525,7 +525,15 @@ static u32 GetFontIndex(const ImGuiManager::FontInfo& font)
 {
 	if (!font.face_name)
 		return 0; // No face name selected
-#define RET_IF_ERR(x) do { if ((x) != FT_Err_Ok) [[unlikely]] { assert(0); return 0; } } while (0)
+#define RET_IF_ERR(x) \
+	do \
+	{ \
+		if ((x) != FT_Err_Ok) [[unlikely]] \
+		{ \
+			assert(0); \
+			return 0; \
+		} \
+	} while (0)
 	if (!s_ft_lib)
 		RET_IF_ERR(FT_Init_FreeType(&s_ft_lib));
 	u32 face_idx = 0;
@@ -898,7 +906,7 @@ void ImGuiManager::DrawOSDMessages(Common::Timer::Value current_time)
 	const float padding = std::ceil(8.0f * scale);
 	const float rounding = std::ceil(5.0f * scale);
 	const float max_width = s_window_width - (margin + padding) * 2.0f;
-	
+
 	float position_y = margin;
 	switch (GSConfig.OsdMessagesPos)
 	{
@@ -907,20 +915,20 @@ void ImGuiManager::DrawOSDMessages(Common::Timer::Value current_time)
 		case OsdOverlayPos::TopRight:
 			position_y = margin;
 			break;
-			
+
 		case OsdOverlayPos::CenterLeft:
 		case OsdOverlayPos::Center:
 		case OsdOverlayPos::CenterRight:
 			position_y = s_window_height * 0.5f;
 			break;
-			
+
 		case OsdOverlayPos::BottomLeft:
 		case OsdOverlayPos::BottomCenter:
 		case OsdOverlayPos::BottomRight:
 			// For bottom positions, start from the bottom and let messages stack upward
 			position_y = s_window_height - margin;
 			break;
-			
+
 		case OsdOverlayPos::None:
 		default:
 			position_y = margin;
@@ -992,16 +1000,16 @@ void ImGuiManager::DrawOSDMessages(Common::Timer::Value current_time)
 		const ImVec2 text_size(
 			font->CalcTextSizeA(font_size, max_width, max_width, msg.text.c_str(), msg.text.c_str() + msg.text.length()));
 		const ImVec2 size(text_size.x + padding * 2.0f, text_size.y + padding * 2.0f);
-		
+
 		// For bottom positions, adjust actual_y to try to account for message height
 		float final_y = actual_y;
-		if (GSConfig.OsdMessagesPos == OsdOverlayPos::BottomLeft || 
-		    GSConfig.OsdMessagesPos == OsdOverlayPos::BottomCenter || 
-		    GSConfig.OsdMessagesPos == OsdOverlayPos::BottomRight)
+		if (GSConfig.OsdMessagesPos == OsdOverlayPos::BottomLeft ||
+			GSConfig.OsdMessagesPos == OsdOverlayPos::BottomCenter ||
+			GSConfig.OsdMessagesPos == OsdOverlayPos::BottomRight)
 		{
 			final_y = actual_y - size.y;
 		}
-		
+
 		const ImVec2 base_pos = CalculateOSDPosition(GSConfig.OsdMessagesPos, margin, size, s_window_width, s_window_height);
 		const ImVec2 pos(base_pos.x, final_y);
 		const ImVec4 text_rect(pos.x + padding, pos.y + padding, pos.x + size.x - padding, pos.y + size.y - padding);
@@ -1011,11 +1019,11 @@ void ImGuiManager::DrawOSDMessages(Common::Timer::Value current_time)
 		dl->AddRect(pos, ImVec2(pos.x + size.x, pos.y + size.y), IM_COL32(0x48, 0x48, 0x48, opacity), rounding);
 		dl->AddText(font, font_size, ImVec2(text_rect.x, text_rect.y), IM_COL32(0xff, 0xff, 0xff, opacity), msg.text.c_str(),
 			msg.text.c_str() + msg.text.length(), max_width, &text_rect);
-		
+
 		// Stack direction depends on the position upward for bottom positions, downward for others
-		if (GSConfig.OsdMessagesPos == OsdOverlayPos::BottomLeft || 
-		    GSConfig.OsdMessagesPos == OsdOverlayPos::BottomCenter || 
-		    GSConfig.OsdMessagesPos == OsdOverlayPos::BottomRight)
+		if (GSConfig.OsdMessagesPos == OsdOverlayPos::BottomLeft ||
+			GSConfig.OsdMessagesPos == OsdOverlayPos::BottomCenter ||
+			GSConfig.OsdMessagesPos == OsdOverlayPos::BottomRight)
 		{
 			position_y -= (size.y + spacing); // Stack upward for bottom positions
 		}

--- a/pcsx2/ImGui/ImGuiManager.cpp
+++ b/pcsx2/ImGui/ImGuiManager.cpp
@@ -1171,6 +1171,21 @@ bool ImGuiManager::ProcessGenericInputEvent(GenericInputBinding key, InputLayout
 	if (static_cast<u32>(key) >= std::size(key_map) || key_map[static_cast<u32>(key)] == ImGuiKey_None)
 		return false;
 
+	// Ignore diagonal D-pad input — neither direction fires when both axes are held simultaneously.
+	static bool s_dpad_h_held = false, s_dpad_v_held = false;
+	const bool is_dpad_h = (key == GenericInputBinding::DPadLeft || key == GenericInputBinding::DPadRight);
+	const bool is_dpad_v = (key == GenericInputBinding::DPadUp || key == GenericInputBinding::DPadDown);
+	if (is_dpad_h || is_dpad_v)
+	{
+		if (is_dpad_h)
+			s_dpad_h_held = (value > 0.0f);
+		else
+			s_dpad_v_held = (value > 0.0f);
+
+		if (s_dpad_h_held && s_dpad_v_held)
+			return false;
+	}
+
 	MTGS::RunOnGSThread(
 		[key = key_map[static_cast<u32>(key)], value, layout]() mutable {
 			if (s_gamepad_swap_noth_west)
@@ -1192,11 +1207,41 @@ void ImGuiManager::ProcessGenericAxisEvent(GenericInputBinding negative_key, Gen
 {
 	static constexpr float DEADZONE = 0.25f;
 
+	// Ignore diagonal analog stick input — neither axis fires when both exceed the deadzone.
+	static float s_left_stick_x = 0.0f, s_left_stick_y = 0.0f;
+	static float s_right_stick_x = 0.0f, s_right_stick_y = 0.0f;
+
+	float suppressed_value = value;
+	if (negative_key == GenericInputBinding::LeftStickLeft)
+	{
+		s_left_stick_x = value;
+		if (std::abs(s_left_stick_y) > DEADZONE)
+			suppressed_value = 0.0f;
+	}
+	else if (negative_key == GenericInputBinding::LeftStickUp)
+	{
+		s_left_stick_y = value;
+		if (std::abs(s_left_stick_x) > DEADZONE)
+			suppressed_value = 0.0f;
+	}
+	else if (negative_key == GenericInputBinding::RightStickLeft)
+	{
+		s_right_stick_x = value;
+		if (std::abs(s_right_stick_y) > DEADZONE)
+			suppressed_value = 0.0f;
+	}
+	else if (negative_key == GenericInputBinding::RightStickUp)
+	{
+		s_right_stick_y = value;
+		if (std::abs(s_right_stick_x) > DEADZONE)
+			suppressed_value = 0.0f;
+	}
+
 	// Treat as binary like the D-pad: either fully pressed or released, with a deadzone.
 	if (negative_key != GenericInputBinding::Unknown)
-		ProcessGenericInputEvent(negative_key, layout, (value < -DEADZONE) ? 1.0f : 0.0f);
+		ProcessGenericInputEvent(negative_key, layout, (suppressed_value < -DEADZONE) ? 1.0f : 0.0f);
 	if (positive_key != GenericInputBinding::Unknown)
-		ProcessGenericInputEvent(positive_key, layout, (value > DEADZONE) ? 1.0f : 0.0f);
+		ProcessGenericInputEvent(positive_key, layout, (suppressed_value > DEADZONE) ? 1.0f : 0.0f);
 }
 
 void ImGuiManager::SwapGamepadNorthWest(bool value)

--- a/pcsx2/ImGui/ImGuiManager.cpp
+++ b/pcsx2/ImGui/ImGuiManager.cpp
@@ -1268,7 +1268,7 @@ void ImGuiManager::ProcessGenericAxisEvent(GenericInputBinding negative_key, Gen
 	if (state)
 	{
 		const float other = is_x_axis ? state->y : state->x;
-		if (std::abs(other) > ACTIVATE_THRESHOLD)
+		if (std::abs(other) > std::abs(value))
 			suppressed_value = 0.0f;
 	}
 

--- a/pcsx2/ImGui/ImGuiManager.h
+++ b/pcsx2/ImGui/ImGuiManager.h
@@ -105,10 +105,10 @@ namespace ImGuiManager
 	bool ProcessHostKeyEvent(InputBindingKey key, float value);
 
 	/// Called on the CPU thread when any input event fires. Allows imgui to take over controller navigation.
-	bool ProcessGenericInputEvent(GenericInputBinding key, InputLayout layout, float value);
+	bool ProcessGenericInputEvent(GenericInputBinding key, InputLayout layout, float value, u32 controller_id = 0);
 
 	/// Called on the CPU thread for a bidirectional analog axis event.
-	void ProcessGenericAxisEvent(GenericInputBinding negative_key, GenericInputBinding positive_key, InputLayout layout, float value);
+	void ProcessGenericAxisEvent(GenericInputBinding negative_key, GenericInputBinding positive_key, InputLayout layout, float value, u32 controller_id = 0);
 
 	/// Called to swap North/West gamepad buttons within ImGui
 	void SwapGamepadNorthWest(bool value);

--- a/pcsx2/ImGui/ImGuiManager.h
+++ b/pcsx2/ImGui/ImGuiManager.h
@@ -107,6 +107,9 @@ namespace ImGuiManager
 	/// Called on the CPU thread when any input event fires. Allows imgui to take over controller navigation.
 	bool ProcessGenericInputEvent(GenericInputBinding key, InputLayout layout, float value);
 
+	/// Called on the CPU thread for a bidirectional analog axis event.
+	void ProcessGenericAxisEvent(GenericInputBinding negative_key, GenericInputBinding positive_key, InputLayout layout, float value);
+
 	/// Called to swap North/West gamepad buttons within ImGui
 	void SwapGamepadNorthWest(bool value);
 

--- a/pcsx2/Input/InputManager.cpp
+++ b/pcsx2/Input/InputManager.cpp
@@ -1317,8 +1317,9 @@ bool InputManager::PreprocessEvent(InputBindingKey key, float value, GenericInpu
 		const GenericInputBinding resolved = (it != s_controller_button_generic_map.end()) ? it->second : generic_key;
 		if (resolved != GenericInputBinding::Unknown)
 		{
+			const u32 controller_id = (static_cast<u32>(key.source_type) << 8) | key.source_index;
 			const InputLayout layout = s_input_sources[static_cast<u32>(InputSourceType::SDL)]->GetControllerLayout(key.source_index);
-			if (ImGuiManager::ProcessGenericInputEvent(resolved, layout, value) && value != 0.0f)
+			if (ImGuiManager::ProcessGenericInputEvent(resolved, layout, value, controller_id) && value != 0.0f)
 				return true;
 		}
 	}
@@ -1330,8 +1331,9 @@ bool InputManager::PreprocessEvent(InputBindingKey key, float value, GenericInpu
 		const GenericInputBinding pos = (it != s_controller_axis_generic_map.end()) ? it->second[1] : axis_pos_key;
 		if (neg != GenericInputBinding::Unknown || pos != GenericInputBinding::Unknown)
 		{
+			const u32 controller_id = (static_cast<u32>(key.source_type) << 8) | key.source_index;
 			const InputLayout layout = s_input_sources[static_cast<u32>(InputSourceType::SDL)]->GetControllerLayout(key.source_index);
-			ImGuiManager::ProcessGenericAxisEvent(neg, pos, layout, value);
+			ImGuiManager::ProcessGenericAxisEvent(neg, pos, layout, value, controller_id);
 		}
 	}
 

--- a/pcsx2/Input/InputManager.cpp
+++ b/pcsx2/Input/InputManager.cpp
@@ -114,7 +114,8 @@ namespace InputManager
 	static void GenerateRelativeMouseEvents();
 
 	static bool DoEventHook(InputBindingKey key, float value);
-	static bool PreprocessEvent(InputBindingKey key, float value, GenericInputBinding generic_key);
+	static bool PreprocessEvent(InputBindingKey key, float value, GenericInputBinding generic_key,
+		GenericInputBinding axis_neg_key, GenericInputBinding axis_pos_key);
 	static bool ProcessEvent(InputBindingKey key, float value, bool skip_button_handlers);
 
 	template <typename T>
@@ -131,6 +132,13 @@ using VibrationBindingArray = std::vector<PadVibrationBinding>;
 static BindingMap s_binding_map;
 static VibrationBindingArray s_pad_vibration_array;
 static std::mutex s_binding_map_write_lock;
+
+// Reverse lookups for controller navigation; user bindings take priority over static defaults.
+using ControllerButtonGenericMap = std::unordered_map<InputBindingKey, GenericInputBinding, InputBindingKeyHash>;
+static ControllerButtonGenericMap s_controller_button_generic_map;
+
+using ControllerAxisGenericMap = std::unordered_map<InputBindingKey, std::array<GenericInputBinding, 2>, InputBindingKeyHash>;
+static ControllerAxisGenericMap s_controller_axis_generic_map;
 
 // Hooks/intercepting (for setting bindings)
 static std::mutex m_event_intercept_mutex;
@@ -905,6 +913,32 @@ void InputManager::AddPadBindings(SettingsInterface& si, u32 pad_index, bool is_
 							Pad::SetControllerState(pad_index, bind_index, ApplySingleBindingScale(sensitivity, deadzone, value));
 						}},
 						bi.bind_type, si, section.c_str(), bi.name, is_profile);
+
+					// Build reverse maps for controller navigation; user bindings take priority over static defaults.
+					if (bi.generic_mapping != GenericInputBinding::Unknown)
+					{
+						for (const std::string& binding_str : bindings)
+						{
+							InputBindingKey bkey;
+							InputSource* bsrc;
+							if (!ParseBindingAndGetSource(binding_str, &bkey, &bsrc))
+								continue;
+
+							if (bkey.source_subtype == InputSubclass::ControllerButton)
+							{
+								s_controller_button_generic_map.emplace(bkey.MaskDirection(), bi.generic_mapping);
+							}
+							else if (bkey.source_subtype == InputSubclass::ControllerAxis)
+							{
+								auto& entry = s_controller_axis_generic_map[bkey.MaskDirection()];
+								// Negate modifier = negative half of axis (e.g. "-Axis0" → LeftStickLeft)
+								if (bkey.modifier == InputModifier::Negate)
+									entry[0] = bi.generic_mapping;
+								else
+									entry[1] = bi.generic_mapping;
+							}
+						}
+					}
 				}
 			}
 			break;
@@ -1071,13 +1105,14 @@ bool InputManager::IsAxisHandler(const InputEventHandler& handler)
 	return std::holds_alternative<InputAxisEventHandler>(handler);
 }
 
-bool InputManager::InvokeEvents(InputBindingKey key, float value, GenericInputBinding generic_key)
+bool InputManager::InvokeEvents(InputBindingKey key, float value, GenericInputBinding generic_key,
+	GenericInputBinding axis_neg_key, GenericInputBinding axis_pos_key)
 {
 	if (DoEventHook(key, value))
 		return true;
 
 	// If imgui ate the event, don't fire our handlers.
-	const bool skip_button_handlers = PreprocessEvent(key, value, generic_key);
+	const bool skip_button_handlers = PreprocessEvent(key, value, generic_key, axis_neg_key, axis_pos_key);
 	return ProcessEvent(key, value, skip_button_handlers);
 }
 
@@ -1258,7 +1293,8 @@ void InputManager::ClearBindStateFromSource(InputBindingKey key)
 	} while (matched);
 }
 
-bool InputManager::PreprocessEvent(InputBindingKey key, float value, GenericInputBinding generic_key)
+bool InputManager::PreprocessEvent(InputBindingKey key, float value, GenericInputBinding generic_key,
+	GenericInputBinding axis_neg_key, GenericInputBinding axis_pos_key)
 {
 	// does imgui want the event?
 	if (key.source_type == InputSourceType::Keyboard)
@@ -1274,11 +1310,29 @@ bool InputManager::PreprocessEvent(InputBindingKey key, float value, GenericInpu
 		if (ImGuiManager::ProcessPointerButtonEvent(key, value))
 			return true;
 	}
-	else if (generic_key != GenericInputBinding::Unknown)
+	else if (key.source_subtype == InputSubclass::ControllerButton)
 	{
-		InputLayout layout = s_input_sources[static_cast<u32>(InputSourceType::SDL)]->GetControllerLayout(key.source_index);
-		if (ImGuiManager::ProcessGenericInputEvent(generic_key, layout, value) && value != 0.0f)
-			return true;
+		// User binding takes priority; fall back to the generic_key passed by the source (static table).
+		const auto it = s_controller_button_generic_map.find(key.MaskDirection());
+		const GenericInputBinding resolved = (it != s_controller_button_generic_map.end()) ? it->second : generic_key;
+		if (resolved != GenericInputBinding::Unknown)
+		{
+			const InputLayout layout = s_input_sources[static_cast<u32>(InputSourceType::SDL)]->GetControllerLayout(key.source_index);
+			if (ImGuiManager::ProcessGenericInputEvent(resolved, layout, value) && value != 0.0f)
+				return true;
+		}
+	}
+	else if (key.source_subtype == InputSubclass::ControllerAxis)
+	{
+		// User binding takes priority; fall back to the neg/pos keys passed by the source (static table).
+		const auto it = s_controller_axis_generic_map.find(key.MaskDirection());
+		const GenericInputBinding neg = (it != s_controller_axis_generic_map.end()) ? it->second[0] : axis_neg_key;
+		const GenericInputBinding pos = (it != s_controller_axis_generic_map.end()) ? it->second[1] : axis_pos_key;
+		if (neg != GenericInputBinding::Unknown || pos != GenericInputBinding::Unknown)
+		{
+			const InputLayout layout = s_input_sources[static_cast<u32>(InputSourceType::SDL)]->GetControllerLayout(key.source_index);
+			ImGuiManager::ProcessGenericAxisEvent(neg, pos, layout, value);
+		}
 	}
 
 	return false;
@@ -1557,6 +1611,8 @@ void InputManager::ReloadBindings(SettingsInterface& si, SettingsInterface& bind
 	s_pad_vibration_array.clear();
 	s_keyboard_event_callbacks.clear();
 	s_pointer_move_callbacks.clear();
+	s_controller_button_generic_map.clear();
+	s_controller_axis_generic_map.clear();
 
 	// Hotkeys use the base configuration, except if the custom hotkeys option is enabled.
 	AddHotkeyBindings(hotkey_binding_si, is_hotkey_profile);

--- a/pcsx2/Input/InputManager.cpp
+++ b/pcsx2/Input/InputManager.cpp
@@ -645,7 +645,7 @@ void InputManager::AddBindings(const std::vector<std::string>& bindings, const I
 			// INISettingsInterface, can just update directly
 			si.SetStringList(section, key, new_bindings);
 			si.Save();
-		} 
+		}
 		else
 		{
 			// LayeredSettingsInterface, Need to find which layer our binding came from
@@ -1629,7 +1629,7 @@ void InputManager::ReloadBindings(SettingsInterface& si, SettingsInterface& bind
 	for (u32 axis = 0; axis <= static_cast<u32>(InputPointerAxis::Y); axis++)
 	{
 		s_pointer_axis_speed[axis] = si.GetFloatValue("Pad", fmt::format("Pointer{}Speed", s_pointer_axis_setting_names[axis]).c_str(), 40.0f) /
-									 ui_ctrl_range * pointer_sensitivity;
+		                             ui_ctrl_range * pointer_sensitivity;
 		s_pointer_axis_dead_zone[axis] = std::min(
 			si.GetFloatValue("Pad", fmt::format("Pointer{}DeadZone", s_pointer_axis_setting_names[axis]).c_str(), 20.0f) / ui_ctrl_range, 1.0f);
 		s_pointer_axis_range[axis] = 1.0f - s_pointer_axis_dead_zone[axis];

--- a/pcsx2/Input/InputManager.h
+++ b/pcsx2/Input/InputManager.h
@@ -271,7 +271,9 @@ namespace InputManager
 
 	/// Updates internal state for any binds for this key, and fires callbacks as needed.
 	/// Returns true if anything was bound to this key, otherwise false.
-	bool InvokeEvents(InputBindingKey key, float value, GenericInputBinding generic_key = GenericInputBinding::Unknown);
+	bool InvokeEvents(InputBindingKey key, float value, GenericInputBinding generic_key = GenericInputBinding::Unknown,
+		GenericInputBinding axis_neg_key = GenericInputBinding::Unknown,
+		GenericInputBinding axis_pos_key = GenericInputBinding::Unknown);
 
 	/// Clears internal state for any binds with a matching source/index.
 	void ClearBindStateFromSource(InputBindingKey key);

--- a/pcsx2/Input/SDLInputSource.cpp
+++ b/pcsx2/Input/SDLInputSource.cpp
@@ -7,7 +7,6 @@
 #include "Host.h"
 
 #include "ImGui/FullscreenUI.h"
-#include "ImGui/ImGuiManager.h"
 
 #include "common/Assertions.h"
 #include "common/Console.h"
@@ -1491,15 +1490,16 @@ bool SDLInputSource::HandleGamepadAxisEvent(const SDL_GamepadAxisEvent* ev)
 
 	const InputBindingKey key(MakeGenericControllerAxisKey(InputSourceType::SDL, it->player_id, ev->axis));
 	const float value = NormalizeS16(ev->value);
-	InputManager::InvokeEvents(key, value);
 
 	if (ev->axis < std::size(s_sdl_generic_binding_axis_mapping))
 	{
-		ImGuiManager::ProcessGenericAxisEvent(
+		InputManager::InvokeEvents(key, value, GenericInputBinding::Unknown,
 			s_sdl_generic_binding_axis_mapping[ev->axis][0],
-			s_sdl_generic_binding_axis_mapping[ev->axis][1],
-			GetControllerLayout(it->player_id),
-			value);
+			s_sdl_generic_binding_axis_mapping[ev->axis][1]);
+	}
+	else
+	{
+		InputManager::InvokeEvents(key, value);
 	}
 
 	return true;

--- a/pcsx2/Input/SDLInputSource.cpp
+++ b/pcsx2/Input/SDLInputSource.cpp
@@ -1513,8 +1513,8 @@ bool SDLInputSource::HandleGamepadButtonEvent(const SDL_GamepadButtonEvent* ev)
 
 	const InputBindingKey key(MakeGenericControllerButtonKey(InputSourceType::SDL, it->player_id, ev->button));
 	const GenericInputBinding generic_key = (ev->button < std::size(s_sdl_generic_binding_button_mapping)) ?
-												s_sdl_generic_binding_button_mapping[ev->button] :
-												GenericInputBinding::Unknown;
+	                                            s_sdl_generic_binding_button_mapping[ev->button] :
+	                                            GenericInputBinding::Unknown;
 	InputManager::InvokeEvents(key, static_cast<float>(ev->down), generic_key);
 	return true;
 }
@@ -1777,6 +1777,6 @@ bool SDLInputSource::IsControllerSixaxis(const ControllerData& cd)
 	// This differing layout also isn't mapped correctly in SDL, I think due to how L2/R2 are exposed.
 	// Also see SetHints regarding reading the pressure sense from DsHidMini's SDF mode.
 	return type == SDL_GAMEPAD_TYPE_PS3 &&
-		   SDL_GetNumJoystickAxes(cd.joystick) == 16 &&
-		   SDL_GetNumJoystickButtons(cd.joystick) == 11;
+	       SDL_GetNumJoystickAxes(cd.joystick) == 16 &&
+	       SDL_GetNumJoystickButtons(cd.joystick) == 11;
 }

--- a/pcsx2/Input/SDLInputSource.cpp
+++ b/pcsx2/Input/SDLInputSource.cpp
@@ -7,6 +7,7 @@
 #include "Host.h"
 
 #include "ImGui/FullscreenUI.h"
+#include "ImGui/ImGuiManager.h"
 
 #include "common/Assertions.h"
 #include "common/Console.h"
@@ -1489,7 +1490,18 @@ bool SDLInputSource::HandleGamepadAxisEvent(const SDL_GamepadAxisEvent* ev)
 		return false;
 
 	const InputBindingKey key(MakeGenericControllerAxisKey(InputSourceType::SDL, it->player_id, ev->axis));
-	InputManager::InvokeEvents(key, NormalizeS16(ev->value));
+	const float value = NormalizeS16(ev->value);
+	InputManager::InvokeEvents(key, value);
+
+	if (ev->axis < std::size(s_sdl_generic_binding_axis_mapping))
+	{
+		ImGuiManager::ProcessGenericAxisEvent(
+			s_sdl_generic_binding_axis_mapping[ev->axis][0],
+			s_sdl_generic_binding_axis_mapping[ev->axis][1],
+			GetControllerLayout(it->player_id),
+			value);
+	}
+
 	return true;
 }
 

--- a/pcsx2/Input/XInputSource.cpp
+++ b/pcsx2/Input/XInputSource.cpp
@@ -513,8 +513,11 @@ void XInputSource::CheckForStateChanges(u32 index, const XINPUT_STATE& new_state
 #define CHECK_AXIS(field, axis, min_value, max_value) \
 	if (ogp.field != ngp.field) \
 	{ \
-		InputManager::InvokeEvents(MakeGenericControllerAxisKey(InputSourceType::XInput, index, axis), \
-			static_cast<float>(ngp.field) / ((ngp.field < 0) ? min_value : max_value)); \
+		const float value = static_cast<float>(ngp.field) / ((ngp.field < 0) ? min_value : max_value); \
+		InputManager::InvokeEvents(MakeGenericControllerAxisKey(InputSourceType::XInput, index, axis), value, \
+			GenericInputBinding::Unknown, \
+			s_xinput_generic_binding_axis_mapping[axis][0], \
+			s_xinput_generic_binding_axis_mapping[axis][1]); \
 	}
 
 	// Y axes is inverted in XInput when compared to SDL.
@@ -560,7 +563,11 @@ void XInputSource::CheckForStateChangesSCP(u32 index, const SCP_EXTN& new_state)
 #define CHECK_AXIS(field, mult) \
 	if (ogp.field != ngp.field) \
 	{ \
-		InputManager::InvokeEvents(MakeGenericControllerAxisKey(InputSourceType::XInput, index, axis), ngp.field* mult); \
+		const float value = ngp.field * mult; \
+		InputManager::InvokeEvents(MakeGenericControllerAxisKey(InputSourceType::XInput, index, axis), value, \
+			GenericInputBinding::Unknown, \
+			s_xinput_generic_binding_axis_mapping[axis][0], \
+			s_xinput_generic_binding_axis_mapping[axis][1]); \
 	} \
 	axis++;
 


### PR DESCRIPTION
### Description of Changes
Enables analog stick navigation in Big Picture Mode by mapping left and right stick axis events to ImGui D-pad inputs. While ImGui provides analog navigation, I did not use them due to unintended behavior (e.g., affecting sidebar navigation).

Diagonal navigation has been disabled for smoother, more predictable movement, aligning behavior more closely with Steam’s Big Picture Mode.

### Rationale behind Changes
Some users may prefer using an analog stick over a D-pad for navigating menus and game titles.

Disabling diagonal inputs helps prevent accidental movement, especially with analog sticks.

Fixes #11763 

### Suggested Testing Steps
1. Navigate Big Picture Mode using the left analog stick and verify it moves the selection up/down/left/right.
2. Hold the analog stick diagonally and verify the selection does not move.
3. Do the same with a D-pad capable of diagonal inputs and verify the same behavior.
4. Verify D-pad navigation still works as before.

### Did you use AI to help find, test, or implement this issue or feature?
Yes. I used AI to learn about and implement ImGui navigation events.
