### PR TITLE
IOP: Map IOP RAM mirrors in recompiler lookup table

### DIFF
--- a/pcsx2/HwWrite.cpp
+++ b/pcsx2/HwWrite.cpp
@@ -178,6 +178,7 @@ void _hwWrite32( u32 mem, u32 value )
 						u64 cycle = psxRegs.cycle;
 						//pgifInit();
 						psxReset();
+						psxCpu->Reset();
 						PSXCLK =  33868800;
 						SPU2::Reset(true);
 						setPs1CDVDSpeed(cdvd.Speed);


### PR DESCRIPTION
### Description of Changes

Map IOP RAM mirror pages throughout kuseg (0x0000-0x1DFF) in the IOP recompiler's lookup table (recLUT). Previously only pages 0x0000-0x007F were mapped, but the PS2 IOP hardware mirrors its 2MB (or 8MB) RAM across the entire kuseg address space (0x00000000-0x1DFFFFFF).

### Rationale behind Changes

The PS2 BIOS uses mirrored IOP RAM addresses during IOP soft resets (SifIopReset). For example, the BIOS reset handler jumps to address `0x0d000100`, which mirrors to physical `0x00000100` in IOP RAM. Without the mirror mapping in recLUT, this jump triggers a "Jump to unmapped recLUT page (PC: 0x0d000100)" crash.

This prevented `SifIopReset()` from working at runtime, which is used by:
- ps2link's reset command (`ps2client reset`)
- Games and homebrew that reload IOP modules
- Any PS2 software that performs IOP soft resets after initial boot

The kseg0/kseg1 mappings (0x8000, 0xa000) remain at 0x80 pages since those kernel segments use direct physical addressing and don't mirror.

### Suggested Testing Steps

1. Boot ps2link in PCSX2
2. Run `ps2client -h 127.0.0.1 reset` (requires EthUDPPorts from PR #14285, or use any method that triggers SifIopReset from PS2 software)
3. **Before fix**: PCSX2 crashes with "Jump to unmapped recLUT page (PC: 0x0d000100)"
4. **After fix**: IOP soft reboot completes successfully — ps2link reloads all modules (SMAP, ps2ip, udptty) and is ready for new commands
5. Run `ps2client -h 127.0.0.1 execee host:hello.elf` after the reset to verify full functionality

Tested with the latest ps2link development release (77aca107) — reset + execee cycle works reliably.

### Did you use AI to help find, test, or implement this issue or feature?

Yes. Claude (Anthropic) was used to investigate the crash through multiple iterations: initially suspected the SBUS_F240 handler (which turned out to be uninvolved), then traced the crash to the IOP BIOS using mirrored RAM addresses not mapped in the recLUT. Debug logging confirmed the IOP register state at crash time (ra=0x000151d0, PC=0x0d000100), which led to identifying the missing kuseg mirror mapping.