### PR TITLE
GS/HW: Add setting to do autoflush draws with a copy loop.

### DIFF
--- a/pcsx2-qt/Settings/GraphicsHardwareFixesSettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsHardwareFixesSettingsTab.ui
@@ -267,6 +267,11 @@
        <string>Enabled (All Primitives)</string>
       </property>
      </item>
+     <item>
+      <property name="text">
+       <string>Batch Enabled (All Primitives)</string>
+      </property>
+     </item>
     </widget>
    </item>
    <item row="7" column="0" colspan="2">

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -417,6 +417,7 @@ enum class GSHWAutoFlushLevel : u8
 	Disabled,
 	SpritesOnly,
 	Enabled,
+	BatchEnabled,
 };
 
 enum class GSGPUTargetCLUTMode : u8

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -1882,6 +1882,7 @@ void GSState::Flush(GSFlushReason reason)
 
 		m_dirty_gs_regs = 0;
 		temp_draw_rect = GSVector4i::zero();
+		ResetAutoFlushList();
 	}
 
 	m_state_flush_reason = GSFlushReason::UNKNOWN;
@@ -2068,6 +2069,11 @@ void GSState::FlushPrim()
 			}
 
 			pxAssert((int)unused < GSUtil::GetVertexCount(PRIM->PRIM));
+		}
+
+		if (HasAutoFlushList())
+		{
+			UpdateAutoFlushList();
 		}
 
 		// If the PSM format of Z is invalid, but it is masked (no write) and ZTST is set to ALWAYS pass (no test, just allow)
@@ -4223,6 +4229,126 @@ GSState::PRIM_OVERLAP GSState::PrimitiveOverlap(bool save_drawlist)
 	return GetPrimitiveOverlapDrawlist(save_drawlist);
 }
 
+template<u32 primclass, bool fst>
+void GSState::ProcessAutoflushDrawlistImpl(float pos_scale, float tex_scale)
+{
+	if (!m_drawlist.empty())
+	{
+		// Chop the barrier drawlist to fit within each autoflush draw.
+		std::vector<size_t> drawlist;
+		drawlist.reserve(m_drawlist.capacity());
+		for (size_t i = 0, j = 0; i < m_autoflush_list.size(); i++)
+		{
+			int prims = static_cast<int>(m_autoflush_list[i]);
+			while (prims > 0)
+			{
+				if (m_drawlist[j] > static_cast<size_t>(prims))
+				{
+					drawlist.push_back(prims);
+					m_drawlist[j] -= prims;
+					prims = 0;
+				}
+				else
+				{
+					drawlist.push_back(m_drawlist[j]);
+					prims -= m_drawlist[j];
+					m_drawlist[j] = 0;
+					j++;
+				}
+			}
+		}
+		m_drawlist = std::move(drawlist);
+	}
+	else
+	{
+		// If we don't need barrier, simply copy the autoflush list as the drawlist
+		// since it makes handling the cases with/without barriers simpler.
+		const size_t n_elems = m_autoflush_list.size();
+		m_drawlist.resize(n_elems);
+		std::memcpy(m_drawlist.data(), m_autoflush_list.data(), sizeof(m_autoflush_list[0]) * n_elems);
+	}
+
+	constexpr int n = GSUtil::GetClassVertexCount(primclass);
+
+	const GSVertex* RESTRICT verts = m_vertex.buff;
+	const u16* RESTRICT index = m_index.buff;
+
+	const auto ProcessBBox = [](GSVector4 bbox, float scale) {
+		bbox += GSVector4(-1.0f, -1.0f, 1.0f, 1.0f); // Expand 1 native pixel.
+		bbox *= scale; // Upscaling
+		bbox = bbox.floor().xyzw(bbox.ceil()); // Rounding.
+		return GSVector4i(bbox);
+	};
+
+	// Compute the texture bboxes.
+	for (size_t i = 0, idx = 0; i < m_autoflush_list.size(); i++)
+	{
+		GSVector4 bbox(FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX);
+
+		const size_t n_prims = m_autoflush_list[i];
+		for (size_t j = 0; j < n_prims; j++, idx += n)
+		{
+			for (size_t k = 0; k < n; k++)
+			{
+				const GSVertex& v = verts[index[idx + k]];
+				const float q = (primclass == GS_SPRITE_CLASS) ? verts[index[idx + 1]].RGBAQ.Q : v.RGBAQ.Q;
+				GSVector4 tex = GetTexCoordsImpl<fst>(v, q);
+				bbox = bbox.min(tex).xyzw(bbox.max(tex));
+			}
+		}
+
+		m_autoflush_bbox.push_back(ProcessBBox(bbox, tex_scale));
+	}
+
+	// Recompute the position bboxes if needed.
+	if (m_drawlist_bbox.size() > 0)
+	{
+		m_drawlist_bbox.clear();
+
+		for (size_t i = 0, idx = 0; i < m_drawlist.size(); i++)
+		{
+			GSVector4i bbox(INT_MAX, INT_MAX, INT_MIN, INT_MIN);
+
+			const size_t n_prims = m_drawlist[i];
+			for (size_t j = 0; j < n_prims; j++, idx += n)
+			{
+				for (size_t k = 0; k < n; k++)
+				{
+					bbox = bbox.runion(GetVertexXY(verts[index[idx + k]]));
+				}
+			}
+
+			const GSVector4i xyof = m_context->scissor.xyof.xyxy();
+			GSVector4 bbox_f = GSVector4(bbox - xyof) / 16.0f;
+			m_drawlist_bbox.push_back(ProcessBBox(bbox_f, pos_scale));
+		}
+	}
+}
+
+void GSState::ProcessAutoflushDrawlist(float pos_scale, float tex_scale)
+{
+	pxAssertRel(PRIM->TME, "Autoflush drawlist only valid with texture mapping.");
+
+	switch (m_vt.m_primclass)
+	{
+		case GS_SPRITE_CLASS:
+			if (PRIM->FST)
+				ProcessAutoflushDrawlistImpl<GS_SPRITE_CLASS, true>(pos_scale, tex_scale);
+			else
+				ProcessAutoflushDrawlistImpl<GS_SPRITE_CLASS, false>(pos_scale, tex_scale);
+			break;
+		case GS_TRIANGLE_CLASS:
+			if (PRIM->FST)
+				ProcessAutoflushDrawlistImpl<GS_TRIANGLE_CLASS, true>(pos_scale, tex_scale);
+			else
+				ProcessAutoflushDrawlistImpl<GS_TRIANGLE_CLASS, false>(pos_scale, tex_scale);
+			break;
+		default:
+			pxFail("Autoflush drawlist only for triangles/sprites.");
+			break;
+	}
+}
+
 bool GSState::SpriteDrawWithoutGaps()
 {
 	// Check that the height matches. Xenosaga 3 draws a letterbox around
@@ -4790,6 +4916,34 @@ void GSState::GetQuadRasterizedPoints(GSVector4& xy, bool keep_order)
 	GetQuadRasterizedPoints(xy, tex_ignore, keep_order);
 }
 
+__forceinline bool GSState::CanUseAutoFlushList() const
+{
+	// Can combine if recursive color draw and source/RT are basically the same
+	// format (aside from 24/32 bit difference).
+	return m_context->TEX0.TBP0 == m_context->FRAME.Block() &&
+		(m_context->TEX0.PSM & ~1) == (m_context->FRAME.PSM & ~1) &&
+		GSIsHardwareRenderer();
+}
+
+__forceinline void GSState::ResetAutoFlushList()
+{
+	m_autoflush_list.clear();
+	m_autoflush_bbox.clear();
+	m_autoflush_tail = 0;
+}
+
+__forceinline void GSState::UpdateAutoFlushList()
+{
+	if (NumQueuedIndices() > 0)
+	{
+		const int n = GSUtil::GetVertexCount(PRIM->PRIM);
+		m_autoflush_list.push_back(NumQueuedIndices() / n);
+		m_autoflush_tail = m_index.tail;
+		temp_draw_rect = GSVector4i::zero(); // Reset draw rect since it's used for autoflush overlap.
+		m_texflush_flag = false; // Reset TEXFLUSH since this is equivalent to starting a new draw.
+	}
+}
+
 __forceinline bool GSState::IsAutoFlushDraw(u32 prim, int& tex_layer)
 {
 	if (!PRIM->TME || (GSConfig.UserHacks_AutoFlush == GSHWAutoFlushLevel::SpritesOnly && prim != GS_SPRITE))
@@ -4931,8 +5085,19 @@ template<u32 prim>
 __forceinline void GSState::HandleAutoFlush()
 {
 	// Kind of a cheat, making the assumption that 2 consecutive fan/strip triangles won't overlap each other (*should* be safe)
-	if ((m_index.tail & 1) && (prim == GS_TRIANGLESTRIP || prim == GS_TRIANGLEFAN) && !m_texflush_flag)
+	if ((NumQueuedIndices() & 1) && (prim == GS_TRIANGLESTRIP || prim == GS_TRIANGLEFAN) && !m_texflush_flag)
 		return;
+
+	const auto DoFlush = [&]() {
+		if (GSConfig.UserHacks_AutoFlush == GSHWAutoFlushLevel::BatchEnabled && CanUseAutoFlushList())
+		{
+			UpdateAutoFlushList();
+		}
+		else
+		{
+			Flush(GSFlushReason::AUTOFLUSH);
+		}
+	};
 
 	// To briefly explain what's going on here, what we are checking for is draws over a texture when the source and destination are themselves.
 	// Because one page of the texture gets buffered in the Texture Cache (the PS2's one) if any of those pixels are overwritten, you still read the old data.
@@ -5133,7 +5298,7 @@ __forceinline void GSState::HandleAutoFlush()
 			return;
 		else if (m_texflush_flag)
 		{
-			Flush(GSFlushReason::AUTOFLUSH);
+			DoFlush();
 			return;
 		}
 
@@ -5153,8 +5318,9 @@ __forceinline void GSState::HandleAutoFlush()
 				const GSVector4i scissor = m_context->scissor.in;
 				GSVector4i old_draw_rect = GSVector4i::zero();
 				int current_draw_end = m_index.tail;
+				const int current_draw_start = static_cast<int>(m_autoflush_tail);
 
-				while (current_draw_end >= n)
+				while (current_draw_end >= current_draw_start + n)
 				{
 					for (int i = current_draw_end - 1; i >= current_draw_end - n; i--)
 					{
@@ -5204,7 +5370,7 @@ __forceinline void GSState::HandleAutoFlush()
 					old_draw_rect = tex_rect.rintersect(old_draw_rect);
 					if (!old_draw_rect.rintersect(scissor).rempty())
 					{
-						Flush(GSFlushReason::AUTOFLUSH);
+						DoFlush();
 						return;
 					}
 
@@ -5231,10 +5397,10 @@ __forceinline void GSState::HandleAutoFlush()
 					area_out = GSVector4i(area_out.x / frame_psm.pgs.x, area_out.y / frame_psm.pgs.y, area_out.z / frame_psm.pgs.x, area_out.w / frame_psm.pgs.y);
 
 					if (!area_out.rintersect(tex_rect).rempty())
-						Flush(GSFlushReason::AUTOFLUSH);
+						DoFlush();
 				}
 				else // Formats are too different so just flush it.
-					Flush(GSFlushReason::AUTOFLUSH);
+					DoFlush();
 			}
 		}
 	}
@@ -5254,7 +5420,7 @@ __forceinline void GSState::VertexKick(u32 skip)
 		return;
 	}
 
-	if (auto_flush && skip == 0 && m_index.tail > 0 && ((m_vertex.tail + 1) - m_vertex.head) >= n)
+	if (auto_flush && skip == 0 && NumQueuedIndices() > 0 && ((m_vertex.tail + 1) - m_vertex.head) >= n)
 	{
 		HandleAutoFlush<prim>();
 	}
@@ -5497,7 +5663,7 @@ __forceinline void GSState::VertexKick(u32 skip)
 	// Update rectangle for the current draw. We can use the re-integer coordinates from min/max here.
 	const GSVector4i draw_min = pmin.zwzw();
 	const GSVector4i draw_max = pmax;
-	if (m_vertex.tail != n)
+	if (NumQueuedIndices() > n)
 		temp_draw_rect = temp_draw_rect.min_i32(draw_min).blend32<12>(temp_draw_rect.max_i32(draw_max));
 	else
 		temp_draw_rect = draw_min.blend32<12>(draw_max);

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2371,6 +2371,7 @@ void GSState::FlushDraw(GSFlushReason reason)
 
 		m_dirty_gs_regs = 0;
 		temp_draw_rect = GSVector4i::zero();
+		ResetAutoFlushList();
 	}
 
 	m_state_flush_reason = GSFlushReason::UNKNOWN;
@@ -2559,6 +2560,11 @@ void GSState::FlushPrim()
 			}
 
 			pxAssert((int)unused < GSUtil::GetVertexCount(PRIM->PRIM));
+		}
+
+		if (HasAutoFlushList())
+		{
+			UpdateAutoFlushList();
 		}
 
 		// If the PSM format of Z is invalid, but it is masked (no write) and ZTST is set to ALWAYS pass (no test, just allow)
@@ -4773,6 +4779,126 @@ GSState::PRIM_OVERLAP GSState::PrimitiveOverlap(bool save_drawlist)
 	return GetPrimitiveOverlapDrawlist(save_drawlist);
 }
 
+template<u32 primclass, bool fst>
+void GSState::ProcessAutoflushDrawlistImpl(float pos_scale, float tex_scale)
+{
+	if (!m_drawlist.empty())
+	{
+		// Chop the barrier drawlist to fit within each autoflush draw.
+		std::vector<size_t> drawlist;
+		drawlist.reserve(m_drawlist.capacity());
+		for (size_t i = 0, j = 0; i < m_autoflush_list.size(); i++)
+		{
+			int prims = static_cast<int>(m_autoflush_list[i]);
+			while (prims > 0)
+			{
+				if (m_drawlist[j] > static_cast<size_t>(prims))
+				{
+					drawlist.push_back(prims);
+					m_drawlist[j] -= prims;
+					prims = 0;
+				}
+				else
+				{
+					drawlist.push_back(m_drawlist[j]);
+					prims -= m_drawlist[j];
+					m_drawlist[j] = 0;
+					j++;
+				}
+			}
+		}
+		m_drawlist = std::move(drawlist);
+	}
+	else
+	{
+		// If we don't need barrier, simply copy the autoflush list as the drawlist
+		// since it makes handling the cases with/without barriers simpler.
+		const size_t n_elems = m_autoflush_list.size();
+		m_drawlist.resize(n_elems);
+		std::memcpy(m_drawlist.data(), m_autoflush_list.data(), sizeof(m_autoflush_list[0]) * n_elems);
+	}
+
+	constexpr int n = GSUtil::GetClassVertexCount(primclass);
+
+	const GSVertex* RESTRICT verts = m_vertex->buff;
+	const u16* RESTRICT index = m_index->buff;
+
+	const auto ProcessBBox = [](GSVector4 bbox, float scale) {
+		bbox += GSVector4(-1.0f, -1.0f, 1.0f, 1.0f); // Expand 1 native pixel.
+		bbox *= scale; // Upscaling
+		bbox = bbox.floor().xyzw(bbox.ceil()); // Rounding.
+		return GSVector4i(bbox);
+	};
+
+	// Compute the texture bboxes.
+	for (size_t i = 0, idx = 0; i < m_autoflush_list.size(); i++)
+	{
+		GSVector4 bbox(FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX);
+
+		const size_t n_prims = m_autoflush_list[i];
+		for (size_t j = 0; j < n_prims; j++, idx += n)
+		{
+			for (size_t k = 0; k < n; k++)
+			{
+				const GSVertex& v = verts[index[idx + k]];
+				const float q = (primclass == GS_SPRITE_CLASS) ? verts[index[idx + 1]].RGBAQ.Q : v.RGBAQ.Q;
+				GSVector4 tex = GetTexCoordsImpl<fst>(v, q);
+				bbox = bbox.min(tex).xyzw(bbox.max(tex));
+			}
+		}
+
+		m_autoflush_bbox.push_back(ProcessBBox(bbox, tex_scale));
+	}
+
+	// Recompute the position bboxes if needed.
+	if (m_drawlist_bbox.size() > 0)
+	{
+		m_drawlist_bbox.clear();
+
+		for (size_t i = 0, idx = 0; i < m_drawlist.size(); i++)
+		{
+			GSVector4i bbox(INT_MAX, INT_MAX, INT_MIN, INT_MIN);
+
+			const size_t n_prims = m_drawlist[i];
+			for (size_t j = 0; j < n_prims; j++, idx += n)
+			{
+				for (size_t k = 0; k < n; k++)
+				{
+					bbox = bbox.runion(GetVertexXY(verts[index[idx + k]]));
+				}
+			}
+
+			const GSVector4i xyof = m_context->scissor.xyof.xyxy();
+			GSVector4 bbox_f = GSVector4(bbox - xyof) / 16.0f;
+			m_drawlist_bbox.push_back(ProcessBBox(bbox_f, pos_scale));
+		}
+	}
+}
+
+void GSState::ProcessAutoflushDrawlist(float pos_scale, float tex_scale)
+{
+	pxAssertRel(PRIM->TME, "Autoflush drawlist only valid with texture mapping.");
+
+	switch (m_vt.m_primclass)
+	{
+		case GS_SPRITE_CLASS:
+			if (PRIM->FST)
+				ProcessAutoflushDrawlistImpl<GS_SPRITE_CLASS, true>(pos_scale, tex_scale);
+			else
+				ProcessAutoflushDrawlistImpl<GS_SPRITE_CLASS, false>(pos_scale, tex_scale);
+			break;
+		case GS_TRIANGLE_CLASS:
+			if (PRIM->FST)
+				ProcessAutoflushDrawlistImpl<GS_TRIANGLE_CLASS, true>(pos_scale, tex_scale);
+			else
+				ProcessAutoflushDrawlistImpl<GS_TRIANGLE_CLASS, false>(pos_scale, tex_scale);
+			break;
+		default:
+			pxFail("Autoflush drawlist only for triangles/sprites.");
+			break;
+	}
+}
+
 bool GSState::SpriteDrawWithoutGaps()
 {
 	// Check that the height matches. Xenosaga 3 draws a letterbox around
@@ -5340,6 +5466,33 @@ void GSState::GetQuadRasterizedPoints(GSVector4& xy, bool keep_order)
 	GetQuadRasterizedPoints(xy, tex_ignore, keep_order);
 }
 
+__forceinline bool GSState::CanUseAutoFlushList() const
+{
+	// Can combine if recursive color draw and source/RT are basically the same
+	// format (aside from 24/32 bit difference).
+	return m_context->TEX0.TBP0 == m_context->FRAME.Block() &&
+		(m_context->TEX0.PSM & ~1) == (m_context->FRAME.PSM & ~1);
+}
+
+__forceinline void GSState::ResetAutoFlushList()
+{
+	m_autoflush_list.clear();
+	m_autoflush_bbox.clear();
+	m_autoflush_tail = 0;
+}
+
+__forceinline void GSState::UpdateAutoFlushList()
+{
+	if (NumQueuedIndices() > 0)
+	{
+		const int n = GSUtil::GetVertexCount(PRIM->PRIM);
+		m_autoflush_list.push_back(NumQueuedIndices() / n);
+		m_autoflush_tail = m_index->tail;
+		temp_draw_rect = GSVector4i::zero(); // Reset draw rect since it's used for autoflush overlap.
+		m_texflush_flag = false; // Reset TEXFLUSH since this is equivalent to starting a new draw.
+	}
+}
+
 __forceinline bool GSState::IsAutoFlushDraw(u32 prim, int& tex_layer)
 {
 	if (!PRIM->TME || (GSConfig.UserHacks_AutoFlush == GSHWAutoFlushLevel::SpritesOnly && prim != GS_SPRITE))
@@ -5441,8 +5594,20 @@ template<u32 prim>
 __forceinline void GSState::HandleAutoFlush()
 {
 	// Kind of a cheat, making the assumption that 2 consecutive fan/strip triangles won't overlap each other (*should* be safe)
-	if ((m_index->tail & 1) && (prim == GS_TRIANGLESTRIP || prim == GS_TRIANGLEFAN) && !m_texflush_flag)
+	if ((NumQueuedIndices() & 1) && (prim == GS_TRIANGLESTRIP || prim == GS_TRIANGLEFAN) && !m_texflush_flag)
 		return;
+	
+	const auto DoFlush = [&]() {
+		if (GSConfig.UserHacks_AutoFlush == GSHWAutoFlushLevel::BatchEnabled &&
+			GSIsHardwareRenderer() && CanUseAutoFlushList())
+		{
+			UpdateAutoFlushList();
+		}
+		else
+		{
+			Flush(GSFlushReason::AUTOFLUSH);
+		}
+	};
 
 	GSVertexBuff& vtx_buff = *m_vertex;
 	GSIndexBuff& idx_buff = *m_index;
@@ -5645,7 +5810,7 @@ __forceinline void GSState::HandleAutoFlush()
 			return;
 		else if (m_texflush_flag)
 		{
-			Flush(GSFlushReason::AUTOFLUSH);
+			DoFlush();
 			return;
 		}
 
@@ -5665,8 +5830,9 @@ __forceinline void GSState::HandleAutoFlush()
 				const GSVector4i scissor = m_context->scissor.in;
 				GSVector4i old_draw_rect = GSVector4i::zero();
 				int current_draw_end = idx_buff.tail;
+				const int current_draw_start = static_cast<int>(m_autoflush_tail);
 
-				while (current_draw_end >= n)
+				while (current_draw_end >= current_draw_start + n)
 				{
 					for (int i = current_draw_end - 1; i >= current_draw_end - n; i--)
 					{
@@ -5716,7 +5882,7 @@ __forceinline void GSState::HandleAutoFlush()
 					old_draw_rect = tex_rect.rintersect(old_draw_rect);
 					if (!old_draw_rect.rintersect(scissor).rempty())
 					{
-						Flush(GSFlushReason::AUTOFLUSH);
+						DoFlush();
 						return;
 					}
 
@@ -5743,10 +5909,10 @@ __forceinline void GSState::HandleAutoFlush()
 					area_out = GSVector4i(area_out.x / frame_psm.pgs.x, area_out.y / frame_psm.pgs.y, area_out.z / frame_psm.pgs.x, area_out.w / frame_psm.pgs.y);
 
 					if (!area_out.rintersect(tex_rect).rempty())
-						Flush(GSFlushReason::AUTOFLUSH);
+						DoFlush();
 				}
 				else // Formats are too different so just flush it.
-					Flush(GSFlushReason::AUTOFLUSH);
+					DoFlush();
 			}
 		}
 	}
@@ -5847,7 +6013,7 @@ __forceinline void GSState::VertexKick(u32 skip)
 		if (CheckOverlapVerts(n))
 			Flush(CONTEXTCHANGE);
 	
-	if (auto_flush && skip == 0 && idx_buff.tail > 0 && ((vtx_buff.tail + 1) - vtx_buff.head) >= n)
+	if (auto_flush && skip == 0 && NumQueuedIndices() > 0 && ((vtx_buff.tail + 1) - vtx_buff.head) >= n)
 	{
 		HandleAutoFlush<prim>();
 	}
@@ -6080,7 +6246,7 @@ __forceinline void GSState::VertexKick(u32 skip)
 
 	// Update rectangle for the current draw. Needs exclusive endpoints.
 	const GSVector4i draw_rect = bbox.sra32<4>() + GSVector4i(0, 0, 1, 1);
-	if (idx_buff.tail != n)
+	if (NumQueuedIndices() != n)
 		temp_draw_rect = temp_draw_rect.runion(draw_rect);
 	else
 		temp_draw_rect = draw_rect;

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -150,6 +150,13 @@ protected:
 		u32 tail;
 	} m_index = {};
 
+	u32 m_autoflush_tail = 0;
+
+	__forceinline u32 NumQueuedIndices() const
+	{
+		return m_index.tail - m_autoflush_tail;
+	}
+
 	struct
 	{
 		GSVertex* buff;
@@ -171,6 +178,10 @@ protected:
 	void UpdateVertexKick();
 
 	void GrowVertexBuffer();
+	bool CanUseAutoFlushList() const;
+	__forceinline bool HasAutoFlushList() const { return m_autoflush_tail > 0; }
+	void ResetAutoFlushList();
+	void UpdateAutoFlushList();
 	bool IsAutoFlushDraw(u32 prim, int& tex_layer);
 	template<u32 prim> void HandleAutoFlush();
 	bool EarlyDetectShuffle(u32 prim);
@@ -376,6 +387,9 @@ public:
 	std::vector<size_t> m_drawlist;
 	std::vector<GSVector4i> m_drawlist_bbox;
 
+	std::vector<size_t> m_autoflush_list;
+	std::vector<GSVector4i> m_autoflush_bbox;
+
 	struct GSPCRTCRegs
 	{
 		struct PCRTCDisplay
@@ -510,6 +524,9 @@ public:
 	PRIM_OVERLAP GetPrimitiveOverlapDrawlistImpl(bool save_drawlist = false, bool save_bbox = false, float bbox_scale = 1.0f);
 	PRIM_OVERLAP GetPrimitiveOverlapDrawlist(bool save_drawlist = false, bool save_bbox = false, float bbox_scale = 1.0f);
 	PRIM_OVERLAP PrimitiveOverlap(bool save_drawlist = false);
+	template<u32 primclass, bool fst>
+	void ProcessAutoflushDrawlistImpl(float pos_scale, float tex_scale);
+	void ProcessAutoflushDrawlist(float pos_scale, float tex_scale);
 	bool SpriteDrawWithoutGaps();
 	void CalculatePrimitiveCoversWithoutGaps();
 	GIFRegTEX0 GetTex0Layer(u32 lod);

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -160,6 +160,13 @@ protected:
 	GSIndexBuff* m_index;
 
 	GSVertexBuff m_draw_vertex = {};
+	
+	u32 m_autoflush_tail = 0;
+
+	__forceinline u32 NumQueuedIndices() const
+	{
+		return m_index->tail - m_autoflush_tail;
+	}
 
 	struct
 	{
@@ -184,6 +191,10 @@ protected:
 	void UpdateVertexKick();
 
 	void GrowVertexBuffer();
+	bool CanUseAutoFlushList() const;
+	__forceinline bool HasAutoFlushList() const { return m_autoflush_tail > 0; }
+	void ResetAutoFlushList();
+	void UpdateAutoFlushList();
 	bool IsAutoFlushDraw(u32 prim, int& tex_layer);
 	template<u32 prim> void HandleAutoFlush();
 	bool EarlyDetectShuffle(u32 prim);
@@ -393,6 +404,9 @@ public:
 	std::vector<size_t> m_drawlist;
 	std::vector<GSVector4i> m_drawlist_bbox;
 
+	std::vector<size_t> m_autoflush_list;
+	std::vector<GSVector4i> m_autoflush_bbox;
+
 	struct GSPCRTCRegs
 	{
 		struct PCRTCDisplay
@@ -537,6 +551,9 @@ public:
 	PRIM_OVERLAP GetPrimitiveOverlapDrawlist(bool save_drawlist = false, bool save_bbox = false,
 		float bbox_scale = 1.0f, u32* max_size = nullptr);
 	PRIM_OVERLAP PrimitiveOverlap(bool save_drawlist = false);
+	template<u32 primclass, bool fst>
+	void ProcessAutoflushDrawlistImpl(float pos_scale, float tex_scale);
+	void ProcessAutoflushDrawlist(float pos_scale, float tex_scale);
 	bool SpriteDrawWithoutGaps();
 	void CalculatePrimitiveCoversWithoutGaps();
 	GIFRegTEX0 GetTex0Layer(u32 lod);

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -758,6 +758,9 @@ struct alignas(16) GSHWDrawConfig
 	u32 indices_per_prim; ///< Number of indices that make up one primitive
 	const std::vector<size_t>* drawlist;          ///< For reducing barriers on sprites
 	const std::vector<GSVector4i>* drawlist_bbox; ///< For RT copy when barriers not available.
+	const std::vector<size_t>* autoflush_list;     ///< For batched autoflush drawing.
+	const std::vector<GSVector4i>* autoflush_bbox; ///< For batched autoflush drawing.
+	bool autoflush;                                ///< Do a batched autoflush draw.
 	GSVector4i scissor; ///< Scissor rect
 	GSVector4i drawarea; ///< Area in the framebuffer which will be modified.
 	Topology topology;  ///< Draw topology

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -1248,6 +1248,9 @@ struct alignas(16) GSHWDrawConfig
 	u32 indices_per_prim;  ///< Number of indices that make up one primitive
 	const std::vector<size_t>* drawlist;          ///< For reducing barriers on sprites
 	const std::vector<GSVector4i>* drawlist_bbox; ///< For RT copy when barriers not available.
+	const std::vector<size_t>* autoflush_list;     ///< For batched autoflush drawing.
+	const std::vector<GSVector4i>* autoflush_bbox; ///< For batched autoflush drawing.
+	bool autoflush;
 	GSVector4i scissor; ///< Scissor rect
 	GSVector4i drawarea; ///< Area in the framebuffer which will be modified.
 	GSVector4i samplearea; ///< Area in the texture which will be sampled.

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -2934,7 +2934,7 @@ void GSDevice11::SendHWDraw(const GSHWDrawConfig& config,
 	GSTexture* draw_rt_clone, GSTexture* draw_rt, GSTexture* draw_ds_clone, GSTexture* draw_ds,
 	const bool one_barrier, const bool full_barrier)
 {
-	if (draw_rt_clone || draw_ds_clone)
+	if (draw_rt_clone || draw_ds_clone || config.autoflush)
 	{
 #ifdef PCSX2_DEVBUILD
 		if ((one_barrier || full_barrier) && !(config.ps.IsFeedbackLoopRT() || config.ps.IsFeedbackLoopDepth())) [[unlikely]]
@@ -2959,7 +2959,54 @@ void GSDevice11::SendHWDraw(const GSHWDrawConfig& config,
 
 		const GSVector4i rtsize(0, 0, (draw_rt ? draw_rt : draw_ds)->GetWidth(), (draw_rt ? draw_rt : draw_ds)->GetHeight());
 
-		if (full_barrier)
+		if (config.autoflush)
+		{
+			const u32 draw_list_size = static_cast<u32>(config.drawlist->size());
+			const u32 indices_per_prim = config.indices_per_prim;
+			const u32 autoflush_list_size = static_cast<u32>(config.autoflush_list->size());
+
+			GL_PUSH("Split the draw (autoflush)");
+
+			const GSVector4i tex_rect = config.tex->GetRect();
+
+			// a: autoflush drawlist position
+			// n: barrier drawlist position
+			// p: number of indices drawn
+			for (u32 a = 0, n = 0, p = 0; a < autoflush_list_size; a++)
+			{
+				const GSVector4i bbox = (*config.autoflush_bbox)[a].rintersect(tex_rect);
+
+				if (!bbox.rempty())
+				{
+					CopyRect(config.rt, config.tex, bbox, bbox.x, bbox.y);
+
+					PSSetShaderResource(0, config.tex);
+					OMSetRenderTargets(config.rt, config.ds, &config.scissor);
+				}
+
+				int prims = static_cast<int>((*config.autoflush_list)[a]);
+
+				while (prims > 0)
+				{
+					const u32 count = (*config.drawlist)[n] * indices_per_prim;
+
+					if (draw_rt_clone || draw_ds_clone)
+					{
+						const GSVector4i original_bbox = (*config.drawlist_bbox)[n].rintersect(config.drawarea);
+						CopyAndBind(ProcessCopyArea(rtsize, original_bbox));
+					}
+
+					DrawIndexedPrimitive(p, count);
+
+					prims -= (*config.drawlist)[n];
+					p += count;
+					n++;
+				}
+			}
+
+			return;
+		}
+		else if (full_barrier)
 		{
 			const u32 draw_list_size = static_cast<u32>(config.drawlist->size());
 			const u32 indices_per_prim = config.indices_per_prim;

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -3362,6 +3362,53 @@ void GSDevice11::SendHWDraw(const GSHWDrawConfig& config,
 		Console.Warning("D3D11: Possible unnecessary copy detected.");
 #endif
 
+	if (config.autoflush)
+	{
+		const u32 indices_per_prim = config.indices_per_prim;
+		const u32 autoflush_list_size = static_cast<u32>(config.autoflush_list->size());
+
+		GL_PUSH("Split the draw (autoflush)");
+
+		const GSVector4i tex_rect = config.tex->GetRect();
+
+		// a: autoflush drawlist position
+		// n: barrier drawlist position
+		// p: number of indices drawn
+		for (u32 a = 0, n = 0, p = 0; a < autoflush_list_size; a++)
+		{
+			const GSVector4i bbox = config.autoflush_bbox->at(a).rintersect(tex_rect);
+
+			if (!bbox.rempty())
+			{
+				CopyRect(config.rt, config.tex, bbox, bbox.x, bbox.y);
+
+				PSSetShaderResource(0, config.tex);
+				OMSetRenderTargets(config.rt, config.ds, nullptr, nullptr, &config.scissor);
+			}
+
+			int prims = static_cast<int>(config.autoflush_list->at(a));
+
+			while (prims > 0)
+			{
+				const u32 count = config.drawlist->at(n) * indices_per_prim;
+
+				if (draw_rt_clone || draw_ds_clone)
+				{
+					const GSVector4i original_bbox = config.drawlist_bbox->at(n).rintersect(config.drawarea);
+					FeedbackCopyAndBind(config, draw_rt, draw_rt_clone, draw_ds, draw_ds_clone, bbox);
+				}
+
+				Draw(config, p, count);
+
+				prims -= config.drawlist->at(n);
+				p += count;
+				n++;
+			}
+		}
+
+		return;
+	}
+
 	if (full_barrier)
 	{
 		const u32 draw_list_size = static_cast<u32>(config.drawlist->size());

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -4470,7 +4470,7 @@ void GSDevice12::SendHWDraw(const PipelineSelector& pipe, const GSHWDrawConfig& 
 
 	const int n_barriers = static_cast<int>(feedback_rt) + static_cast<int>(feedback_depth);
 
-	if (feedback_rt || feedback_depth)
+	if (feedback_rt || feedback_depth || config.autoflush)
 	{
 #ifdef PCSX2_DEVBUILD
 		if ((one_barrier || full_barrier) && !(config.ps.IsFeedbackLoopRT() || config.ps.IsFeedbackLoopDepth())) [[unlikely]]
@@ -4483,15 +4483,75 @@ void GSDevice12::SendHWDraw(const PipelineSelector& pipe, const GSHWDrawConfig& 
 		if ((one_barrier || full_barrier) && feedback_depth)
 			PSSetShaderResource(4, draw_ds, false, true);
 		
-		if (full_barrier)
+		if (config.autoflush)
+		{
+			const u32 draw_list_size = static_cast<u32>(config.drawlist->size());
+			const u32 indices_per_prim = config.indices_per_prim;
+			const u32 autoflush_list_size = static_cast<u32>(config.autoflush_list->size());
+
+			GL_PUSH("Split the draw (autoflush)");
+			g_perfmon.Put(GSPerfMon::Barriers, n_barriers * (draw_list_size - autoflush_list_size));
+			
+			EndRenderPass();
+
+			const GSVector4i tex_rect = config.tex->GetRect();
+
+			// a: autoflush drawlist position
+			// n: barrier drawlist position
+			// p: number of indices drawn
+			for (u32 a = 0, n = 0, p = 0; a < autoflush_list_size; a++)
+			{
+				const GSVector4i bbox = (*config.autoflush_bbox)[a].rintersect(tex_rect);
+				const bool copy = !bbox.rempty();
+
+				if (copy)
+				{
+					CopyRect(config.rt, config.tex, bbox, bbox.x, bbox.y);
+
+					PSSetShaderResource(TEXTURE_TEXTURE, config.tex, true);
+					OMSetRenderTargets(config.rt, nullptr, config.ds, config.scissor);
+				}
+
+				int prims = static_cast<int>((*config.autoflush_list)[a]);
+
+				bool first = true;
+				while (prims > 0)
+				{
+					const u32 count = (*config.drawlist)[n] * indices_per_prim;
+
+					// Skip the first barrier if copy/transition has covered it.
+					if (!first || !copy)
+					{
+						if (feedback_rt)
+							FeedbackBarrier(draw_rt);
+						if (feedback_depth)
+							FeedbackBarrier(draw_ds);
+					}
+
+					if (BindDrawPipeline(pipe))
+						DrawIndexedPrimitive(p, count);
+
+					prims -= (*config.drawlist)[n];
+					p += count;
+					n++;
+					first = false;
+				}
+			}
+
+			return;
+		}
+		else if (full_barrier)
 		{
 			pxAssert(config.drawlist && !config.drawlist->empty());
 			const u32 draw_list_size = static_cast<u32>(config.drawlist->size());
 			const u32 indices_per_prim = config.indices_per_prim;
+			const u32 autoflush_list_size = static_cast<u32>(config.autoflush_list ? config.autoflush_list->size() : 0);
 
 			GL_PUSH("Split the draw");
 			g_perfmon.Put(GSPerfMon::Barriers, n_barriers * draw_list_size);
 
+			// n: barrier drawlist position
+			// p: number of indices drawn
 			for (u32 n = 0, p = 0; n < draw_list_size; n++)
 			{
 				const u32 count = (*config.drawlist)[n] * indices_per_prim;

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -4752,7 +4752,7 @@ void GSDevice12::SendHWDraw(const PipelineSelector& pipe, const GSHWDrawConfig& 
 		return;
 	}
 
-	if (feedback_rt || feedback_depth)
+	if (feedback_rt || feedback_depth || config.autoflush)
 	{
 #ifdef PCSX2_DEVBUILD
 		if ((one_barrier || full_barrier) && !(config.IsFeedbackLoopRT(config.ps) || config.IsFeedbackLoopDepth(config.ps))) [[unlikely]]
@@ -4765,11 +4765,68 @@ void GSDevice12::SendHWDraw(const PipelineSelector& pipe, const GSHWDrawConfig& 
 		if ((one_barrier || full_barrier) && feedback_depth)
 			PSSetShaderResource(TEXTURE_DEPTH, draw_ds, false, ResourceType::FBL);
 		
-		if (full_barrier)
+		if (config.autoflush)
+		{
+			const u32 indices_per_prim = config.indices_per_prim;
+			const u32 autoflush_list_size = static_cast<u32>(config.autoflush_list->size());
+
+			GL_PUSH("Split the draw (autoflush)");
+			
+			EndRenderPass();
+
+			const GSVector4i tex_rect = config.tex->GetRect();
+
+			// a: autoflush drawlist position
+			// n: barrier drawlist position
+			// p: number of indices drawn
+			for (u32 a = 0, n = 0, p = 0; a < autoflush_list_size; a++)
+			{
+				const GSVector4i bbox = config.autoflush_bbox->at(a).rintersect(tex_rect);
+				const bool copy = !bbox.rempty();
+
+				if (copy)
+				{
+					CopyRect(config.rt, config.tex, bbox, bbox.x, bbox.y);
+
+					PSSetShaderResource(TEXTURE_TEXTURE, config.tex, true);
+					OMSetRenderTargets(config.rt, nullptr, config.ds, config.scissor);
+				}
+
+				int prims = static_cast<int>(config.autoflush_list->at(a));
+
+				bool first = true;
+				while (prims > 0)
+				{
+					const u32 count = config.drawlist->at(n) * indices_per_prim;
+
+					// Skip the first barrier if copy/transition has covered it.
+					if (!first || !copy)
+					{
+						if (feedback_rt)
+							FeedbackBarrier(draw_rt);
+						if (feedback_depth)
+							FeedbackBarrier(draw_ds);
+						g_perfmon.Put(GSPerfMon::Barriers, n_barriers);
+					}
+
+					if (BindDrawPipeline(pipe))
+						Draw(config, p, count);
+
+					prims -= config.drawlist->at(n);
+					p += count;
+					n++;
+					first = false;
+				}
+			}
+
+			return;
+		}
+		else if (full_barrier)
 		{
 			pxAssert(config.drawlist && !config.drawlist->empty());
 			const u32 draw_list_size = static_cast<u32>(config.drawlist->size());
 			const u32 indices_per_prim = config.indices_per_prim;
+			const u32 autoflush_list_size = static_cast<u32>(config.autoflush_list ? config.autoflush_list->size() : 0);
 
 			GL_PUSH("Split the draw");
 			g_perfmon.Put(GSPerfMon::Barriers, n_barriers * draw_list_size);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -6066,7 +6066,7 @@ void GSRendererHW::DetermineVSConfig(GSTextureCache::Target* rt, float rtscale, 
 	m_conf.vs.iip = !IsFlatShaded();
 }
 
-void GSRendererHW::DetermineBarriers(GSTextureCache::Target* rt)
+void GSRendererHW::DetermineBarriers(GSTextureCache::Target* rt, GSTextureCache::Source* tex)
 {
 	const GSDevice::FeatureSupport& features = g_gs_device->Features();
 
@@ -6109,6 +6109,18 @@ void GSRendererHW::DetermineBarriers(GSTextureCache::Target* rt)
 	if (m_conf.require_full_barrier && (g_gs_device->Features().texture_barrier || g_gs_device->Features().multidraw_fb_copy))
 	{
 		ComputeDrawlistGetSize(rt->m_scale);
+		m_conf.drawlist = &m_drawlist;
+		m_conf.drawlist_bbox = &m_drawlist_bbox;
+	}
+
+	if (m_conf.tex && HasAutoFlushList())
+	{
+		GL_INS("HW: Using autoflush list for %lld draws %s barriers",
+			m_autoflush_list.size(), m_conf.require_full_barrier ? "with" : "without");
+		ProcessAutoflushDrawlist(rt->GetScale(), tex->GetScale());
+		m_conf.autoflush = true;
+		m_conf.autoflush_list = &m_autoflush_list;
+		m_conf.autoflush_bbox = &m_autoflush_bbox;
 		m_conf.drawlist = &m_drawlist;
 		m_conf.drawlist_bbox = &m_drawlist_bbox;
 	}
@@ -6872,17 +6884,18 @@ void GSRendererHW::EmulateBlending(int rt_alpha_min, int rt_alpha_max, DATEOptio
 			break;
 	}
 
-	if (features.framebuffer_fetch)
+	const auto ForceSWBlend = [&]() {
+		sw_blending = true;
+		color_dest_blend = false;
+		accumulation_blend = false;
+		blend_mix = false;
+	};
+
+	if (features.framebuffer_fetch && (one_barrier || m_conf.require_full_barrier))
 	{
 		// If we have fbfetch, use software blending when we need the fb value for anything else.
 		// This saves outputting the second color when it's not needed.
-		if (one_barrier || m_conf.require_full_barrier)
-		{
-			sw_blending = true;
-			color_dest_blend = false;
-			accumulation_blend = false;
-			blend_mix = false;
-		}
+		ForceSWBlend();
 	}
 
 	if (m_conf.alpha_test == GSHWDrawConfig::AlphaTestMode::FEEDBACK &&
@@ -6890,10 +6903,13 @@ void GSRendererHW::EmulateBlending(int rt_alpha_min, int rt_alpha_max, DATEOptio
 	{
 		// If we are doing feedback alpha test with a second RT we must use SW blending to avoid
 		// mixing dual source blending with multiple render targets.
-		sw_blending = true;
-		color_dest_blend = false;
-		accumulation_blend = false;
-		blend_mix = false;
+		ForceSWBlend();
+	}
+
+	if (HasAutoFlushList() && COLCLAMP.CLAMP == 0)
+	{
+		// The autoflush list isn't compatible with HDR HW colclip, so use SW blending.
+		ForceSWBlend();
 	}
 
 	// Color clip
@@ -7594,8 +7610,9 @@ __ri void GSRendererHW::EmulateTextureSampler(const GSTextureCache::Target* rt, 
 			bilinear &= m_vt.IsLinear();
 		}
 
-		// Depth format
-		if (tex->m_texture->IsDepthStencil())
+		// Depth format. With autoflush, the source copy is switched to color so
+		// we must check that instead.
+		if (src_copy ? src_copy->IsDepthStencil() : tex->m_texture->IsDepthStencil())
 		{
 			// Require a float conversion if the texure is a depth format
 			m_conf.ps.depth_fmt = (psm.bpp == 16) ? 2 : 1;
@@ -7848,6 +7865,11 @@ __ri void GSRendererHW::HandleTextureHazards(const GSTextureCache::Target* rt, c
 		{
 			src_target = tex->m_from_target;
 		}
+		else if (HasAutoFlushList() && tex->m_texture->IsDepthStencil())
+		{
+			// The autoflush list needs a color source so that it can use GPU copies for updates.
+			src_target = rt;
+		}
 		else
 		{
 			// No match.
@@ -8029,7 +8051,11 @@ __ri void GSRendererHW::HandleTextureHazards(const GSTextureCache::Target* rt, c
 		return;
 	}
 
-	if (m_downscale_source)
+	if (HasAutoFlushList())
+	{
+		GL_CACHE("HW: Using autoflush list, skipping RT copy.");
+	}
+	else if (m_downscale_source)
 	{
 		// Can't use box filtering on depth (yet), or fractional scales.
 		if (src_target->m_texture->IsDepthStencil() || std::floor(src_target->GetScale()) != src_target->GetScale())
@@ -8196,7 +8222,7 @@ bool GSRendererHW::CanUseTexIsFB(const GSTextureCache::Target* rt, const GSTextu
 		const GSVector4 diff(m_vt.m_min.p.upld(m_vt.m_max.p) - m_vt.m_min.t.upld(m_vt.m_max.t));
 		if (m_cached_ctx.FRAME.FBMSK == 0x00FFFFFF && (diff.abs() < GSVector4(1.0f)).alltrue())
 		{
-			GL_CACHE("HW: Elabling tex-is-fb hack for Jak.");
+			GL_CACHE("HW: Enabling tex-is-fb hack for Jak.");
 			return true;
 		}
 
@@ -8830,7 +8856,7 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 	}
 
 	// Barriers must be determined before indices are modified via HandleProvokingVertexFirst/SetupIA.
-	DetermineBarriers(rt);
+	DetermineBarriers(rt, tex);
 
 	// Perform second pass setup here once barriers are determined.
 	EmulateAlphaTestSecondPass();

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -6012,9 +6012,10 @@ void GSRendererHW::EmulateDATESelectMethod(DATEOptions& date_options, GSTextureC
 			m_conf.require_full_barrier = true;
 			date_options.barrier = true;
 		}
-		else if (features.feedback_loops() && m_conf.require_full_barrier)
+		else if ((features.feedback_loops() && m_conf.require_full_barrier) || HasAutoFlushList())
 		{
 			// Full barrier is enabled (likely sw fbmask), we need to use date barrier.
+			// If autoflush list is used, we cannot use DATE primid.
 			GL_PERF("DATE: Accurate with alpha %d-%d", GetAlphaMinMax().min, GetAlphaMinMax().max);
 			m_conf.require_full_barrier = true;
 			date_options.barrier = true;
@@ -6257,6 +6258,18 @@ void GSRendererHW::DetermineBarriers(GSTextureCache::Target* rt, GSTextureCache:
 	if (m_conf.require_full_barrier && features.feedback_loops())
 	{
 		ComputeDrawlistGetSize(rt->m_scale);
+		m_conf.drawlist = &m_drawlist;
+		m_conf.drawlist_bbox = &m_drawlist_bbox;
+	}
+
+	if (m_conf.tex && HasAutoFlushList())
+	{
+		GL_INS("HW: Using autoflush list for %lld draws %s barriers",
+			m_autoflush_list.size(), m_conf.require_full_barrier ? "with" : "without");
+		ProcessAutoflushDrawlist(rt->GetScale(), tex->GetScale());
+		m_conf.autoflush = true;
+		m_conf.autoflush_list = &m_autoflush_list;
+		m_conf.autoflush_bbox = &m_autoflush_bbox;
 		m_conf.drawlist = &m_drawlist;
 		m_conf.drawlist_bbox = &m_drawlist_bbox;
 	}
@@ -7025,6 +7038,9 @@ void GSRendererHW::EmulateBlending(int rt_alpha_min, int rt_alpha_max, DATEOptio
 		// mixing dual source blending with multiple render targets.
 		(m_conf.ps.IsFeedbackLoopDepth() && !features.depth_feedback) ||
 		
+		// The autoflush list isn't compatible with HW colclip, so use SW blending.
+		(HasAutoFlushList() && COLCLAMP.CLAMP == 0) ||
+
 		// Force SW blending with barriers.
 		GSConfig.UseDebugBlend;
 	
@@ -7597,6 +7613,12 @@ void GSRendererHW::DetermineROVUsage(GSTextureCache::Target* rt, GSTextureCache:
 		return;
 	}
 
+	if (m_conf.autoflush)
+	{
+		GL_INS("ROV: Disabled because doing batched autoflush");
+		return;
+	}
+
 	const bool color_write = rt && m_conf.colormask.wrgba != 0;
 	const bool depth_write = ds && m_cached_ctx.DepthWrite();
 
@@ -8123,8 +8145,9 @@ __ri void GSRendererHW::EmulateTextureSampler(const GSTextureCache::Target* rt, 
 			bilinear &= m_vt.IsLinear();
 		}
 
-		// Depth format
-		if (tex->m_texture->IsDepthLike())
+		// Depth format. With autoflush, the source copy is switched to color so
+		// we must check that instead.
+		if (src_copy ? src_copy->IsDepthLike() : tex->m_texture->IsDepthLike())
 		{
 			// Require a float conversion if the texure is a depth format
 			m_conf.ps.depth_fmt = (psm.bpp == 16) ? 2 : 1;
@@ -8465,6 +8488,11 @@ __ri void GSRendererHW::HandleTextureHazards(const GSTextureCache::Target* rt, c
 
 			src_target = tex->m_from_target;
 		}
+		else if (HasAutoFlushList() && tex->m_texture->IsDepthStencil())
+		{
+			// The autoflush list needs a color source so that it can use GPU copies for updates.
+			src_target = rt;
+		}
 		else
 		{
 			// No match.
@@ -8643,7 +8671,11 @@ __ri void GSRendererHW::HandleTextureHazards(const GSTextureCache::Target* rt, c
 		return;
 	}
 
-	if (m_downscale_source)
+	if (HasAutoFlushList())
+	{
+		GL_CACHE("HW: Using autoflush list, skipping RT copy.");
+	}
+	else if (m_downscale_source)
 	{
 		// Can't use box filtering on depth (yet), or fractional scales.
 		if (src_target->m_texture->IsDepthStencil() || std::floor(src_target->GetScale()) != src_target->GetScale())
@@ -8808,7 +8840,7 @@ bool GSRendererHW::CanUseTexIsFB(const GSTextureCache::Target* rt, const GSTextu
 		const GSVector4 diff(m_vt.m_min.p.upld(m_vt.m_max.p) - m_vt.m_min.t.upld(m_vt.m_max.t));
 		if (m_cached_ctx.FRAME.FBMSK == 0x00FFFFFF && (diff.abs() < GSVector4(1.0f)).alltrue())
 		{
-			GL_CACHE("HW: Elabling tex-is-fb hack for Jak.");
+			GL_CACHE("HW: Enabling tex-is-fb hack for Jak.");
 			return true;
 		}
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -243,7 +243,7 @@ private:
 
 	void DetermineVSConfig(GSTextureCache::Target* rt, float rtscale, const GSVector2i& rtsize,
 		const GSVector2i& unscaled_size, float& vs_scale_x, float& vs_scale_y);
-	void DetermineBarriers(GSTextureCache::Target* rt);
+	void DetermineBarriers(GSTextureCache::Target* rt, GSTextureCache::Source* tex);
 
 	void SetTCOffset();
 	bool NextDrawColClip() const;

--- a/pcsx2/GS/Renderers/HW/GSRendererHWMultiISA.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHWMultiISA.cpp
@@ -3,6 +3,8 @@
 
 #include "GSRendererHW.h"
 
+#include "GS/GSGL.h"
+#include "GS/GSUtil.h"
 #include "GS/Renderers/SW/GSTextureCacheSW.h"
 #include "GS/Renderers/SW/GSRasterizer.h"
 
@@ -10,6 +12,7 @@ class CURRENT_ISA::GSRendererHWFunctions
 {
 public:
 	static bool SwPrimRender(GSRendererHW& hw, bool invalidate_tc, bool add_ee_transfer);
+	static bool SwPrimRender(GSRendererHW& hw, bool invalidate_tc, bool add_ee_transfer, u32 start, u32 count);
 
 	static void Populate(GSRendererHW& renderer)
 	{
@@ -28,7 +31,7 @@ void CURRENT_ISA::GSRendererHWPopulateFunctions(GSRendererHW& renderer)
 static GSVector4i s_dimx_storage[8];
 static GIFRegDIMX s_last_dimx;
 
-bool GSRendererHWFunctions::SwPrimRender(GSRendererHW& hw, bool invalidate_tc, bool add_ee_transfer)
+bool GSRendererHWFunctions::SwPrimRender(GSRendererHW& hw, bool invalidate_tc, bool add_ee_transfer, u32 start, u32 count)
 {
 	GSVertexTrace& vt = hw.m_vt;
 	const GIFRegPRIM* PRIM = hw.PRIM;
@@ -45,8 +48,8 @@ bool GSRendererHWFunctions::SwPrimRender(GSRendererHW& hw, bool invalidate_tc, b
 	data.buff = nullptr;
 	data.vertex = hw.m_sw_vertex_buffer.data();
 	data.vertex_count = hw.m_vertex.next;
-	data.index = hw.m_index.buff;
-	data.index_count = hw.m_index.tail;
+	data.index = hw.m_index.buff + start;
+	data.index_count = count;
 	data.scanmsk_value = env.SCANMSK.MSK;
 
 	// Skip per pixel division if q is constant.
@@ -562,4 +565,28 @@ bool GSRendererHWFunctions::SwPrimRender(GSRendererHW& hw, bool invalidate_tc, b
 	}
 
 	return true;
+}
+
+bool GSRendererHWFunctions::SwPrimRender(GSRendererHW& hw, bool invalidate_tc, bool add_ee_transfer)
+{
+	GL_INS("HW: SwPrimRender draw %lld", GSState::s_n);
+	if (hw.HasAutoFlushList())
+	{
+		// The SW renderer does not handle the autoflush list, so we need to flush here.
+		const u32 n = static_cast<u32>(GSUtil::GetClassVertexCount(hw.m_vt.m_primclass));
+		for (size_t i = 0, start = 0; i < hw.m_autoflush_list.size(); i++)
+		{
+			const u32 count = hw.m_autoflush_list[i] * n;
+			if (!SwPrimRender(hw, invalidate_tc, add_ee_transfer, start, count))
+			{
+				return false;
+			}
+			start += count;
+		}
+		return true;
+	}
+	else
+	{
+		return SwPrimRender(hw, invalidate_tc, add_ee_transfer, 0, hw.m_index.tail);
+	}
 }

--- a/pcsx2/GS/Renderers/HW/GSRendererHWMultiISA.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHWMultiISA.cpp
@@ -3,6 +3,8 @@
 
 #include "GSRendererHW.h"
 
+#include "GS/GSGL.h"
+#include "GS/GSUtil.h"
 #include "GS/Renderers/SW/GSTextureCacheSW.h"
 #include "GS/Renderers/SW/GSRasterizer.h"
 
@@ -10,6 +12,7 @@ class CURRENT_ISA::GSRendererHWFunctions
 {
 public:
 	static bool SwPrimRender(GSRendererHW& hw, bool invalidate_tc, bool add_ee_transfer);
+	static bool SwPrimRender(GSRendererHW& hw, bool invalidate_tc, bool add_ee_transfer, u32 start, u32 count);
 
 	static void Populate(GSRendererHW& renderer)
 	{
@@ -28,7 +31,7 @@ void CURRENT_ISA::GSRendererHWPopulateFunctions(GSRendererHW& renderer)
 static GSVector4i s_dimx_storage[8];
 static GIFRegDIMX s_last_dimx;
 
-bool GSRendererHWFunctions::SwPrimRender(GSRendererHW& hw, bool invalidate_tc, bool add_ee_transfer)
+bool GSRendererHWFunctions::SwPrimRender(GSRendererHW& hw, bool invalidate_tc, bool add_ee_transfer, u32 start, u32 count)
 {
 	GSVertexTrace& vt = hw.m_vt;
 	const GIFRegPRIM* PRIM = hw.PRIM;
@@ -45,8 +48,8 @@ bool GSRendererHWFunctions::SwPrimRender(GSRendererHW& hw, bool invalidate_tc, b
 	data.buff = nullptr;
 	data.vertex = hw.m_sw_vertex_buffer.data();
 	data.vertex_count = hw.m_vertex->next;
-	data.index = hw.m_index->buff;
-	data.index_count = hw.m_index->tail;
+	data.index = hw.m_index->buff + start;
+	data.index_count = count;
 	data.scanmsk_value = env.SCANMSK.MSK;
 
 	// Skip per pixel division if q is constant.
@@ -562,4 +565,28 @@ bool GSRendererHWFunctions::SwPrimRender(GSRendererHW& hw, bool invalidate_tc, b
 	}
 
 	return true;
+}
+
+bool GSRendererHWFunctions::SwPrimRender(GSRendererHW& hw, bool invalidate_tc, bool add_ee_transfer)
+{
+	GL_INS("HW: SwPrimRender draw %lld", GSState::s_n);
+	if (hw.HasAutoFlushList())
+	{
+		// The SW renderer does not handle the autoflush list, so we need to flush here.
+		const u32 n = static_cast<u32>(GSUtil::GetClassVertexCount(hw.m_vt.m_primclass));
+		for (size_t i = 0, start = 0; i < hw.m_autoflush_list.size(); i++)
+		{
+			const u32 count = hw.m_autoflush_list[i] * n;
+			if (!SwPrimRender(hw, invalidate_tc, add_ee_transfer, start, count))
+			{
+				return false;
+			}
+			start += count;
+		}
+		return true;
+	}
+	else
+	{
+		return SwPrimRender(hw, invalidate_tc, add_ee_transfer, 0, hw.m_index->tail);
+	}
 }

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
@@ -434,8 +434,8 @@ public:
 
 	void SetupDestinationAlpha(GSTexture* rt, GSTexture* ds, const GSVector4i& r, SetDATM datm);
 	void RenderHW(GSHWDrawConfig& config) override;
-	void SendHWDraw(GSHWDrawConfig& config, id<MTLRenderCommandEncoder> enc, id<MTLBuffer> buffer, size_t off,
-		bool one_barrier, bool full_barrier);
+	void SendHWDraw(GSHWDrawConfig& config, const Map& verts, id<MTLRenderCommandEncoder> enc, id<MTLBuffer> buffer,
+		size_t off, bool one_barrier, bool full_barrier);
 
 	// MARK: Debug
 

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
@@ -214,6 +214,13 @@ public:
 
 	using PSSelector = GSHWDrawConfig::PSSelector;
 
+	enum class DrawPass
+	{
+		Main,
+		AlphaSecond,
+		PrimIDInit,
+	};
+
 	// MARK: Permanent resources
 	std::shared_ptr<std::pair<std::mutex, GSDeviceMTL*>> m_backref;
 	GSMTLDevice m_dev;
@@ -464,11 +471,11 @@ public:
 
 	// MARK: Render HW
 
+	void RestartRenderPassForAutoflush(GSHWDrawConfig& config, const Map& verts, DrawPass pass);
 	void SetupDestinationAlpha(GSTexture* rt, GSTexture* ds, const GSVector4i& r, SetDATM datm);
 	void PrepareROVTexture(GSTexture** ptex);
 	void RenderHW(GSHWDrawConfig& config) override;
-	void SendHWDraw(GSHWDrawConfig& config, id<MTLRenderCommandEncoder> enc, id<MTLBuffer> buffer, size_t off,
-		bool one_barrier, bool full_barrier);
+	void SendHWDraw(GSHWDrawConfig& config, id<MTLRenderCommandEncoder> enc, const Map& verts, id<MTLBuffer> index, size_t off, DrawPass pass);
 
 	// MARK: Debug
 

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -2241,7 +2241,7 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 			pxAssert(config.require_full_barrier == false && config.drawlist == nullptr);
 			MRESetHWPipelineState(config.vs, config.ps, {}, {});
 			MREInitHWDraw(config, allocation);
-			SendHWDraw(config, m_current_render.encoder, index_buffer, index_buffer_offset, false, false);
+			SendHWDraw(config, allocation, m_current_render.encoder, index_buffer, index_buffer_offset, false, false);
 			config.ps.date = 3;
 			break;
 		}
@@ -2288,7 +2288,7 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 	MRESetHWPipelineState(config.vs, config.ps, config.blend, config.colormask);
 	MRESetDSS(config.depth);
 
-	SendHWDraw(config, mtlenc, index_buffer, index_buffer_offset, config.require_one_barrier, config.require_full_barrier);
+	SendHWDraw(config, allocation, mtlenc, index_buffer, index_buffer_offset, config.require_one_barrier, config.require_full_barrier);
 
 	if (config.alpha_second_pass.enable)
 	{
@@ -2299,7 +2299,7 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 		}
 		MRESetHWPipelineState(config.vs, config.alpha_second_pass.ps, config.blend, config.alpha_second_pass.colormask);
 		MRESetDSS(config.alpha_second_pass.depth);
-		SendHWDraw(config, mtlenc, index_buffer, index_buffer_offset, config.alpha_second_pass.require_one_barrier, config.alpha_second_pass.require_full_barrier);
+		SendHWDraw(config, allocation, mtlenc, index_buffer, index_buffer_offset, config.alpha_second_pass.require_one_barrier, config.alpha_second_pass.require_full_barrier);
 	}
 
 	if (colclip_rt)
@@ -2321,7 +2321,7 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 		Recycle(primid_tex);
 }}
 
-void GSDeviceMTL::SendHWDraw(GSHWDrawConfig& config, id<MTLRenderCommandEncoder> enc, id<MTLBuffer> buffer, size_t off, bool one_barrier, bool full_barrier)
+void GSDeviceMTL::SendHWDraw(GSHWDrawConfig& config, const Map& verts, id<MTLRenderCommandEncoder> enc, id<MTLBuffer> buffer, size_t off, bool one_barrier, bool full_barrier)
 {
 	MTLPrimitiveType topology;
 	switch (config.topology)
@@ -2344,8 +2344,70 @@ void GSDeviceMTL::SendHWDraw(GSHWDrawConfig& config, id<MTLRenderCommandEncoder>
 		return;
 	}
 
+	if (config.autoflush)
+	{
+		const u32 draw_list_size = static_cast<u32>(config.drawlist->size());
+		const u32 indices_per_prim = config.indices_per_prim;
+		const u32 autoflush_list_size = static_cast<u32>(config.autoflush_list->size());
 
-	if (full_barrier)
+		[enc pushDebugGroup:[NSString stringWithFormat:@"Full barrier split draw (%d primitives in %zu autoflush groups, %zu barrier groups)",
+			config.nindices / config.indices_per_prim, autoflush_list_size, draw_list_size]];
+
+		GSTexture* stencil = (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::StencilOne ||
+		                     config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::Stencil) ?
+		                     config.ds : nullptr;
+
+		const GSVector4i tex_rect = config.tex->GetRect();
+
+		// a: autoflush drawlist position
+		// n: barrier drawlist position
+		// p: number of indices drawn
+		for (u32 a = 0, n = 0, p = 0; a < autoflush_list_size; a++)
+		{
+			const GSVector4i bbox = (*config.autoflush_bbox)[a].rintersect(tex_rect);
+			const bool do_copy = !bbox.rempty();
+
+			if (do_copy)
+			{
+				EndRenderPass();
+
+				CopyRect(config.rt, config.tex, bbox, bbox.x, bbox.y);
+
+				BeginRenderPass(@"RenderHW Autoflush", config.rt, MTLLoadActionLoad, config.ds, MTLLoadActionLoad, stencil, MTLLoadActionLoad);
+				MREInitHWDraw(config, verts);
+			}
+
+			int prims = static_cast<int>((*config.autoflush_list)[a]);
+
+			bool first = true;
+			while (prims > 0)
+			{
+				const u32 count = (*config.drawlist)[n] * indices_per_prim;
+
+				// Skip the first barrier if copy/transition has covered it.
+				if (!first || !do_copy)
+				{
+					textureBarrier(enc);
+					g_perfmon.Put(GSPerfMon::Barriers, 1);
+				}
+
+			[enc drawIndexedPrimitives:topology
+			                indexCount:count
+			                 indexType:MTLIndexTypeUInt16
+			               indexBuffer:buffer
+			         indexBufferOffset:off + p * sizeof(*config.indices)];
+
+				prims -= (*config.drawlist)[n];
+				p += count;
+				n++;
+				first = false;
+			}
+		}
+
+		[enc popDebugGroup];
+		return;
+	}
+	else if (full_barrier)
 	{
 		pxAssert(config.drawlist && !config.drawlist->empty());
 

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -2323,6 +2323,68 @@ static bool usesStencil(GSHWDrawConfig::DestinationAlphaMode dstalpha)
 	}
 }
 
+static bool configFullBarrier(GSHWDrawConfig& config, GSDeviceMTL::DrawPass pass)
+{
+	switch (pass)
+	{
+		case GSDeviceMTL::DrawPass::Main:
+			return config.require_full_barrier;
+		case GSDeviceMTL::DrawPass::AlphaSecond:
+			return config.alpha_second_pass.require_full_barrier;
+		case GSDeviceMTL::DrawPass::PrimIDInit:
+			return false;
+	}
+}
+
+static bool configOneBarrier(GSHWDrawConfig& config, GSDeviceMTL::DrawPass pass)
+{
+	switch (pass)
+	{
+		case GSDeviceMTL::DrawPass::Main:
+			return config.require_one_barrier;
+		case GSDeviceMTL::DrawPass::AlphaSecond:
+			return config.alpha_second_pass.require_one_barrier;
+		case GSDeviceMTL::DrawPass::PrimIDInit:
+			return false;
+	}
+}
+
+static GSHWDrawConfig::PSSelector& configPSSelector(GSHWDrawConfig& config, GSDeviceMTL::DrawPass pass)
+{
+	switch (pass)
+	{
+		case GSDeviceMTL::DrawPass::Main:
+		case GSDeviceMTL::DrawPass::PrimIDInit:
+			return config.ps;
+		case GSDeviceMTL::DrawPass::AlphaSecond:
+			return config.alpha_second_pass.ps;
+	}
+}
+
+static GSHWDrawConfig::ColorMaskSelector& configColorMask(GSHWDrawConfig& config, GSDeviceMTL::DrawPass pass)
+{
+	switch (pass)
+	{
+		case GSDeviceMTL::DrawPass::Main:
+		case GSDeviceMTL::DrawPass::PrimIDInit:
+			return config.colormask;
+		case GSDeviceMTL::DrawPass::AlphaSecond:
+			return config.alpha_second_pass.colormask;
+	}
+}
+
+static GSHWDrawConfig::DepthStencilSelector& configDepth(GSHWDrawConfig& config, GSDeviceMTL::DrawPass pass)
+{
+	switch (pass)
+	{
+		case GSDeviceMTL::DrawPass::Main:
+		case GSDeviceMTL::DrawPass::PrimIDInit:
+			return config.depth;
+		case GSDeviceMTL::DrawPass::AlphaSecond:
+			return config.alpha_second_pass.depth;
+	}
+}
+
 void GSDeviceMTL::MREInitHWDraw(GSHWDrawConfig& config, const Map& verts)
 {
 	MRESetScissor(config.scissor);
@@ -2343,6 +2405,34 @@ __fi void GSDeviceMTL::PrepareROVTexture(GSTexture** ptex)
 	tex->m_last_read  = m_current_draw;
 	tex->m_last_write = m_current_draw;
 	*ptex = nullptr;
+}
+
+void GSDeviceMTL::RestartRenderPassForAutoflush(GSHWDrawConfig& config, const Map& verts, DrawPass pass)
+{
+	// Does not handle colclip HW and DATE PrimID, as those pipeline combinations are not compatible with autoflush.
+
+	GSTexture* rt = config.rt;
+	GSTexture* ds = config.ds;
+	GSTexture* stencil = usesStencil(config.destination_alpha) ? config.ds : nullptr;
+
+	const bool full_barrier = configFullBarrier(config, pass);
+	const bool one_barrier = configOneBarrier(config, pass);
+
+	BeginRenderPass(@"Autoflush", rt, MTLLoadActionLoad, ds, MTLLoadActionLoad, stencil, MTLLoadActionLoad);
+
+	id<MTLRenderCommandEncoder> mtlenc = m_current_render.encoder;
+
+	if (usesStencil(config.destination_alpha))
+		[mtlenc setStencilReferenceValue:1];
+
+	MREInitHWDraw(config, verts);
+	if (one_barrier || full_barrier)
+		MRESetTexture(rt, GSMTLTextureIndexRenderTarget);
+	if (config.blend.constant_enable)
+		MRESetBlendColor(config.blend.constant);
+	
+	MRESetHWPipelineState(config.vs, configPSSelector(config, pass), config.blend, configColorMask(config, pass));
+	MRESetDSS(configDepth(config, pass));
 }
 
 void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
@@ -2463,7 +2553,7 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 			pxAssert(config.require_full_barrier == false && config.drawlist == nullptr);
 			MRESetHWPipelineState(config.vs, config.ps, {}, {});
 			MREInitHWDraw(config, allocation);
-			SendHWDraw(config, m_current_render.encoder, index_buffer, index_buffer_offset, false, false);
+			SendHWDraw(config, m_current_render.encoder, allocation, index_buffer, index_buffer_offset, DrawPass::PrimIDInit);
 			config.ps.date = 3;
 			break;
 		}
@@ -2531,7 +2621,7 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 	MRESetHWPipelineState(config.vs, config.ps, config.blend, config.colormask);
 	MRESetDSS(config.depth);
 
-	SendHWDraw(config, mtlenc, index_buffer, index_buffer_offset, config.require_one_barrier, config.require_full_barrier);
+	SendHWDraw(config, m_current_render.encoder, allocation, index_buffer, index_buffer_offset, DrawPass::Main);
 
 	if (config.alpha_second_pass.enable)
 	{
@@ -2542,7 +2632,7 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 		}
 		MRESetHWPipelineState(config.vs, config.alpha_second_pass.ps, config.blend, config.alpha_second_pass.colormask);
 		MRESetDSS(config.alpha_second_pass.depth);
-		SendHWDraw(config, mtlenc, index_buffer, index_buffer_offset, config.alpha_second_pass.require_one_barrier, config.alpha_second_pass.require_full_barrier);
+		SendHWDraw(config, m_current_render.encoder, allocation, index_buffer, index_buffer_offset, DrawPass::AlphaSecond);
 	}
 
 	if (colclip_rt)
@@ -2582,7 +2672,7 @@ static void EncodeDraw(id<MTLRenderCommandEncoder> enc, MTLPrimitiveType topolog
 	}
 }
 
-void GSDeviceMTL::SendHWDraw(GSHWDrawConfig& config, id<MTLRenderCommandEncoder> enc, id<MTLBuffer> buffer, size_t off, bool one_barrier, bool full_barrier)
+void GSDeviceMTL::SendHWDraw(GSHWDrawConfig& config, id<MTLRenderCommandEncoder> enc, const Map& verts, id<MTLBuffer> buffer, size_t off, DrawPass pass)
 {
 	MTLPrimitiveType topology;
 	switch (config.topology)
@@ -2599,8 +2689,67 @@ void GSDeviceMTL::SendHWDraw(GSHWDrawConfig& config, id<MTLRenderCommandEncoder>
 		return;
 	}
 
+	const bool full_barrier = configFullBarrier(config, pass);
+	const bool one_barrier = configOneBarrier(config, pass);
 
-	if (full_barrier)
+	if (config.autoflush)
+	{
+		const u32 draw_list_size = static_cast<u32>(config.drawlist->size());
+		const u32 indices_per_prim = config.indices_per_prim;
+		const u32 autoflush_list_size = static_cast<u32>(config.autoflush_list->size());
+
+		[enc insertDebugSignpost:[NSString stringWithFormat:@"Full barrier split draw (%d primitives in %d autoflush groups, %d barrier groups)",
+			config.nindices / config.indices_per_prim, autoflush_list_size, draw_list_size]];
+
+		const GSVector4i tex_rect = config.tex->GetRect();
+
+		// a: autoflush drawlist position
+		// n: barrier drawlist position
+		// p: number of indices drawn
+		for (u32 a = 0, n = 0, p = 0; a < autoflush_list_size; a++)
+		{
+			[enc insertDebugSignpost:[NSString stringWithFormat:@"Autoflush pass %d, draw %d, prim %d", a, n, p / indices_per_prim]];
+
+			const GSVector4i bbox = config.autoflush_bbox->at(a).rintersect(tex_rect);
+			const bool do_copy = !bbox.rempty();
+
+			if (do_copy)
+			{
+				EndRenderPass();
+
+				CopyRect(config.rt, config.tex, bbox, bbox.x, bbox.y);
+
+				RestartRenderPassForAutoflush(config, verts, pass);
+				
+				enc = m_current_render.encoder;
+			}
+
+			int prims = static_cast<int>(config.autoflush_list->at(a));
+
+			bool first = true;
+			while (prims > 0)
+			{
+				const u32 count = config.drawlist->at(n) * indices_per_prim;
+
+				// Skip the first barrier if renderpass restart has covered it.
+				if (!first || !do_copy)
+				{
+					textureBarrier(enc);
+					g_perfmon.Put(GSPerfMon::Barriers, 1);
+				}
+
+				EncodeDraw(enc, topology, count, buffer, off, p);
+
+				prims -= config.drawlist->at(n);
+				p += count;
+				n++;
+				first = false;
+			}
+		}
+
+		return;
+	}
+	else if (full_barrier)
 	{
 		pxAssert(config.drawlist && !config.drawlist->empty());
 
@@ -2618,7 +2767,6 @@ void GSDeviceMTL::SendHWDraw(GSHWDrawConfig& config, id<MTLRenderCommandEncoder>
 		[enc insertDebugSignpost:[NSString stringWithFormat:@"Split single draw (%d primitives) into %zu draws: consecutive draws(frequency):%s",
 			config.nindices / config.indices_per_prim, config.drawlist->size(), message.c_str()]];
 #endif
-
 
 		g_perfmon.Put(GSPerfMon::DrawCalls, config.drawlist->size());
 		g_perfmon.Put(GSPerfMon::Barriers, config.drawlist->size());

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -3009,7 +3009,58 @@ void GSDeviceOGL::SendHWDraw(const GSHWDrawConfig& config,
 
 	const GSVector4i rtsize(0, 0, (draw_rt ? draw_rt : draw_ds)->GetWidth(), (draw_rt ? draw_rt : draw_ds)->GetHeight());
 
-	if (full_barrier)
+	if (config.autoflush)
+	{
+		const u32 draw_list_size = static_cast<u32>(config.drawlist->size());
+		const u32 indices_per_prim = config.indices_per_prim;
+		const u32 autoflush_list_size = static_cast<u32>(config.autoflush_list->size());
+
+		GL_PUSH("Split the draw (autoflush)");
+
+		const GSVector4i tex_rect = config.tex->GetRect();
+
+		// a: autoflush drawlist position
+		// n: barrier drawlist position
+		// p: number of indices drawn
+		for (u32 a = 0, n = 0, p = 0; a < autoflush_list_size; a++)
+		{
+			const GSVector4i bbox = (*config.autoflush_bbox)[a].rintersect(tex_rect);
+			const bool copy = !bbox.rempty();
+
+			if (copy)
+			{
+				CopyRect(config.rt, config.tex, bbox, bbox.x, bbox.y);
+
+				PSSetShaderResource(0, config.tex);
+				OMSetRenderTargets(config.rt, config.ds_as_rt, config.ds, &config.scissor);
+			}
+
+			int prims = static_cast<int>((*config.autoflush_list)[a]);
+
+			bool first = true;
+			while (prims > 0)
+			{
+				const u32 count = (*config.drawlist)[n] * indices_per_prim;
+
+				// Skip the first barrier if copy/transition has covered it.
+				if (!first || !copy)
+				{
+					glTextureBarrier();
+					g_perfmon.Put(GSPerfMon::Barriers, 1);
+				}
+
+				DrawIndexedPrimitive(p, count);
+
+				prims -= (*config.drawlist)[n];
+				p += count;
+				n++;
+				first = false;
+			}
+		}
+
+		return;
+	}
+	else if (full_barrier)
 	{
 		pxAssert(config.drawlist && !config.drawlist->empty());
 		

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -3258,7 +3258,59 @@ void GSDeviceOGL::SendHWDraw(const GSHWDrawConfig& config,
 		Console.Warning("OpenGL: Possible unnecessary barrier detected.");
 #endif
 
-	if (full_barrier)
+	const GSVector4i rtsize(0, 0, (draw_rt ? draw_rt : draw_ds)->GetWidth(), (draw_rt ? draw_rt : draw_ds)->GetHeight());
+
+	if (config.autoflush)
+	{
+		const u32 indices_per_prim = config.indices_per_prim;
+		const u32 autoflush_list_size = static_cast<u32>(config.autoflush_list->size());
+
+		GL_PUSH("Split the draw (autoflush)");
+
+		const GSVector4i tex_rect = config.tex->GetRect();
+
+		// a: autoflush drawlist position
+		// n: barrier drawlist position
+		// p: number of indices drawn
+		for (u32 a = 0, n = 0, p = 0; a < autoflush_list_size; a++)
+		{
+			const GSVector4i bbox = config.autoflush_bbox->at(a).rintersect(tex_rect);
+			const bool copy = !bbox.rempty();
+
+			if (copy)
+			{
+				CopyRect(config.rt, config.tex, bbox, bbox.x, bbox.y);
+
+				PSSetShaderResource(0, config.tex);
+				OMSetRenderTargets(config.rt, m_ds_as_rt, config.ds, &config.scissor);
+			}
+
+			int prims = static_cast<int>((*config.autoflush_list)[a]);
+
+			bool first = true;
+			while (prims > 0)
+			{
+				const u32 count = config.drawlist->at(n) * indices_per_prim;
+
+				// Skip the first barrier if copy/transition has covered it.
+				if (!first || !copy)
+				{
+					glTextureBarrier();
+					g_perfmon.Put(GSPerfMon::Barriers, 1);
+				}
+
+				Draw(config, p, count);
+
+				prims -= config.drawlist->at(n);
+				p += count;
+				n++;
+				first = false;
+			}
+		}
+
+		return;
+	}
+	else if (full_barrier)
 	{
 		pxAssert(config.drawlist && !config.drawlist->empty());
 		

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -6243,7 +6243,74 @@ void GSDeviceVK::SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt, 
 		}
 	};
 
-	if (full_barrier)
+	if (config.autoflush)
+	{
+		const u32 draw_list_size = static_cast<u32>(config.drawlist->size());
+		const u32 indices_per_prim = config.indices_per_prim;
+		const u32 autoflush_list_size = static_cast<u32>(config.autoflush_list->size());
+
+		GL_PUSH("Split the draw (autoflush)");
+
+		const GSVector4i tex_rect = config.tex->GetRect();
+
+		const PipelineSelector& pipe = m_pipeline_selector;
+		GSTextureVK* rt = static_cast<GSTextureVK*>(config.rt);
+		GSTextureVK* ds = static_cast<GSTextureVK*>(config.ds);
+
+		pxAssert(!rt || rt->GetState() == GSTexture::State::Dirty);
+		pxAssert(!ds || ds->GetState() == GSTexture::State::Dirty);
+
+		// RT and DS should have already been set to dirty, the load ops should be
+		// either LOAD if non-null or DONT_CARE if null.
+		const VkRenderPass render_pass = GetTFXRenderPass(pipe.rt, pipe.ds, pipe.ps.colclip_hw,
+			config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::Stencil, pipe.IsRTFeedbackLoop(),
+			pipe.IsTestingAndSamplingDepth(), GetLoadOpForTexture(rt), GetLoadOpForTexture(ds));
+
+		// a: autoflush drawlist position
+		// n: barrier drawlist position
+		// p: number of indices drawn
+		for (u32 a = 0, n = 0, p = 0; a < autoflush_list_size; a++)
+		{
+			const GSVector4i bbox = (*config.autoflush_bbox)[a].rintersect(tex_rect);
+			const bool copy = !bbox.rempty();
+
+			if (copy)
+			{
+				EndRenderPass();
+				CopyRect(config.rt, config.tex, bbox, bbox.x, bbox.y);
+
+				PSSetShaderResource(TFX_TEXTURE_TEXTURE, config.tex, true);
+				OMSetRenderTargets(config.rt, config.ds, config.scissor, m_current_framebuffer_feedback_loop);
+				
+				BeginRenderPass(render_pass, config.drawarea);
+			}
+
+			int prims = static_cast<int>((*config.autoflush_list)[a]);
+
+			bool first = true;
+			while (prims > 0)
+			{
+				const u32 count = (*config.drawlist)[n] * indices_per_prim;
+
+				// Skip the first barrier if copy/transition has covered it.
+				if (!first || !copy)
+				{
+					IssueBarriers();
+				}
+
+				if (BindDrawPipeline(m_pipeline_selector))
+					DrawIndexedPrimitive(p, count);
+
+				prims -= (*config.drawlist)[n];
+				p += count;
+				n++;
+				first = false;
+			}
+		}
+
+		return;
+	}
+	else if (full_barrier)
 	{
 		pxAssert(config.drawlist && !config.drawlist->empty());
 

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -6573,7 +6573,74 @@ void GSDeviceVK::SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt, 
 		}
 	};
 
-	if (full_barrier)
+	if (config.autoflush)
+	{
+		const u32 indices_per_prim = config.indices_per_prim;
+		const u32 autoflush_list_size = static_cast<u32>(config.autoflush_list->size());
+
+		GL_PUSH("Split the draw (autoflush)");
+
+		const GSVector4i tex_rect = config.tex->GetRect();
+
+		const PipelineSelector& pipe = m_pipeline_selector;
+		GSTextureVK* rt = static_cast<GSTextureVK*>(config.rt);
+		GSTextureVK* ds = static_cast<GSTextureVK*>(config.ds);
+
+		pxAssert(!rt || rt->GetState() == GSTexture::State::Dirty);
+		pxAssert(!ds || ds->GetState() == GSTexture::State::Dirty);
+
+		// RT and DS should have already been set to dirty, the load ops should be
+		// either LOAD if non-null or DONT_CARE if null.
+		const VkRenderPass render_pass = GetTFXRenderPass(pipe.rt, pipe.ds, pipe.ps.colclip_hw,
+			config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::Stencil, pipe.IsRTFeedbackLoop(),
+			pipe.IsTestingAndSamplingDepth(), GetLoadOpForTexture(rt), GetLoadOpForTexture(ds));
+
+		// a: autoflush drawlist position
+		// n: barrier drawlist position
+		// p: number of indices drawn
+		for (u32 a = 0, n = 0, p = 0; a < autoflush_list_size; a++)
+		{
+			const GSVector4i bbox = config.autoflush_bbox->at(a).rintersect(tex_rect);
+			const bool copy = !bbox.rempty();
+
+			if (copy)
+			{
+				EndRenderPass();
+				CopyRect(config.rt, config.tex, bbox, bbox.x, bbox.y);
+
+				PSSetShaderResource(TFX_TEXTURE_TEXTURE, config.tex, true);
+				OMSetRenderTargets(config.rt, config.ds, config.scissor, m_current_framebuffer_feedback_loop);
+				
+				BeginRenderPass(render_pass, config.drawarea);
+			}
+
+			int prims = static_cast<int>(config.autoflush_list->at(a));
+
+			bool first = true;
+			while (prims > 0)
+			{
+				const u32 count = config.drawlist->at(n) * indices_per_prim;
+
+				// Skip the first barrier if copy/transition has covered it.
+				if (!first || !copy)
+				{
+					IssueBarriers();
+					g_perfmon.Put(GSPerfMon::Barriers, n_barriers);
+				}
+
+				if (BindDrawPipeline(m_pipeline_selector))
+					Draw(config, p, count);
+
+				prims -= config.drawlist->at(n);
+				p += count;
+				n++;
+				first = false;
+			}
+		}
+
+		return;
+	}
+	else if (full_barrier)
 	{
 		pxAssert(config.drawlist && !config.drawlist->empty());
 


### PR DESCRIPTION
### Description of Changes
Add a new autoflush setting ("batched autoflush") to do autoflush draws with a copy loop.

### Rationale behind Changes
Can reduce draws and improve performance in autoflush heavy games such as Jak 2 (dump attached).

Does not always improve stats/performance, as it can interact negatively with heuristics such as tex-is-fb, TC aging, early alpha test abort, etc.

Should not cause graphical regression, though it can cause tiny pixel difference (compared to standard autoflush) due to interactions with texel rounding and tex-is-fb heuristics.

### Suggested Testing Steps
Enable the setting using GUI Settings>Graphics>Hardware Fixes>Auto Flush>Batch Enabled (after checking "Manual Hardware renderer Fixes" in Settings>Graphics>Rendering).

Alternatively, add the following to PCSX2.ini:
```
[EmuCore/GS]
...
UserHacks = true
UserHacks_AutoFlushLevel = 3
```

Try games known to be heavy on autoflush with any HW renderer.

[Jak.II_SCUS-97265_20230303034214.gs.xz.zip](https://github.com/user-attachments/files/26734288/Jak.II_SCUS-97265_20230303034214.gs.xz.zip)

### Did you use AI to help find, test, or implement this issue or feature?
Some questions about DX12 usage during debugging.