### PR TITLE
GS/TC: Fix alpha write masking check in target update.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -3001,7 +3001,7 @@ GSTextureCache::Target* GSTextureCache::LookupTarget(GIFRegTEX0 TEX0, const GSVe
 
 		if ((preserve_target || !dst->m_valid.rintersect(draw_rect).eq(dst->m_valid)) &&
 			!dst->m_valid_rgb && !FullRectDirty(dst, 0x7) &&
-			(GSLocalMemory::m_psm[TEX0.PSM].trbpp < 24 || fbmask != 0x00FFFFFFu))
+			(GSLocalMemory::m_psm[TEX0.PSM].trbpp < 24 || ((fbmask & 0x00FFFFFFu) != 0x00FFFFFFu)))
 		{
 			// Neo Contra clears 0x1400 with Z16S, then uses that address to upload C32 frames, this gets confused and makes a mess of it.
 			// TODO: Look in to making sure bad format conversions don't happen.


### PR DESCRIPTION
Status: draft until dumps runs complete.

### Description of Changes
Fix a masking check in target lookups that check if only alpha is written in the draw.

Thanks @refractionpcsx2 for help during debugging.

### Rationale behind Changes
Avoid incorrectly updating RGB in  target when we don't need it, since this may nuke depth targets in the process.

Fixes https://github.com/PCSX2/pcsx2/issues/14299.

### Suggested Testing Steps
Test the dump in the issue, or any game with any HW renderer.

### Did you use AI to help find, test, or implement this issue or feature?
No.