### PR TITLE
GS:MTL: Support 32K textures on M5

### DIFF
--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -35,14 +35,7 @@ std::vector<GSAdapterInfo> GetMetalAdapterList()
 	{
 		GSAdapterInfo ai;
 		ai.name = [[dev name] UTF8String];
-		
-		ai.max_texture_size = 8192;
-		if ([dev supportsFeatureSet:MTLFeatureSet_macOS_GPUFamily1_v1])
-			ai.max_texture_size = 16384;
-		if (@available(macOS 10.15, iOS 13.0, *))
-			if ([dev supportsFamily:MTLGPUFamilyApple3])
-				ai.max_texture_size = 16384;
-
+		ai.max_texture_size = GSMTLDevice::GetMaxTextureSize(dev);
 		ai.max_upscale_multiplier = GSGetMaxUpscaleMultiplier(ai.max_texture_size);
 		list.push_back(std::move(ai));
 	}

--- a/pcsx2/GS/Renderers/Metal/GSMTLDeviceInfo.h
+++ b/pcsx2/GS/Renderers/Metal/GSMTLDeviceInfo.h
@@ -42,6 +42,8 @@ struct GSMTLDevice
 	GSMTLDevice() = default;
 	explicit GSMTLDevice(MRCOwned<id<MTLDevice>> dev);
 
+	static u32 GetMaxTextureSize(id<MTLDevice> dev);
+
 	bool IsOk() const { return dev && shaders; }
 	void Reset()
 	{

--- a/pcsx2/GS/Renderers/Metal/GSMTLDeviceInfo.mm
+++ b/pcsx2/GS/Renderers/Metal/GSMTLDeviceInfo.mm
@@ -200,6 +200,9 @@ u32 GSMTLDevice::GetMaxTextureSize(id<MTLDevice> dev)
 {
 	if (@available(macOS 10.15, iOS 13.0, *))
 	{
+		MTLGPUFamily apple10 = static_cast<MTLGPUFamily>(1010); // Avoid relying on latest SDK, define ourselves
+		if ([dev supportsFamily:apple10])
+			return 32768;
 		if ([dev supportsFamily:MTLGPUFamilyApple3])
 			return 16384;
 	}

--- a/pcsx2/GS/Renderers/Metal/GSMTLDeviceInfo.mm
+++ b/pcsx2/GS/Renderers/Metal/GSMTLDeviceInfo.mm
@@ -191,14 +191,21 @@ GSMTLDevice::GSMTLDevice(MRCOwned<id<MTLDevice>> dev)
 	else
 		features.slow_color_compression = [[dev name] containsString:@"AMD"] || [[dev name] isEqualToString:@"Intel HD Graphics 4000"];
 
-	features.max_texsize = 8192;
-	if ([dev supportsFeatureSet:MTLFeatureSet_macOS_GPUFamily1_v1])
-		features.max_texsize = 16384;
-	if (@available(macOS 10.15, iOS 13.0, *))
-		if ([dev supportsFamily:MTLGPUFamilyApple3])
-			features.max_texsize = 16384;
+	features.max_texsize = GetMaxTextureSize(dev);
 
 	this->dev = std::move(dev);
+}
+
+u32 GSMTLDevice::GetMaxTextureSize(id<MTLDevice> dev)
+{
+	if (@available(macOS 10.15, iOS 13.0, *))
+	{
+		if ([dev supportsFamily:MTLGPUFamilyApple3])
+			return 16384;
+	}
+	if ([dev supportsFeatureSet:MTLFeatureSet_macOS_GPUFamily1_v1])
+		return 16384;
+	return 8192;
 }
 
 const char* to_string(GSMTLDevice::MetalVersion ver)


### PR DESCRIPTION
### Description of Changes
Adds 32K texture support to the Metal renderer on supporting hardware (currently M5 only)

### Rationale behind Changes
If there's hardware support we should give software support

### Suggested Testing Steps
If anyone has an M5, see if you can use high upscale multipliers

### Did you use AI to help find, test, or implement this issue or feature?
No