### PR TITLE
GS: Clear texture binding on slot 2 if it was bound previously.

### DIFF
--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -4285,6 +4285,12 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 		if (!draw_rt && m_current_render_target && config.tex != m_current_render_target &&
 			m_current_render_target->GetSize() == draw_ds->GetSize())
 		{
+			// Clear texture binding when it's bound to RT, a previous feedbackloop might have used slot 2,
+			// if so we need to unbind it to avoid rt hazards, we only need to do this with texture barriers.
+			if (m_features.texture_barrier && !(config.require_one_barrier || config.require_full_barrier) &&
+				static_cast<GSTexture12*>(m_current_render_target)->GetSRVDescriptor() == m_tfx_textures[2])
+				PSSetShaderResource(2, nullptr, false);
+
 			draw_rt = m_current_render_target;
 			m_pipeline_selector.rt = true;
 		}

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -2865,6 +2865,15 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 	if (!draw_rt && GLState::rt && GLState::ds == draw_ds && config.tex != GLState::rt &&
 		GLState::rt->GetSize() == draw_ds->GetSize() && !draw_ds_as_rt)
 	{
+		// Clear texture binding when it's bound to RT, a previous feedbackloop might have used slot 2,
+		// if so we need to unbind it to avoid rt hazards, we only need to do this with texture barriers.
+		if (m_features.texture_barrier && !(config.require_one_barrier || config.require_full_barrier) &&
+			static_cast<GSTextureOGL*>(GLState::rt)->GetID() == GLState::tex_unit[2])
+		{
+			GLState::tex_unit[2] = 0;
+			glBindTextureUnit(2, 0);
+		}
+
 		draw_rt = GLState::rt;
 		fb_optimization_needs_barrier = !GLState::rt_written;
 	}

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -5902,6 +5902,12 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 		if (!draw_rt && m_current_render_target && config.tex != m_current_render_target &&
 			m_current_render_target->GetSize() == draw_ds->GetSize())
 		{
+			// Clear texture binding when it's bound to RT, a previous feedbackloop might have used slot 2,
+			// if so we need to unbind it to avoid rt hazards, we only need to do this with texture barriers.
+			if (m_features.texture_barrier && !(config.require_one_barrier || config.require_full_barrier) &&
+				static_cast<GSTextureVK*>(m_current_render_target) == m_tfx_textures[2])
+				PSSetShaderResource(2, nullptr, false);
+
 			draw_rt = m_current_render_target;
 			m_pipeline_selector.rt = true;
 		}


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS: Clear texture binding on slot 2 if it was bound previously.

Clear texture binding when it's bound to RT, a previous feedbackloop might have used slot 2, if so we need to unbind it to avoid rt hazards, we only need to do this with texture barriers.

This is only required for render pass optimizations where we reuse the old bound rt.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Bugfix, rt hazards.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test games listed in the txt file on dx12/gl/vk.
[Slot 2.txt](https://github.com/user-attachments/files/26753452/Slot.2.txt)

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
