### PR TITLE
GS/GL/DX11: Don't bind source tex on shader resource if it's tex is fb with no barrier.

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -2804,7 +2804,7 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 
 	// Preemptively bind srv if possible.
 	// We update the local state, then if there are srv conflicts PSUnbindConflictingSRVs will update the gpu state.
-	if (config.tex)
+	if (config.tex && config.tex != config.rt)
 	{
 		CommitClear(config.tex);
 		if (m_state.cached_rt_view != config.tex && m_state.cached_dsv != config.tex)
@@ -2820,7 +2820,7 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 	// Should be called before changing current gpu state.
 	PSUnbindConflictingSRVs(colclip_rt ? colclip_rt : config.rt, read_only_dsv ? nullptr : config.ds);
 
-	if (config.tex)
+	if (config.tex && config.tex != config.rt)
 		PSSetShaderResource(0, config.tex);
 	if (config.pal)
 		PSSetShaderResource(1, config.pal);

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -2599,7 +2599,7 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 		GLState::scissor = config.scissor;
 	}
 
-	if (config.tex)
+	if (config.tex && (m_features.texture_barrier || (config.tex != config.rt)))
 		CommitClear(config.tex, true);
 	if (config.pal)
 		CommitClear(config.pal, true);
@@ -2715,7 +2715,7 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 	}
 	IASetPrimitiveTopology(topology);
 
-	if (config.tex)
+	if (config.tex && (m_features.texture_barrier || (config.tex != config.rt)))
 		PSSetShaderResource(0, config.tex);
 	if (config.pal)
 		PSSetShaderResource(1, config.pal);


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/GL/DX11: Don't bind source tex on shader resource if it's tex is fb with no barrier.\
Texture will be copied, the copy will be used as a shader resource. Avoids useless binds.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Optimization.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Smoke test some shuffle games such as GT4, Hitman, Death By Degrees on dx11 and gl.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.