### PR TITLE
Qt: Fix Games Not Launching on the Correct Display When Rendering to Main

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -2582,7 +2582,7 @@ void MainWindow::createDisplayWidget(bool fullscreen, bool render_to_main)
 
 #ifdef DISPLAY_SURFACE_WINDOW
 		if (isVisible() && g_emu_thread->shouldRenderToMain())
-			m_display_surface->setPosition(screen()->availableGeometry().topLeft());
+			m_display_surface->setGeometry(screen()->geometry());
 		else
 			restoreDisplayWindowGeometryFromConfig();
 


### PR DESCRIPTION
### Description of Changes
Replace setPosition with setGeometry. This makes sure when rendering to main window, it stays on the current display the main window is currently positioned at. 

### Rationale behind Changes
This fixes the bug where rendering to main a game would launch on the primary monitor instead of the monitor that is currently on. Not everyone may need this fix (see comments under #14289 ). Before testing, make sure your multi-monitor setup needs this fix.

### Suggested Testing Steps
1. Verify "Render to Separate Window " is not turned on in the Interface settings.
2. Move the main window to a monitor that isn't your primary, start a game, fullscreen it (or Start Fullscreen), and check the main window hasn't moved to your primary monitor. 

### Did you use AI to help find, test, or implement this issue or feature?
No.
