### PR TITLE
Qt: Re-arrange Display Settings layout

### DIFF
--- a/pcsx2-qt/Settings/GraphicsDisplaySettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsDisplaySettingsTab.ui
@@ -19,278 +19,8 @@
   <property name="windowTitle">
    <string/>
   </property>
-  <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
-   <item row="3" column="0">
-    <widget class="QLabel" name="interlacingLabel">
-     <property name="text">
-      <string>Deinterlacing:</string>
-     </property>
-     <property name="buddy">
-      <cstring>interlacing</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QComboBox" name="fullscreenModes"/>
-   </item>
-   <item row="7" column="0" colspan="2">
-    <layout class="QGridLayout" name="displayGridLayout">
-     <item row="1" column="1">
-      <widget class="QCheckBox" name="integerScaling">
-       <property name="text">
-        <string>Integer Scaling</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QCheckBox" name="widescreenPatches">
-       <property name="text">
-        <string>Apply Widescreen Patches</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QCheckBox" name="noInterlacingPatches">
-       <property name="text">
-        <string>Apply No-Interlacing Patches</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QCheckBox" name="PCRTCAntiBlur">
-       <property name="text">
-        <string>Anti-Blur</string>
-       </property>
-       <property name="shortcut">
-        <string>Ctrl+S</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QCheckBox" name="disableInterlaceOffset">
-       <property name="text">
-        <string>Disable Interlace Offset</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QCheckBox" name="PCRTCOffsets">
-       <property name="text">
-        <string>Screen Offsets</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QCheckBox" name="PCRTCOverscan">
-       <property name="text">
-        <string>Show Overscan</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="fmvAspectRatioLabel">
-     <property name="text">
-      <string>FMV Aspect Ratio Override:</string>
-     </property>
-     <property name="buddy">
-      <cstring>fmvAspectRatio</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QComboBox" name="aspectRatio">
-     <item>
-      <property name="text">
-       <string>Fit to Window / Fullscreen</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Auto Standard (4:3 Interlaced / 3:2 Progressive)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Standard (4:3)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Widescreen (16:9)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Native/Full (10:7)</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QComboBox" name="bilinearFiltering">
-     <item>
-      <property name="text">
-       <string>None</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Smooth: Refers to the texture clarity.">Bilinear (Smooth)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Sharp: Refers to the texture clarity.">Bilinear (Sharp)</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="verticalStretchLabel">
-     <property name="text">
-      <string>Vertical Stretch:</string>
-     </property>
-     <property name="buddy">
-      <cstring>stretchY</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="fsModeLabel">
-     <property name="text">
-      <string>Fullscreen Mode:</string>
-     </property>
-     <property name="buddy">
-      <cstring>fullscreenModes</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="billinearLabel">
-     <property name="text">
-      <string>Bilinear Filtering:</string>
-     </property>
-     <property name="buddy">
-      <cstring>bilinearFiltering</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QComboBox" name="fmvAspectRatio">
-     <item>
-      <property name="text">
-       <string>Off (Default)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Auto Standard (4:3 Interlaced / 3:2 Progressive)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Standard (4:3)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Widescreen (16:9)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Native/Full (10:7)</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="cropLabel">
-     <property name="text">
-      <string>Crop:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="aspectRatioLabel">
-     <property name="text">
-      <string>Aspect Ratio:</string>
-     </property>
-     <property name="buddy">
-      <cstring>aspectRatio</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QComboBox" name="interlacing">
-     <item>
-      <property name="text">
-       <string>Automatic (Default)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>No Deinterlacing</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Weave: deinterlacing method that can be translated or left as-is in English. Sawtooth: refers to the jagged effect weave deinterlacing has on motion.">Weave (Top Field First, Sawtooth)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Weave: deinterlacing method that can be translated or left as-is in English. Sawtooth: refers to the jagged effect weave deinterlacing has on motion.">Weave (Bottom Field First, Sawtooth)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Bob: deinterlacing method that refers to the way it makes video look like it's bobbing up and down.">Bob (Top Field First, Full Frames)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Bob: deinterlacing method that refers to the way it makes video look like it's bobbing up and down.">Bob (Bottom Field First, Full Frames)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Blend: deinterlacing method that blends the colors of the two frames, can be translated or left as-is in English.">Blend (Top Field First, Merge 2 Fields)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Blend: deinterlacing method that blends the colors of the two frames, can be translated or left as-is in English.">Blend (Bottom Field First, Merge 2 Fields)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Adaptive: deinterlacing method that should be translated.">Adaptive (Top Field First, Similar to Bob + Weave)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string extracomment="Adaptive: deinterlacing method that should be translated.">Adaptive (Bottom Field First, Similar to Bob + Weave)</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="QSpinBox" name="stretchY">
-     <property name="suffix">
-      <string extracomment="Percentage sign that shows next to a value. You might want to add a space before if your language requires it.">%</string>
-     </property>
-     <property name="minimum">
-      <number>1</number>
-     </property>
-     <property name="maximum">
-      <number>300</number>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0">
+  <layout class="QGridLayout" name="gridLayout" columnstretch="0,0">
+   <item row="10" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Orientation::Vertical</enum>
@@ -303,89 +33,414 @@
      </property>
     </spacer>
    </item>
-   <item row="6" column="1">
-    <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1,0,1">
-     <item row="0" column="3">
-      <widget class="QSpinBox" name="cropTop">
-       <property name="suffix">
-        <string>px</string>
-       </property>
-       <property name="maximum">
-        <number>1000</number>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="2">
-      <widget class="QLabel" name="cropTopLabel">
-       <property name="text">
-        <string extracomment="Warning: short space constraints. Abbreviate if necessary.">Top:</string>
-       </property>
-       <property name="buddy">
-        <cstring>cropTop</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="cropLeftLabel">
-       <property name="text">
-        <string extracomment="Warning: short space constraints. Abbreviate if necessary.">Left:</string>
-       </property>
-       <property name="buddy">
-        <cstring>cropLeft</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QSpinBox" name="cropLeft">
-       <property name="suffix">
-        <string>px</string>
-       </property>
-       <property name="maximum">
-        <number>1000</number>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="cropRightLabel">
-       <property name="text">
-        <string extracomment="Warning: short space constraints. Abbreviate if necessary.">Right:</string>
-       </property>
-       <property name="buddy">
-        <cstring>cropRight</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QSpinBox" name="cropRight">
-       <property name="suffix">
-        <string>px</string>
-       </property>
-       <property name="maximum">
-        <number>1000</number>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="2">
-      <widget class="QLabel" name="cropBottomLabel">
-       <property name="text">
-        <string extracomment="Warning: short space constraints. Abbreviate if necessary.">Bottom:</string>
-       </property>
-       <property name="buddy">
-        <cstring>cropBottom</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="3">
-      <widget class="QSpinBox" name="cropBottom">
-       <property name="suffix">
-        <string>px</string>
-       </property>
-       <property name="maximum">
-        <number>1000</number>
-       </property>
-      </widget>
-     </item>
-    </layout>
+   <item row="9" column="0" colspan="2">
+    <widget class="QGroupBox" name="miscGroupBox">
+     <property name="title">
+      <string>Display Options</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1">
+      <item row="8" column="1">
+       <widget class="QComboBox" name="bilinearFiltering">
+        <item>
+         <property name="text">
+          <string>None</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string extracomment="Smooth: Refers to the texture clarity.">Bilinear (Smooth)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string extracomment="Sharp: Refers to the texture clarity.">Bilinear (Sharp)</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="9" column="1">
+       <widget class="QSpinBox" name="stretchY">
+        <property name="suffix">
+         <string extracomment="Percentage sign that shows next to a value. You might want to add a space before if your language requires it.">%</string>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>300</number>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="fmvAspectRatioLabel">
+        <property name="text">
+         <string>FMV Aspect Ratio Override:</string>
+        </property>
+        <property name="buddy">
+         <cstring>fmvAspectRatio</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QComboBox" name="fullscreenModes"/>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="fsModeLabel">
+        <property name="text">
+         <string>Fullscreen Mode:</string>
+        </property>
+        <property name="buddy">
+         <cstring>fullscreenModes</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="interlacingLabel">
+        <property name="text">
+         <string>Deinterlacing:</string>
+        </property>
+        <property name="buddy">
+         <cstring>interlacing</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QComboBox" name="fmvAspectRatio">
+        <item>
+         <property name="text">
+          <string>Off (Default)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Auto Standard (4:3 Interlaced / 3:2 Progressive)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Standard (4:3)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Widescreen (16:9)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Native/Full (10:7)</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="billinearLabel">
+        <property name="text">
+         <string>Bilinear Filtering:</string>
+        </property>
+        <property name="buddy">
+         <cstring>bilinearFiltering</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="0" colspan="2">
+       <layout class="QHBoxLayout" name="bottomLayout">
+        <item>
+         <layout class="QGridLayout" name="displayGridLayout">
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="widescreenPatches">
+            <property name="text">
+             <string>Apply Widescreen Patches</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="noInterlacingPatches">
+            <property name="text">
+             <string>Apply No-Interlacing Patches</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="0">
+           <widget class="QCheckBox" name="PCRTCOverscan">
+            <property name="text">
+             <string>Show Overscan</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QCheckBox" name="disableInterlaceOffset">
+            <property name="text">
+             <string>Disable Interlace Offset</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QCheckBox" name="PCRTCAntiBlur">
+            <property name="text">
+             <string>Anti-Blur</string>
+            </property>
+            <property name="shortcut">
+             <string>Ctrl+S</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="0">
+           <widget class="QCheckBox" name="PCRTCOffsets">
+            <property name="text">
+             <string>Screen Offsets</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QCheckBox" name="integerScaling">
+            <property name="text">
+             <string>Integer Scaling</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="cropBox">
+          <property name="title">
+           <string extracomment="Try to use Sony's official terminology for this. A good place to start would be in the console or the DualShock 2's manual. If this element was officially translated to your language by Sony in later DualShocks, you may use that term.">Crop:</string>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_5">
+           <item row="3" column="1" colspan="2">
+            <widget class="QGroupBox" name="cropBottomBox">
+             <property name="title">
+              <string>Bottom</string>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_4">
+              <property name="leftMargin">
+               <number>6</number>
+              </property>
+              <property name="topMargin">
+               <number>6</number>
+              </property>
+              <property name="rightMargin">
+               <number>6</number>
+              </property>
+              <property name="bottomMargin">
+               <number>6</number>
+              </property>
+              <item row="0" column="0">
+               <widget class="QSpinBox" name="cropBottom">
+                <property name="suffix">
+                 <string>px</string>
+                </property>
+                <property name="maximum">
+                 <number>1000</number>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item row="2" column="0" colspan="2">
+            <widget class="QGroupBox" name="cropLeftBox">
+             <property name="title">
+              <string>Left</string>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_3">
+              <property name="leftMargin">
+               <number>6</number>
+              </property>
+              <property name="topMargin">
+               <number>6</number>
+              </property>
+              <property name="rightMargin">
+               <number>6</number>
+              </property>
+              <property name="bottomMargin">
+               <number>6</number>
+              </property>
+              <item row="0" column="0">
+               <widget class="QSpinBox" name="cropLeft">
+                <property name="suffix">
+                 <string>px</string>
+                </property>
+                <property name="maximum">
+                 <number>1000</number>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item row="0" column="1" colspan="2">
+            <widget class="QGroupBox" name="cropTopBox">
+             <property name="title">
+              <string>Top</string>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_6">
+              <property name="leftMargin">
+               <number>6</number>
+              </property>
+              <property name="topMargin">
+               <number>6</number>
+              </property>
+              <property name="rightMargin">
+               <number>6</number>
+              </property>
+              <property name="bottomMargin">
+               <number>6</number>
+              </property>
+              <item row="1" column="0">
+               <widget class="QSpinBox" name="cropTop">
+                <property name="suffix">
+                 <string>px</string>
+                </property>
+                <property name="maximum">
+                 <number>1000</number>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item row="2" column="2" colspan="2">
+            <widget class="QGroupBox" name="cropRightBox">
+             <property name="title">
+              <string>Right</string>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_7">
+              <property name="leftMargin">
+               <number>6</number>
+              </property>
+              <property name="topMargin">
+               <number>6</number>
+              </property>
+              <property name="rightMargin">
+               <number>6</number>
+              </property>
+              <property name="bottomMargin">
+               <number>6</number>
+              </property>
+              <item row="0" column="0">
+               <widget class="QSpinBox" name="cropRight">
+                <property name="suffix">
+                 <string>px</string>
+                </property>
+                <property name="maximum">
+                 <number>1000</number>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="9" column="0">
+       <widget class="QLabel" name="verticalStretchLabel">
+        <property name="text">
+         <string>Vertical Stretch:</string>
+        </property>
+        <property name="buddy">
+         <cstring>stretchY</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QComboBox" name="aspectRatio">
+        <item>
+         <property name="text">
+          <string>Fit to Window / Fullscreen</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Auto Standard (4:3 Interlaced / 3:2 Progressive)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Standard (4:3)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Widescreen (16:9)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Native/Full (10:7)</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="aspectRatioLabel">
+        <property name="text">
+         <string>Aspect Ratio:</string>
+        </property>
+        <property name="buddy">
+         <cstring>aspectRatio</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="QComboBox" name="interlacing">
+        <item>
+         <property name="text">
+          <string>Automatic (Default)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>No Deinterlacing</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string extracomment="Weave: deinterlacing method that can be translated or left as-is in English. Sawtooth: refers to the jagged effect weave deinterlacing has on motion.">Weave (Top Field First, Sawtooth)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string extracomment="Weave: deinterlacing method that can be translated or left as-is in English. Sawtooth: refers to the jagged effect weave deinterlacing has on motion.">Weave (Bottom Field First, Sawtooth)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string extracomment="Bob: deinterlacing method that refers to the way it makes video look like it's bobbing up and down.">Bob (Top Field First, Full Frames)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string extracomment="Bob: deinterlacing method that refers to the way it makes video look like it's bobbing up and down.">Bob (Bottom Field First, Full Frames)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string extracomment="Blend: deinterlacing method that blends the colors of the two frames, can be translated or left as-is in English.">Blend (Top Field First, Merge 2 Fields)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string extracomment="Blend: deinterlacing method that blends the colors of the two frames, can be translated or left as-is in English.">Blend (Bottom Field First, Merge 2 Fields)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string extracomment="Adaptive: deinterlacing method that should be translated.">Adaptive (Top Field First, Similar to Bob + Weave)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string extracomment="Adaptive: deinterlacing method that should be translated.">Adaptive (Bottom Field First, Similar to Bob + Weave)</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
   </layout>
  </widget>
@@ -396,17 +451,17 @@
   <tabstop>interlacing</tabstop>
   <tabstop>bilinearFiltering</tabstop>
   <tabstop>stretchY</tabstop>
-  <tabstop>cropLeft</tabstop>
-  <tabstop>cropRight</tabstop>
-  <tabstop>cropTop</tabstop>
-  <tabstop>cropBottom</tabstop>
   <tabstop>widescreenPatches</tabstop>
   <tabstop>noInterlacingPatches</tabstop>
   <tabstop>PCRTCAntiBlur</tabstop>
   <tabstop>integerScaling</tabstop>
-  <tabstop>PCRTCOffsets</tabstop>
   <tabstop>disableInterlaceOffset</tabstop>
+  <tabstop>PCRTCOffsets</tabstop>
   <tabstop>PCRTCOverscan</tabstop>
+  <tabstop>cropTop</tabstop>
+  <tabstop>cropLeft</tabstop>
+  <tabstop>cropRight</tabstop>
+  <tabstop>cropBottom</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/pcsx2-qt/Settings/GraphicsHardwareRenderingSettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsHardwareRenderingSettingsTab.ui
@@ -13,210 +13,223 @@
   <property name="windowTitle">
    <string/>
   </property>
-  <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
-   <item row="1" column="0">
-    <widget class="QLabel" name="textureFilteringLabel">
-     <property name="text">
-      <string>Texture Filtering:</string>
-     </property>
-     <property name="buddy">
-      <cstring>textureFiltering</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QComboBox" name="dithering">
-     <item>
-      <property name="text">
-       <string>Off</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Scaled</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Unscaled (Default)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Force 32bit</string>
-      </property>
-     </item>
-    </widget>
-   </item>
+  <layout class="QGridLayout" name="gridLayout" columnstretch="0,0">
    <item row="6" column="0" colspan="2">
     <layout class="QGridLayout" name="hardwareRenderingOptionsLayout">
-     <item row="0" column="1">
-      <widget class="QCheckBox" name="accurateAlphaTest">
-       <property name="text">
-        <string>Accurate Alpha Test</string>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="0">
-      <widget class="QCheckBox" name="mipmapping">
-       <property name="text">
-        <string>Mipmapping</string>
+      <widget class="QGroupBox" name="renderingGroupBox">
+       <property name="title">
+        <string>Rendering Options</string>
        </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QCheckBox" name="hwAA1">
-       <property name="text">
-        <string>AA1</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QCheckBox" name="enableHWFixes">
-       <property name="text">
-        <string>Manual Hardware Renderer Fixes</string>
-       </property>
+       <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1">
+        <item row="15" column="0">
+         <widget class="QLabel" name="ditheringLabel">
+          <property name="text">
+           <string>Dithering:</string>
+          </property>
+          <property name="buddy">
+           <cstring>dithering</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QComboBox" name="upscaleMultiplier"/>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="internalResLabel">
+          <property name="text">
+           <string>Internal Resolution:</string>
+          </property>
+          <property name="buddy">
+           <cstring>upscaleMultiplier</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QComboBox" name="textureFiltering">
+          <item>
+           <property name="text">
+            <string>Nearest</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Bilinear (Forced)</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Bilinear (PS2)</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Bilinear (Forced excluding sprite)</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="6" column="1">
+         <widget class="QComboBox" name="trilinearFiltering">
+          <item>
+           <property name="text">
+            <string>Automatic (Default)</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Off (None)</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Trilinear (PS2)</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Trilinear (Forced)</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="16" column="0">
+         <widget class="QLabel" name="blendingLabel">
+          <property name="text">
+           <string>Blending Accuracy:</string>
+          </property>
+          <property name="buddy">
+           <cstring>blending</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="0">
+         <widget class="QLabel" name="trilinearFilterLabel">
+          <property name="text">
+           <string>Trilinear Filtering:</string>
+          </property>
+          <property name="buddy">
+           <cstring>trilinearFiltering</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="0">
+         <widget class="QLabel" name="anisotropicFilteringLabel">
+          <property name="text">
+           <string>Anisotropic Filtering:</string>
+          </property>
+          <property name="buddy">
+           <cstring>anisotropicFiltering</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="16" column="1">
+         <widget class="QComboBox" name="blending">
+          <item>
+           <property name="text">
+            <string>Minimum</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Basic (Recommended)</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Medium</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>High</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Full (Slow)</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Maximum (Very Slow)</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="15" column="1">
+         <widget class="QComboBox" name="dithering">
+          <item>
+           <property name="text">
+            <string>Off</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Scaled</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Unscaled (Default)</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Force 32bit</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="7" column="1">
+         <widget class="QComboBox" name="anisotropicFiltering"/>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="textureFilteringLabel">
+          <property name="text">
+           <string>Texture Filtering:</string>
+          </property>
+          <property name="buddy">
+           <cstring>textureFiltering</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="17" column="0" colspan="2">
+         <layout class="QGridLayout" name="renderingGridLayout">
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="mipmapping">
+            <property name="text">
+             <string>Mipmapping</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QCheckBox" name="enableHWFixes">
+            <property name="text">
+             <string>Manual Hardware Renderer Fixes</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="hwAA1">
+            <property name="text">
+             <string>AA1</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QCheckBox" name="accurateAlphaTest">
+            <property name="text">
+             <string>Accurate Alpha Test</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
       </widget>
      </item>
     </layout>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="anisotropicFilteringLabel">
-     <property name="text">
-      <string>Anisotropic Filtering:</string>
-     </property>
-     <property name="buddy">
-      <cstring>anisotropicFiltering</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QComboBox" name="anisotropicFiltering"/>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="internalResLabel">
-     <property name="text">
-      <string>Internal Resolution:</string>
-     </property>
-     <property name="buddy">
-      <cstring>upscaleMultiplier</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QComboBox" name="upscaleMultiplier"/>
-   </item>
-   <item row="1" column="1">
-    <widget class="QComboBox" name="textureFiltering">
-     <item>
-      <property name="text">
-       <string>Nearest</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Bilinear (Forced)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Bilinear (PS2)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Bilinear (Forced excluding sprite)</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="ditheringLabel">
-     <property name="text">
-      <string>Dithering:</string>
-     </property>
-     <property name="buddy">
-      <cstring>dithering</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="QComboBox" name="blending">
-     <item>
-      <property name="text">
-       <string>Minimum</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Basic (Recommended)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Medium</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>High</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Full (Slow)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Maximum (Very Slow)</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QComboBox" name="trilinearFiltering">
-     <item>
-      <property name="text">
-       <string>Automatic (Default)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Off (None)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Trilinear (PS2)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Trilinear (Forced)</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="blendingLabel">
-     <property name="text">
-      <string>Blending Accuracy:</string>
-     </property>
-     <property name="buddy">
-      <cstring>blending</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="trilinearFilterLabel">
-     <property name="text">
-      <string>Trilinear Filtering:</string>
-     </property>
-     <property name="buddy">
-      <cstring>trilinearFiltering</cstring>
-     </property>
-    </widget>
    </item>
    <item row="7" column="0">
     <spacer name="verticalSpacer">

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -282,7 +282,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 
 #ifndef _WIN32
 	// Exclusive fullscreen control is Windows-only.
-	m_advanced.advancedOptionsFormLayout->removeRow(2);
+	m_advanced.advancedOptionsFormLayout->removeRow(m_advanced.exclusiveFullscreenControl);
 	m_advanced.exclusiveFullscreenControl = nullptr;
 #endif
 
@@ -290,13 +290,13 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 	if (!dialog()->isPerGameSettings())
 	{
 		// Only allow disabling readbacks for per-game settings, it's too dangerous.
-		m_advanced.advancedOptionsFormLayout->removeRow(0);
+		m_advanced.advancedOptionsFormLayout->removeRow(m_advanced.gsDownloadMode);
 		m_advanced.gsDownloadMode = nullptr;
 
 		// Don't allow setting hardware fixes globally.
 		// Too many stupid YouTube "best settings" guides that break other games.
-		m_hw.hardwareRenderingOptionsLayout->removeWidget(m_hw.enableHWFixes);
-		delete m_hw.enableHWFixes;
+		m_hw.renderingGridLayout->layout()->removeWidget(m_hw.enableHWFixes);
+		m_hw.enableHWFixes->deleteLater();
 		m_hw.enableHWFixes = nullptr;
 	}
 #endif

--- a/pcsx2-qt/Settings/GraphicsSoftwareRenderingSettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsSoftwareRenderingSettingsTab.ui
@@ -13,80 +13,89 @@
   <property name="windowTitle">
    <string/>
   </property>
-  <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
-   <item row="1" column="0">
-    <widget class="QLabel" name="extraSWThreadsLabel">
-     <property name="text">
-      <string>Software Rendering Threads:</string>
-     </property>
-     <property name="buddy">
-      <cstring>extraSWThreads</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="swTextureFilteringLabel">
-     <property name="text">
-      <string>Texture Filtering:</string>
-     </property>
-     <property name="buddy">
-      <cstring>swTextureFiltering</cstring>
-     </property>
-    </widget>
-   </item>
+  <layout class="QGridLayout" name="gridLayout" columnstretch="0,0">
    <item row="2" column="0" colspan="2">
-    <layout class="QGridLayout" name="swRenderingLayout">
-     <item row="0" column="1">
-      <widget class="QCheckBox" name="swMipmap">
-       <property name="text">
-        <string>Mipmapping</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QCheckBox" name="swAutoFlush">
-       <property name="text">
-        <string>Auto Flush</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="0" column="1">
-    <widget class="QComboBox" name="swTextureFiltering">
-     <property name="enabled">
-      <bool>true</bool>
+    <widget class="QGroupBox" name="swGroupBox">
+     <property name="title">
+      <string>Rendering Options</string>
      </property>
-     <property name="layoutDirection">
-      <enum>Qt::LayoutDirection::LeftToRight</enum>
-     </property>
-     <item>
-      <property name="text">
-       <string>Nearest</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Bilinear (Forced)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Bilinear (PS2)</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Bilinear (Forced excluding sprite)</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QSpinBox" name="extraSWThreads">
-     <property name="suffix">
-      <string> threads</string>
-     </property>
+     <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1">
+      <item row="0" column="0">
+       <widget class="QLabel" name="extraSWThreadsLabel">
+        <property name="text">
+         <string>Software Rendering Threads:</string>
+        </property>
+        <property name="buddy">
+         <cstring>extraSWThreads</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QComboBox" name="swTextureFiltering">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="layoutDirection">
+         <enum>Qt::LayoutDirection::LeftToRight</enum>
+        </property>
+        <item>
+         <property name="text">
+          <string>Nearest</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Bilinear (Forced)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Bilinear (PS2)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Bilinear (Forced excluding sprite)</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QSpinBox" name="extraSWThreads">
+        <property name="suffix">
+         <string> threads</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="swTextureFilteringLabel">
+        <property name="text">
+         <string>Texture Filtering:</string>
+        </property>
+        <property name="buddy">
+         <cstring>swTextureFiltering</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="2">
+       <layout class="QGridLayout" name="swRenderingGridLayout">
+        <item row="0" column="1">
+         <widget class="QCheckBox" name="swMipmap">
+          <property name="text">
+           <string>Mipmapping</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QCheckBox" name="swAutoFlush">
+          <property name="text">
+           <string>Auto Flush</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
     </widget>
    </item>
    <item row="3" column="0">
@@ -105,8 +114,8 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>swTextureFiltering</tabstop>
   <tabstop>extraSWThreads</tabstop>
+  <tabstop>swTextureFiltering</tabstop>
   <tabstop>swAutoFlush</tabstop>
   <tabstop>swMipmap</tabstop>
  </tabstops>

--- a/pcsx2-qt/Settings/GraphicsTextureReplacementSettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsTextureReplacementSettingsTab.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QGroupBox" name="textureOptions">
      <property name="title">
-      <string>Options</string>
+      <string>Texture Replacement Options</string>
      </property>
      <layout class="QGridLayout" name="textureOptionLayout">
       <item row="3" column="0">
@@ -100,11 +100,11 @@
         <property name="text">
          <string>PCSX2 will dump and load texture replacements from this directory.</string>
         </property>
+        <property name="textInteractionFlags">
+         <set>Qt::TextInteractionFlag::TextBrowserInteraction</set>
+        </property>
         <property name="buddy">
          <cstring>texturesDirectory</cstring>
-        </property>
-        <property name="textInteractionFlags">
-         <set>Qt::TextBrowserInteraction</set>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

This PR re-arrange the display settings section to be more cleaner and more concise.

<img width="1038" height="961" alt="image" src="https://github.com/user-attachments/assets/88cb0336-c332-49b3-816f-d6eb5a99b62f" />

The Checkboxes in some section has also been given GroupBox as well to make them more tidy.

<img width="1038" height="961" alt="image" src="https://github.com/user-attachments/assets/943f832a-a8c5-4610-99ba-21d78ee352c9" />


### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

A more intuitive UI makes a better UX.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

Just make sure i didn't break any of the settings.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
Nope, just constant headbanging and fist-fight with Qt Widgets Designer.