### PR TITLE
GameDB: Fix name of SLES-54961

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -28407,7 +28407,7 @@ SLES-54960:
   name: "Godzilla - Unleashed"
   region: "PAL-M5"
 SLES-54961:
-  name: "World series of poker 2008"
+  name: "World Series of Poker 2008 - Battle for the Bracelets"
   region: "PAL-E"
 SLES-54962:
   name: "Guitar Hero III - Legends of Rock"


### PR DESCRIPTION
It was of low quality.

### Description of Changes
"World series of poker 2008" > "World Series of Poker 2008 - Battle for the Bracelets"

### Rationale behind Changes
NTSC version already has proper name.

### Did you use AI to help find, test, or implement this issue or feature?
No.
