### PR TITLE
Hotkeys: Check if the memory card is busy before resetting

### DIFF
--- a/pcsx2/Hotkeys.cpp
+++ b/pcsx2/Hotkeys.cpp
@@ -238,7 +238,7 @@ DEFINE_HOTKEY("ShutdownVM", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP(
 DEFINE_HOTKEY("ResetVM", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Reset Virtual Machine"),
 	[](s32 pressed) {
 		if (!pressed && VMManager::HasValidVM())
-			VMManager::Reset();
+			VMManager::RequestReset();
 	})
 DEFINE_HOTKEY("ReloadPatches", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Reload Patches"),
 	[](s32 pressed) {

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1743,6 +1743,22 @@ void VMManager::Shutdown(bool save_resume_state)
 	LoadSettings();
 }
 
+bool VMManager::RequestReset()
+{
+	if (MemcardBusy::IsBusy())
+	{
+		Host::AddIconOSDMessage("RequestReset", ICON_FA_TRIANGLE_EXCLAMATION,
+			TRANSLATE_STR("VMManager",
+				"The memory card is busy, so the reset operation has been cancelled to prevent data loss."),
+			Host::OSD_WARNING_DURATION);
+		return false;
+	}
+
+	VMManager::Reset();
+
+	return true;
+}
+
 void VMManager::Reset()
 {
 	pxAssert(HasValidVM());

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -124,6 +124,9 @@ namespace VMManager
 	/// Destroys all system components.
 	void Shutdown(bool save_resume_state);
 
+	/// Resets all subsystems to a cold boot if it's safe to do so.
+	bool RequestReset();
+
 	/// Resets all subsystems to a cold boot.
 	void Reset();
 


### PR DESCRIPTION
### Description of Changes
- Add a new VMManager::RequestReset function, that checks if the memory card is busy before resetting.
- Make the reset hotkey call this function instead.

### Rationale behind Changes
Prevent data loss. It looks like we previously just forgot to check this here.

### Suggested Testing Steps
Try using the reset hotkey while saving a game (using a memory card you don't care about).

### Did you use AI to help find, test, or implement this issue or feature?
No.
