### PR TITLE
GS/VK: Fix flat specifier in VK shader.

### DIFF
--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -39,7 +39,7 @@ layout(location = 0) out VSOutput
 	#endif
 
 	float inv_cov; // We use the inverse to make it simpler to interpolate.
-	uint interior; // 1 for triangle interior; 0 for edge;
+	flat uint interior; // 1 for triangle interior; 0 for edge;
 } vsOut;
 
 #if VS_EXPAND == VS_EXPAND_NONE

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 87; // Last changed in PR 14336
+static constexpr u32 SHADER_CACHE_VERSION = 88; // Last changed in PR 14187


### PR DESCRIPTION
### Description of Changes
Adds 'flat' specifier to integer output from vertex stage to fragment stage.

### Rationale behind Changes
Avoid undefined behavior on different drivers. Similar issue to https://github.com/PCSX2/pcsx2/pull/14336 on GL.

### Suggested Testing Steps
Shouldn't really need testing.

I briefly tested on VK by running a dump with AA1 enabled.

### Did you use AI to help find, test, or implement this issue or feature?
No.
