### PR TITLE
Qt: Fix Big Picture Mode mnemonic shortcut lost after state change

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1704,7 +1704,7 @@ void MainWindow::onStartFullscreenUITriggered()
 
 void MainWindow::onFullscreenUIStateChange(bool running)
 {
-	m_ui.actionStartFullscreenUI->setText(running ? tr("Stop Big Picture Mode") : tr("Start Big Picture Mode"));
+	m_ui.actionStartFullscreenUI->setText(running ? tr("Stop Big Picture Mode") : tr("Start Big Picture &Mode"));
 	m_ui.actionToolbarStartFullscreenUI->setText(running ? tr("Exit Big Picture", "In Toolbar") : tr("Big Picture", "In Toolbar"));
 }
 


### PR DESCRIPTION
### Description of Changes
`onFullscreenUIStateChange()` was setting the action text to `"Start Big Picture Mode"` (without the `&` mnemonic) when exiting Big Picture mode, while the `.ui` file correctly defines it as `"Start Big Picture &Mode"`. This caused the keyboard shortcut to stop working after exiting Big Picture mode.

### Rationale behind Changes
The Qt mnemonic ampersand (`&`) was missing from the `tr()` call in `onFullscreenUIStateChange()`, causing the underlined shortcut letter to disappear from the System menu after exiting Big Picture mode. The fix reuses strings that already exist in all translation files, so no translation updates are needed.

### Suggested Testing Steps
1. Launch PCSX2
2. Open System menu -> confirm M is underlined in "Start Big Picture Mode"
3. Enter Big Picture mode
4. Exit Big Picture mode
5. Open System menu again -> M should still be underlined

Fixes #13584

### Did you use AI to help find, test, or implement this issue or feature?
No
