### PR TITLE
Qt: Make the SettingWidget default match the settings interface default

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -399,8 +399,8 @@ void MainWindow::connectSignals()
 	m_ui.actionEnableVerboseLogging->setChecked(true);
 	m_ui.actionEnableVerboseLogging->setEnabled(false);
 #endif
-	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableEEConsoleLogging, "Logging", "EnableEEConsole", true);
-	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableIOPConsoleLogging, "Logging", "EnableIOPConsole", true);
+	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableEEConsoleLogging, "Logging", "EnableEEConsole", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableIOPConsoleLogging, "Logging", "EnableIOPConsole", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableLogWindow, "Logging", "EnableLogWindow", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableFileLogging, "Logging", "EnableFileLogging", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableLogTimestamps, "Logging", "EnableTimestamps", true);


### PR DESCRIPTION
### Description of Changes
Make the UI default the same as the generated default for the EE and IOP logging enables.

### Rationale behind Changes
I believe this caused a bug where the UI would show that the EE and IOP console logging was enabled, but it wasn't actually. You were required to uncheck and check it to enable it.

### Suggested Testing Steps
With a fresh config, see if EE and IOP console logging options are enabled. They shouldn't be.
When you enable them, EE or IOP output from a game or homebrew should work.

### Did you use AI to help find, test, or implement this issue or feature?
No
