### PR TITLE
GS/GL: Drop requirement for GLAD_GL_ARB_draw_buffers_blend.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -10003,7 +10003,8 @@ void GSRendererHW::StartDepthAsRTFeedback()
 	{
 		GL_PUSH("HW: Creating temporary R32 RT for depth feedback");
 
-		pxAssert(m_conf.ps.no_color1); // Should not be dual-source blending with multiple render targets.
+		 // Should not be hw blending with multiple render targets.
+		pxAssert(!m_conf.blend.enable && !m_conf.blend_multi_pass.blend.enable);
 
 		// We should have depth output or feedback doesn't make sense.
 		// We will output to both the depth buffer and color clone simultaneously in the shader.

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -2425,7 +2425,7 @@ void GSDeviceOGL::OMSetBlendState(bool enable, GLenum src_factor, GLenum dst_fac
 		if (!GLState::blend)
 		{
 			GLState::blend = true;
-			glEnablei(GL_BLEND, 0);
+			glEnable(GL_BLEND);
 		}
 
 		if (is_constant && GLState::bf != constant)
@@ -2438,7 +2438,7 @@ void GSDeviceOGL::OMSetBlendState(bool enable, GLenum src_factor, GLenum dst_fac
 		if (GLState::eq_RGB != op)
 		{
 			GLState::eq_RGB = op;
-			glBlendEquationSeparatei(0, op, GL_FUNC_ADD);
+			glBlendEquationSeparate(op, GL_FUNC_ADD);
 		}
 
 		if (GLState::f_sRGB != src_factor || GLState::f_dRGB != dst_factor ||
@@ -2448,7 +2448,7 @@ void GSDeviceOGL::OMSetBlendState(bool enable, GLenum src_factor, GLenum dst_fac
 			GLState::f_dRGB = dst_factor;
 			GLState::f_sA = src_factor_alpha;
 			GLState::f_dA = dst_factor_alpha;
-			glBlendFuncSeparatei(0, src_factor, dst_factor, src_factor_alpha, dst_factor_alpha);
+			glBlendFuncSeparate(src_factor, dst_factor, src_factor_alpha, dst_factor_alpha);
 		}
 	}
 	else
@@ -2456,7 +2456,7 @@ void GSDeviceOGL::OMSetBlendState(bool enable, GLenum src_factor, GLenum dst_fac
 		if (GLState::blend)
 		{
 			GLState::blend = false;
-			glDisablei(GL_BLEND, 0);
+			glDisable(GL_BLEND);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/GL: Drop requirement for GLAD_GL_ARB_draw_buffers_blend.
Currently we don't use hw blend on individual render targets so we can revert to old behavior while keeping compatibility with older drivers.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Fixes crashes on older Mesa drivers on llvmpipe sw, might help other drivers/gpus that we don't know about.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Try the latest release from:
https://fdossena.com/?p=mesa/index.frag
see if it crashes on windows on gl.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.