### PR TITLE
GS/DX12: Fix render pass optimization not being properly hit.

### DIFF
--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -4288,12 +4288,12 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 			draw_rt = m_current_render_target;
 			m_pipeline_selector.rt = true;
 		}
-	}
-	else if (!draw_ds && m_current_depth_target && config.tex != m_current_depth_target &&
-			 m_current_depth_target->GetSize() == draw_rt->GetSize())
-	{
-		draw_ds = m_current_depth_target;
-		m_pipeline_selector.ds = true;
+		else if (!draw_ds && m_current_depth_target && config.tex != m_current_depth_target &&
+				 m_current_depth_target->GetSize() == draw_rt->GetSize())
+		{
+			draw_ds = m_current_depth_target;
+			m_pipeline_selector.ds = true;
+		}
 	}
 
 	GSTexture12* draw_ds_as_rt = static_cast<GSTexture12*>(config.ds_as_rt);

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -3363,7 +3363,7 @@ void GSDevice12::ExecuteCommandListAndRestartRenderPass(bool wait_for_completion
 {
 	Console.Warning("D3D12: Executing command buffer due to '%s'", reason);
 
-	const bool was_in_render_pass = m_in_render_pass;
+	const bool was_in_render_pass = InRenderPass();
 	EndRenderPass();
 	ExecuteCommandList(GetWaitType(wait_for_completion, GSConfig.HWSpinCPUForReadbacks));
 	InvalidateCachedState();
@@ -4278,7 +4278,7 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 		(draw_ds && static_cast<GSTexture12*>(draw_ds)->GetSRVDescriptor() == m_tfx_textures[0])))
 		PSSetShaderResource(0, nullptr, false);
 
-	if (m_in_render_pass && (m_current_render_target == draw_rt || m_current_depth_target == draw_ds))
+	if (InRenderPass() && (m_current_render_target == draw_rt || m_current_depth_target == draw_ds))
 	{
 		// avoid restarting the render pass just to switch from rt+depth to rt and vice versa
 		// keep the depth even if doing colclip hw draws, because the next draw will probably re-enable depth
@@ -4338,7 +4338,7 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 	}
 
 	// Begin render pass if new target or out of the area.
-	if (!m_in_render_pass)
+	if (!InRenderPass())
 	{
 		GSVector4 clear_color = draw_rt ? draw_rt->GetUNormClearColor() : GSVector4::zero();
 		if (pipe.ps.colclip_hw)


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/DX12: Fix render pass optimization not being properly hit.
The depth target render pass optimization wasn't being hit properly, so let's synch it with the other renderers.

Some games do gain some render passes but this is now the correct behaviour, the block should be inside.
This was probably a bad copy paste.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Optimization, speed.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Most render pass reductions are within single to double digits, triple digits worth benchmarking are mentioned below:
```
Winning Post 7 SLPM-66904_20230228212709
Render Passes: -289 [869=>580]
Sly_2_-_Band_of_Thieves_SCUS-97316_20221019165824
Render Passes: -609 [668=>59]
Tekken_5_SLUS-21059_20240108195029
Render Passes: -173 [207=>34]
```

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.