### PR TITLE
GS:MTL: Depth feedback support

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -1007,6 +1007,23 @@ bool GSDevice::ResizeRenderTarget(GSTexture** t, int w, int h, bool preserve_con
 	return true;
 }
 
+void GSDevice::BeginDSAsRT(GSTexture* ds, const GSVector4i& drawarea)
+{
+	// Create a temporary RT and copy the area needed for the draw.
+	const int w = ds->GetWidth();
+	const int h = ds->GetHeight();
+	m_ds_as_rt = g_gs_device->CreateRenderTarget(w, h, GSTexture::Format::Float32, false, true);
+	const GSVector4 dRect(drawarea);
+	const GSVector4 sRect(dRect.x / w, dRect.y / h, dRect.z / w, dRect.w / h);
+	StretchRect(ds, sRect, m_ds_as_rt, dRect, ShaderConvert::FLOAT32_DEPTH_TO_COLOR, false);
+}
+
+void GSDevice::EndDSAsRT()
+{
+	Recycle(m_ds_as_rt);
+	m_ds_as_rt = nullptr;
+}
+
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-function"

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -928,12 +928,7 @@ public:
 		Performance
 	};
 
-	enum class DepthFeedbackSupport : u8
-	{
-		None,      // No support for depth feedback loops.
-		Depth,     // Implement depth feedback loops directly on the depth buffer.
-		DepthAsRT, // Implement depth feedback loops by first converting depth to a color RT.
-	};
+	using DepthFeedbackSupport = GSShader::DepthFeedbackSupport;
 
 	// clang-format off
 	struct FeatureSupport

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -946,12 +946,14 @@ public:
 		bool stencil_buffer       : 1; ///< Supports stencil buffer, and can use for DATE.
 		bool cas_sharpening       : 1; ///< Supports sufficient functionality for contrast adaptive sharpening.
 		bool test_and_sample_depth: 1; ///< Supports concurrently binding the depth-stencil buffer for sampling and depth testing.
-		bool depth_feedback       : 1; ///< Depth feedback loops can be done with DS directly (otherwise need to copy to separate RT).
+		bool depth_feedback       : 1; ///< Depth feedback loops can be done with DS directly (otherwise need to copy to separate RT).  Implies `feedback_loops`.
 		bool aa1                  : 1; ///< Supports the GS AA1 feature.
 		FeatureSupport()
 		{
 			memset(this, 0, sizeof(*this));
 		}
+		/// Supports feedback loops through either texture barriers or rt copies.
+		bool feedback_loops() const { return texture_barrier || multidraw_fb_copy; }
 	};
 
 	struct MultiStretchRect

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -1071,7 +1071,7 @@ public:
 
 	bool IsDSInRTActive() const { return m_ds_as_rt; }
 	/// Create a temporary color clone of depth for depth feedback
-	void BeginDSAsRT(GSTexture* ds, const GSVector4i& drawarea);
+	virtual void BeginDSAsRT(GSTexture* ds, const GSVector4i& drawarea);
 	void EndDSAsRT();
 
 	/// Returns a string representing the specified API.

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -928,8 +928,6 @@ public:
 		Performance
 	};
 
-	using DepthFeedbackSupport = GSShader::DepthFeedbackSupport;
-
 	// clang-format off
 	struct FeatureSupport
 	{
@@ -948,7 +946,7 @@ public:
 		bool stencil_buffer       : 1; ///< Supports stencil buffer, and can use for DATE.
 		bool cas_sharpening       : 1; ///< Supports sufficient functionality for contrast adaptive sharpening.
 		bool test_and_sample_depth: 1; ///< Supports concurrently binding the depth-stencil buffer for sampling and depth testing.
-		DepthFeedbackSupport depth_feedback : 2; ///< Support for depth feedback loops.
+		bool depth_feedback       : 1; ///< Depth feedback loops can be done with DS directly (otherwise need to copy to separate RT).
 		bool aa1                  : 1; ///< Supports the GS AA1 feature.
 		FeatureSupport()
 		{

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -810,7 +810,6 @@ struct alignas(16) GSHWDrawConfig
 	};
 
 	GSTexture* rt;        ///< Render target
-	GSTexture* ds_as_rt;  ///< Depth as color (if supported)
 	GSTexture* ds;        ///< Depth stencil
 	GSTexture* tex;       ///< Source texture
 	GSTexture* pal;       ///< Palette texture
@@ -1037,6 +1036,7 @@ protected:
 	GSTexture* m_current = nullptr;
 	GSTexture* m_cas = nullptr;
 	GSTexture* m_colclip_rt = nullptr; ///< Temp hw colclip texture
+	GSTexture* m_ds_as_rt = nullptr; ///< Depth as color
 
 	bool AcquireWindow(bool recreate_window);
 
@@ -1073,6 +1073,11 @@ public:
 	GSTexture* GetColorClipTexture() const { return m_colclip_rt; }
 		
 	void SetColorClipTexture(GSTexture* tex) { m_colclip_rt = tex; }
+
+	bool IsDSInRTActive() const { return m_ds_as_rt; }
+	/// Create a temporary color clone of depth for depth feedback
+	void BeginDSAsRT(GSTexture* ds, const GSVector4i& drawarea);
+	void EndDSAsRT();
 
 	/// Returns a string representing the specified API.
 	static const char* RenderAPIToString(RenderAPI api);

--- a/pcsx2/GS/Renderers/Common/GSShaderEnums.h
+++ b/pcsx2/GS/Renderers/Common/GSShaderEnums.h
@@ -19,6 +19,13 @@ enum class VSExpand : uint8_t
 	TriangleAA1 = 5,
 };
 
+enum class DepthFeedbackSupport : uint32_t
+{
+	None      = 0, ///< No support for depth feedback loops.
+	Depth     = 1, ///< Implement depth feedback loops directly on the depth buffer.
+	DepthAsRT = 2, ///< Implement depth feedback loops by first converting depth to a color RT.
+};
+
 enum class PS_ATST : uint32_t
 {
 	NONE = 0,
@@ -37,6 +44,15 @@ enum class PS_AFAIL : uint32_t
 	RGB_ONLY = 3,      ///< RGB only with hardware Z discard and software A discard
 	RGB_ONLY_DSB = 4,  ///< RGB only with dual source blend
 	RGB_ONLY_SW_Z = 5, ///< RGB only with software Z discard
+};
+
+// Identical to GS_ZTST
+enum class ZTST : uint32_t
+{
+	NEVER   = 0,
+	ALWAYS  = 1,
+	GEQUAL  = 2,
+	GREATER = 3,
 };
 
 enum class PS_AA1 : uint32_t

--- a/pcsx2/GS/Renderers/Common/GSShaderEnums.h
+++ b/pcsx2/GS/Renderers/Common/GSShaderEnums.h
@@ -19,13 +19,6 @@ enum class VSExpand : uint8_t
 	TriangleAA1 = 5,
 };
 
-enum class DepthFeedbackSupport : uint32_t
-{
-	None      = 0, ///< No support for depth feedback loops.
-	Depth     = 1, ///< Implement depth feedback loops directly on the depth buffer.
-	DepthAsRT = 2, ///< Implement depth feedback loops by first converting depth to a color RT.
-};
-
 enum class PS_ATST : uint32_t
 {
 	NONE = 0,

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -646,7 +646,7 @@ void GSDevice11::SetFeatures(IDXGIAdapter1* adapter)
 	m_features.vs_expand = (!GSConfig.DisableVertexShaderExpand && m_feature_level >= D3D_FEATURE_LEVEL_11_0);
 	m_features.cas_sharpening = (m_feature_level >= D3D_FEATURE_LEVEL_11_0);
 	m_features.test_and_sample_depth = (m_feature_level >= D3D_FEATURE_LEVEL_11_0);
-	m_features.aa1 = GSConfig.HWAA1 && m_features.vs_expand && m_features.multidraw_fb_copy;
+	m_features.aa1 = GSConfig.HWAA1 && m_features.vs_expand && m_features.feedback_loops();
 
 	m_max_texture_size = (m_feature_level >= D3D_FEATURE_LEVEL_11_0) ?
 	                         D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION :

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -68,15 +68,7 @@ GSDevice11::GSDevice11()
 	m_features.stencil_buffer = true;
 	m_features.cas_sharpening = true;
 	m_features.test_and_sample_depth = false;
-	if (m_features.multidraw_fb_copy && (GSConfig.DepthFeedbackMode == GSDepthFeedbackMode::Auto ||
-		GSConfig.DepthFeedbackMode == GSDepthFeedbackMode::Depth))
-	{
-		m_features.depth_feedback = GSDevice::DepthFeedbackSupport::Depth;
-	}
-	else
-	{
-		m_features.depth_feedback = GSDevice::DepthFeedbackSupport::None;
-	}
+	m_features.depth_feedback = true;
 }
 
 GSDevice11::~GSDevice11() = default;
@@ -654,7 +646,7 @@ void GSDevice11::SetFeatures(IDXGIAdapter1* adapter)
 	m_features.vs_expand = (!GSConfig.DisableVertexShaderExpand && m_feature_level >= D3D_FEATURE_LEVEL_11_0);
 	m_features.cas_sharpening = (m_feature_level >= D3D_FEATURE_LEVEL_11_0);
 	m_features.test_and_sample_depth = (m_feature_level >= D3D_FEATURE_LEVEL_11_0);
-	m_features.aa1 = GSConfig.HWAA1 && m_features.vs_expand && (m_features.depth_feedback != GSDevice::DepthFeedbackSupport::None);
+	m_features.aa1 = GSConfig.HWAA1 && m_features.vs_expand && m_features.multidraw_fb_copy;
 
 	m_max_texture_size = (m_feature_level >= D3D_FEATURE_LEVEL_11_0) ?
 	                         D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION :
@@ -2998,7 +2990,7 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 	}
 
 	if (draw_ds && (config.require_one_barrier || (config.require_full_barrier && m_features.multidraw_fb_copy)) &&
-		m_features.depth_feedback == GSDevice::DepthFeedbackSupport::Depth && config.ps.IsFeedbackLoopDepth())
+		m_features.depth_feedback && config.ps.IsFeedbackLoopDepth())
 	{
 		// Requires a copy of the DS.
 		draw_ds_clone = CreateTexture(rtsize.x, rtsize.y, 1, draw_ds->GetFormat(), true);

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -1406,7 +1406,7 @@ bool GSDevice12::CheckFeatures(const u32& vendor_id)
 	m_features.test_and_sample_depth = true;
 	m_features.vs_expand = !GSConfig.DisableVertexShaderExpand;
 	m_features.depth_feedback = false;
-	m_features.aa1 = GSConfig.HWAA1 && m_features.vs_expand && m_features.texture_barrier;
+	m_features.aa1 = GSConfig.HWAA1 && m_features.vs_expand && m_features.feedback_loops();
 
 	m_features.dxt_textures = SupportsTextureFormat(DXGI_FORMAT_BC1_UNORM) &&
 	                          SupportsTextureFormat(DXGI_FORMAT_BC2_UNORM) &&

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -4356,7 +4356,7 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 		}
 	}
 
-	GSTexture12* draw_ds_as_rt = static_cast<GSTexture12*>(config.ds_as_rt);
+	GSTexture12* draw_ds_as_rt = static_cast<GSTexture12*>(m_ds_as_rt);
 
 	const bool feedback_rt = draw_rt && (config.require_one_barrier || (config.require_full_barrier && m_features.texture_barrier) || (config.tex && config.tex == config.rt));
 	const bool feedback_depth = draw_ds_as_rt != nullptr;
@@ -4611,7 +4611,7 @@ void GSDevice12::UpdateHWPipelineSelector(GSHWDrawConfig& config)
 	m_pipeline_selector.topology = static_cast<u32>(config.topology);
 	m_pipeline_selector.rt = config.rt != nullptr;
 	m_pipeline_selector.ds = config.ds != nullptr;
-	m_pipeline_selector.ds_as_rt = config.ds_as_rt != nullptr;
+	m_pipeline_selector.ds_as_rt = m_ds_as_rt != nullptr;
 }
 
 void GSDevice12::UploadHWDrawVerticesAndIndices(GSHWDrawConfig& config)

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -1405,17 +1405,8 @@ bool GSDevice12::CheckFeatures(const u32& vendor_id)
 	m_features.cas_sharpening = true;
 	m_features.test_and_sample_depth = true;
 	m_features.vs_expand = !GSConfig.DisableVertexShaderExpand;
-	if (m_features.texture_barrier && (GSConfig.DepthFeedbackMode == GSDepthFeedbackMode::Auto ||
-		GSConfig.DepthFeedbackMode == GSDepthFeedbackMode::DepthAsRT))
-	{
-		m_features.depth_feedback = GSDevice::DepthFeedbackSupport::DepthAsRT;
-	}
-	else
-	{
-		m_features.depth_feedback = GSDevice::DepthFeedbackSupport::None;
-	}
-		
-	m_features.aa1 = GSConfig.HWAA1 && m_features.vs_expand && (m_features.depth_feedback != GSDevice::DepthFeedbackSupport::None);
+	m_features.depth_feedback = false;
+	m_features.aa1 = GSConfig.HWAA1 && m_features.vs_expand && m_features.texture_barrier;
 
 	m_features.dxt_textures = SupportsTextureFormat(DXGI_FORMAT_BC1_UNORM) &&
 	                          SupportsTextureFormat(DXGI_FORMAT_BC2_UNORM) &&

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -8929,7 +8929,22 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 
 	SetupIA(rtscale, vs_scale_x, vs_scale_y, m_channel_shuffle_width != 0);
 
-	StartDepthAsRTFeedback(); // Depends on the drawarea and alpha test having been determined.
+	if (m_conf.ds && m_conf.ps.IsFeedbackLoopDepth() && g_gs_device->Features().depth_feedback == GSDevice::DepthFeedbackSupport::DepthAsRT)
+	{
+		GL_PUSH("HW: Creating temporary R32 RT for depth feedback");
+
+		// Should not be hw blending with multiple render targets.
+		pxAssert(!m_conf.blend.enable && !m_conf.blend_multi_pass.blend.enable);
+		// We should have depth output or feedback doesn't make sense.
+		// We will output to both the depth buffer and color clone simultaneously in the shader.
+		pxAssert(m_conf.depth.zwe);
+		// HW depth test should be disabled in place of SW depth test
+		pxAssert(m_conf.depth.ztst == ZTST_ALWAYS);
+		// Second pass alpha shouldn't be enabled
+		pxAssert(!m_conf.alpha_second_pass.enable);
+
+		g_gs_device->BeginDSAsRT(m_conf.ds, m_conf.drawarea);
+	}
 	
 	if (GSConfig.SaveHWConfig && GSConfig.ShouldDump(s_n, g_perfmon.GetFrame()))
 	{
@@ -8941,7 +8956,8 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 	else
 		m_last_rt = rt;
 
-	CleanupDepthAsRTFeedback();
+	if (g_gs_device->IsDSInRTActive())
+		g_gs_device->EndDSAsRT();
 }
 
 // If the EE uploaded a new CLUT since the last draw, use that.
@@ -10459,52 +10475,8 @@ std::size_t GSRendererHW::ComputeDrawlistGetSize(float scale)
 	return m_drawlist.size();
 }
 
-void GSRendererHW::StartDepthAsRTFeedback()
-{
-	// Create a temporary depth color target
-	if (m_conf.ds && m_conf.ps.IsFeedbackLoopDepth() &&
-		g_gs_device->Features().depth_feedback == GSDevice::DepthFeedbackSupport::DepthAsRT)
-	{
-		GL_PUSH("HW: Creating temporary R32 RT for depth feedback");
-
-		 // Should not be hw blending with multiple render targets.
-		pxAssert(!m_conf.blend.enable && !m_conf.blend_multi_pass.blend.enable);
-
-		// We should have depth output or feedback doesn't make sense.
-		// We will output to both the depth buffer and color clone simultaneously in the shader.
-		pxAssert(m_conf.depth.zwe || (m_conf.alpha_second_pass.enable && m_conf.alpha_second_pass.depth.zwe));
-
-		// Disable HW depth test since we will be using SW depth test (if needed).
-		m_conf.depth.ztst = ZTST_ALWAYS;
-		if (m_conf.alpha_second_pass.enable && m_conf.alpha_second_pass.depth.zwe)
-		{
-			// Do the same with the alpha second pass.
-			m_conf.alpha_second_pass.depth.ztst = ZTST_ALWAYS;
-		}
-
-		// Create a temporary RT and copy the area needed for the draw.
-		const int w = m_conf.ds->GetWidth();
-		const int h = m_conf.ds->GetHeight();
-		m_conf.ds_as_rt = g_gs_device->CreateRenderTarget(w, h, GSTexture::Format::Float32, false, true);
-		const GSVector4 dRect(m_conf.drawarea);
-		const GSVector4 sRect(dRect.x / w, dRect.y / h, dRect.z / w, dRect.w / h);
-		g_gs_device->StretchRect(m_conf.ds, sRect, m_conf.ds_as_rt, dRect, ShaderConvert::FLOAT32_DEPTH_TO_COLOR, false);
-		g_perfmon.Put(GSPerfMon::TextureCopies, 1.0);
-	}
-}
-
-void GSRendererHW::CleanupDepthAsRTFeedback()
-{
-	if (m_conf.ds_as_rt)
-	{
-		g_gs_device->Recycle(m_conf.ds_as_rt);
-		m_conf.ds_as_rt = nullptr;
-	}
-}
-
 bool GSRendererHW::IsCoverageAlphaSupported()
 {
-	return IsCoverageAlpha() &&
-	       ((m_vt.m_primclass == GS_LINE_CLASS || m_vt.m_primclass == GS_TRIANGLE_CLASS) &&
-			   g_gs_device->Features().aa1);
+	return IsCoverageAlpha() && g_gs_device->Features().aa1 &&
+	       (m_vt.m_primclass == GS_LINE_CLASS || m_vt.m_primclass == GS_TRIANGLE_CLASS);
 }

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5796,7 +5796,7 @@ void GSRendererHW::EmulateZbufferAA1()
 {
 	const GSDevice::FeatureSupport& features = g_gs_device->Features();
 
-	pxAssert(!features.aa1 || features.depth_feedback != GSDevice::DepthFeedbackSupport::None);
+	pxAssert(!features.aa1 || features.texture_barrier || features.multidraw_fb_copy);
 
 	if (IsCoverageAlphaSupported())
 	{
@@ -6149,8 +6149,7 @@ void GSRendererHW::DetermineBarriers(GSTextureCache::Target* rt)
 
 		// If we use depth feedback directly, we must use barriers for the depth texture.
 		// If we use depth-as-color feedback, then FB fetch can be used for depth also.
-		bool need_barriers_for_depth = m_conf.ps.IsFeedbackLoopDepth() &&
-			(features.depth_feedback == GSDevice::DepthFeedbackSupport::Depth);
+		bool need_barriers_for_depth = m_conf.ps.IsFeedbackLoopDepth() && features.depth_feedback;
 
 		if (!need_barriers_for_depth)
 		{
@@ -6952,8 +6951,7 @@ void GSRendererHW::EmulateBlending(int rt_alpha_min, int rt_alpha_max, DATEOptio
 		}
 	}
 
-	if (m_conf.alpha_test == GSHWDrawConfig::AlphaTestMode::FEEDBACK &&
-		features.depth_feedback == GSDevice::DepthFeedbackSupport::DepthAsRT)
+	if (m_conf.alpha_test == GSHWDrawConfig::AlphaTestMode::FEEDBACK && !features.depth_feedback)
 	{
 		// If we are doing feedback alpha test with a second RT we must use SW blending to avoid
 		// mixing dual source blending with multiple render targets.
@@ -8435,7 +8433,7 @@ void GSRendererHW::EmulateAlphaTest(DATEOptions& date_options)
 	const bool free_fbfetch_feedback = features.framebuffer_fetch && !afail_needs_depth;
 
 	// Determine if we have the correct features for depth feedback.
-	const bool depth_feedback_supported = features.depth_feedback != GSDevice::DepthFeedbackSupport::None;
+	const bool depth_feedback_supported = features.texture_barrier || features.multidraw_fb_copy;
 
 	// We need depth feedback but do not have the correct features.
 	const bool avoid_feedback = afail_needs_depth && !depth_feedback_supported;
@@ -8929,7 +8927,7 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 
 	SetupIA(rtscale, vs_scale_x, vs_scale_y, m_channel_shuffle_width != 0);
 
-	if (m_conf.ds && m_conf.ps.IsFeedbackLoopDepth() && g_gs_device->Features().depth_feedback == GSDevice::DepthFeedbackSupport::DepthAsRT)
+	if (m_conf.ds && m_conf.ps.IsFeedbackLoopDepth() && !g_gs_device->Features().depth_feedback)
 	{
 		GL_PUSH("HW: Creating temporary R32 RT for depth feedback");
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5796,7 +5796,7 @@ void GSRendererHW::EmulateZbufferAA1()
 {
 	const GSDevice::FeatureSupport& features = g_gs_device->Features();
 
-	pxAssert(!features.aa1 || features.texture_barrier || features.multidraw_fb_copy);
+	pxAssert(!features.aa1 || features.feedback_loops());
 
 	if (IsCoverageAlphaSupported())
 	{
@@ -5817,7 +5817,7 @@ void GSRendererHW::EmulateZbufferAA1()
 					m_conf.depth.ztst = ZTST_ALWAYS; // Disable HW Z test.
 
 					// We need barriers for the feedback
-					if (features.texture_barrier || features.multidraw_fb_copy)
+					if (features.feedback_loops())
 					{
 						m_conf.require_one_barrier |= (m_prim_overlap == PRIM_OVERLAP_NO);
 						m_conf.require_full_barrier |= (m_prim_overlap != PRIM_OVERLAP_NO);
@@ -5938,7 +5938,7 @@ void GSRendererHW::EmulateDATESelectMethod(DATEOptions& date_options, GSTextureC
 			m_conf.require_full_barrier = true;
 			date_options.barrier = true;
 		}
-		else if ((features.texture_barrier || features.multidraw_fb_copy) && m_conf.require_full_barrier)
+		else if (features.feedback_loops() && m_conf.require_full_barrier)
 		{
 			// Full barrier is enabled (likely sw fbmask), we need to use date barrier.
 			GL_PERF("DATE: Accurate with alpha %d-%d", GetAlphaMinMax().min, GetAlphaMinMax().max);
@@ -5950,7 +5950,7 @@ void GSRendererHW::EmulateDATESelectMethod(DATEOptions& date_options, GSTextureC
 			GL_PERF("DATE: Accurate with alpha %d-%d", GetAlphaMinMax().min, GetAlphaMinMax().max);
 			date_options.primid = true;
 		}
-		else if (features.texture_barrier || features.multidraw_fb_copy)
+		else if (features.feedback_loops())
 		{
 			GL_PERF("DATE: Accurate with alpha %d-%d", GetAlphaMinMax().min, GetAlphaMinMax().max);
 			m_conf.require_full_barrier = true;
@@ -6162,19 +6162,19 @@ void GSRendererHW::DetermineBarriers(GSTextureCache::Target* rt)
 	pxAssert(!m_conf.require_full_barrier || !m_conf.ps.colclip_hw);
 
 	// Swap full barrier for one barrier when there's no overlap, or a shuffle.
-	if ((features.texture_barrier || features.multidraw_fb_copy) && m_conf.require_full_barrier && (m_prim_overlap == PRIM_OVERLAP_NO || m_conf.ps.shuffle || m_channel_shuffle))
+	if (features.feedback_loops() && m_conf.require_full_barrier && (m_prim_overlap == PRIM_OVERLAP_NO || m_conf.ps.shuffle || m_channel_shuffle))
 	{
 		m_conf.require_full_barrier = false;
 		m_conf.require_one_barrier = true;
 	}
-	else if (!(features.texture_barrier || features.multidraw_fb_copy))
+	else if (!features.feedback_loops())
 	{
 		// These shouldn't be enabled if texture barriers aren't supported, make sure they are off.
 		m_conf.ps.write_rg = 0;
 		m_conf.require_full_barrier = false;
 	}
 
-	if (m_conf.require_full_barrier && (g_gs_device->Features().texture_barrier || g_gs_device->Features().multidraw_fb_copy))
+	if (m_conf.require_full_barrier && features.feedback_loops())
 	{
 		ComputeDrawlistGetSize(rt->m_scale);
 		m_conf.drawlist = &m_drawlist;
@@ -6246,9 +6246,8 @@ void GSRendererHW::EmulateTextureShuffleAndFbmask(GSTextureCache::Target* rt, GS
 
 		// If date is enabled you need to test the green channel instead of the alpha channel.
 		// Only enable this code in DATE mode to reduce the number of shaders.
-		m_conf.ps.write_rg = (process_rg & SHUFFLE_WRITE) && (features.texture_barrier || features.multidraw_fb_copy) &&
-		                     m_cached_ctx.TEST.DATE;
-		
+		m_conf.ps.write_rg = (process_rg & SHUFFLE_WRITE) && features.feedback_loops() && m_cached_ctx.TEST.DATE;
+
 		m_conf.ps.real16src = m_texture_shuffle.real_16_bit_source;
 
 		// Shuffle that copies B to A, which are in the same column.
@@ -6362,7 +6361,7 @@ void GSRendererHW::EmulateTextureShuffleAndFbmask(GSTextureCache::Target* rt, GS
 			   have been invalidated before subsequent Draws are executed.
 			 */
 			// No blending so hit unsafe path.
-			if (!PRIM->ABE || !(~ff_fbmask & ~zero_fbmask & 0x7) || !(features.texture_barrier || features.multidraw_fb_copy))
+			if (!PRIM->ABE || !(~ff_fbmask & ~zero_fbmask & 0x7) || !features.feedback_loops())
 			{
 				GL_INS("HW: FBMASK Unsafe SW emulated fb_mask:%x on %d bits format", m_cached_ctx.FRAME.FBMSK,
 					(m_conf.ps.dst_fmt == GSLocalMemory::PSM_FMT_16) ? 16 : 32);
@@ -6872,7 +6871,7 @@ void GSRendererHW::EmulateBlending(int rt_alpha_min, int rt_alpha_max, DATEOptio
 	// Condition 2: One barrier is already enabled, prims don't overlap or is a channel shuffle so let's use sw blend instead.
 	// Condition 3: A texture shuffle is unlikely to overlap, so we can prefer full sw blend.
 	// Condition 4: If it's tex in fb draw and there's no overlap prefer sw blend, fb is already being read.
-	const bool prefer_sw_blend = ((features.texture_barrier || features.multidraw_fb_copy) && m_conf.require_full_barrier) || (m_conf.require_one_barrier && (no_prim_overlap || m_channel_shuffle)) || m_conf.ps.shuffle || (no_prim_overlap && (m_conf.tex == m_conf.rt));
+	const bool prefer_sw_blend = (features.feedback_loops() && m_conf.require_full_barrier) || (m_conf.require_one_barrier && (no_prim_overlap || m_channel_shuffle)) || m_conf.ps.shuffle || (no_prim_overlap && (m_conf.tex == m_conf.rt));
 	const bool free_blend = blend_non_recursive // Free sw blending, doesn't require barriers or reading fb
 	                        || accumulation_blend; // Mix of hw/sw blending
 
@@ -6883,7 +6882,7 @@ void GSRendererHW::EmulateBlending(int rt_alpha_min, int rt_alpha_max, DATEOptio
 	const bool blend_multipass_group = blend_multi_pass_support && !features.texture_barrier &&
 		(bmix1_multi_pass1 || bmix1_multi_pass2 || bmix3_multi_pass || (blend_flag & (BLEND_HW3 | BLEND_HW4 | BLEND_HW5 | BLEND_HW6 | BLEND_HW7 | BLEND_HW8 | BLEND_HW9)));
 
-	const bool barriers_supported = features.texture_barrier || features.multidraw_fb_copy;
+	const bool barriers_supported = features.feedback_loops();
 	const bool blend_requires_barrier =
 		// We don't want the cases to be enabled if barriers aren't supported so limit it to no overlap.
 		(no_prim_overlap || barriers_supported)
@@ -7049,7 +7048,7 @@ void GSRendererHW::EmulateBlending(int rt_alpha_min, int rt_alpha_max, DATEOptio
 
 				m_conf.ps.pabe = 1;
 			}
-			else if (features.texture_barrier || features.multidraw_fb_copy)
+			else if (features.feedback_loops())
 			{
 				// PABE sw blend:
 				// Disable hw/sw mix and do pure sw blend with reading the framebuffer.
@@ -7222,7 +7221,7 @@ void GSRendererHW::EmulateBlending(int rt_alpha_min, int rt_alpha_max, DATEOptio
 			const bool blend_non_recursive_one_barrier = blend_non_recursive && blend_ad_alpha_masked;
 			if (blend_non_recursive_one_barrier)
 				m_conf.require_one_barrier |= true;
-			else if (features.texture_barrier || features.multidraw_fb_copy)
+			else if (features.feedback_loops())
 				m_conf.require_full_barrier |= !blend_non_recursive;
 			else
 				m_conf.require_one_barrier |= !blend_non_recursive;
@@ -7875,7 +7874,7 @@ __ri void GSRendererHW::HandleTextureHazards(const GSTextureCache::Target* rt, c
 			{
 				m_conf.tex = nullptr;
 				m_conf.ps.tex_is_fb = true;
-				if (m_prim_overlap == PRIM_OVERLAP_NO || !(g_gs_device->Features().texture_barrier || g_gs_device->Features().multidraw_fb_copy))
+				if (m_prim_overlap == PRIM_OVERLAP_NO || !g_gs_device->Features().feedback_loops())
 					m_conf.require_one_barrier = true;
 				else
 					m_conf.require_full_barrier = true;
@@ -7955,7 +7954,7 @@ __ri void GSRendererHW::HandleTextureHazards(const GSTextureCache::Target* rt, c
 			const int horizontal_offset = ((page_offset % src_target->m_TEX0.TBW) * GSLocalMemory::m_psm[src_target->m_TEX0.PSM].pgs.x);
 			const int vertical_offset = ((page_offset / src_target->m_TEX0.TBW) * GSLocalMemory::m_psm[src_target->m_TEX0.PSM].pgs.y);
 
-			if (g_gs_device->Features().texture_barrier || g_gs_device->Features().multidraw_fb_copy)
+			if (g_gs_device->Features().feedback_loops())
 			{
 				const u32 max_skip = ((m_channel_shuffle_finish || !m_channel_shuffle_width) ? 1 : m_channel_shuffle_width) << 5;
 				const bool new_shuffle = !(m_last_channel_shuffle_fbmsk == m_context->FRAME.FBMSK &&
@@ -8179,7 +8178,7 @@ bool GSRendererHW::CanUseTexIsFB(const GSTextureCache::Target* rt, const GSTextu
 	}
 
 	// No barriers -> we can't use tex-is-fb when there's overlap.
-	if (!(g_gs_device->Features().texture_barrier || g_gs_device->Features().multidraw_fb_copy) && m_prim_overlap != PRIM_OVERLAP_NO)
+	if (!g_gs_device->Features().feedback_loops() && m_prim_overlap != PRIM_OVERLAP_NO)
 	{
 		GL_CACHE("HW: Disabling tex-is-fb due to no barriers.");
 		return false;
@@ -8426,14 +8425,13 @@ void GSRendererHW::EmulateAlphaTest(DATEOptions& date_options)
 	// do not require depth feedback.
 	const bool free_barrier_feedback =
 		((m_conf.require_one_barrier && feedback_one_pass) || m_conf.require_full_barrier) &&
-		(features.texture_barrier || features.multidraw_fb_copy) &&
-		!afail_needs_depth;
+		features.feedback_loops() && !afail_needs_depth;
 
 	// Determine if we can use FB-fetch for color only feedback.
 	const bool free_fbfetch_feedback = features.framebuffer_fetch && !afail_needs_depth;
 
 	// Determine if we have the correct features for depth feedback.
-	const bool depth_feedback_supported = features.texture_barrier || features.multidraw_fb_copy;
+	const bool depth_feedback_supported = features.feedback_loops();
 
 	// We need depth feedback but do not have the correct features.
 	const bool avoid_feedback = afail_needs_depth && !depth_feedback_supported;
@@ -8456,7 +8454,7 @@ void GSRendererHW::EmulateAlphaTest(DATEOptions& date_options)
 		m_conf.cb_ps.FogColor_AREF.a = ps_aref;
 		m_conf.ps.afail = static_cast<PS_AFAIL>(afail);
 
-		if ((afail_needs_rt || afail_needs_depth) && (features.texture_barrier || features.multidraw_fb_copy))
+		if ((afail_needs_rt || afail_needs_depth) && features.feedback_loops())
 		{
 			m_conf.require_one_barrier |= feedback_one_pass;
 			m_conf.require_full_barrier |= !feedback_one_pass;

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -402,8 +402,4 @@ public:
 
 	/// Does the current draw allow using AA1 coverage (if AA1 is enabled).
 	bool IsCoverageAlphaSupported() override;
-
-	/// Create a temporary color clone of depth for depth feedback (DX12 and GL only right now)
-	void StartDepthAsRTFeedback();
-	void CleanupDepthAsRTFeedback();
 };

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
@@ -318,6 +318,8 @@ public:
 	MRCOwned<id<MTLBlitCommandEncoder>> m_late_texture_upload_encoder;
 	MRCOwned<id<MTLCommandBuffer>> m_vertex_upload_cmdbuf;
 	MRCOwned<id<MTLBlitCommandEncoder>> m_vertex_upload_encoder;
+	id<MTLTexture> m_ds_as_rt_texture = nil;
+	GSTexture* m_ds_as_rt_gstexture = nullptr;
 
 	struct DebugEntry
 	{
@@ -417,6 +419,7 @@ public:
 	void UpdateCLUTTexture(GSTexture* sTex, float sScale, u32 offsetX, u32 offsetY, GSTexture* dTex, u32 dOffset, u32 dSize) override;
 	void ConvertToIndexedTexture(GSTexture* sTex, float sScale, u32 offsetX, u32 offsetY, u32 SBW, u32 SPSM, GSTexture* dTex, u32 DBW, u32 DPSM) override;
 	void FilteredDownsampleTexture(GSTexture* sTex, GSTexture* dTex, u32 downsample_factor, const GSVector2i& clamp_min, const GSVector4& dRect) override;
+	void BeginDSAsRT(GSTexture* ds, const GSVector4i& drawarea) override;
 
 	void FlushClears(GSTexture* tex);
 

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
@@ -40,14 +40,15 @@ struct PipelineSelectorExtrasMTL
 			GSDevice::BlendFactor dst_factor_alpha : 4;
 			GSDevice::BlendOp     blend_op : 2;
 			bool blend_enable : 1;
-			bool has_depth : 1;
-			bool has_stencil : 1;
+			bool has_depth    : 1;
+			bool has_stencil  : 1;
+			bool has_rt1      : 1;
 		};
 		u32 fullkey;
 	};
 
 	PipelineSelectorExtrasMTL(): fullkey(0) {}
-	PipelineSelectorExtrasMTL(GSHWDrawConfig::BlendState blend, GSTexture* rt, GSHWDrawConfig::ColorMaskSelector cms, bool has_depth, bool has_stencil)
+	PipelineSelectorExtrasMTL(GSHWDrawConfig::BlendState blend, GSTexture* rt, GSHWDrawConfig::ColorMaskSelector cms, bool has_depth, bool has_stencil, bool has_rt1)
 		: fullkey(0)
 	{
 		this->rt = rt ? rt->GetFormat() : GSTexture::Format::Invalid;
@@ -65,6 +66,7 @@ struct PipelineSelectorExtrasMTL
 		this->blend_enable = blend.enable;
 		this->has_depth   = has_depth;
 		this->has_stencil = has_stencil;
+		this->has_rt1     = has_rt1;
 	}
 };
 struct PipelineSelectorMTL
@@ -267,7 +269,7 @@ public:
 	std::unordered_map<PSSelector, MRCOwned<id<MTLFunction>>> m_hw_ps;
 	std::unordered_map<PipelineSelectorMTL, MRCOwned<id<MTLRenderPipelineState>>> m_hw_pipeline;
 
-	MRCOwned<MTLRenderPassDescriptor*> m_render_pass_desc[8];
+	MRCOwned<MTLRenderPassDescriptor*> m_render_pass_desc[16];
 
 	MRCOwned<id<MTLSamplerState>> m_sampler_hw[1 << 8];
 
@@ -287,7 +289,7 @@ public:
 		GSTexture* color_target = nullptr;
 		GSTexture* depth_target = nullptr;
 		GSTexture* stencil_target = nullptr;
-		GSTexture* tex[8] = {};
+		GSTexture* tex[GSMTLTextureIndexCount] = {};
 		void* vertex_buffer = nullptr;
 		void* name = nullptr;
 		struct Has
@@ -298,6 +300,7 @@ public:
 			bool blend_color  : 1;
 			bool pipeline_sel : 1;
 			bool sampler      : 1;
+			bool rt1_depth    : 1;
 		} has = {};
 		DepthStencilSelector depth_sel = DepthStencilSelector::NoDepth();
 		// Clear line (Things below here are tracked by `has` and don't need to be cleared to reset)
@@ -347,6 +350,8 @@ public:
 	id<MTLCommandBuffer> GetRenderCmdBufWithoutCreate();
 	/// Get the spin fence if spinning is enabled.
 	id<MTLFence> GetSpinFence();
+	/// Get the texture to use as RT1 depth for the given depth texture
+	id<MTLTexture> GetRT1DepthTexture(GSTextureMTL* depth);
 	/// Called by command buffers when they finish
 	void DrawCommandBufferFinished(u64 draw, id<MTLCommandBuffer> buffer);
 	/// Flush pending operations from all encoders to the GPU
@@ -356,7 +361,7 @@ public:
 	/// End current render pass without flushing
 	void EndRenderPass();
 	/// Begin a new render pass (may reuse existing)
-	void BeginRenderPass(NSString* name, GSTexture* color, MTLLoadAction color_load, GSTexture* depth, MTLLoadAction depth_load, GSTexture* stencil = nullptr, MTLLoadAction stencil_load = MTLLoadActionDontCare);
+	void BeginRenderPass(NSString* name, GSTexture* color, MTLLoadAction color_load, GSTexture* depth, MTLLoadAction depth_load, GSTexture* stencil = nullptr, MTLLoadAction stencil_load = MTLLoadActionDontCare, bool rt1 = false);
 	/// Call at the end of each frame
 	void FrameCompleted();
 

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -245,6 +245,11 @@ id<MTLFence> GSDeviceMTL::GetSpinFence()
 	return m_spin_timer ? m_spin_fence : nil;
 }
 
+id<MTLTexture> GSDeviceMTL::GetRT1DepthTexture(GSTextureMTL* depth)
+{
+	return static_cast<GSTextureMTL*>(m_ds_as_rt)->GetTexture();
+}
+
 void GSDeviceMTL::DrawCommandBufferFinished(u64 draw, id<MTLCommandBuffer> buffer)
 {
 	// We can do the update non-atomically because we only ever update under the lock
@@ -388,14 +393,15 @@ void GSDeviceMTL::EndRenderPass()
 	}
 }
 
-void GSDeviceMTL::BeginRenderPass(NSString* name, GSTexture* color, MTLLoadAction color_load, GSTexture* depth, MTLLoadAction depth_load, GSTexture* stencil, MTLLoadAction stencil_load)
+void GSDeviceMTL::BeginRenderPass(NSString* name, GSTexture* color, MTLLoadAction color_load, GSTexture* depth, MTLLoadAction depth_load, GSTexture* stencil, MTLLoadAction stencil_load, bool rt1)
 {
 	GSTextureMTL* mc = static_cast<GSTextureMTL*>(color);
 	GSTextureMTL* md = static_cast<GSTextureMTL*>(depth);
 	GSTextureMTL* ms = static_cast<GSTextureMTL*>(stencil);
 	bool needs_new = color   != m_current_render.color_target
 	              || depth   != m_current_render.depth_target
-	              || stencil != m_current_render.stencil_target;
+	              || stencil != m_current_render.stencil_target
+	              || rt1     != m_current_render.has.rt1_depth;
 	GSVector4 color_clear;
 	float depth_clear;
 	// Depth and stencil might be the same, so do all invalidation checks before resetting invalidation
@@ -449,6 +455,7 @@ void GSDeviceMTL::BeginRenderPass(NSString* name, GSTexture* color, MTLLoadActio
 	if (mc) idx |= 1;
 	if (md) idx |= 2;
 	if (ms) idx |= 4;
+	if (rt1) idx |= 8;
 
 	MTLRenderPassDescriptor* desc = m_render_pass_desc[idx];
 	if (mc)
@@ -474,6 +481,11 @@ void GSDeviceMTL::BeginRenderPass(NSString* name, GSTexture* color, MTLLoadActio
 		pxAssert(stencil_load != MTLLoadActionClear);
 		desc.stencilAttachment.loadAction = stencil_load;
 	}
+	if (rt1)
+	{
+		pxAssert(md);
+		desc.colorAttachments[1].texture = GetRT1DepthTexture(md);
+	}
 
 	EndRenderPass();
 	m_current_render.encoder = MRCRetain([GetRenderCmdBuf() renderCommandEncoderWithDescriptor:desc]);
@@ -485,6 +497,7 @@ void GSDeviceMTL::BeginRenderPass(NSString* name, GSTexture* color, MTLLoadActio
 	m_current_render.color_target = color;
 	m_current_render.depth_target = depth;
 	m_current_render.stencil_target = stencil;
+	m_current_render.has.rt1_depth |= rt1;
 	pxAssertRel(m_current_render.encoder, "Failed to create render encoder!");
 }
 
@@ -849,6 +862,21 @@ static MRCOwned<id<MTLSamplerState>> CreateSampler(id<MTLDevice> dev, GSHWDrawCo
 	return ret;
 }
 
+static GSDevice::DepthFeedbackSupport getDepthFeedback(const GSMTLDevice& dev, bool fbfetch)
+{
+	switch (GSConfig.DepthFeedbackMode)
+	{
+		case GSDepthFeedbackMode::None:      return GSDevice::DepthFeedbackSupport::None;
+		case GSDepthFeedbackMode::Auto:      return dev.features.preferred_depth_feedback;
+		case GSDepthFeedbackMode::DepthAsRT: return GSDevice::DepthFeedbackSupport::DepthAsRT;
+		case GSDepthFeedbackMode::Depth:
+			if (!fbfetch)
+				return GSDevice::DepthFeedbackSupport::Depth;
+			else
+				return GSDevice::DepthFeedbackSupport::DepthAsRT; // Depth + FBFetch not supported
+	}
+}
+
 bool GSDeviceMTL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 { @autoreleasepool {
 	if (!GSDevice::Create(vsync_mode, allow_present_throttle))
@@ -935,12 +963,13 @@ bool GSDeviceMTL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 	m_features.stencil_buffer = true;
 	m_features.cas_sharpening = true;
 	m_features.test_and_sample_depth = true;
-	m_features.depth_feedback = GSDevice::DepthFeedbackSupport::None;
+	m_features.depth_feedback = getDepthFeedback(m_dev, m_features.framebuffer_fetch);
 	m_max_texture_size = m_dev.features.max_texsize;
 
 	// Init metal stuff
 	m_fn_constants = MRCTransfer([MTLFunctionConstantValues new]);
-	setFnConstantB(m_fn_constants, m_dev.features.framebuffer_fetch, GSMTLConstantIndex_FRAMEBUFFER_FETCH);
+	setFnConstantB(m_fn_constants, m_features.framebuffer_fetch, GSMTLConstantIndex_FRAMEBUFFER_FETCH);
+	setFnConstantI(m_fn_constants, m_features.depth_feedback, GSMTLConstantIndex_DEPTH_FEEDBACK);
 
 	m_draw_sync_fence = MRCTransfer([m_dev.dev newFence]);
 	[m_draw_sync_fence setLabel:@"Draw Sync Fence"];
@@ -976,11 +1005,27 @@ bool GSDeviceMTL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 	applyAttribute(m_hw_vertex, GSMTLAttributeIndexUV, MTLVertexFormatUShort2,          offsetof(GSVertex, UV),      GSMTLBufferIndexHWVertices);
 	applyAttribute(m_hw_vertex, GSMTLAttributeIndexF,  MTLVertexFormatUChar4Normalized, offsetof(GSVertex, FOG),     GSMTLBufferIndexHWVertices);
 
-	for (auto& desc : m_render_pass_desc)
+	for (size_t i = 0; i < std::size(m_render_pass_desc); i++)
 	{
-		desc = MRCTransfer([MTLRenderPassDescriptor new]);
+		const bool depth   = i & 2;
+		const bool stencil = i & 4;
+		const bool rt1     = i & 8;
+		if (rt1 && m_features.depth_feedback != GSDevice::DepthFeedbackSupport::DepthAsRT)
+			continue;
+		if (rt1 && !depth)
+			continue;
+		if (stencil && m_features.framebuffer_fetch)
+			continue;
+		auto desc = MRCTransfer([MTLRenderPassDescriptor new]);
 		[[desc   depthAttachment] setStoreAction:MTLStoreActionStore];
 		[[desc stencilAttachment] setStoreAction:MTLStoreActionStore];
+		if (rt1)
+		{
+			MTLRenderPassColorAttachmentDescriptor* color1 = [[desc colorAttachments] objectAtIndexedSubscript:1];
+			[color1 setStoreAction:MTLStoreActionDontCare];
+			[color1 setLoadAction:MTLLoadActionLoad];
+		}
+		m_render_pass_desc[i] = desc;
 	}
 
 	// Init samplers
@@ -1800,7 +1845,7 @@ static MTLBlendOperation ConvertBlendOp(GSDevice::BlendOp generic)
 
 void GSDeviceMTL::MRESetHWPipelineState(GSHWDrawConfig::VSSelector vssel, GSHWDrawConfig::PSSelector pssel, GSHWDrawConfig::BlendState blend, GSHWDrawConfig::ColorMaskSelector cms)
 {
-	PipelineSelectorExtrasMTL extras(blend, m_current_render.color_target, cms, m_current_render.depth_target, m_current_render.stencil_target);
+	PipelineSelectorExtrasMTL extras(blend, m_current_render.color_target, cms, m_current_render.depth_target, m_current_render.stencil_target, m_current_render.has.rt1_depth);
 	PipelineSelectorMTL fullsel(vssel, pssel, extras);
 	if (m_current_render.has.pipeline_sel && fullsel == m_current_render.pipeline_sel)
 		return;
@@ -1842,6 +1887,7 @@ void GSDeviceMTL::MRESetHWPipelineState(GSHWDrawConfig::VSSelector vssel, GSHWDr
 		setFnConstantI(m_fn_constants, pssel.date,                  GSMTLConstantIndex_PS_DATE);
 		setFnConstantI(m_fn_constants, pssel.atst,                  GSMTLConstantIndex_PS_ATST);
 		setFnConstantI(m_fn_constants, pssel.afail,                 GSMTLConstantIndex_PS_AFAIL);
+		setFnConstantI(m_fn_constants, pssel.ztst,                  GSMTLConstantIndex_PS_ZTST);
 		setFnConstantI(m_fn_constants, pssel.tfx,                   GSMTLConstantIndex_PS_TFX);
 		setFnConstantB(m_fn_constants, pssel.tcc,                   GSMTLConstantIndex_PS_TCC);
 		setFnConstantI(m_fn_constants, pssel.wms,                   GSMTLConstantIndex_PS_WMS);
@@ -1919,6 +1965,11 @@ void GSDeviceMTL::MRESetHWPipelineState(GSHWDrawConfig::VSSelector vssel, GSHWDr
 		color.destinationRGBBlendFactor = ConvertBlendFactor(extras.dst_factor);
 		color.sourceAlphaBlendFactor = ConvertBlendFactor(extras.src_factor_alpha);
 		color.destinationAlphaBlendFactor = ConvertBlendFactor(extras.dst_factor_alpha);
+	}
+	if (extras.has_rt1)
+	{
+		MTLRenderPipelineColorAttachmentDescriptor* color1 = [[pdesc colorAttachments] objectAtIndexedSubscript:1];
+		[color1 setPixelFormat:MTLPixelFormatR32Float];
 	}
 	NSString* pname = [NSString stringWithFormat:@"HW Render %x.%x.%llx.%x", vssel_mtl.key, pssel.key_hi, pssel.key_lo, extras.fullkey];
 	auto pipeline = MakePipeline(pdesc, vs, ps, pname);
@@ -2266,7 +2317,9 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 		return;
 	}
 
-	BeginRenderPass(@"RenderHW", rt, MTLLoadActionLoad, config.ds, MTLLoadActionLoad, stencil, MTLLoadActionLoad);
+	const bool feedback_depth = config.ps.IsFeedbackLoopDepth();
+	const bool rt1 = feedback_depth && m_features.depth_feedback == GSDevice::DepthFeedbackSupport::DepthAsRT;
+	BeginRenderPass(@"RenderHW", rt, MTLLoadActionLoad, config.ds, MTLLoadActionLoad, stencil, MTLLoadActionLoad, rt1);
 	id<MTLRenderCommandEncoder> mtlenc = m_current_render.encoder;
 	FlushDebugEntries(mtlenc);
 	if (usesStencil(config.destination_alpha))
@@ -2274,6 +2327,12 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 	MREInitHWDraw(config, allocation);
 	if (config.require_one_barrier || config.require_full_barrier)
 		MRESetTexture(rt, GSMTLTextureIndexRenderTarget);
+	if (feedback_depth && !m_features.framebuffer_fetch)
+	{
+		bool depth_as_rt = m_features.depth_feedback == GSDevice::DepthFeedbackSupport::DepthAsRT;
+		GSTexture* tex = depth_as_rt ? m_ds_as_rt : config.ds;
+		MRESetTexture(tex, GSMTLTextureIndexDepthTarget);
+	}
 	if (primid_tex)
 		MRESetTexture(primid_tex, GSMTLTextureIndexPrimIDs);
 	if (config.blend.constant_enable)

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -870,18 +870,17 @@ static MRCOwned<id<MTLSamplerState>> CreateSampler(id<MTLDevice> dev, GSHWDrawCo
 	return ret;
 }
 
-static GSDevice::DepthFeedbackSupport getDepthFeedback(const GSMTLDevice& dev, bool fbfetch)
+static bool getDepthFeedback(const GSMTLDevice& dev, bool fbfetch)
 {
 	switch (GSConfig.DepthFeedbackMode)
 	{
-		case GSDepthFeedbackMode::None:      return GSDevice::DepthFeedbackSupport::None;
-		case GSDepthFeedbackMode::Auto:      return dev.features.preferred_depth_feedback;
-		case GSDepthFeedbackMode::DepthAsRT: return GSDevice::DepthFeedbackSupport::DepthAsRT;
+		case GSDepthFeedbackMode::Auto:
+			return dev.features.depth_feedback;
 		case GSDepthFeedbackMode::Depth:
-			if (!fbfetch)
-				return GSDevice::DepthFeedbackSupport::Depth;
-			else
-				return GSDevice::DepthFeedbackSupport::DepthAsRT; // Depth + FBFetch not supported
+			// Depth feedback + FBFetch not supported
+			return !fbfetch;
+		default:
+			return false;
 	}
 }
 
@@ -977,7 +976,7 @@ bool GSDeviceMTL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 	// Init metal stuff
 	m_fn_constants = MRCTransfer([MTLFunctionConstantValues new]);
 	setFnConstantB(m_fn_constants, m_features.framebuffer_fetch, GSMTLConstantIndex_FRAMEBUFFER_FETCH);
-	setFnConstantI(m_fn_constants, m_features.depth_feedback, GSMTLConstantIndex_DEPTH_FEEDBACK);
+	setFnConstantB(m_fn_constants, m_features.depth_feedback,    GSMTLConstantIndex_DEPTH_FEEDBACK);
 
 	m_draw_sync_fence = MRCTransfer([m_dev.dev newFence]);
 	[m_draw_sync_fence setLabel:@"Draw Sync Fence"];
@@ -1018,7 +1017,7 @@ bool GSDeviceMTL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 		const bool depth   = i & 2;
 		const bool stencil = i & 4;
 		const bool rt1     = i & 8;
-		if (rt1 && m_features.depth_feedback != GSDevice::DepthFeedbackSupport::DepthAsRT)
+		if (rt1 && m_features.depth_feedback)
 			continue;
 		if (rt1 && !depth)
 			continue;
@@ -1332,6 +1331,7 @@ std::string GSDeviceMTL::GetDriverInfo() const
 	desc += "\n    Framebuffer Fetch:   " + std::string(m_dev.features.framebuffer_fetch   ? "Supported" : "Unsupported");
 	desc += "\n    Memoryless Textures: " + std::string(m_dev.features.memoryless_textures ? "Supported" : "Unsupported");
 	desc += "\n    Primitive ID:        " + std::string(m_dev.features.primid              ? "Supported" : "Unsupported");
+	desc += "\n    Depth Feedback:      " + std::string(m_dev.features.depth_feedback      ? "Supported" : "Unsupported");
 	desc += "\n    Shader Version:      " + std::string(to_string(m_dev.features.shader_version));
 	desc += "\n    Max Texture Size:    " + std::to_string(m_dev.features.max_texsize);
 	return desc;
@@ -2379,7 +2379,7 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 	}
 
 	const bool feedback_depth = config.ps.IsFeedbackLoopDepth();
-	const bool rt1 = feedback_depth && m_features.depth_feedback == GSDevice::DepthFeedbackSupport::DepthAsRT;
+	const bool rt1 = feedback_depth && !m_features.depth_feedback;
 	BeginRenderPass(@"RenderHW", rt, MTLLoadActionLoad, config.ds, MTLLoadActionLoad, stencil, MTLLoadActionLoad, rt1);
 	id<MTLRenderCommandEncoder> mtlenc = m_current_render.encoder;
 	FlushDebugEntries(mtlenc);
@@ -2390,8 +2390,7 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 		MRESetTexture(rt, GSMTLTextureIndexRenderTarget);
 	if (feedback_depth)
 	{
-		bool depth_as_rt = m_features.depth_feedback == GSDevice::DepthFeedbackSupport::DepthAsRT;
-		GSTexture* tex = depth_as_rt && !m_features.framebuffer_fetch ? m_ds_as_rt : config.ds;
+		GSTexture* tex = !m_features.depth_feedback && !m_features.framebuffer_fetch ? m_ds_as_rt : config.ds;
 		MRESetTexture(tex, GSMTLTextureIndexDepthTarget);
 	}
 	if (primid_tex)

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -95,6 +95,11 @@ GSDeviceMTL::GSDeviceMTL()
 
 GSDeviceMTL::~GSDeviceMTL()
 {
+	// m_ds_as_rt_texture is owned if the device has memoryless textures
+	if (m_dev.features.memoryless_textures)
+		[m_ds_as_rt_texture release];
+	else if (m_ds_as_rt_gstexture)
+		delete m_ds_as_rt_gstexture;
 }
 
 GSDeviceMTL::Map GSDeviceMTL::Allocate(UploadBuffer& buffer, size_t amt)
@@ -247,7 +252,10 @@ id<MTLFence> GSDeviceMTL::GetSpinFence()
 
 id<MTLTexture> GSDeviceMTL::GetRT1DepthTexture(GSTextureMTL* depth)
 {
-	return static_cast<GSTextureMTL*>(m_ds_as_rt)->GetTexture();
+	if (m_dev.features.framebuffer_fetch)
+		return m_ds_as_rt_texture;
+	else
+		return static_cast<GSTextureMTL*>(m_ds_as_rt)->GetTexture();
 }
 
 void GSDeviceMTL::DrawCommandBufferFinished(u64 draw, id<MTLCommandBuffer> buffer)
@@ -1023,7 +1031,15 @@ bool GSDeviceMTL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 		{
 			MTLRenderPassColorAttachmentDescriptor* color1 = [[desc colorAttachments] objectAtIndexedSubscript:1];
 			[color1 setStoreAction:MTLStoreActionDontCare];
-			[color1 setLoadAction:MTLLoadActionLoad];
+			if (m_features.framebuffer_fetch)
+			{
+				[color1 setLoadAction:MTLLoadActionClear];
+				[color1 setClearColor:MTLClearColorMake(-1, 0, 0, 0)];
+			}
+			else
+			{
+				[color1 setLoadAction:MTLLoadActionLoad];
+			}
 		}
 		m_render_pass_desc[i] = desc;
 	}
@@ -1311,12 +1327,13 @@ bool GSDeviceMTL::SupportsExclusiveFullscreen() const { return false; }
 std::string GSDeviceMTL::GetDriverInfo() const
 { @autoreleasepool {
 	std::string desc([[m_dev.dev description] UTF8String]);
-	desc += "\n    Texture Swizzle:   " + std::string(m_dev.features.texture_swizzle   ? "Supported" : "Unsupported");
-	desc += "\n    Unified Memory:    " + std::string(m_dev.features.unified_memory    ? "Supported" : "Unsupported");
-	desc += "\n    Framebuffer Fetch: " + std::string(m_dev.features.framebuffer_fetch ? "Supported" : "Unsupported");
-	desc += "\n    Primitive ID:      " + std::string(m_dev.features.primid            ? "Supported" : "Unsupported");
-	desc += "\n    Shader Version:    " + std::string(to_string(m_dev.features.shader_version));
-	desc += "\n    Max Texture Size:  " + std::to_string(m_dev.features.max_texsize);
+	desc += "\n    Texture Swizzle:     " + std::string(m_dev.features.texture_swizzle     ? "Supported" : "Unsupported");
+	desc += "\n    Unified Memory:      " + std::string(m_dev.features.unified_memory      ? "Supported" : "Unsupported");
+	desc += "\n    Framebuffer Fetch:   " + std::string(m_dev.features.framebuffer_fetch   ? "Supported" : "Unsupported");
+	desc += "\n    Memoryless Textures: " + std::string(m_dev.features.memoryless_textures ? "Supported" : "Unsupported");
+	desc += "\n    Primitive ID:        " + std::string(m_dev.features.primid              ? "Supported" : "Unsupported");
+	desc += "\n    Shader Version:      " + std::string(to_string(m_dev.features.shader_version));
+	desc += "\n    Max Texture Size:    " + std::to_string(m_dev.features.max_texsize);
 	return desc;
 }}
 
@@ -1801,6 +1818,50 @@ void GSDeviceMTL::FilteredDownsampleTexture(GSTexture* sTex, GSTexture* dTex, u3
 
 	DoStretchRect(sTex, GSVector4::zero(), dTex, dRect, pipeline, false, LoadAction::DontCareIfFull, &uniform, sizeof(uniform));
 }}
+
+static id<MTLTexture> CreateDSAsRTTexture(id<MTLDevice> dev, NSUInteger width, NSUInteger height, MTLStorageMode storage, NSString* name)
+{
+	MTLTextureDescriptor *desc = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatR32Float width:width height:height mipmapped:false];
+	[desc setUsage:MTLTextureUsageRenderTarget];
+	[desc setStorageMode:storage];
+	id<MTLTexture> result = [dev newTextureWithDescriptor:desc];
+	[result setLabel:name];
+	return result;
+}
+
+void GSDeviceMTL::BeginDSAsRT(GSTexture* ds, const GSVector4i& drawarea)
+{
+	if (!m_features.framebuffer_fetch)
+		return GSDevice::BeginDSAsRT(ds, drawarea);
+	u32 needed_width = ds->GetWidth();
+	u32 needed_height = ds->GetHeight();
+	u32 current_width = static_cast<u32>([m_ds_as_rt_texture width]);
+	u32 current_height = static_cast<u32>([m_ds_as_rt_texture height]);
+	if (m_dev.features.memoryless_textures)
+	{
+		if (needed_width > current_width || needed_height > current_height) [[unlikely]] @autoreleasepool
+		{
+			u32 width = std::max(needed_width, current_width);
+			u32 height = std::max(needed_height, current_height);
+			[m_ds_as_rt_texture release];
+			m_ds_as_rt_texture = CreateDSAsRTTexture(m_dev.dev, width, height, MTLStorageModeMemoryless, @"DS as RT");
+		}
+	}
+	else
+	{
+		if (needed_width == current_width && needed_height == current_height)
+			return;
+		if (m_ds_as_rt_gstexture)
+			Recycle(m_ds_as_rt_gstexture);
+		m_ds_as_rt_gstexture = CreateRenderTarget(needed_width, needed_height, GSTexture::Format::Float32, false, true);
+		m_ds_as_rt_texture = static_cast<GSTextureMTL*>(m_ds_as_rt_gstexture)->GetTexture();
+		@autoreleasepool
+		{
+			NSString* name = [NSString stringWithFormat:@"DS as RT %dx%d", needed_width, needed_height];
+			[m_ds_as_rt_texture setLabel:name];
+		}
+	}
+}
 
 void GSDeviceMTL::FlushClears(GSTexture* tex)
 {
@@ -2327,10 +2388,10 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 	MREInitHWDraw(config, allocation);
 	if (config.require_one_barrier || config.require_full_barrier)
 		MRESetTexture(rt, GSMTLTextureIndexRenderTarget);
-	if (feedback_depth && !m_features.framebuffer_fetch)
+	if (feedback_depth)
 	{
 		bool depth_as_rt = m_features.depth_feedback == GSDevice::DepthFeedbackSupport::DepthAsRT;
-		GSTexture* tex = depth_as_rt ? m_ds_as_rt : config.ds;
+		GSTexture* tex = depth_as_rt && !m_features.framebuffer_fetch ? m_ds_as_rt : config.ds;
 		MRESetTexture(tex, GSMTLTextureIndexDepthTarget);
 	}
 	if (primid_tex)
@@ -2365,7 +2426,7 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 
 			Recycle(colclip_rt);
 			
-			g_gs_device->SetColorClipTexture(nullptr);
+			SetColorClipTexture(nullptr);
 		}
 	}
 

--- a/pcsx2/GS/Renderers/Metal/GSMTLDeviceInfo.h
+++ b/pcsx2/GS/Renderers/Metal/GSMTLDeviceInfo.h
@@ -34,6 +34,7 @@ struct GSMTLDevice
 		bool primid                 : 1;
 		bool slow_color_compression : 1; ///< Color compression seems to slow down rt read on AMD
 		bool has_fast_half          : 1;
+		bool memoryless_textures    : 1;
 		MetalVersion shader_version;
 		DepthFeedbackSupport preferred_depth_feedback : 8;
 		int max_texsize;

--- a/pcsx2/GS/Renderers/Metal/GSMTLDeviceInfo.h
+++ b/pcsx2/GS/Renderers/Metal/GSMTLDeviceInfo.h
@@ -24,8 +24,6 @@ struct GSMTLDevice
 		Metal23, ///< Metal 2.3 (macOS 11, iOS 14)
 	};
 
-	using DepthFeedbackSupport = GSShader::DepthFeedbackSupport;
-
 	struct Features
 	{
 		bool unified_memory         : 1;
@@ -35,8 +33,8 @@ struct GSMTLDevice
 		bool slow_color_compression : 1; ///< Color compression seems to slow down rt read on AMD
 		bool has_fast_half          : 1;
 		bool memoryless_textures    : 1;
+		bool depth_feedback         : 1;
 		MetalVersion shader_version;
-		DepthFeedbackSupport preferred_depth_feedback : 8;
 		int max_texsize;
 	};
 

--- a/pcsx2/GS/Renderers/Metal/GSMTLDeviceInfo.h
+++ b/pcsx2/GS/Renderers/Metal/GSMTLDeviceInfo.h
@@ -11,6 +11,7 @@
 
 #include "common/MRCHelpers.h"
 #include "common/Pcsx2Types.h"
+#include "GS/Renderers/Common/GSShaderEnums.h"
 #include <Metal/Metal.h>
 
 struct GSMTLDevice
@@ -23,15 +24,18 @@ struct GSMTLDevice
 		Metal23, ///< Metal 2.3 (macOS 11, iOS 14)
 	};
 
+	using DepthFeedbackSupport = GSShader::DepthFeedbackSupport;
+
 	struct Features
 	{
-		bool unified_memory;
-		bool texture_swizzle;
-		bool framebuffer_fetch;
-		bool primid;
-		bool slow_color_compression; ///< Color compression seems to slow down rt read on AMD
-		bool has_fast_half;
+		bool unified_memory         : 1;
+		bool texture_swizzle        : 1;
+		bool framebuffer_fetch      : 1;
+		bool primid                 : 1;
+		bool slow_color_compression : 1; ///< Color compression seems to slow down rt read on AMD
+		bool has_fast_half          : 1;
 		MetalVersion shader_version;
+		DepthFeedbackSupport preferred_depth_feedback : 8;
 		int max_texsize;
 	};
 

--- a/pcsx2/GS/Renderers/Metal/GSMTLDeviceInfo.mm
+++ b/pcsx2/GS/Renderers/Metal/GSMTLDeviceInfo.mm
@@ -147,7 +147,7 @@ GSMTLDevice::GSMTLDevice(MRCOwned<id<MTLDevice>> dev)
 
 	if (@available(macOS 11.0, iOS 13.0, *))
 		if ([dev supportsFamily:MTLGPUFamilyApple1])
-			features.framebuffer_fetch = true;
+			features.framebuffer_fetch = features.memoryless_textures = true;
 
 	if (@available(macOS 10.15, iOS 13.0, *))
 		if ([dev supportsFamily:MTLGPUFamilyMac2] || [dev supportsFamily:MTLGPUFamilyApple1])

--- a/pcsx2/GS/Renderers/Metal/GSMTLDeviceInfo.mm
+++ b/pcsx2/GS/Renderers/Metal/GSMTLDeviceInfo.mm
@@ -164,7 +164,7 @@ GSMTLDevice::GSMTLDevice(MRCOwned<id<MTLDevice>> dev)
 	if (features.primid && !detectPrimIDSupport(dev, shaders))
 		features.primid = false;
 
-	features.preferred_depth_feedback = DepthFeedbackSupport::DepthAsRT;
+	features.depth_feedback = false;
 
 	NSString* name = [dev name];
 	if ([name containsString:@"Intel"])
@@ -175,7 +175,7 @@ GSMTLDevice::GSMTLDevice(MRCOwned<id<MTLDevice>> dev)
 			{
 				case DetectionResult::HaswellOrNotIntel:
 					// Older Intel GPUs seem to be fine with depth feedback
-					features.preferred_depth_feedback = DepthFeedbackSupport::Depth;
+					features.depth_feedback = true;
 					break;
 				case DetectionResult::Broadwell:
 					features.primid = false; // Broken
@@ -192,12 +192,12 @@ GSMTLDevice::GSMTLDevice(MRCOwned<id<MTLDevice>> dev)
 		// RDNA+ seems to work fine with depth feedback
 		if (@available(macOS 13, iOS 16, *))
 			if ([dev supportsFamily:MTLGPUFamilyMetal3])
-				features.preferred_depth_feedback = DepthFeedbackSupport::Depth;
+				features.depth_feedback = true;
 	}
 	else if ([name containsString:@"NVIDIA"])
 	{
 		// macOS only supports Kepler, which seems to work fine with depth feedback
-		features.preferred_depth_feedback = DepthFeedbackSupport::Depth;
+		features.depth_feedback = true;
 	}
 	else if ([name containsString:@"Apple"])
 	{

--- a/pcsx2/GS/Renderers/Metal/GSMTLDeviceInfo.mm
+++ b/pcsx2/GS/Renderers/Metal/GSMTLDeviceInfo.mm
@@ -164,20 +164,48 @@ GSMTLDevice::GSMTLDevice(MRCOwned<id<MTLDevice>> dev)
 	if (features.primid && !detectPrimIDSupport(dev, shaders))
 		features.primid = false;
 
-	if (!features.framebuffer_fetch && features.shader_version >= MetalVersion::Metal23)
+	features.preferred_depth_feedback = DepthFeedbackSupport::DepthAsRT;
+
+	NSString* name = [dev name];
+	if ([name containsString:@"Intel"])
 	{
-		switch (detectIntelGPU(dev, shaders))
+		if (!features.framebuffer_fetch && features.shader_version >= MetalVersion::Metal23)
 		{
-			case DetectionResult::HaswellOrNotIntel:
-				break;
-			case DetectionResult::Broadwell:
-				features.primid = false; // Broken
-				break;
-			case DetectionResult::Skylake:
-				features.primid = false; // Broken
-				features.framebuffer_fetch = true;
-				break;
+			switch (detectIntelGPU(dev, shaders))
+			{
+				case DetectionResult::HaswellOrNotIntel:
+					// Older Intel GPUs seem to be fine with depth feedback
+					features.preferred_depth_feedback = DepthFeedbackSupport::Depth;
+					break;
+				case DetectionResult::Broadwell:
+					features.primid = false; // Broken
+					break;
+				case DetectionResult::Skylake:
+					features.primid = false; // Broken
+					features.framebuffer_fetch = true;
+					break;
+			}
 		}
+	}
+	else if ([name containsString:@"AMD"])
+	{
+		// RDNA+ seems to work fine with depth feedback
+		if (@available(macOS 13, iOS 16, *))
+			if ([dev supportsFamily:MTLGPUFamilyMetal3])
+				features.preferred_depth_feedback = DepthFeedbackSupport::Depth;
+	}
+	else if ([name containsString:@"NVIDIA"])
+	{
+		// macOS only supports Kepler, which seems to work fine with depth feedback
+		features.preferred_depth_feedback = DepthFeedbackSupport::Depth;
+	}
+	else if ([name containsString:@"Apple"])
+	{
+		// No special settings
+	}
+	else
+	{
+		Console.Warning("Unrecognized GPU vendor %s", [name UTF8String]);
 	}
 
 	if (features.framebuffer_fetch && GSConfig.DisableFramebufferFetch)

--- a/pcsx2/GS/Renderers/Metal/GSMTLSharedHeader.h
+++ b/pcsx2/GS/Renderers/Metal/GSMTLSharedHeader.h
@@ -20,6 +20,8 @@ enum GSMTLTextureIndex
 	GSMTLTextureIndexPalette,
 	GSMTLTextureIndexRenderTarget,
 	GSMTLTextureIndexPrimIDs,
+	GSMTLTextureIndexDepthTarget,
+	GSMTLTextureIndexCount,
 };
 
 struct GSMTLConvertPSUniform
@@ -154,6 +156,7 @@ enum GSMTLFnConstants
 {
 	GSMTLConstantIndex_CAS_SHARPEN_ONLY,
 	GSMTLConstantIndex_FRAMEBUFFER_FETCH,
+	GSMTLConstantIndex_DEPTH_FEEDBACK,
 	GSMTLConstantIndex_FST,
 	GSMTLConstantIndex_IIP,
 	GSMTLConstantIndex_VS_POINT_SIZE,
@@ -168,6 +171,7 @@ enum GSMTLFnConstants
 	GSMTLConstantIndex_PS_DATE,
 	GSMTLConstantIndex_PS_ATST,
 	GSMTLConstantIndex_PS_AFAIL,
+	GSMTLConstantIndex_PS_ZTST,
 	GSMTLConstantIndex_PS_TFX,
 	GSMTLConstantIndex_PS_TCC,
 	GSMTLConstantIndex_PS_WMS,

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -1285,7 +1285,7 @@ constant bool NEEDS_DS_FBF = false;
 constant float ds_fbf = 0;
 #endif
 constant bool NEEDS_DS_TEX   = SW_DEPTH && DEPTH_FEEDBACK == DepthFeedbackSupport::DepthAsRT && !NEEDS_DS_FBF;
-constant bool NEEDS_DS_DEPTH = SW_DEPTH && DEPTH_FEEDBACK == DepthFeedbackSupport::Depth;
+constant bool NEEDS_DS_DEPTH = SW_DEPTH && DEPTH_FEEDBACK == DepthFeedbackSupport::Depth || NEEDS_DS_FBF;
 
 fragment MainPSOut ps_main(
 	MainPSIn in [[stage_in]],
@@ -1331,7 +1331,10 @@ fragment MainPSOut ps_main(
 				main.current_depth = ds_depth.read(coord);
 				break;
 			case DepthFeedbackSupport::DepthAsRT:
-				main.current_depth = HAS_FBFETCH ? ds_fbf : ds_tex.read(coord).x;
+				if (NEEDS_DS_FBF)
+					main.current_depth = ds_fbf < 0 ? ds_depth.read(coord) : ds_fbf;
+				else
+					main.current_depth = ds_tex.read(coord).x;
 				break;
 			case DepthFeedbackSupport::None:
 				// Should never happen

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -12,7 +12,7 @@ constant uint SHUFFLE_READ = 1;
 constant uint SHUFFLE_READWRITE = 3;
 
 constant bool HAS_FBFETCH           [[function_constant(GSMTLConstantIndex_FRAMEBUFFER_FETCH)]];
-constant uint DEPTH_FEEDBACK_RAW    [[function_constant(GSMTLConstantIndex_DEPTH_FEEDBACK)]];
+constant bool DEPTH_FEEDBACK        [[function_constant(GSMTLConstantIndex_DEPTH_FEEDBACK)]];
 constant bool FST                   [[function_constant(GSMTLConstantIndex_FST)]];
 constant bool IIP                   [[function_constant(GSMTLConstantIndex_IIP)]];
 constant bool VS_POINT_SIZE         [[function_constant(GSMTLConstantIndex_VS_POINT_SIZE)]];
@@ -73,12 +73,10 @@ constant bool PS_MANUAL_LOD         [[function_constant(GSMTLConstantIndex_PS_MA
 constant bool PS_REGION_RECT        [[function_constant(GSMTLConstantIndex_PS_REGION_RECT)]];
 constant uint PS_SCANMSK            [[function_constant(GSMTLConstantIndex_PS_SCANMSK)]];
 
-using GSShader::DepthFeedbackSupport;
 using GSShader::VSExpand;
 using AFAIL = GSShader::PS_AFAIL;
 using ATST = GSShader::PS_ATST;
 using GSShader::ZTST;
-constant DepthFeedbackSupport DEPTH_FEEDBACK = static_cast<DepthFeedbackSupport>(DEPTH_FEEDBACK_RAW);
 constant VSExpand VS_EXPAND_TYPE = static_cast<VSExpand>(VS_EXPAND_TYPE_RAW);
 constant AFAIL PS_AFAIL = static_cast<AFAIL>(PS_AFAIL_RAW);
 constant ATST  PS_ATST  = static_cast<ATST>(PS_ATST_RAW);
@@ -120,7 +118,7 @@ constant bool PS_COLOR1 = !PS_NO_COLOR1;
 constant bool PS_ZOUTPUT = PS_ZCLAMP || PS_ZFLOOR || SW_DEPTH;
 constant bool PS_ZOUTPUT_LESS = PS_ZOUTPUT && !SW_DEPTH;
 constant bool PS_ZOUTPUT_ANY  = PS_ZOUTPUT && SW_DEPTH;
-constant bool PS_ZOUTPUT_COLOR = PS_ZOUTPUT_ANY && DEPTH_FEEDBACK == DepthFeedbackSupport::DepthAsRT;
+constant bool PS_ZOUTPUT_COLOR = PS_ZOUTPUT_ANY && !DEPTH_FEEDBACK;
 
 struct MainVSIn
 {
@@ -1278,14 +1276,14 @@ fragment float4 fbfetch_test(float4 in [[color(0), raster_order_group(0)]])
 
 constant bool NEEDS_RT_TEX = NEEDS_RT && !HAS_FBFETCH;
 constant bool NEEDS_RT_FBF = NEEDS_RT &&  HAS_FBFETCH;
-constant bool NEEDS_DS_FBF = SW_DEPTH &&  HAS_FBFETCH && DEPTH_FEEDBACK == DepthFeedbackSupport::DepthAsRT;
+constant bool NEEDS_DS_FBF = SW_DEPTH &&  HAS_FBFETCH && !DEPTH_FEEDBACK;
 #else
 constant bool NEEDS_RT_TEX = NEEDS_RT;
 constant bool NEEDS_DS_FBF = false;
 constant float ds_fbf = 0;
 #endif
-constant bool NEEDS_DS_TEX   = SW_DEPTH && DEPTH_FEEDBACK == DepthFeedbackSupport::DepthAsRT && !NEEDS_DS_FBF;
-constant bool NEEDS_DS_DEPTH = SW_DEPTH && DEPTH_FEEDBACK == DepthFeedbackSupport::Depth || NEEDS_DS_FBF;
+constant bool NEEDS_DS_TEX   = SW_DEPTH && !DEPTH_FEEDBACK && !NEEDS_DS_FBF;
+constant bool NEEDS_DS_DEPTH = SW_DEPTH && DEPTH_FEEDBACK || NEEDS_DS_FBF;
 
 fragment MainPSOut ps_main(
 	MainPSIn in [[stage_in]],
@@ -1325,22 +1323,12 @@ fragment MainPSOut ps_main(
 
 	if (SW_DEPTH)
 	{
-		switch (DEPTH_FEEDBACK)
-		{
-			case DepthFeedbackSupport::Depth:
-				main.current_depth = ds_depth.read(coord);
-				break;
-			case DepthFeedbackSupport::DepthAsRT:
-				if (NEEDS_DS_FBF)
-					main.current_depth = ds_fbf < 0 ? ds_depth.read(coord) : ds_fbf;
-				else
-					main.current_depth = ds_tex.read(coord).x;
-				break;
-			case DepthFeedbackSupport::None:
-				// Should never happen
-				main.current_depth = 0;
-				break;
-		}
+		if (DEPTH_FEEDBACK)
+			main.current_depth = ds_depth.read(coord);
+		else if (NEEDS_DS_FBF)
+			main.current_depth = ds_fbf < 0 ? ds_depth.read(coord) : ds_fbf;
+		else
+			main.current_depth = ds_tex.read(coord).x;
 	}
 
 	if (NEEDS_RT)

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -12,6 +12,7 @@ constant uint SHUFFLE_READ = 1;
 constant uint SHUFFLE_READWRITE = 3;
 
 constant bool HAS_FBFETCH           [[function_constant(GSMTLConstantIndex_FRAMEBUFFER_FETCH)]];
+constant uint DEPTH_FEEDBACK_RAW    [[function_constant(GSMTLConstantIndex_DEPTH_FEEDBACK)]];
 constant bool FST                   [[function_constant(GSMTLConstantIndex_FST)]];
 constant bool IIP                   [[function_constant(GSMTLConstantIndex_IIP)]];
 constant bool VS_POINT_SIZE         [[function_constant(GSMTLConstantIndex_VS_POINT_SIZE)]];
@@ -26,6 +27,7 @@ constant bool PS_FOG                [[function_constant(GSMTLConstantIndex_PS_FO
 constant uint PS_DATE               [[function_constant(GSMTLConstantIndex_PS_DATE)]];
 constant uint PS_ATST_RAW           [[function_constant(GSMTLConstantIndex_PS_ATST)]];
 constant uint PS_AFAIL_RAW          [[function_constant(GSMTLConstantIndex_PS_AFAIL)]];
+constant uint PS_ZTST_RAW           [[function_constant(GSMTLConstantIndex_PS_ZTST)]];
 constant uint PS_TFX                [[function_constant(GSMTLConstantIndex_PS_TFX)]];
 constant bool PS_TCC                [[function_constant(GSMTLConstantIndex_PS_TCC)]];
 constant uint PS_WMS                [[function_constant(GSMTLConstantIndex_PS_WMS)]];
@@ -71,12 +73,16 @@ constant bool PS_MANUAL_LOD         [[function_constant(GSMTLConstantIndex_PS_MA
 constant bool PS_REGION_RECT        [[function_constant(GSMTLConstantIndex_PS_REGION_RECT)]];
 constant uint PS_SCANMSK            [[function_constant(GSMTLConstantIndex_PS_SCANMSK)]];
 
+using GSShader::DepthFeedbackSupport;
 using GSShader::VSExpand;
 using AFAIL = GSShader::PS_AFAIL;
 using ATST = GSShader::PS_ATST;
+using GSShader::ZTST;
+constant DepthFeedbackSupport DEPTH_FEEDBACK = static_cast<DepthFeedbackSupport>(DEPTH_FEEDBACK_RAW);
 constant VSExpand VS_EXPAND_TYPE = static_cast<VSExpand>(VS_EXPAND_TYPE_RAW);
 constant AFAIL PS_AFAIL = static_cast<AFAIL>(PS_AFAIL_RAW);
 constant ATST  PS_ATST  = static_cast<ATST>(PS_ATST_RAW);
+constant ZTST  PS_ZTST  = static_cast<ZTST>(PS_ZTST_RAW);
 
 #if defined(__METAL_MACOS__) && __METAL_VERSION__ >= 220
 	#define PRIMID_SUPPORT 1
@@ -103,12 +109,18 @@ constant bool SW_BLEND = (PS_BLEND_A != PS_BLEND_B) || PS_BLEND_D;
 constant bool SW_AD_TO_HW = (PS_BLEND_C == 1 && PS_A_MASKED);
 constant bool NEEDS_RT_FOR_BLEND = (((PS_BLEND_A != PS_BLEND_B) && (PS_BLEND_A == 1 || PS_BLEND_B == 1 || PS_BLEND_C == 1)) || PS_BLEND_D == 1 || SW_AD_TO_HW);
 constant bool NEEDS_RT_EARLY = PS_TEX_IS_FB || PS_DATE >= 5;
-constant bool NEEDS_RT_FOR_AFAIL = PS_AFAIL == AFAIL::ZB_ONLY || PS_AFAIL == AFAIL::RGB_ONLY;
+constant bool NEEDS_RT_FOR_AFAIL = PS_AFAIL == AFAIL::ZB_ONLY || PS_AFAIL == AFAIL::RGB_ONLY || PS_AFAIL == AFAIL::RGB_ONLY_SW_Z;
 constant bool NEEDS_RT = NEEDS_RT_FOR_AFAIL || NEEDS_RT_EARLY || (!PS_PRIM_CHECKING_INIT && (PS_FBMASK || NEEDS_RT_FOR_BLEND));
+constant bool NEEDS_DEPTH_FOR_AFAIL = PS_AFAIL == AFAIL::FB_ONLY || PS_AFAIL == AFAIL::RGB_ONLY_SW_Z;
+constant bool NEEDS_DEPTH_FOR_ZTST  = PS_ZTST == ZTST::GEQUAL || PS_ZTST == ZTST::GREATER;
+constant bool SW_DEPTH = NEEDS_DEPTH_FOR_AFAIL || NEEDS_DEPTH_FOR_ZTST;
 
 constant bool PS_COLOR0 = !PS_NO_COLOR;
 constant bool PS_COLOR1 = !PS_NO_COLOR1;
-constant bool PS_ZOUTPUT = PS_ZCLAMP || PS_ZFLOOR;
+constant bool PS_ZOUTPUT = PS_ZCLAMP || PS_ZFLOOR || SW_DEPTH;
+constant bool PS_ZOUTPUT_LESS = PS_ZOUTPUT && !SW_DEPTH;
+constant bool PS_ZOUTPUT_ANY  = PS_ZOUTPUT && SW_DEPTH;
+constant bool PS_ZOUTPUT_COLOR = PS_ZOUTPUT_ANY && DEPTH_FEEDBACK == DepthFeedbackSupport::DepthAsRT;
 
 struct MainVSIn
 {
@@ -144,7 +156,18 @@ struct MainPSOut
 {
 	float4 c0 [[color(0), index(0), function_constant(PS_COLOR0)]];
 	float4 c1 [[color(0), index(1), function_constant(PS_COLOR1)]];
-	float depth [[depth(less), function_constant(PS_ZOUTPUT)]];
+	float depthColor [[color(1), function_constant(PS_ZOUTPUT_COLOR)]];
+	float depthLess [[depth(less), function_constant(PS_ZOUTPUT_LESS)]];
+	float depthAny  [[depth(any),  function_constant(PS_ZOUTPUT_ANY)]];
+	void setDepth(float depth)
+	{
+		if (PS_ZOUTPUT_LESS)
+			depthLess = depth;
+		if (PS_ZOUTPUT_ANY)
+			depthAny = depth;
+		if (PS_ZOUTPUT_COLOR)
+			depthColor = depth;
+	}
 };
 
 // MARK: - Vertex functions
@@ -299,6 +322,7 @@ struct PSMain
 	texture2d<float> prim_id_tex;
 	sampler tex_sampler;
 	float4 current_color;
+	float current_depth;
 	uint prim_id;
 	const thread MainPSIn& in;
 	constant GSMTLMainPSUniform& cb;
@@ -1061,6 +1085,17 @@ struct PSMain
 	MainPSOut ps_main()
 	{
 		MainPSOut out = {};
+		float input_z = in.p.z;
+		if (PS_ZFLOOR)
+			input_z = floor(input_z * 0x1p32) * 0x1p-32;
+
+		if (PS_ZTST == ZTST::GEQUAL || PS_ZTST == ZTST::GREATER)
+		{
+			if (PS_ZTST == ZTST::GEQUAL && input_z < current_depth)
+				discard_fragment();
+			if (PS_ZTST == ZTST::GREATER && input_z <= current_depth)
+				discard_fragment();
+		}
 
 		if (PS_SCANMSK & 2)
 		{
@@ -1211,18 +1246,25 @@ struct PSMain
 		{
 			out.c0.a = PS_RTA_CORRECTION ? C.a / 128.f : C.a / 255.f;
 			out.c0.rgb = PS_COLCLIP_HW ? float3(C.rgb / 65535.f) : C.rgb / 255.f;
-			if (PS_AFAIL == AFAIL::RGB_ONLY && !atst_pass)
-				out.c0.a = current_color.a;
 		}
 		if (PS_COLOR1)
 			out.c1 = alpha_blend;
-		
-		float depth_value = PS_ZFLOOR ? (floor(in.p.z * exp2(32.0f)) * exp2(-32.0f)) : in.p.z;
-		
+
 		if (PS_ZCLAMP)
-			out.depth = min(depth_value, cb.max_depth);
-		else if (PS_ZFLOOR)
-			out.depth = depth_value;
+			input_z = min(input_z, cb.max_depth);
+
+		if (!atst_pass)
+		{
+			if (PS_AFAIL == AFAIL::RGB_ONLY_SW_Z || PS_AFAIL == AFAIL::RGB_ONLY)
+				out.c0.a = current_color.a;
+			else if (PS_AFAIL == AFAIL::ZB_ONLY)
+				out.c0 = current_color;
+
+			if (PS_AFAIL == AFAIL::RGB_ONLY_SW_Z || PS_AFAIL == AFAIL::FB_ONLY)
+				input_z = current_depth;
+		}
+
+		out.setDepth(input_z);
 
 		return out;
 	}
@@ -1236,9 +1278,14 @@ fragment float4 fbfetch_test(float4 in [[color(0), raster_order_group(0)]])
 
 constant bool NEEDS_RT_TEX = NEEDS_RT && !HAS_FBFETCH;
 constant bool NEEDS_RT_FBF = NEEDS_RT &&  HAS_FBFETCH;
+constant bool NEEDS_DS_FBF = SW_DEPTH &&  HAS_FBFETCH && DEPTH_FEEDBACK == DepthFeedbackSupport::DepthAsRT;
 #else
 constant bool NEEDS_RT_TEX = NEEDS_RT;
+constant bool NEEDS_DS_FBF = false;
+constant float ds_fbf = 0;
 #endif
+constant bool NEEDS_DS_TEX   = SW_DEPTH && DEPTH_FEEDBACK == DepthFeedbackSupport::DepthAsRT && !NEEDS_DS_FBF;
+constant bool NEEDS_DS_DEPTH = SW_DEPTH && DEPTH_FEEDBACK == DepthFeedbackSupport::Depth;
 
 fragment MainPSOut ps_main(
 	MainPSIn in [[stage_in]],
@@ -1249,12 +1296,15 @@ fragment MainPSOut ps_main(
 #endif
 #if FBFETCH_SUPPORT
 	float4 rt_fbf [[color(0), raster_order_group(0), function_constant(NEEDS_RT_FBF)]],
+	float  ds_fbf [[color(1), raster_order_group(1), function_constant(NEEDS_DS_FBF)]],
 #endif
 	texture2d<float> tex       [[texture(GSMTLTextureIndexTex),          function_constant(PS_TEX_IS_COLOR)]],
 	depth2d<float>   depth     [[texture(GSMTLTextureIndexTex),          function_constant(PS_TEX_IS_DEPTH)]],
 	texture2d<float> palette   [[texture(GSMTLTextureIndexPalette),      function_constant(PS_HAS_PALETTE)]],
 	texture2d<float> rt        [[texture(GSMTLTextureIndexRenderTarget), function_constant(NEEDS_RT_TEX)]],
-	texture2d<float> primidtex [[texture(GSMTLTextureIndexPrimIDs),      function_constant(PS_PRIM_CHECKING_READ)]])
+	texture2d<float> primidtex [[texture(GSMTLTextureIndexPrimIDs),      function_constant(PS_PRIM_CHECKING_READ)]],
+	texture2d<float> ds_tex    [[texture(GSMTLTextureIndexDepthTarget),  function_constant(NEEDS_DS_TEX)]],
+	depth2d<float>   ds_depth  [[texture(GSMTLTextureIndexDepthTarget),  function_constant(NEEDS_DS_DEPTH)]])
 {
 	PSMain main(in, cb);
 	main.tex_sampler = s;
@@ -1271,12 +1321,31 @@ fragment MainPSOut ps_main(
 		main.prim_id = primid;
 #endif
 
+	uint2 coord = uint2(in.p.xy);
+
+	if (SW_DEPTH)
+	{
+		switch (DEPTH_FEEDBACK)
+		{
+			case DepthFeedbackSupport::Depth:
+				main.current_depth = ds_depth.read(coord);
+				break;
+			case DepthFeedbackSupport::DepthAsRT:
+				main.current_depth = HAS_FBFETCH ? ds_fbf : ds_tex.read(coord).x;
+				break;
+			case DepthFeedbackSupport::None:
+				// Should never happen
+				main.current_depth = 0;
+				break;
+		}
+	}
+
 	if (NEEDS_RT)
 	{
 #if FBFETCH_SUPPORT
-		main.current_color = HAS_FBFETCH ? rt_fbf : rt.read(uint2(in.p.xy));
+		main.current_color = HAS_FBFETCH ? rt_fbf : rt.read(coord);
 #else
-		main.current_color = rt.read(uint2(in.p.xy));
+		main.current_color = rt.read(coord);
 #endif
 	}
 	else

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -845,38 +845,12 @@ bool GSDeviceOGL::CheckFeatures()
 	m_features.prefer_new_textures = false;
 	m_features.stencil_buffer = true;
 	m_features.test_and_sample_depth = m_features.texture_barrier;
-	if (m_features.texture_barrier)
+	// Auto select chooses depth-as-rt as it appears to be more compatible across hardware.
+	m_features.depth_feedback = GSConfig.DepthFeedbackMode == GSDepthFeedbackMode::Depth;
+	if (!m_features.texture_barrier && m_features.multidraw_fb_copy)
 	{
-		// Auto select chooses depth-as-rt as it appears to be more compatible across hardware.
-		if (GSConfig.DepthFeedbackMode == GSDepthFeedbackMode::DepthAsRT ||
-			GSConfig.DepthFeedbackMode == GSDepthFeedbackMode::Auto)
-		{
-			m_features.depth_feedback = GSDevice::DepthFeedbackSupport::DepthAsRT;
-		}
-		else if (GSConfig.DepthFeedbackMode == GSDepthFeedbackMode::Depth)
-		{
-			m_features.depth_feedback = GSDevice::DepthFeedbackSupport::Depth;
-		}
-		else
-		{
-			m_features.depth_feedback = GSDevice::DepthFeedbackSupport::None;
-		}
-	}
-	else if (m_features.multidraw_fb_copy)
-	{
-		if (GSConfig.DepthFeedbackMode == GSDepthFeedbackMode::Depth ||
-			GSConfig.DepthFeedbackMode == GSDepthFeedbackMode::Auto)
-		{
-			m_features.depth_feedback = GSDevice::DepthFeedbackSupport::Depth;
-		}
-		else
-		{
-			m_features.depth_feedback = GSDevice::DepthFeedbackSupport::None;
-		}
-	}
-	else
-	{
-		m_features.depth_feedback = GSDevice::DepthFeedbackSupport::None;
+		// Multidraw fb copy can do depth feedback just fine
+		m_features.depth_feedback |= GSConfig.DepthFeedbackMode == GSDepthFeedbackMode::Auto;
 	}
 
 	if (GLAD_GL_ARB_shader_storage_buffer_object)
@@ -909,7 +883,7 @@ bool GSDeviceOGL::CheckFeatures()
 		Console.Warning("GLAD_GL_ARB_conservative_depth is not supported. This will reduce performance.");
 	}
 	
-	m_features.aa1 = GSConfig.HWAA1 && m_features.vs_expand && (m_features.depth_feedback != GSDevice::DepthFeedbackSupport::None);
+	m_features.aa1 = GSConfig.HWAA1 && m_features.vs_expand && (m_features.texture_barrier || m_features.multidraw_fb_copy);
 
 	return true;
 }
@@ -1477,22 +1451,17 @@ std::string GSDeviceOGL::GenGlslHeader(const std::string_view entry, GLenum type
 		header += "#define PS_HAS_CONSERVATIVE_DEPTH 0\n";
 	}
 
-	switch (m_features.depth_feedback)
+	if (!m_features.texture_barrier && !m_features.multidraw_fb_copy)
 	{
-		case GSDevice::DepthFeedbackSupport::None:
-			header += "#define DEPTH_FEEDBACK_SUPPORT 0\n"; // None
-			static_assert(static_cast<int>(GSDevice::DepthFeedbackSupport::None) == 0);
-			break;
-		case GSDevice::DepthFeedbackSupport::Depth:
-			header += "#define DEPTH_FEEDBACK_SUPPORT 1\n"; // Depth
-			static_assert(static_cast<int>(GSDevice::DepthFeedbackSupport::Depth) == 1);
-			break;
-		case GSDevice::DepthFeedbackSupport::DepthAsRT:
-			header += "#define DEPTH_FEEDBACK_SUPPORT 2\n"; // Depth as RT
-			static_assert(static_cast<int>(GSDevice::DepthFeedbackSupport::DepthAsRT) == 2);
-			break;
-		default:
-			pxFail("Incorrect depth feedback support."); // Impossible
+		header += "#define DEPTH_FEEDBACK_SUPPORT 0\n"; // None
+	}
+	else if (m_features.depth_feedback)
+	{
+		header += "#define DEPTH_FEEDBACK_SUPPORT 1\n"; // Depth
+	}
+	else
+	{
+		header += "#define DEPTH_FEEDBACK_SUPPORT 2\n"; // Depth as RT
 	}
 
 	// Allow to puts several shader in 1 files
@@ -2829,10 +2798,9 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 		PSSetShaderResource(1, config.pal);
 	if (m_features.texture_barrier && (config.require_one_barrier || config.require_full_barrier))
 		PSSetShaderResource(2, colclip_rt ? colclip_rt : config.rt);
-	const bool depth_feedback = m_features.depth_feedback == GSDevice::DepthFeedbackSupport::Depth;
-	if (m_features.texture_barrier && (config.require_one_barrier || config.require_full_barrier) && config.ps.IsFeedbackLoopDepth() &&
-		(depth_feedback || m_features.depth_feedback == GSDevice::DepthFeedbackSupport::DepthAsRT))
-		PSSetShaderResource(4, depth_feedback ? config.ds : m_ds_as_rt);
+	if (m_features.texture_barrier && (config.require_one_barrier || config.require_full_barrier) && config.ps.IsFeedbackLoopDepth())
+		PSSetShaderResource(4, m_features.depth_feedback ? config.ds : m_ds_as_rt);
+
 	SetupSampler(config.sampler);
 
 	if (m_vs_cb_cache.Update(config.cb_vs))
@@ -2968,7 +2936,7 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 	}
 
 	if (draw_ds && (config.require_one_barrier || (config.require_full_barrier && m_features.multidraw_fb_copy)) &&
-		!m_features.texture_barrier && depth_feedback && config.ps.IsFeedbackLoopDepth())
+		!m_features.texture_barrier && m_features.depth_feedback && config.ps.IsFeedbackLoopDepth())
 	{
 		// Requires a copy of the DS.
 		draw_ds_clone = CreateTexture(rtsize.x, rtsize.y, 1, draw_ds->GetFormat(), true);

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -2832,7 +2832,7 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 	const bool depth_feedback = m_features.depth_feedback == GSDevice::DepthFeedbackSupport::Depth;
 	if (m_features.texture_barrier && (config.require_one_barrier || config.require_full_barrier) && config.ps.IsFeedbackLoopDepth() &&
 		(depth_feedback || m_features.depth_feedback == GSDevice::DepthFeedbackSupport::DepthAsRT))
-		PSSetShaderResource(4, depth_feedback ? config.ds : config.ds_as_rt);
+		PSSetShaderResource(4, depth_feedback ? config.ds : m_ds_as_rt);
 	SetupSampler(config.sampler);
 
 	if (m_vs_cb_cache.Update(config.cb_vs))
@@ -2848,7 +2848,7 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 
 	SetupPipeline(psel);
 
-	bool rt_hazard_barrier = config.tex && (config.tex == config.ds || config.tex == config.rt || config.tex == config.ds_as_rt);
+	bool rt_hazard_barrier = config.tex && (config.tex == config.ds || config.tex == config.rt);
 	// In Time Crisis:
 	// 1. Fullscreen sprite reads depth and writes alpha (rt_hazard_barrier true from config.ds == config.tex)
 	// 2. Fullscreen sprite writes gray, rta hw blend blends based on dst alpha.
@@ -2906,7 +2906,7 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 		PSSetShaderResource(3, primid_texture);
 	}
 
-	if (config.ds_as_rt)
+	if (m_ds_as_rt)
 	{
 		// We must clear the blend equation of any dual source blending factors or
 		// it may interact badly with MRTs, even if blending is disabled.
@@ -2926,7 +2926,7 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 	}
 
 	GSTexture* draw_rt = colclip_rt ? colclip_rt : config.rt;
-	GSTexture* draw_ds_as_rt = config.ds_as_rt;
+	GSTexture* draw_ds_as_rt = m_ds_as_rt;
 	GSTexture* draw_ds = config.ds;
 
 	// Clear texture binding when it's bound to RT or DS.

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -883,7 +883,7 @@ bool GSDeviceOGL::CheckFeatures()
 		Console.Warning("GLAD_GL_ARB_conservative_depth is not supported. This will reduce performance.");
 	}
 	
-	m_features.aa1 = GSConfig.HWAA1 && m_features.vs_expand && (m_features.texture_barrier || m_features.multidraw_fb_copy);
+	m_features.aa1 = GSConfig.HWAA1 && m_features.vs_expand && m_features.feedback_loops();
 
 	return true;
 }

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -2702,8 +2702,8 @@ bool GSDeviceVK::CheckFeatures()
 	m_features.line_expand =
 		(m_device_features.wideLines && limits.lineWidthRange[0] <= f_upscale && limits.lineWidthRange[1] >= f_upscale);
 
-	m_features.depth_feedback = m_features.texture_barrier;
-	m_features.aa1 = GSConfig.HWAA1 && m_features.vs_expand && m_features.texture_barrier;
+	m_features.depth_feedback = m_features.feedback_loops();
+	m_features.aa1 = GSConfig.HWAA1 && m_features.vs_expand && m_features.feedback_loops();
 
 	DevCon.WriteLn("Optional features:%s%s%s%s%s", m_features.primitive_id ? " primitive_id" : "",
 		m_features.texture_barrier ? " texture_barrier" : "", m_features.framebuffer_fetch ? " framebuffer_fetch" : "",

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -2702,18 +2702,8 @@ bool GSDeviceVK::CheckFeatures()
 	m_features.line_expand =
 		(m_device_features.wideLines && limits.lineWidthRange[0] <= f_upscale && limits.lineWidthRange[1] >= f_upscale);
 
-	if (m_features.texture_barrier && (GSConfig.DepthFeedbackMode == GSDepthFeedbackMode::Auto ||
-		GSConfig.DepthFeedbackMode == GSDepthFeedbackMode::Depth))
-	{
-		m_features.depth_feedback = GSDevice::DepthFeedbackSupport::Depth;
-	}
-	else
-	{
-		m_features.depth_feedback = GSDevice::DepthFeedbackSupport::None;
-	}
-
-
-	m_features.aa1 = GSConfig.HWAA1 && m_features.vs_expand && (m_features.depth_feedback != GSDevice::DepthFeedbackSupport::None);
+	m_features.depth_feedback = m_features.texture_barrier;
+	m_features.aa1 = GSConfig.HWAA1 && m_features.vs_expand && m_features.texture_barrier;
 
 	DevCon.WriteLn("Optional features:%s%s%s%s%s", m_features.primitive_id ? " primitive_id" : "",
 		m_features.texture_barrier ? " texture_barrier" : "", m_features.framebuffer_fetch ? " framebuffer_fetch" : "",


### PR DESCRIPTION
### Description of Changes
Metal implementation for #13631

### Rationale behind Changes
Feature parity for Metal renderer

### Suggested Testing Steps
- Test things that were tested on #13631 on Metal
- Make sure I didn't break depth feedback for other renderers (especially OpenGL since I just rebased over some changes to OGL depth feedback handling and might have missed something)

### Did you use AI to help find, test, or implement this issue or feature?
No