### PR TITLE
IOP: Reset recompiler and map RAM mirrors on IOP soft reset

### DIFF
--- a/pcsx2/HwWrite.cpp
+++ b/pcsx2/HwWrite.cpp
@@ -178,6 +178,7 @@ void _hwWrite32( u32 mem, u32 value )
 						u64 cycle = psxRegs.cycle;
 						//pgifInit();
 						psxReset();
+						psxCpu->Reset();
 						PSXCLK =  33868800;
 						SPU2::Reset(true);
 						setPs1CDVDSpeed(cdvd.Speed);

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -955,16 +955,23 @@ void recResetIOP()
 	// The bottom 2 bits of PC are always zero, so we <<14 to "compress"
 	// the pc indexer into it's lower common denominator.
 
-	// We're only mapping 20 pages here in 4 places.
-	// 0x80 comes from : (Ps2MemSize::IopRam / _64kb) * 4
-
-	for (int i = 0; i < 0x80; i++)
+	// Map IOP RAM with mirrors throughout kuseg (0x0000-0x1DFF).
+	// The PS2 IOP mirrors its 2MB (or 8MB) RAM across the entire kuseg
+	// address space. The BIOS uses mirrored addresses (e.g. 0x0d000100
+	// which maps to physical 0x00000100) during IOP soft resets.
 	{
-		u32 mask = (Ps2MemSize::ExposedIopRam / _64kb) - 1;
+		const u32 mask = (Ps2MemSize::ExposedIopRam / _64kb) - 1;
 
-		recLUT_SetPage(psxRecLUT, psxhwLUT, recRAM, 0x0000, i, i & mask);
-		recLUT_SetPage(psxRecLUT, psxhwLUT, recRAM, 0x8000, i, i & mask);
-		recLUT_SetPage(psxRecLUT, psxhwLUT, recRAM, 0xa000, i, i & mask);
+		for (int i = 0; i < 0x1e00; i++)
+		{
+			recLUT_SetPage(psxRecLUT, psxhwLUT, recRAM, 0x0000, i, i & mask);
+		}
+
+		for (int i = 0; i < 0x80; i++)
+		{
+			recLUT_SetPage(psxRecLUT, psxhwLUT, recRAM, 0x8000, i, i & mask);
+			recLUT_SetPage(psxRecLUT, psxhwLUT, recRAM, 0xa000, i, i & mask);
+		}
 	}
 
 	for (int i = 0x1fc0; i < 0x2000; i++)


### PR DESCRIPTION
## Summary

Fixes IOP soft reset (`SifIopReset`) crashing with stale recompiler blocks.

When `SifIopReset` triggers (SBUS_F240 bit 19), `psxReset()` reloads the IOP BIOS kernel into RAM but does **not** flush the IOP recompiler cache. The recompiler keeps stale compiled x86 blocks for IOP RAM addresses that now contain different code. When the fresh kernel executes, the recompiler serves old translations, causing the IOP to crash on garbage instructions (`psxUNK`).

### Changes

1. **`psxCpu->Reset()` after `psxReset()` in the SBUS_F240 handler** — flushes all cached recompiler blocks, forcing fresh recompilation from the new RAM contents. This is the critical fix.

2. **Map IOP RAM mirrors in recLUT (kuseg pages 0x0000-0x1DFF)** — the PS2 IOP mirrors its 2MB RAM across the entire kuseg address space. The BIOS uses mirrored addresses during soft resets (e.g. `0x0d000100` → physical `0x00000100`). Without mirrored pages in recLUT, code at mirrored addresses hits unmapped pages.

### How it was found

Tested with ps2link performing `SifIopReset` via `ps2client reset`. Without the fix:
- `psxReset()` reloads the IOP kernel
- IOP starts executing (DEV9 hardware detection runs)
- Recompiler serves stale blocks → `psxUNK: f0000102` crash
- The "Soft reboot" log message never appears after the reset

With the fix, the recompiler cache is flushed and the IOP reboots cleanly.

### Test plan

- [ ] `ps2client reset` performs a clean IOP soft reboot
- [ ] Consecutive `ps2client reset` commands work
- [ ] `ps2client execee` + `ps2client reset` cycle works
- [ ] No regression in normal game boot (which also uses IOP soft resets during BIOS init)