### PR TITLE
YAML: Improve error handling

### DIFF
--- a/common/YAML.cpp
+++ b/common/YAML.cpp
@@ -3,8 +3,6 @@
 
 #include "YAML.h"
 
-#include "Assertions.h"
-
 #if RYML_VERSION_MAJOR > 0 || RYML_VERSION_MINOR >= 11
 #include "c4/yml/error.def.hpp" // for ryml::err_basic_format etc
 #endif
@@ -28,15 +26,16 @@ std::optional<ryml::Tree> ParseYAMLFromString(ryml::csubstr yaml, ryml::csubstr 
 	callbacks.set_user_data(static_cast<void*>(&context));
 
 	callbacks.set_error_basic([](ryml::csubstr msg, const ryml::ErrorDataBasic& errdata, void* user_data) {
+		RapidYAMLContext* context = static_cast<RapidYAMLContext*>(user_data);
+
 		std::string description;
 		auto callback = [&description](ryml::csubstr string) {
 			description.append(string.str, string.len);
 		};
 		ryml::err_basic_format(std::move(callback), msg, errdata);
 
-		// We might have already returned, so don't try to recover.
-		pxFailRel(description.c_str());
-		std::abort();
+		Error::SetString(context->error, std::move(description));
+		std::longjmp(context->env, 1);
 	});
 
 	callbacks.set_error_parse([](ryml::csubstr msg, const ryml::ErrorDataParse& errdata, void* user_data) {
@@ -53,15 +52,16 @@ std::optional<ryml::Tree> ParseYAMLFromString(ryml::csubstr yaml, ryml::csubstr 
 	});
 
 	callbacks.set_error_visit([](ryml::csubstr msg, const ryml::ErrorDataVisit& errdata, void* user_data) {
+		RapidYAMLContext* context = static_cast<RapidYAMLContext*>(user_data);
+
 		std::string description;
 		auto callback = [&description](ryml::csubstr string) {
 			description.append(string.str, string.len);
 		};
 		ryml::err_visit_format(std::move(callback), msg, errdata);
 
-		// We've probably already returned, so don't try to recover.
-		pxFailRel(description.c_str());
-		std::abort();
+		Error::SetString(context->error, std::move(description));
+		std::longjmp(context->env, 1);
 	});
 #else
 	callbacks.m_user_data = static_cast<void*>(&context);


### PR DESCRIPTION
### Description of Changes

Try to recover from more types of errors during parsing.

I've cut this PR down a lot to try and get the first half of it in for 2.8.

### Rationale behind Changes
In #14207 I made a mistake where I thought the error callbacks I setup would be called after parsing was completed, however in that case a completely different set of error callbacks are used instead, so it should be safe to try and recover from all types of errors during parsing.

There probably won't be that much difference in terms of behaviour, it should only affect very edge case stuff.

### Suggested Testing Steps

Try corrupting the game DB/folder memory cards, see that error handling still works reasonably.

### Did you use AI to help find, test, or implement this issue or feature?
No.
