### PR TITLE
GS/HW: Fix shader compile errors and warnings from AA1 on GL.

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -1438,8 +1438,8 @@ uint load_index(uint _i)
 {
 	uint i = _i + BaseIndex;
 	// i is even => load lower 16 bits; i odd => load upper 16 bits.
-	uint shift = (i & 1) << 4;
-	return (IndexBuffer.Load(i >> 1) >> shift) & 0xFFFF;
+	uint shift = (i & 1u) << 4u;
+	return (IndexBuffer.Load(i >> 1u) >> shift) & 0xFFFFu;
 }
 
 VS_INPUT load_vertex(uint index)

--- a/bin/resources/shaders/opengl/tfx_vgs.glsl
+++ b/bin/resources/shaders/opengl/tfx_vgs.glsl
@@ -37,7 +37,7 @@ out SHADER
 		flat vec4 c;
 	#endif
 	float inv_cov; // We use the inverse to make it simpler to interpolate.
-	uint interior; // 1 for triangle interior; 0 for edge;
+	flat uint interior; // 1 for triangle interior; 0 for edge.
 } VSout;
 
 const float exp_min32 = exp2(-32.0f);
@@ -138,8 +138,8 @@ uint load_index(uint _i)
 {
 	uint i = _i + BaseIndex;
 	// i is even => load lower 16 bits; i odd => load upper 16 bits.
-	uint shift = (i & 1) << 4;
-	return (index_buffer[i >> 1] >> shift) & 0xFFFF;
+	uint shift = (i & 1u) << 4u;
+	return (index_buffer[i >> 1u] >> shift) & 0xFFFFu;
 }
 
 ProcessedVertex load_vertex(uint index)

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -140,8 +140,8 @@ uint load_index(uint _i)
 {
 	uint i = _i + BaseIndex;
 	// i is even => load lower 16 bits; i odd => load upper 16 bits.
-	uint shift = (i & 1) << 4;
-	return (index_buffer[i >> 1] >> shift) & 0xFFFF;
+	uint shift = (i & 1u) << 4u;
+	return (index_buffer[i >> 1u] >> shift) & 0xFFFFu;
 }
 
 ProcessedVertex load_vertex(uint index)

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 86; // Last changed in PR 13681
+static constexpr u32 SHADER_CACHE_VERSION = 87; // Last changed in PR 14336


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/HW: Fix shader compile errors and warnings from AA1 on GL.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Regression fixes from #13681

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test dump from https://github.com/PCSX2/pcsx2/pull/13681#issuecomment-4284753668 on gl.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.