### PR TITLE
Qt: Add RetroAchievements to Setup Wizard

### DIFF
--- a/bin/resources/icons/ra-icon.svg
+++ b/bin/resources/icons/ra-icon.svg
@@ -1,106 +1,14 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   height="275"
-   width="570"
-   version="1.1"
-   viewBox="0 0 150.81249 72.760419"
-   id="svg4"
-   sodipodi:docname="RetroAchievements_logo_square.svg"
-   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
-   inkscape:export-filename="RetroAchievements_logo_square.png"
-   inkscape:export-xdpi="960"
-   inkscape:export-ydpi="960"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <defs
-     id="defs4">
-    <linearGradient
-       id="linearGradient6"
-       inkscape:collect="always">
-      <stop
-         style="stop-color:#ca9800;stop-opacity:1;"
-         offset="0.5"
-         id="stop6" />
-      <stop
-         style="stop-color:#ffe080;stop-opacity:1;"
-         offset="1"
-         id="stop7" />
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 570 275">
+  <defs>
+    <linearGradient id="a" x1="217.45" y1="974.97" x2="217.45" y2="950.13" gradientTransform="matrix(8.48 0 0 -8.33 -1680.66 8153.87)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#89b4ee"/>
+      <stop offset=".32" stop-color="#1066dd"/>
     </linearGradient>
-    <linearGradient
-       id="linearGradient4"
-       inkscape:collect="always">
-      <stop
-         style="stop-color:#87b6f8;stop-opacity:1;"
-         offset="0"
-         id="stop4" />
-      <stop
-         style="stop-color:#0f65dd;stop-opacity:1;"
-         offset="0.50065017"
-         id="stop5" />
+    <linearGradient id="b" x1="245.24" y1="976.59" x2="245.24" y2="948.51" gradientTransform="matrix(8.48 0 0 -8.33 -1686.3 8153.87)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#e5cd83"/>
+      <stop offset=".32" stop-color="#cc9a00"/>
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4"
-       id="linearGradient5"
-       x1="229.8"
-       y1="-556.42499"
-       x2="229.8"
-       y2="-531.58502"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6"
-       id="linearGradient7"
-       x1="257.58826"
-       y1="-529.96503"
-       x2="257.58826"
-       y2="-558.04498"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.66412404)" />
   </defs>
-  <sodipodi:namedview
-     id="namedview4"
-     pagecolor="#505050"
-     bordercolor="#eeeeee"
-     borderopacity="1"
-     inkscape:showpageshadow="0"
-     inkscape:pageopacity="0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#505050"
-     inkscape:document-units="mm"
-     showguides="true"
-     inkscape:zoom="0.54074219"
-     inkscape:cx="213.59532"
-     inkscape:cy="218.21859"
-     inkscape:window-width="1536"
-     inkscape:window-height="898"
-     inkscape:window-x="-6"
-     inkscape:window-y="-6"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg4" />
-  <g
-     transform="matrix(5.6312119,0,0,5.6312119,-392.00615,-696.01846)"
-     id="g4">
-    <g
-       transform="matrix(0.35278,0,0,-0.35278,-4.3083,326.78)"
-       id="g3">
-      <g
-         aria-label="RA"
-         style="font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal"
-         transform="matrix(1.1293,0,0,-1.1092,-28.246,-45.784)"
-         id="g2">
-        <path
-           style="font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;fill:url(#linearGradient5)"
-           d="m 217.38,-553.59 h 11.73 q 1.89,0 3.12,1.14 1.26,1.14 1.26,3.45 0,0.99 -0.33,1.86 -0.33,0.84 -0.93,1.47 -0.57,0.63 -1.38,0.99 -0.81,0.36 -1.74,0.36 h -0.99 l 8.55,15.03 h -4.29 l -5.94,-10.29 v 10.29 h -3.99 v -19.17 h 6.51 q 0.24,0 0.36,-0.18 0.15,-0.18 0.15,-0.39 0,-0.21 -0.15,-0.36 -0.12,-0.18 -0.36,-0.18 h -7.59 v 20.28 h -3.99 z m 12.66,10.26 q 0.87,-0.06 1.68,-0.51 0.84,-0.45 1.47,-1.2 0.63,-0.75 1.02,-1.74 0.39,-1.02 0.39,-2.22 0,-1.23 -0.39,-2.28 -0.39,-1.05 -1.11,-1.8 -0.72,-0.75 -1.74,-1.17 -0.99,-0.42 -2.25,-0.42 h -11.73 v -4.05 h 11.73 q 1.98,0 3.72,0.75 1.74,0.75 3.03,2.07 1.29,1.32 2.01,3.09 0.75,1.77 0.75,3.81 0,2.58 -0.87,4.47 -0.87,1.86 -2.37,3 l 6.84,12.24 h -4.08 z"
-           id="path1" />
-        <path
-           style="font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;fill:url(#linearGradient7)"
-           d="m 253.50413,-532.8 h 12.45 l -7.62,-21.15 q -0.09,-0.3 -0.54,-0.54 -0.45,-0.24 -0.87,-0.24 -0.48,0 -0.9,0.24 -0.39,0.24 -0.48,0.54 l -8.67,24.66 h -3.99 l 9.27,-26.16 q 0.21,-0.63 0.6,-1.2 0.39,-0.6 0.96,-1.05 0.6,-0.48 1.38,-0.75 0.81,-0.27 1.83,-0.27 1.02,0 1.8,0.27 0.78,0.27 1.35,0.75 0.6,0.45 0.99,1.05 0.39,0.57 0.63,1.2 l 9.27,26.16 h -17.46 z m 0,-1.08 v -1.14 l -1.92,5.73 h -3.63 l 8.25,-23.91 q 0.06,-0.18 0.27,-0.3 0.24,-0.15 0.45,-0.15 0.21,0 0.45,0.15 0.24,0.12 0.3,0.3 l 6.84,19.32 z m 3.42,-11.13 -2.4,7.56 h 4.89 z"
-           id="path2" />
-      </g>
-    </g>
-  </g>
+  <path d="M57.83 57.67h99.46c10.68 0 19.5 3.16 26.45 9.49 7.12 6.33 10.68 15.91 10.68 28.73 0 5.5-.93 10.66-2.8 15.49-1.87 4.66-4.49 8.74-7.89 12.24-3.22 3.5-7.12 6.25-11.7 8.24-4.58 2-9.5 3-14.75 3h-8.39l72.5 125.17h-36.38l-50.37-85.7v85.7h-33.83V100.4h55.2c1.36 0 2.37-.5 3.05-1.5.85-1 1.27-2.08 1.27-3.25s-.42-2.17-1.27-3c-.68-1-1.7-1.5-3.05-1.5H91.65v168.9H57.82V57.67Zm107.34 85.45c4.92-.33 9.67-1.75 14.24-4.25 4.75-2.5 8.9-5.83 12.46-9.99s6.44-8.99 8.65-14.49c2.2-5.66 3.31-11.83 3.31-18.49 0-6.83-1.1-13.16-3.31-18.99-2.2-5.83-5.34-10.83-9.41-14.99s-8.99-7.41-14.75-9.74c-5.6-2.33-11.96-3.5-19.08-3.5H57.83V14.95h99.46c11.19 0 21.71 2.08 31.54 6.25s18.4 9.91 25.69 17.24 12.97 15.91 17.04 25.73c4.24 9.83 6.36 20.4 6.36 31.73q0 21.48-7.38 37.23c-4.92 10.33-11.62 18.66-20.1 24.98l58 101.94h-34.59z" style="fill:url(#a)"/>
+  <path d="M364.13 230.82H469.7L405.09 54.68c-.51-1.67-2.03-3.16-4.58-4.5s-5-2-7.38-2c-2.71 0-5.26.67-7.63 2-2.2 1.33-3.56 2.83-4.07 4.5l-73.51 205.37h-33.83l78.6-217.87c1.19-3.5 2.88-6.83 5.09-9.99 2.2-3.33 4.92-6.25 8.14-8.74 3.39-2.67 7.29-4.75 11.7-6.25 4.58-1.5 9.75-2.25 15.52-2.25s10.85.75 15.26 2.25 8.22 3.58 11.45 6.25c3.39 2.5 6.19 5.41 8.39 8.74 2.2 3.16 3.99 6.5 5.34 9.99l78.6 217.87H364.13zm0-9v-9.49l-16.28 47.72h-30.78l69.95-199.13c.34-1 1.1-1.83 2.29-2.5 1.36-.83 2.63-1.25 3.82-1.25s2.46.42 3.82 1.25c1.36.67 2.2 1.5 2.54 2.5l58 160.9zm29-92.69-20.35 62.96h41.46z" style="fill:url(#b)"/>
 </svg>

--- a/pcsx2-qt/Settings/AchievementLoginDialog.cpp
+++ b/pcsx2-qt/Settings/AchievementLoginDialog.cpp
@@ -52,12 +52,14 @@ void AchievementLoginDialog::loginClicked()
 		const bool result = Achievements::Login(username.c_str(), password.c_str(), &error);
 		const QString message = QString::fromStdString(error.GetDescription());
 
-		QtHost::RunOnUIThread([dialog, result, message = std::move(message)]() {
-			if (!dialog)
-				return;
+		QMetaObject::invokeMethod(
+			qApp, [dialog, result, message = std::move(message)]() {
+				if (!dialog)
+					return;
 
-			dialog->processLoginResult(result, message);
-		});
+				dialog->processLoginResult(result, message);
+			},
+			Qt::QueuedConnection);
 	});
 }
 

--- a/pcsx2-qt/SetupWizardDialog.cpp
+++ b/pcsx2-qt/SetupWizardDialog.cpp
@@ -1,17 +1,18 @@
 // SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
 // SPDX-License-Identifier: GPL-3.0+
 
+#include "pcsx2/Achievements.h"
 #include "pcsx2/SIO/Pad/Pad.h"
 #include "QtHost.h"
 #include "QtUtils.h"
 #include "SettingWidgetBinder.h"
+#include "Settings/AchievementLoginDialog.h"
 #include "Settings/BIOSSettingsWidget.h"
 #include "Settings/ControllerSettingWidgetBinder.h"
 #include "Settings/InterfaceSettingsWidget.h"
 #include "SetupWizardDialog.h"
 
-#include <QtCore/QLocale>
-#include <QtWidgets/QMessageBox>
+#include "common/StringUtil.h"
 
 SetupWizardDialog::SetupWizardDialog()
 {
@@ -109,6 +110,10 @@ void SetupWizardDialog::pageChangedTo(int page)
 			resizeDirectoryListColumns();
 			break;
 
+		case Page_RetroAchievements:
+			refreshRetroAchievementsLoginState();
+			break;
+
 		default:
 			break;
 	}
@@ -160,6 +165,7 @@ void SetupWizardDialog::setupUi()
 	m_page_labels[Page_BIOS] = m_ui.labelBIOS;
 	m_page_labels[Page_GameList] = m_ui.labelGameList;
 	m_page_labels[Page_Controller] = m_ui.labelController;
+	m_page_labels[Page_RetroAchievements] = m_ui.labelRetroAchievements;
 	m_page_labels[Page_Complete] = m_ui.labelComplete;
 
 	connect(m_ui.back, &QPushButton::clicked, this, &SetupWizardDialog::previousPage);
@@ -170,6 +176,7 @@ void SetupWizardDialog::setupUi()
 	setupBIOSPage();
 	setupGameListPage();
 	setupControllerPage();
+	setupRetroAchievementsPage();
 }
 
 void SetupWizardDialog::setupLanguagePage()
@@ -405,6 +412,91 @@ void SetupWizardDialog::setupControllerPage()
 	connect(g_emu_thread, &EmuThread::onInputDeviceConnected, this, &SetupWizardDialog::onInputDeviceConnected);
 	connect(g_emu_thread, &EmuThread::onInputDeviceDisconnected, this, &SetupWizardDialog::onInputDeviceDisconnected);
 	g_emu_thread->enumerateInputDevices();
+}
+
+void SetupWizardDialog::setupRetroAchievementsPage()
+{
+	const QString base_path(QtHost::GetResourcesBasePath());
+	QtUtils::SetScalableIcon(m_ui.raLogo, QIcon(QStringLiteral("%1/icons/ra-icon.svg").arg(base_path)), QSize(56, 56));
+
+	if (Achievements::IsUsingRAIntegration())
+	{
+		m_ui.raIntegrationLabel->setVisible(true);
+		m_ui.raContentWidget->setVisible(false);
+		return;
+	}
+
+	SettingWidgetBinder::BindWidgetToBoolSetting(
+		nullptr, m_ui.raEnableAchievements, "Achievements", "Enabled", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(
+		nullptr, m_ui.raHardcoreMode, "Achievements", "ChallengeMode", false);
+	connect(m_ui.raLoginButton, &QPushButton::clicked, this, &SetupWizardDialog::onRetroAchievementsLoginLogoutPressed);
+	connect(m_ui.raViewProfileButton, &QPushButton::clicked, this, &SetupWizardDialog::onRetroAchievementsViewProfilePressed);
+	refreshRetroAchievementsLoginState();
+}
+
+void SetupWizardDialog::refreshRetroAchievementsLoginState()
+{
+	const std::string username(Host::GetBaseStringSettingValue("Achievements", "Username"));
+	const bool logged_in = !username.empty();
+
+	if (logged_in)
+	{
+		const u64 login_unix_timestamp =
+			StringUtil::FromChars<u64>(Host::GetBaseStringSettingValue("Achievements", "LoginTimestamp", "0")).value_or(0);
+		const QDateTime login_timestamp(QDateTime::fromSecsSinceEpoch(static_cast<qint64>(login_unix_timestamp)));
+		m_ui.raLoginStatus->setText(tr("Username: %1\nLogin token generated on %2.")
+				.arg(QString::fromStdString(username))
+				.arg(login_timestamp.toString(Qt::TextDate)));
+		m_ui.raLoginButton->setText(tr("Logout"));
+	}
+	else
+	{
+		m_ui.raLoginStatus->setText(tr("Not Logged In."));
+		m_ui.raLoginButton->setText(tr("Login..."));
+	}
+
+	m_ui.raViewProfileButton->setEnabled(logged_in);
+}
+
+void SetupWizardDialog::onRetroAchievementsLoginLogoutPressed()
+{
+	if (!Host::GetBaseStringSettingValue("Achievements", "Username").empty())
+	{
+		Host::RunOnCPUThread([]() { Achievements::Logout(); }, true);
+		refreshRetroAchievementsLoginState();
+		return;
+	}
+
+	AchievementLoginDialog login(this, Achievements::LoginRequestReason::UserInitiated);
+	if (login.exec() != 0)
+		return;
+
+	refreshRetroAchievementsLoginState();
+
+	// Login can enable achievements, keep the checkbox state in sync.
+	if (!m_ui.raEnableAchievements->isChecked() &&
+		Host::GetBaseBoolSettingValue("Achievements", "Enabled", false))
+	{
+		QSignalBlocker sb(m_ui.raEnableAchievements);
+		m_ui.raEnableAchievements->setChecked(true);
+	}
+	if (!m_ui.raHardcoreMode->isChecked() &&
+		Host::GetBaseBoolSettingValue("Achievements", "ChallengeMode", false))
+	{
+		QSignalBlocker sb(m_ui.raHardcoreMode);
+		m_ui.raHardcoreMode->setChecked(true);
+	}
+}
+
+void SetupWizardDialog::onRetroAchievementsViewProfilePressed()
+{
+	const std::string username(Host::GetBaseStringSettingValue("Achievements", "Username"));
+	if (username.empty())
+		return;
+
+	const QByteArray encoded_username(QUrl::toPercentEncoding(QString::fromStdString(username)));
+	QtUtils::OpenURL(this, QUrl(QStringLiteral("https://retroachievements.org/user/%1").arg(QString::fromUtf8(encoded_username))));
 }
 
 void SetupWizardDialog::openAutomaticMappingMenu(u32 port, QLabel* update_label)

--- a/pcsx2-qt/SetupWizardDialog.h
+++ b/pcsx2-qt/SetupWizardDialog.h
@@ -42,6 +42,8 @@ private Q_SLOTS:
 	void onInputDevicesEnumerated(const QList<QPair<QString, QString>>& devices);
 	void onInputDeviceConnected(const QString& identifier, const QString& device_name);
 	void onInputDeviceDisconnected(const QString& identifier);
+	void onRetroAchievementsLoginLogoutPressed();
+	void onRetroAchievementsViewProfilePressed();
 
 protected:
 	void resizeEvent(QResizeEvent* event);
@@ -53,6 +55,7 @@ private:
 		Page_BIOS,
 		Page_GameList,
 		Page_Controller,
+		Page_RetroAchievements,
 		Page_Complete,
 		Page_Count,
 	};
@@ -62,6 +65,8 @@ private:
 	void setupBIOSPage();
 	void setupGameListPage();
 	void setupControllerPage();
+	void setupRetroAchievementsPage();
+	void refreshRetroAchievementsLoginState();
 
 	void pageChangedTo(int page);
 	void updatePageLabels(int prev_page);

--- a/pcsx2-qt/SetupWizardDialog.ui
+++ b/pcsx2-qt/SetupWizardDialog.ui
@@ -92,6 +92,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QLabel" name="labelRetroAchievements">
+         <property name="text">
+          <string>RetroAchievements</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QLabel" name="labelComplete">
          <property name="text">
           <string>Complete</string>
@@ -118,12 +125,12 @@
    <item row="0" column="1">
     <widget class="QStackedWidget" name="pages">
      <property name="currentIndex">
-      <number>3</number>
+      <number>4</number>
      </property>
      <widget class="QWidget" name="page">
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <property name="spacing">
-        <number>10</number>
+        <number>4</number>
        </property>
        <property name="leftMargin">
         <number>0</number>
@@ -622,6 +629,256 @@
           <size>
            <width>20</width>
            <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="pageRetroAchievements">
+      <layout class="QVBoxLayout" name="verticalLayout_8">
+       <property name="spacing">
+        <number>4</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_12">
+         <item>
+          <widget class="QLabel" name="raLogo">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>56</width>
+             <height>56</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>56</width>
+             <height>56</height>
+            </size>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="raSectionLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>14</pointsize>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>RetroAchievements</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_11">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QLabel" name="raIntroLabel">
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;justify&quot;&gt;PCSX2 supports RetroAchievements, a service that adds achievements, leaderboards, and extra challenges to classic games.&lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;Sign in below to link your account and start earning achievements in supported titles, or create a free account at &lt;a href=&quot;https://retroachievements.org/createaccount.php&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#27bf73;&quot;&gt;retroachievements.org/createaccount.php&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;Using RetroAchievements is completely optional and not required to use PCSX2.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::TextFormat::RichText</enum>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="margin">
+          <number>2</number>
+         </property>
+         <property name="openExternalLinks">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="raIntegrationLabel">
+         <property name="visible">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>RAIntegration is being used, built-in RetroAchievements support is disabled.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QWidget" name="raContentWidget" native="true">
+         <layout class="QVBoxLayout" name="verticalLayout_9">
+          <property name="spacing">
+           <number>4</number>
+          </property>
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QGroupBox" name="raSettingsBox">
+            <property name="title">
+             <string/>
+            </property>
+            <layout class="QHBoxLayout" name="horizontalLayout_11">
+             <item>
+              <widget class="QCheckBox" name="raEnableAchievements">
+               <property name="text">
+                <string>Enable Achievements</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="raHardcoreMode">
+               <property name="text">
+                <string>Enable Hardcore Mode</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer_10">
+               <property name="orientation">
+                <enum>Qt::Orientation::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="raAccountBox">
+            <property name="title">
+             <string>Account</string>
+            </property>
+            <layout class="QHBoxLayout" name="horizontalLayout_7" stretch="1,0,0,0">
+             <item>
+              <widget class="QLabel" name="raLoginStatus">
+               <property name="text">
+                <string>Not Logged In.</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+               </property>
+               <property name="textInteractionFlags">
+                <set>Qt::TextInteractionFlag::TextBrowserInteraction</set>
+               </property>
+               <property name="buddy">
+                <cstring>raViewProfileButton</cstring>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer_9">
+               <property name="orientation">
+                <enum>Qt::Orientation::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QPushButton" name="raViewProfileButton">
+               <property name="text">
+                <string>View Profile...</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="raLoginButton">
+               <property name="text">
+                <string>Login...</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="raFooterLabel">
+            <property name="text">
+             <string>You can customize additional RetroAchievements options later in Settings &gt; Achievements.</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_5">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>0</height>
           </size>
          </property>
         </spacer>


### PR DESCRIPTION
### Description of Changes
- Added a RetroAchievements section to the Qt setup wizard.
- Fixed a login hang when signing in from the wizard (before main window startup).
- Updated the RetroAchievements icon gradient. (The svg version of the logo was originally done by @fffathur before he had a GitHub account. He recently touched up the file to fix some issues with the gradients and make it match the original much better.)

### Rationale behind Changes
Makes RA setup available during first time use

### Suggested Testing Steps
Try adding `-setupwizard` to the cli args of the execuable and it should let you login to RetroAchievements and enable HC mode.

### Did you use AI to help find, test, or implement this issue or feature?
No