### PR TITLE
GHActions: Check msbuild compile succeeds

### DIFF
--- a/.github/workflows/windows_build_qt.yml
+++ b/.github/workflows/windows_build_qt.yml
@@ -150,7 +150,7 @@ jobs:
             cmake --build build --config Release || exit /b
             cmake --install build --config Release || exit /b
           ) else (
-            msbuild "PCSX2_qt.sln" /m /v:m /p:Configuration="${{ inputs.configuration }}" /p:Platform="${{ inputs.platform }}"
+            msbuild "PCSX2_qt.sln" /m /v:m /p:Configuration="${{ inputs.configuration }}" /p:Platform="${{ inputs.platform }}" || exit /b
           )
           REM We can use Segoe UI Emoji so we don't need to bundle this
           del bin\resources\fonts\Twemoji*


### PR DESCRIPTION
### Description of Changes
Check that compiling with msbuild succeeds.

### Rationale behind Changes
The msbuild project files may need to be updated to reflect windows changes.
Having the CI actually check the compile result will make it easier for Linux based developers to spot when this is needed.

### Suggested Testing Steps
Check CI
I did a run here without the wil the include fix https://github.com/TheLastRar/pcsx2/actions/runs/24592187257/job/71915071086

### Did you use AI to help find, test, or implement this issue or feature?
No
