### PR TITLE
GS/GL: Initialise stencil ref/mask during device creation

### DIFF
--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -553,6 +553,9 @@ bool GSDeviceOGL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 		glDisable(GL_MULTISAMPLE);
 
 		glDisable(GL_DITHER); // Honestly I don't know!
+
+		// Initialise stencil ref/mask.
+		glStencilFunc(GLState::stencil_func, 1, 1);
 	}
 
 	// ****************************************************************


### PR DESCRIPTION
### Description of Changes
Initialise stencil ref/mask during device creation

### Rationale behind Changes
`SetupStencil()` only calls `glStencilFunc()` if we change the stencil function.
If we've never changed away from the default stencil function when we perform stencil date, then the stencil reference are left at the default of 0.
Explicitly setting these values during create ensures that create reference values are set.
Fixes #14293 

### Suggested Testing Steps
Test the OpenGL render
See #14293 for an affected dump (Barriers need to be force disabled)
I've not done a dump run.

### Did you use AI to help find, test, or implement this issue or feature?
No
