### PR TITLE
Fix/achievements winhttp timeout crash

### DIFF
--- a/common/HTTPDownloaderWinHTTP.cpp
+++ b/common/HTTPDownloaderWinHTTP.cpp
@@ -56,6 +56,11 @@ bool HTTPDownloaderWinHttp::Initialize(std::string user_agent)
 		return false;
 	}
 
+	DWORD timeout_ms = 15000;
+	WinHttpSetOption(m_hSession, WINHTTP_OPTION_CONNECT_TIMEOUT, &timeout_ms, sizeof(timeout_ms));
+	WinHttpSetOption(m_hSession, WINHTTP_OPTION_SEND_TIMEOUT, &timeout_ms, sizeof(timeout_ms));
+	WinHttpSetOption(m_hSession, WINHTTP_OPTION_RECEIVE_TIMEOUT, &timeout_ms, sizeof(timeout_ms));
+
 	return true;
 }
 
@@ -286,14 +291,16 @@ bool HTTPDownloaderWinHttp::StartRequest(HTTPDownloader::Request* request)
 
 	if (!result && GetLastError() != ERROR_IO_PENDING)
 	{
-		Console.Error("WinHttpSendRequest() failed: %u", GetLastError());
-		req->status_code = HTTP_STATUS_ERROR;
-		req->state.store(Request::State::Complete);
+    Console.Error("WinHttpSendRequest() failed: %u", GetLastError());
+    req->status_code = HTTP_STATUS_ERROR;
+    req->state.store(Request::State::Complete);
 	}
-
-	DevCon.WriteLn("Started HTTP request for '%s'", req->url.c_str());
-	req->state = Request::State::Started;
-	req->start_time = Common::Timer::GetCurrentValue();
+	else
+	{
+    DevCon.WriteLn("Started HTTP request for '%s'", req->url.c_str());
+    req->state = Request::State::Started;
+    req->start_time = Common::Timer::GetCurrentValue();
+	}
 	return true;
 }
 

--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -747,9 +747,11 @@ void Achievements::ClientServerCall(
 	{
 		rc_api_server_response_t rr;
 		rr.http_status_code = (status_code <= 0) ? (status_code == HTTPDownloader::HTTP_STATUS_CANCELLED ?
-		                                                   RC_API_SERVER_RESPONSE_CLIENT_ERROR :
-		                                                   RC_API_SERVER_RESPONSE_RETRYABLE_CLIENT_ERROR)
-		                                         : status_code;
+        												RC_API_SERVER_RESPONSE_CLIENT_ERROR :
+    												status_code == HTTPDownloader::HTTP_STATUS_TIMEOUT ?
+        												RC_API_SERVER_RESPONSE_RETRYABLE_CLIENT_ERROR :
+        												RC_API_SERVER_RESPONSE_CLIENT_ERROR)  // HTTP_STATUS_ERROR = hard fail, don't retry
+    											: status_code;
 		rr.body_length = data.size();
 		rr.body = reinterpret_cast<const char*>(data.data());
 


### PR DESCRIPTION
### Description of Changes
Fix crash when RetroAchievements server is unreachable due to a censored or blocking network connection. Affects any network that hangs connections rather than refusing them (error 12002 / `ERROR_WINHTTP_TIMEOUT`).

### Rationale behind Changes
Three bugs in the WinHTTP layer caused a crash instead of a graceful failure:

1. **State overwrite in `StartRequest()`** — when `WinHttpSendRequest` fails synchronously, the request state was correctly set to `Complete` but then immediately overwritten with `Started` unconditionally. The async callback never fires for a failed send, so the request hung until the app-level timeout.

2. **Competing timeouts** — WinHTTP's default receive timeout and the app-level timeout are both 30s, creating a race between the WinHTTP callback thread and the polling thread. Explicit WinHTTP timeouts (15s) ensure the async error always fires before the poll loop races it.

3. **Incorrect error mapping in `ClientServerCall()`** — `HTTP_STATUS_ERROR` was mapped to `RC_API_SERVER_RESPONSE_RETRYABLE_CLIENT_ERROR`, causing rc_client to retry indefinitely on hard WinHTTP failures. On a network that consistently hangs connections this retry loop leads to a crash. Fixed by mapping it to `CLIENT_ERROR` (non-retryable).

Closes #14277

### Suggested Testing Steps
Add `127.0.0.1 retroachievements.org` to your hosts file, launch PCSX2 with achievements enabled, and verify it logs an error and continues running instead of crashing after ~30 seconds.

### Did you use AI to help find, test, or implement this issue or feature?
Yes. Used Claude to help trace the root cause through the WinHTTP callback chain and identify the three contributing bugs. All changes were reviewed and understood before submission.