### PR TITLE
VMManager/QT/FSUI: Basic .m3u playlist support

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -49,6 +49,7 @@
 
 #include <QtCore/QDateTime>
 #include <QtCore/QDir>
+#include <QtCore/QFileInfo>
 #include <QtGui/QCloseEvent>
 #include <QtWidgets/QFileDialog>
 #include <QtWidgets/QInputDialog>
@@ -1687,11 +1688,37 @@ void MainWindow::onRemoveDiscActionTriggered()
 
 void MainWindow::onChangeDiscMenuAboutToShow()
 {
-	// TODO: This is where we would populate the playlist if there is one.
+	const std::vector<std::string>& playlist = VMManager::GetM3UPlaylistEntries();
+	if (playlist.empty())
+		return;
+
+	m_change_disc_playlist_actions.clear();
+	m_change_disc_playlist_actions.append(m_ui.menuChangeDisc->addSeparator());
+
+	const int active_index = VMManager::GetM3UPlaylistCurrentIndex();
+	for (int i = 0; i < static_cast<int>(playlist.size()); ++i)
+	{
+		const QString label = tr("%1: %2").arg(i + 1).arg(QFileInfo(QString::fromStdString(playlist[i])).fileName());
+		QAction* action = m_ui.menuChangeDisc->addAction(label);
+		action->setCheckable(true);
+		action->setChecked(i == active_index);
+		action->setToolTip(QString::fromStdString(playlist[i]));
+		const std::string target_path = playlist[i];
+		connect(action, &QAction::triggered, this, [target_path]() {
+			g_emu_thread->changeDisc(CDVD_SourceType::Iso, QString::fromStdString(target_path));
+		});
+		m_change_disc_playlist_actions.append(action);
+	}
 }
 
 void MainWindow::onChangeDiscMenuAboutToHide()
 {
+	for (QAction* action : m_change_disc_playlist_actions)
+	{
+		m_ui.menuChangeDisc->removeAction(action);
+		action->deleteLater();
+	}
+	m_change_disc_playlist_actions.clear();
 }
 
 void MainWindow::onLoadStateMenuAboutToShow()

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -63,7 +63,7 @@
 #endif
 
 const char* MainWindow::OPEN_FILE_FILTER =
-	QT_TRANSLATE_NOOP("MainWindow", "All File Types (*.bin *.iso *.cue *.mdf *.chd *.cso *.zso *.gz *.elf *.irx *.gs *.gs.xz *.gs.zst *.dump);;"
+	QT_TRANSLATE_NOOP("MainWindow", "All File Types (*.bin *.iso *.cue *.mdf *.chd *.cso *.zso *.gz *.elf *.irx *.gs *.gs.xz *.gs.zst *.dump *.m3u);;"
 									"Single-Track Raw Images (*.bin *.iso);;"
 									"Cue Sheets (*.cue);;"
 									"Media Descriptor File (*.mdf);;"
@@ -74,9 +74,10 @@ const char* MainWindow::OPEN_FILE_FILTER =
 									"ELF Executables (*.elf);;"
 									"IRX Executables (*.irx);;"
 									"GS Dumps (*.gs *.gs.xz *.gs.zst);;"
-									"Block Dumps (*.dump)");
+									"Block Dumps (*.dump);;"
+									"M3U Playlists (*.m3u)");
 
-const char* MainWindow::DISC_IMAGE_FILTER = QT_TRANSLATE_NOOP("MainWindow", "All File Types (*.bin *.iso *.cue *.mdf *.chd *.cso *.zso *.gz *.dump);;"
+const char* MainWindow::DISC_IMAGE_FILTER = QT_TRANSLATE_NOOP("MainWindow", "All File Types (*.bin *.iso *.cue *.mdf *.chd *.cso *.zso *.gz *.dump *.m3u);;"
 																			"Single-Track Raw Images (*.bin *.iso);;"
 																			"Cue Sheets (*.cue);;"
 																			"Media Descriptor File (*.mdf);;"
@@ -84,7 +85,8 @@ const char* MainWindow::DISC_IMAGE_FILTER = QT_TRANSLATE_NOOP("MainWindow", "All
 																			"CSO Images (*.cso);;"
 																			"ZSO Images (*.zso);;"
 																			"GZ Images (*.gz);;"
-																			"Block Dumps (*.dump)");
+																			"Block Dumps (*.dump);;"
+																			"M3U Playlists (*.m3u)");
 
 MainWindow* g_main_window = nullptr;
 

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -306,6 +306,8 @@ private:
 	InputRecordingViewer* m_input_recording_viewer = nullptr;
 	AutoUpdaterDialog* m_auto_updater_dialog = nullptr;
 
+	QList<QAction*> m_change_disc_playlist_actions;
+
 	QProgressBar* m_status_progress_widget = nullptr;
 	QLabel* m_status_verbose_widget = nullptr;
 	QLabel* m_status_renderer_widget = nullptr;

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -1631,7 +1631,8 @@ void FullscreenUI::DrawPauseMenu(MainWindowType type)
 		}
 	}
 
-	const ImVec2 window_size(LayoutScale(500.0f, LAYOUT_SCREEN_HEIGHT));
+	const float window_width = (s_current_pause_submenu == PauseSubMenu::ChangeDisc) ? display_size.x : 500.0f;
+	const ImVec2 window_size(LayoutScale(window_width, LAYOUT_SCREEN_HEIGHT));
 	const ImVec2 window_pos(0.0f, display_size.y - LayoutScale(LAYOUT_FOOTER_HEIGHT) - window_size.y);
 
 	if (BeginFullscreenWindow(window_pos, window_size, "pause_menu", ImVec4(0.0f, 0.0f, 0.0f, 0.0f), 0.0f,
@@ -1647,8 +1648,9 @@ void FullscreenUI::DrawPauseMenu(MainWindowType type)
 		const std::vector<std::string>& change_disc_playlist = VMManager::GetM3UPlaylistEntries();
 		const u32 change_disc_item_count = static_cast<u32>(change_disc_playlist.size()) + 2; // +2 for back and from file
 		const bool just_focused = ResetFocusHere();
+		const float y_align = (s_current_pause_submenu == PauseSubMenu::ChangeDisc) ? 0.5f : 1.0f;
 		BeginMenuButtons((s_current_pause_submenu == PauseSubMenu::ChangeDisc) ? change_disc_item_count : submenu_item_count[static_cast<u32>(s_current_pause_submenu)],
-			1.0f, ImGuiFullscreen::LAYOUT_MENU_BUTTON_X_PADDING,
+			y_align, ImGuiFullscreen::LAYOUT_MENU_BUTTON_X_PADDING,
 			ImGuiFullscreen::LAYOUT_MENU_BUTTON_Y_PADDING, ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
 
 		if (!ImGui::IsPopupOpen(0u, ImGuiPopupFlags_AnyPopup))

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -964,9 +964,16 @@ void FullscreenUI::RequestChangeDisc()
 {
 	ConfirmShutdownIfMemcardBusy([](bool result) {
 		if (result)
-			DoChangeDiscFromFile();
+		{
+			if (!VMManager::GetM3UPlaylistEntries().empty())
+				OpenPauseSubMenu(PauseSubMenu::ChangeDisc);
+			else
+				DoChangeDiscFromFile();
+		}
 		else
+		{
 			ClosePauseMenu();
+		}
 	});
 }
 
@@ -1634,10 +1641,14 @@ void FullscreenUI::DrawPauseMenu(MainWindowType type)
 			11, // None
 			4, // Exit
 			3, // Achievements
+			0,  // ChangeDisc placeholder
 		};
 
+		const std::vector<std::string>& change_disc_playlist = VMManager::GetM3UPlaylistEntries();
+		const u32 change_disc_item_count = static_cast<u32>(change_disc_playlist.size()) + 2; // +2 for back and from file
 		const bool just_focused = ResetFocusHere();
-		BeginMenuButtons(submenu_item_count[static_cast<u32>(s_current_pause_submenu)], 1.0f, ImGuiFullscreen::LAYOUT_MENU_BUTTON_X_PADDING,
+		BeginMenuButtons((s_current_pause_submenu == PauseSubMenu::ChangeDisc) ? change_disc_item_count : submenu_item_count[static_cast<u32>(s_current_pause_submenu)],
+			1.0f, ImGuiFullscreen::LAYOUT_MENU_BUTTON_X_PADDING,
 			ImGuiFullscreen::LAYOUT_MENU_BUTTON_Y_PADDING, ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
 
 		if (!ImGui::IsPopupOpen(0u, ImGuiPopupFlags_AnyPopup))
@@ -1667,6 +1678,10 @@ void FullscreenUI::DrawPauseMenu(MainWindowType type)
 					case PauseSubMenu::Achievements:
 						first_id = ImGui::GetID(FSUI_ICONSTR(ICON_PF_BACKWARD, "Back To Pause Menu"));
 						last_id = ImGui::GetID(FSUI_ICONSTR(ICON_FA_STOPWATCH, "Leaderboards"));
+						break;
+					case PauseSubMenu::ChangeDisc:
+						first_id = ImGui::GetID(FSUI_ICONSTR(ICON_PF_BACKWARD, "Back To Pause Menu"));
+						last_id = ImGui::GetID(FSUI_ICONSTR(ICON_FA_FOLDER_OPEN, "From File..."));
 						break;
 				}
 
@@ -1796,6 +1811,33 @@ void FullscreenUI::DrawPauseMenu(MainWindowType type)
 
 				if (ActiveButton(FSUI_ICONSTR(ICON_FA_STOPWATCH, "Leaderboards"), false))
 					OpenLeaderboardsWindow();
+			}
+			break;
+
+
+			case PauseSubMenu::ChangeDisc:
+			{
+				if (ActiveButton(FSUI_ICONSTR(ICON_PF_BACKWARD, "Back To Pause Menu"), false) || WantsToCloseMenu())
+					OpenPauseSubMenu(PauseSubMenu::None);
+
+				const std::vector<std::string>& playlist = VMManager::GetM3UPlaylistEntries();
+				const int active_index = VMManager::GetM3UPlaylistCurrentIndex();
+
+				for (int i = 0; i < static_cast<int>(playlist.size()); ++i)
+				{
+					const std::string label = fmt::format("{}: {}", i + 1, Path::GetFileName(playlist[i]));
+					const bool is_active = (i == active_index);
+					if (ActiveButton(FSUI_ICONSTR(ICON_FA_COMPACT_DISC, label.c_str()), is_active))
+					{
+						Host::RunOnCPUThread([path = playlist[i]]() { VMManager::ChangeDisc(CDVD_SourceType::Iso, path); });
+						ClosePauseMenu();
+					}
+				}
+
+				if (ActiveButton(FSUI_ICONSTR(ICON_FA_FOLDER_OPEN, "From File..."), false))
+				{
+					DoChangeDiscFromFile();
+				}
 			}
 			break;
 		}

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -746,7 +746,7 @@ ImGuiFullscreen::FileSelectorFilters FullscreenUI::GetOpenFileFilters()
 
 ImGuiFullscreen::FileSelectorFilters FullscreenUI::GetDiscImageFilters()
 {
-	return {"*.bin", "*.iso", "*.cue", "*.mdf", "*.chd", "*.cso", "*.zso", "*.gz"};
+	return {"*.bin", "*.iso", "*.cue", "*.mdf", "*.chd", "*.cso", "*.zso", "*.gz", "*.m3u"};
 }
 
 ImGuiFullscreen::FileSelectorFilters FullscreenUI::GetAudioFileFilters()

--- a/pcsx2/ImGui/FullscreenUI_Internal.h
+++ b/pcsx2/ImGui/FullscreenUI_Internal.h
@@ -155,6 +155,7 @@ namespace FullscreenUI
 		None,
 		Exit,
 		Achievements,
+		ChangeDisc,
 	};
 
 	enum class SettingsPage

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -46,6 +46,7 @@
 #include "common/Console.h"
 #include "common/Error.h"
 #include "common/FileSystem.h"
+#include "common/Path.h"
 #include "common/FPControl.h"
 #include "common/ScopedGuard.h"
 #include "common/SettingsWrapper.h"
@@ -1235,6 +1236,41 @@ bool VMManager::HasBootedELF()
 	return s_current_crc != 0 && s_elf_executed;
 }
 
+static std::vector<std::string> ParseM3UPlaylist(const std::string& m3u_path)
+{
+	std::vector<std::string> disc_paths;
+
+	const std::optional<std::string> content = FileSystem::ReadFileToString(m3u_path.c_str());
+	if (!content.has_value())
+		return disc_paths;
+
+	const std::string_view m3u_dir = Path::GetDirectory(m3u_path);
+
+	const std::vector<std::string_view> lines = StringUtil::SplitString(*content, '\n', false);
+	for (const std::string_view line : lines)
+	{
+		// Skip empty lines and comments
+		const std::string_view trimmed = StringUtil::StripWhitespace(line);
+		if (trimmed.empty() || trimmed[0] == '#')
+			continue;
+
+		// Resolve relative paths
+		std::string disc_path;
+		if (Path::IsAbsolute(trimmed))
+		{
+			disc_path = std::string(trimmed);
+		}
+		else
+		{
+			disc_path = Path::Combine(m3u_dir, trimmed);
+		}
+
+		disc_paths.push_back(std::move(disc_path));
+	}
+
+	return disc_paths;
+}
+
 bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 {
 	if (!filename.empty())
@@ -1266,6 +1302,20 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 			}
 
 			s_elf_override = filename;
+			return true;
+		}
+		else if (StringUtil::EndsWithNoCase(filename, ".m3u"))
+		{
+			const std::vector<std::string> disc_paths = ParseM3UPlaylist(filename);
+			if (disc_paths.empty())
+			{
+				Error::SetStringFmt(error, TRANSLATE_FS("VMManager", "M3U playlist '{}' does not contain any valid disc paths."), filename);
+				return false;
+			}
+
+			// For now, just load the first disc
+			CDVDsys_SetFile(CDVD_SourceType::Iso, disc_paths[0]);
+			CDVDsys_ChangeSource(CDVD_SourceType::Iso);
 			return true;
 		}
 		else
@@ -2424,7 +2474,7 @@ bool VMManager::IsSaveStateFileName(const std::string_view path)
 
 bool VMManager::IsDiscFileName(const std::string_view path)
 {
-	static const char* extensions[] = {".iso", ".bin", ".img", ".mdf", ".gz", ".cso", ".zso", ".chd"};
+	static const char* extensions[] = {".iso", ".bin", ".img", ".mdf", ".gz", ".cso", ".zso", ".chd", ".m3u"};
 
 	for (const char* test_extension : extensions)
 	{

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1236,6 +1236,37 @@ bool VMManager::HasBootedELF()
 	return s_current_crc != 0 && s_elf_executed;
 }
 
+static std::string s_current_m3u_playlist_source;
+static std::vector<std::string> s_current_m3u_playlist_entries;
+static int s_current_m3u_playlist_index = -1;
+
+static void ClearM3UPlaylist()
+{
+	s_current_m3u_playlist_source.clear();
+	s_current_m3u_playlist_entries.clear();
+	s_current_m3u_playlist_index = -1;
+}
+
+static void SetM3UPlaylist(const std::string& m3u_path, std::vector<std::string> entries, int current_index)
+{
+	s_current_m3u_playlist_source = m3u_path;
+	s_current_m3u_playlist_entries = std::move(entries);
+	s_current_m3u_playlist_index = current_index;
+}
+
+static void UpdateM3UPlaylistCurrentIndex(const std::string& current_disc_path)
+{
+	s_current_m3u_playlist_index = -1;
+	for (size_t i = 0; i < s_current_m3u_playlist_entries.size(); ++i)
+	{
+		if (s_current_m3u_playlist_entries[i] == current_disc_path)
+		{
+			s_current_m3u_playlist_index = static_cast<int>(i);
+			return;
+		}
+	}
+}
+
 static std::vector<std::string> ParseM3UPlaylist(const std::string& m3u_path)
 {
 	std::vector<std::string> disc_paths;
@@ -1273,6 +1304,7 @@ static std::vector<std::string> ParseM3UPlaylist(const std::string& m3u_path)
 
 bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 {
+	ClearM3UPlaylist();
 	if (!filename.empty())
 	{
 		if (!FileSystem::FileExists(filename.c_str()))
@@ -1280,7 +1312,7 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 			Error::SetStringFmt(error, TRANSLATE_FS("VMManager", "Requested filename '{}' does not exist."), filename);
 			return false;
 		}
-
+		
 		if (IsGSDumpFileName(filename))
 		{
 			CDVDsys_ChangeSource(CDVD_SourceType::NoDisc);
@@ -1313,8 +1345,8 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 				return false;
 			}
 
-			// For now, just load the first disc
-			CDVDsys_SetFile(CDVD_SourceType::Iso, disc_paths[0]);
+			SetM3UPlaylist(filename, disc_paths, 0);
+			CDVDsys_SetFile(CDVD_SourceType::Iso, s_current_m3u_playlist_entries[0]);
 			CDVDsys_ChangeSource(CDVD_SourceType::Iso);
 			return true;
 		}
@@ -2367,6 +2399,28 @@ bool VMManager::ChangeDisc(CDVD_SourceType source, std::string path)
 	const CDVD_SourceType old_type = CDVDsys_GetSourceType();
 	const std::string old_path(CDVDsys_GetFile(old_type));
 
+	if (source == CDVD_SourceType::Iso && StringUtil::EndsWithNoCase(path, ".m3u"))
+	{
+		const std::vector<std::string> disc_paths = ParseM3UPlaylist(path);
+		if (disc_paths.empty())
+		{
+			return false;
+		}
+
+		SetM3UPlaylist(path, disc_paths, 0);
+		path = s_current_m3u_playlist_entries[0];
+	}
+	else if (source != CDVD_SourceType::Iso)
+	{
+		ClearM3UPlaylist();
+	}
+	else if (!path.empty())
+	{
+		UpdateM3UPlaylistCurrentIndex(path);
+		if (s_current_m3u_playlist_index < 0)
+			ClearM3UPlaylist();
+	}
+
 	CDVDsys_ChangeSource(source);
 	if (!path.empty())
 		CDVDsys_SetFile(source, path);
@@ -2419,6 +2473,16 @@ bool VMManager::ChangeDisc(CDVD_SourceType source, std::string path)
 	cdvd.Tray.trayState = CDVD_DISC_OPEN;
 	UpdateDiscDetails(false);
 	return result;
+}
+
+const std::vector<std::string>& VMManager::GetM3UPlaylistEntries()
+{
+	return s_current_m3u_playlist_entries;
+}
+
+int VMManager::GetM3UPlaylistCurrentIndex()
+{
+	return s_current_m3u_playlist_index;
 }
 
 bool VMManager::SetELFOverride(std::string path)

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -89,6 +89,12 @@ namespace VMManager
 	/// Returns the path of the disc currently running.
 	std::string GetDiscPath();
 
+	/// Returns the list of disc paths from the currently loaded M3U playlist.
+	const std::vector<std::string>& GetM3UPlaylistEntries();
+
+	/// Returns the current selected disc index for the loaded M3U playlist, or -1 if none.
+	int GetM3UPlaylistCurrentIndex();
+
 	/// Returns the serial of the disc currently running.
 	std::string GetDiscSerial();
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

This gives PCSX2 the ability to parse .m3u files for multidisc games when opening via the System -> Start File menu. It automatically loads the first disc, and lists all discs in the System -> Change Disc menu as well as in a new FullscreenUI submenu that Change Disc opens when the current disc was launched from an .m3u file. (When not launched from a .m3u file, the FSUI Change Disc option opens the file browser as before.)

<img width="1108" height="666" alt="Screenshot (14)" src="https://github.com/user-attachments/assets/e6ad4942-5fe5-4091-b22b-37233f52b8a9" />

<img width="2256" height="1398" alt="Metal Gear Solid 3 - Subsistence  Disc 1 of 3  4_14_2026 10_14_07 PM" src="https://github.com/user-attachments/assets/750c0c13-9185-4a4d-ba27-322bfa5abdf7" />

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

I want this for Batocera, where .m3u files are the correct way to group multidisc games.

Fixes https://github.com/PCSX2/pcsx2/issues/6696

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

I tested a Windows build, both via the System -> Start File menu in PCSX2, and by right-clicking a .m3u file in explorer and choosing Open with, then finding the executable for my modified pcsx2 build.

I tested the second commit by switching discs a few times.

I have not yet tested it in Batocera, but I think it will work.

I have also not yet tested how it handles save states where your on a subsequent disc. I'm moderately concerned that the "just load the first disk" behavior I chose could cause trouble there. (I don't have any save files beyond the first disk of any multidisc games.)

### Did you use AI to help find, test, or implement this issue or feature?
Yes, I had copilot plan this out, then I tweaked the plan a bit, then had it implement it. I reviewed the code and made a few changes.

### Future work

I think these ideas would make sense, but I'm not not planning on adding them in this PR:

* Remember which file of the playlist was last loaded, at least when automatically loading savestates
* Maybe make a hotkey to switch to the next disk(?)
* Maybe add .m3u support to the main "all games" list(?)