### PR TITLE
Qt: Fix Windows Auto HDR not triggering via registry opt-in

### DIFF
--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -2037,6 +2037,74 @@ static void SignalHandler(int signal)
 
 #ifdef _WIN32
 
+static void RegisterAutoHDR(bool enable)
+{
+	// Get the actual exe path (varies by build: pcsx2-qt.exe, pcsx2-qtx64.exe, etc.)
+	wchar_t exe_path[MAX_PATH];
+	if (GetModuleFileNameW(nullptr, exe_path, MAX_PATH) == 0)
+		return;
+
+	HKEY base_key;
+	if (RegCreateKeyExW(HKEY_CURRENT_USER, L"SOFTWARE\\Microsoft\\Direct3D",
+			0, nullptr, 0, KEY_READ | KEY_WRITE, nullptr, &base_key, nullptr) != ERROR_SUCCESS)
+		return;
+
+	// Find an existing entry for this exe or the first free slot.
+	wchar_t subkey_name[32];
+	HKEY app_key = nullptr;
+	bool is_existing = false;
+	for (int i = 0; i < 128; i++)
+	{
+		swprintf_s(subkey_name, L"Application%d", i);
+
+		HKEY candidate;
+		if (RegCreateKeyExW(base_key, subkey_name, 0, nullptr, 0, KEY_READ | KEY_WRITE,
+				nullptr, &candidate, nullptr) != ERROR_SUCCESS)
+			break;
+
+		wchar_t name_val[MAX_PATH] = {};
+		DWORD name_val_size = sizeof(name_val);
+		DWORD type = 0;
+		const bool has_name = RegQueryValueExW(candidate, L"Name", nullptr, &type,
+								  reinterpret_cast<BYTE*>(name_val), &name_val_size) == ERROR_SUCCESS;
+
+		if (!has_name || _wcsicmp(name_val, exe_path) == 0)
+		{
+			app_key = candidate;
+			is_existing = has_name;
+			break;
+		}
+		RegCloseKey(candidate);
+	}
+
+	if (app_key)
+	{
+		if (enable)
+		{
+			RegSetValueExW(app_key, L"Name", 0, REG_SZ,
+				reinterpret_cast<const BYTE*>(exe_path), static_cast<DWORD>((wcslen(exe_path) + 1) * sizeof(wchar_t)));
+
+			constexpr const wchar_t behaviors[] = L"BufferUpgradeOverride=1";
+			RegSetValueExW(app_key, L"D3DBehaviors", 0, REG_SZ,
+				reinterpret_cast<const BYTE*>(behaviors), sizeof(behaviors));
+		}
+		else if (is_existing)
+		{
+			// Remove D3DBehaviors so Auto HDR no longer activates.
+			RegDeleteValueW(app_key, L"D3DBehaviors");
+		}
+
+		RegCloseKey(app_key);
+	}
+
+	RegCloseKey(base_key);
+}
+
+void QtHost::UpdateAutoHDRRegistration(bool enable)
+{
+	RegisterAutoHDR(enable);
+}
+
 static BOOL WINAPI ConsoleCtrlHandler(DWORD dwCtrlType)
 {
 	if (dwCtrlType != CTRL_C_EVENT)
@@ -2297,8 +2365,8 @@ bool QtHost::ParseCommandLineOptions(const QStringList& args, std::shared_ptr<VM
 		Console.Warning("Skipping autoboot due to no boot parameters.");
 		autoboot.reset();
 	}
-	
-	if(autoboot && autoboot->start_turbo.value_or(false) && autoboot->start_unlimited.value_or(false))
+
+	if (autoboot && autoboot->start_turbo.value_or(false) && autoboot->start_unlimited.value_or(false))
 	{
 		Console.Warning("Both turbo and unlimited frame limit modes requested. Using unlimited.");
 		autoboot->start_turbo.reset();
@@ -2414,6 +2482,10 @@ int main(int argc, char* argv[])
 	// Bail out if we can't find any config.
 	if (!QtHost::InitializeConfig())
 		return EXIT_FAILURE;
+
+#ifdef _WIN32
+	RegisterAutoHDR(Host::GetBoolSettingValue("EmuCore/GS", "EnableAutoHDR", false));
+#endif
 
 	// Are we just setting up the configuration?
 	if (s_test_config_and_exit)

--- a/pcsx2-qt/QtHost.h
+++ b/pcsx2-qt/QtHost.h
@@ -298,4 +298,9 @@ namespace QtHost
 	/// inside its exec function, which would cause a crash.
 	void LockVMWithDialog();
 	void UnlockVMWithDialog();
+
+#ifdef _WIN32
+	/// Registers or unregisters PCSX2 with Windows for Auto HDR.
+	void UpdateAutoHDRRegistration(bool enable);
+#endif
 } // namespace QtHost

--- a/pcsx2-qt/Settings/GraphicsDisplaySettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsDisplaySettingsTab.ui
@@ -87,6 +87,16 @@
        </property>
       </widget>
      </item>
+     <item row="3" column="1">
+      <widget class="QCheckBox" name="enableAutoHDR">
+       <property name="toolTip">
+        <string>Registers PCSX2 with Windows so that Auto HDR is applied to the game image. Requires Direct3D 11 or Direct3D 12. Requires restarting PCSX2 to take effect.</string>
+       </property>
+       <property name="text">
+        <string>Enable Windows Auto HDR</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item row="2" column="0">

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0+
 
 #include "GraphicsSettingsWidget.h"
+#include "QtHost.h"
 #include "QtUtils.h"
 #include "SettingWidgetBinder.h"
 #include "SettingsWindow.h"
@@ -222,6 +223,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 	// Advanced Settings
 	//////////////////////////////////////////////////////////////////////////
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_advanced.useBlitSwapChain, "EmuCore/GS", "UseBlitSwapChain", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_display.enableAutoHDR, "EmuCore/GS", "EnableAutoHDR", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_advanced.useDebugDevice, "EmuCore/GS", "UseDebugDevice", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_advanced.disableMailboxPresentation, "EmuCore/GS", "DisableMailboxPresentation", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_advanced.extendedUpscales, "EmuCore/GS", "ExtendedUpscalingMultipliers", false);
@@ -271,6 +273,11 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 
 	connect(m_header.rendererDropdown, &QComboBox::currentIndexChanged, this, &GraphicsSettingsWidget::onRendererChanged);
 	connect(m_header.adapterDropdown, &QComboBox::currentIndexChanged, this, &GraphicsSettingsWidget::onAdapterChanged);
+#ifdef _WIN32
+	connect(m_display.enableAutoHDR, &QCheckBox::checkStateChanged, this, [](Qt::CheckState state) {
+		QtHost::UpdateAutoHDRRegistration(state == Qt::Checked);
+	});
+#endif
 	connect(m_hw.enableHWFixes, &QCheckBox::checkStateChanged, this, &GraphicsSettingsWidget::updateRendererDependentOptions);
 	connect(m_advanced.extendedUpscales, &QCheckBox::checkStateChanged, this, &GraphicsSettingsWidget::updateRendererDependentOptions);
 	connect(m_hw.textureFiltering, &QComboBox::currentIndexChanged, this, &GraphicsSettingsWidget::onTextureFilteringChange);
@@ -281,6 +288,8 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 	// Exclusive fullscreen control is Windows-only.
 	m_advanced.advancedOptionsFormLayout->removeRow(2);
 	m_advanced.exclusiveFullscreenControl = nullptr;
+	// Auto HDR is Windows-only.
+	m_display.enableAutoHDR->setVisible(false);
 #endif
 
 #ifndef PCSX2_DEVBUILD
@@ -738,6 +747,12 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 			tr("Change the compression algorithm used when creating a GS dump."));
 
 		//: Blit = a data operation. You might want to write it as-is, but fully uppercased. More information: https://en.wikipedia.org/wiki/Bit_blit \nSwap chain: see Microsoft's Terminology Portal.
+		dialog()->registerWidgetHelp(m_display.enableAutoHDR, tr("Enable Windows Auto HDR"), tr("Unchecked"),
+			tr("Registers PCSX2 with Windows to enable Auto HDR on the game image. "
+			   "Windows Auto HDR automatically enhances SDR content with high dynamic range on supported displays. "
+			   "Only applies when using the Direct3D 11 or Direct3D 12 renderers. "
+			   "Requires restarting PCSX2 to take effect."));
+
 		dialog()->registerWidgetHelp(m_advanced.useBlitSwapChain, tr("Use Blit Swap Chain"), tr("Unchecked"),
 			//: Blit = a data operation. You might want to write it as-is, but fully uppercased. More information: https://en.wikipedia.org/wiki/Bit_blit
 			tr("Uses a blit presentation model instead of flipping when using the Direct3D 11 "


### PR DESCRIPTION
### Description of Changes

Adds a setting in the Graphics Display tab to enable Windows Auto HDR for PCSX2. When enabled, PCSX2 registers itself in the Windows registry under "HKCU\SOFTWARE\Microsoft\Direct3D" with "BufferUpgradeOverride=1", which forces Windows to treat PCSX2 as an Auto HDR eligible application. The setting defaults to off and requires restarting PCSX2 to take effect.

### Rationale behind Changes

PCSX2 was previously on Microsoft's Auto HDR whitelist when the executable was named "pcsx2.exe". When the executable was renamed to "pcsx2-qt.exe", Auto HDR detection no longer worked because the whitelist entry no longer matched.

Being on the whitelist is not the only requirement. The swap chain must also meet specific characteristics. After investigating the swap chain code, PCSX2 satisfies all of them: it uses the DXGI flip model, an SDR surface format, and a top-level composited window handle. Even when manually reverting to the whitelisted executable name ("pcsx2.exe"), altering these characteristics, for example switching to a 10-bit surface format, still prevents Auto HDR from activating. This confirms that being on the whitelist alone is not sufficient, as the swap chain requirements must also be met.

The simplest fix would be restoring the original "pcsx2.exe" name. However, enabling Windows Auto HDR alone is likely not a strong enough justification for that change. While users can manually rename the executable to restore Auto HDR functionality, this workaround is not discoverable to most users and may introduce unintended issues.

This PR instead takes a more robust approach by programmatically registering whichever executable name is running, whether that is "pcsx2-qt.exe", "pcsx2-qtx64.exe" in Visual Studio builds, or any future variant. It also provides a straightforward way for users to enable Windows Auto HDR directly through the settings.

One known limitation is that the Windows Auto HDR popup notification does not appear. This appears to be reserved for applications on the official Microsoft whitelist.

### Suggested Testing Steps

1. Enable the "Enable Windows Auto HDR" setting in Settings > Graphics > Display.
2. Restart PCSX2.
3. Launch a game using the Direct3D 11 or Direct3D 12 renderer.
4. Open the Xbox Game Bar.
5. Navigate to Settings > More Settings > Gaming Features and verify the Auto HDR intensity slider is present and functional.
6. Disable the setting, restart PCSX2, launch a game, and verify Auto HDR is no longer active.
7. Verify the Auto HDR intensity slider may still be visible, but changing it has no effect when Auto HDR is disabled.

### Did you use AI to help find, test, or implement this issue or feature?

Yes. I used AI to investigate PCSX2's swap chain characteristics and test various combinations such as flip model, surface format, and window handle type to confirm that the swap chain satisfies Windows Auto HDR requirements. The registry opt-in mechanism was identified through research into open source tools that implement a similar approach.