### PR TITLE
DEV9: Add EthUDPPorts config for inbound UDP in Sockets mode

### DIFF
--- a/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
@@ -132,6 +132,9 @@ DEV9SettingsWidget::DEV9SettingsWidget(SettingsWindow* settings_dialog, QWidget*
 	onEthDNSModeChanged(m_ui.ethDNS2Mode, m_ui.ethDNS2Mode->currentIndex(), m_ui.ethDNS2Addr, "DEV9/Eth", "ModeDNS2");
 	connect(m_ui.ethDNS2Mode, &QComboBox::currentIndexChanged, this, [&](int index) { onEthDNSModeChanged(m_ui.ethDNS2Mode, index, m_ui.ethDNS2Addr, "DEV9/Eth", "ModeDNS2"); });
 
+	// UDP Ports
+	SettingWidgetBinder::BindWidgetToStringSetting(sif, m_ui.ethUDPPorts, "DEV9/Eth", "EthUDPPorts", "");
+
 	//////////////////////////////////////////////////////////////////////////
 	// DNS Settings
 	//////////////////////////////////////////////////////////////////////////

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.ui
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.ui
@@ -190,6 +190,26 @@
           <item row="5" column="2">
            <widget class="QComboBox" name="ethDNS2Mode"/>
           </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="ethUDPPortsLabel">
+            <property name="text">
+             <string>UDP Ports:</string>
+            </property>
+            <property name="buddy">
+             <cstring>ethUDPPorts</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1" colspan="2">
+           <widget class="QLineEdit" name="ethUDPPorts">
+            <property name="placeholderText">
+             <string>Comma-separated list (e.g. 18194, 18193)</string>
+            </property>
+            <property name="toolTip">
+             <string>Pre-bind UDP ports on the host for inbound PS2 traffic. Required for ps2client/ps2link communication in Sockets mode.</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
         <widget class="QWidget" name="tab_2">

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1059,6 +1059,10 @@ struct Pcsx2Config
 
 		std::vector<HostEntry> EthHosts;
 
+		// Comma-separated list of UDP ports to pre-bind for inbound traffic.
+		// Allows host-to-PS2 communication in Sockets mode (e.g. ps2link on port 18194).
+		std::string EthUDPPorts;
+
 		bool HddEnable{false};
 		std::string HddFile;
 

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1061,6 +1061,10 @@ struct Pcsx2Config
 
 		std::vector<HostEntry> EthHosts;
 
+		// Comma-separated list of UDP ports to pre-bind for inbound traffic.
+		// Allows host-to-PS2 communication in Sockets mode (e.g. ps2link on port 18194).
+		std::string EthUDPPorts;
+
 		bool HddEnable{false};
 		std::string HddFile;
 

--- a/pcsx2/DEV9/Sessions/UDP_Session/UDP_FixedPort.cpp
+++ b/pcsx2/DEV9/Sessions/UDP_Session/UDP_FixedPort.cpp
@@ -84,6 +84,10 @@ namespace Sessions
 
 		if (!success)
 		{
+			// Don't close listening ports on socket errors.
+			if (isListening)
+				return std::nullopt;
+
 			// See Reset() for why we copy the vector.
 			std::vector<UDP_BaseSession*> connectionsCopy;
 			{
@@ -119,6 +123,11 @@ namespace Sessions
 						return ret;
 				}
 			}
+			// For pre-bound listening ports, accept packets from any source
+			// even without a matching child session (e.g. ps2link commands).
+			if (isListening)
+				return ret;
+
 			Console.Error("DEV9: UDP: Unexpected packet, dropping");
 		}
 		return std::nullopt;
@@ -170,7 +179,9 @@ namespace Sessions
 		if (index != connections.end())
 		{
 			connections.erase(index);
-			if (connections.size() == 0)
+			// Don't close listening ports when all children disconnect —
+			// they must stay open to accept new inbound connections.
+			if (connections.size() == 0 && !isListening)
 			{
 				open.store(false);
 				RaiseEventConnectionClosed();

--- a/pcsx2/DEV9/Sessions/UDP_Session/UDP_FixedPort.h
+++ b/pcsx2/DEV9/Sessions/UDP_Session/UDP_FixedPort.h
@@ -30,6 +30,9 @@ namespace Sessions
 
 	public:
 		const u16 port = 0;
+		// When true, accept inbound packets from any source even without
+		// a matching child session (for pre-bound listening ports).
+		bool isListening{false};
 
 	private:
 		std::mutex connectionSentry;

--- a/pcsx2/DEV9/sockets.cpp
+++ b/pcsx2/DEV9/sockets.cpp
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
 // SPDX-License-Identifier: GPL-3.0+
 
+#include <sstream>
+
 #include "common/Assertions.h"
 #include "common/StringUtil.h"
 #include "common/ScopedGuard.h"
@@ -185,6 +187,60 @@ SocketAdapter::SocketAdapter()
 
 	sendThreadId = std::this_thread::get_id();
 
+	// Pre-bind configured UDP ports for inbound traffic.
+	// This allows host-to-PS2 communication (e.g. ps2link commands)
+	// by creating listening sockets before the PS2 sends any traffic.
+	if (!EmuConfig.DEV9.EthUDPPorts.empty())
+	{
+		std::istringstream portStream(EmuConfig.DEV9.EthUDPPorts);
+		std::string portStr;
+		while (std::getline(portStream, portStr, ','))
+		{
+			// Trim whitespace
+			portStr.erase(0, portStr.find_first_not_of(" \t"));
+			portStr.erase(portStr.find_last_not_of(" \t") + 1);
+
+			if (portStr.empty())
+				continue;
+
+			const int portNum = std::atoi(portStr.c_str());
+			if (portNum <= 0 || portNum > 65535)
+			{
+				Console.Error("DEV9: Socket: Invalid UDP listen port: %s", portStr.c_str());
+				continue;
+			}
+
+			const u16 port = static_cast<u16>(portNum);
+
+			ConnectionKey fKey{};
+			fKey.protocol = static_cast<u8>(IP_Type::UDP);
+			fKey.ps2Port = port;
+			fKey.srvPort = 0;
+
+			// Use the configured PS2 IP from settings for packet routing.
+			// In Sockets mode, dhcpServer.ps2IP is always 192.0.2.100 (virtual),
+			// but the PS2 may use a different static IP (e.g. from IPCONFIG.DAT).
+			const IP_Address configuredIP = *reinterpret_cast<const IP_Address*>(&EmuConfig.DEV9.PS2IP);
+			const IP_Address listenSourceIP = (configuredIP.integer != 0) ? configuredIP : dhcpServer.ps2IP;
+
+			Console.WriteLn("DEV9: Socket: Pre-binding UDP listen port %d (PS2 IP: %d.%d.%d.%d)", port,
+				listenSourceIP.bytes[0], listenSourceIP.bytes[1],
+				listenSourceIP.bytes[2], listenSourceIP.bytes[3]);
+
+			UDP_FixedPort* fPort = new UDP_FixedPort(fKey, adapterIP, port);
+			fPort->isListening = true;
+			fPort->AddConnectionClosedHandler([&](BaseSession* session) { HandleFixedPortClosed(session); });
+
+			fPort->destIP = {};
+			fPort->sourceIP = listenSourceIP;
+
+			connections.Add(fKey, fPort);
+			fixedUDPPorts.Add(port, fPort);
+
+			fPort->Init();
+		}
+	}
+
 	initialized = true;
 }
 
@@ -234,6 +290,7 @@ bool SocketAdapter::recv(NetPacket* pkt)
 				IP_Packet* ipPkt = new IP_Packet(pl->payload.release());
 				ipPkt->destinationIP = session->sourceIP;
 				ipPkt->sourceIP = pl->sourceIP;
+				ipPkt->timeToLive = 64;
 
 				EthernetFrame frame(ipPkt);
 				frame.sourceMAC = internalMAC;

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1346,6 +1346,8 @@ void Pcsx2Config::DEV9Options::LoadSave(SettingsWrapper& wrap)
 		SettingsWrapEntry(AutoGateway);
 		SettingsWrapEnumEx(ModeDNS1, "ModeDNS1", DnsModeNames);
 		SettingsWrapEnumEx(ModeDNS2, "ModeDNS2", DnsModeNames);
+
+		SettingsWrapEntry(EthUDPPorts);
 	}
 
 	if (wrap.IsLoading())
@@ -1419,6 +1421,8 @@ bool Pcsx2Config::DEV9Options::operator==(const DEV9Options& right) const
 		   OpEqu(ModeDNS2) &&
 
 		   OpEqu(EthHosts) &&
+
+		   OpEqu(EthUDPPorts) &&
 
 		   OpEqu(HddEnable) &&
 		   OpEqu(HddFile);

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1341,6 +1341,8 @@ void Pcsx2Config::DEV9Options::LoadSave(SettingsWrapper& wrap)
 		SettingsWrapEntry(AutoGateway);
 		SettingsWrapEnumEx(ModeDNS1, "ModeDNS1", DnsModeNames);
 		SettingsWrapEnumEx(ModeDNS2, "ModeDNS2", DnsModeNames);
+
+		SettingsWrapEntry(EthUDPPorts);
 	}
 
 	if (wrap.IsLoading())
@@ -1414,6 +1416,8 @@ bool Pcsx2Config::DEV9Options::operator==(const DEV9Options& right) const
 		   OpEqu(ModeDNS2) &&
 
 		   OpEqu(EthHosts) &&
+
+		   OpEqu(EthUDPPorts) &&
 
 		   OpEqu(HddEnable) &&
 		   OpEqu(HddFile);


### PR DESCRIPTION
### Description of Changes

Add an `EthUDPPorts` setting (comma-separated port list) that pre-binds UDP ports on the host when using Sockets mode. This allows inbound UDP traffic from the host to reach the emulated PS2.

Currently in Sockets mode, UDP ports are only bound when the PS2 sends a packet first. PS2 software that listens for incoming UDP without sending first (e.g. ps2link on port 18194) cannot receive traffic from the host. This change creates `UDP_FixedPort` entries at adapter initialization with an `isListening` flag that accepts packets from any source.

A "UDP Ports" text field is added to the Network & HDD settings page (Intercept DHCP tab) so users can configure this from the UI.

Also fixes two issues with received IP packets:
- Set TTL=64 (was 0, which could cause the PS2 network stack to discard packets)
- Use configured `PS2IP` for destination routing on listening ports (`dhcpServer.ps2IP` is always `192.0.2.100` in Sockets mode, which doesn't match the PS2's static IP)

### Rationale behind Changes

Enables `ps2client` (the standard PS2 development tool) to communicate with ps2link running inside PCSX2, which is essential for PS2 homebrew development workflows. Previously, `ps2client` commands like `execee` and `reset` could only work on real hardware because the Sockets adapter didn't support inbound UDP.

With this change, developers can use:
```
ps2client -h 127.0.0.1 execee host:program.elf
ps2client -h 127.0.0.1 reset
```

### Suggested Testing Steps

1. Go to Settings > Network & HDD
2. Set Ethernet Device Type to Sockets, enable Ethernet
3. In the Intercept DHCP tab: enable Intercept DHCP, set PS2 Address to match your ps2link IPCONFIG.DAT (e.g. `192.168.1.10`), and set UDP Ports to `18194`
4. Boot ps2link in PCSX2
5. Verify ports are bound: `lsof -nP -c PCSX2 | grep UDP` should show `*:18194`
6. Run `ps2client -h 127.0.0.1 execee host:hello.elf` — the ELF should load and execute
7. Run `ps2client -h 127.0.0.1 reset` — ps2link should process the reset command (note: PCSX2's IOP recompiler may crash on the soft reboot, which is a pre-existing limitation)

### Did you use AI to help find, test, or implement this issue or feature?

Yes. Claude (Anthropic) was used to analyze the DEV9 Sockets adapter architecture, implement the changes, and iteratively debug the packet routing (destination IP mismatch and TTL=0 issues).