### PR TITLE
Qt: Fix Main Window Visibility in Exclusive Fullscreen Mode

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1114,7 +1114,7 @@ bool MainWindow::shouldHideMainWindow() const
 {
 	// NOTE: We can't use isRenderingToMain() here, because this happens post-fullscreen-switch.
 	return (Host::GetBoolSettingValue("UI", "HideMainWindowWhenRunning", false) && !g_emu_thread->shouldRenderToMain()) ||
-	       (g_emu_thread->shouldRenderToMain() && (isRenderingFullscreen() || m_is_temporarily_windowed)) ||
+	       (g_emu_thread->shouldRenderToMain() && (isRenderingFullscreen() || g_emu_thread->isExclusiveFullscreen() || m_is_temporarily_windowed)) ||
 	       Host::InNoGUIMode();
 }
 

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -2538,6 +2538,7 @@ std::optional<WindowInfo> MainWindow::acquireRenderWindow(bool recreate_window, 
 		return std::nullopt;
 	}
 
+	m_display_is_exclusive_fullscreen = g_emu_thread->isExclusiveFullscreen();
 	g_emu_thread->connectDisplaySignals(m_display_surface);
 
 	updateWindowTitle();
@@ -2709,6 +2710,7 @@ void MainWindow::releaseRenderWindow()
 	// Now we can safely destroy the display window.
 	destroyDisplayWidget(true);
 	m_display_created = false;
+	m_display_is_exclusive_fullscreen = false;
 
 	m_ui.actionViewSystemDisplay->setEnabled(false);
 	m_ui.actionFullscreen->setEnabled(false);
@@ -2719,7 +2721,7 @@ void MainWindow::destroyDisplayWidget(bool show_game_list)
 	if (!m_display_surface)
 		return;
 
-	if (!m_display_surface->isFullScreen() && !isRenderingToMain())
+	if (!(m_display_surface->isFullScreen() || m_display_is_exclusive_fullscreen) && !isRenderingToMain())
 		saveDisplayWindowGeometryToConfig();
 
 	if (isRenderingToMain())

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -317,6 +317,7 @@ private:
 	QMenu* m_settings_toolbar_menu = nullptr;
 
 	bool m_display_created = false;
+	bool m_display_is_exclusive_fullscreen = false;
 	bool m_relative_mouse_mode = false;
 	bool m_hide_mouse_cursor = false;
 	bool m_was_paused_on_surface_loss = false;


### PR DESCRIPTION
### Description of Changes
shouldHideMainWindow() in MainWindow.cpp now checks if render-to-main and exclusive fullscreen are both enabled.

### Rationale behind Changes
Fullscreen modes do not actually render to the main window. Instead, they use a separate window and hide the main window. That is why in acquireRenderWindow() in QtHost.cpp, render_to_main is set to false when any fullscreen mode is enabled.

One edge case was not being handled: render-to-main enabled, starting windowed, and then switching to exclusive fullscreen. In that case, the main window becomes visible and remains visible.

### Suggested Testing Steps
1. Verify that "Start Fullscreen" and "Render To Separate Window" are disabled.
2. Set "Fullscreen Mode" to any resolution/refresh rate option rather than "Borderless Fullscreen".
3. Start a game in windowed mode, then switch to fullscreen.
4. Verify that no main window is visible in the background. Check the taskbar as well.

### Did you use AI to help find, test, or implement this issue or feature?
No.
