### PR TITLE
GS/TC: Use temporary source on invalid source TEX0

### DIFF
--- a/pcsx2/GS/GSUtil.cpp
+++ b/pcsx2/GS/GSUtil.cpp
@@ -339,3 +339,27 @@ const char* GSUtil::GetPSMName(int psm)
 	}
 	return "BAD_PSM";
 }
+
+bool GSUtil::IsValidPSM(int psm)
+{
+	switch (psm)
+	{
+		case PSMCT32:
+		case PSMCT24:
+		case PSMCT16:
+		case PSMCT16S:
+		case PSMT8:
+		case PSMT4:
+		case PSMT8H:
+		case PSMT4HL:
+		case PSMT4HH:
+		case PSMZ32:
+		case PSMZ24:
+		case PSMZ16:
+		case PSMZ16S:
+		case PSGPU24:
+			return true;
+		default:
+			return false;
+	}
+}

--- a/pcsx2/GS/GSUtil.h
+++ b/pcsx2/GS/GSUtil.h
@@ -28,6 +28,8 @@ public:
 	static const char* GetACName(u32 ac);
 	static const char* GetPerfMonCounterName(GSPerfMon::counter_t counter, bool hw = true);
 
+	static bool IsValidPSM(int psm);
+
 	static const u32* HasSharedBitsPtr(u32 dpsm);
 	static bool HasSharedBits(u32 spsm, const u32* ptr);
 	static bool HasSharedBits(u32 spsm, u32 dpsm);

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1340,6 +1340,14 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const bool is_color, const 
 		return nullptr;
 	}
 
+	// Invalid values show up in dumps but it's unclear if it's a core issue or a bug in the games.
+	// Abort the draw to prevent the lookup from corrupting the TC.
+	if (!GSUtil::IsValidPSM(static_cast<int>(TEX0.PSM)) && TEX0.TBW > 32)
+	{
+		GL_CACHE("TC: Invalid TEX0 (TBW=%d, PSM=%x), aborting draw.", TEX0.TBW, TEX0.PSM);
+		return nullptr;
+	}
+
 	const GSVector2i compare_lod(lod ? *lod : GSVector2i(0, 0));
 	Source* src = nullptr;
 

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1340,6 +1340,14 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const bool is_color, const 
 		return nullptr;
 	}
 
+	// Invalid values show up in dumps but it's unclear if it's a core issue or a bug in the games.
+	// Return a temporary source to prevent the lookup from corrupting the TC.
+	if (TEX0.TBW > 32 && !GSUtil::IsValidPSM(static_cast<int>(TEX0.PSM)))
+	{
+		GL_CACHE("TC: Invalid TEX0 (TBW=%d, PSM=%x), using temporary source.", TEX0.TBW, TEX0.PSM);
+		return CreateSource(TEX0, TEXA, CLAMP, nullptr, 0, 0, nullptr, nullptr, nullptr, SourceRegion(), true);
+	}
+
 	const GSVector2i compare_lod(lod ? *lod : GSVector2i(0, 0));
 	Source* src = nullptr;
 


### PR DESCRIPTION
### Description of Changes
Create a temporary source if TEX0 looks invalid.

### Rationale behind Changes
Fixes frame flicker in the attached dump provided by @JordanTheToaster.
Fixes https://github.com/PCSX2/pcsx2/issues/13134

Lookups with an invalid TEX0 was nuking frames.

[The Sopranos - Road to Respect_SLUS-21388_20250813162601.gs.zst.zip](https://github.com/user-attachments/files/26846291/The.Sopranos.-.Road.to.Respect_SLUS-21388_20250813162601.gs.zst.zip)

### Suggested Testing Steps
Test the attached dump on the HW renderer.

### Did you use AI to help find, test, or implement this issue or feature?
No.