### PR TITLE
GS/TC: Remove debug code left by accident.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1432,7 +1432,7 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const bool is_color, const 
 				// Transfers completely outside the valid area may not have been given a dirty rect, so we need both checks.
 				const bool t_maybe_dirty = !t->m_dirty.empty() || !t->OverlapsValid(bp, bw, psm, req_rect);
 
-				if ((bp == t->m_TEX0.TBP0 && t_maybe_dirty && GSUtil::GetChannelMask(psm) == GSUtil::GetChannelMask(t->m_TEX0.PSM) && GSRendererHW::GetInstance()->m_draw_transfers.size() > 0) || GSState::s_n==421)
+				if (bp == t->m_TEX0.TBP0 && t_maybe_dirty && GSUtil::GetChannelMask(psm) == GSUtil::GetChannelMask(t->m_TEX0.PSM) && GSRendererHW::GetInstance()->m_draw_transfers.size() > 0)
 				{
 					bool can_use = true;
 


### PR DESCRIPTION
### Description of Changes
Remove some debug code left in by accident.

Mostly likely from one of the TC PRs I made recently.

### Rationale behind Changes
The code is not meant to be in release.

### Suggested Testing Steps
No testing really required.

### Did you use AI to help find, test, or implement this issue or feature?
No.