### PR TITLE
GS/HW: Use correct draw functions in backend passes.

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -1180,9 +1180,7 @@ void GSDevice11::DrawPrimitive()
 
 void GSDevice11::DrawIndexedPrimitive()
 {
-	g_perfmon.Put(GSPerfMon::DrawCalls, 1);
-	PSUpdateShaderState(true, true);
-	m_ctx->DrawIndexed(m_index.count, m_index.start, m_vertex.start);
+	DrawIndexedPrimitive(0, m_index.count);
 }
 
 void GSDevice11::DrawIndexedPrimitive(int offset, int count)
@@ -1209,6 +1207,25 @@ void GSDevice11::DrawIndexedPrimitiveVSExpand(int offset, int count, bool vs_ind
 		VSSetPushConstants(m_vertex.start);
 		m_ctx->DrawIndexed(count, m_index.start + offset, 0);
 	}
+}
+
+void GSDevice11::Draw(const GSHWDrawConfig& config, int offset, int count)
+{
+	if (config.vs.expand != GSHWDrawConfig::VSExpand::None)
+	{
+		const bool vs_indexing = config.vs.UseVSExpandIndexBuffer();
+		const u32 vs_indexing_expansion = GetExpansionFactor(config.vs.expand);
+		DrawIndexedPrimitiveVSExpand(offset, count, vs_indexing, vs_indexing_expansion);
+	}
+	else
+	{
+		DrawIndexedPrimitive(offset, count);
+	}
+}
+
+void GSDevice11::Draw(const GSHWDrawConfig& config)
+{
+	Draw(config, 0, m_index.count);
 }
 
 void GSDevice11::CommitClear(GSTexture* t)
@@ -2917,7 +2934,7 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 		SetupOM(dss, blend, 0);
 		OMSetRenderTargets(primid_texture, config.ds, &config.scissor, read_only_dsv);
 		SetRenderHWShaderResources(config, nullptr);
-		DrawIndexedPrimitive();
+		Draw(config);
 
 		config.ps.date = 3;
 		config.alpha_second_pass.ps.date = 3;
@@ -2975,7 +2992,7 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 		config.ps.dither = config.blend_multi_pass.dither;
 		SetupPS(config.ps, &config.cb_ps, config.sampler);
 		SetupOM(config.depth, OMBlendSelector(config.colormask, config.blend_multi_pass.blend), config.blend_multi_pass.blend.constant);
-		DrawIndexedPrimitive();
+		Draw(config);
 	}
 
 	if (config.alpha_second_pass.enable)
@@ -3017,21 +3034,6 @@ void GSDevice11::SendHWDraw(const GSHWDrawConfig& config,
 	GSTexture* draw_rt_clone, GSTexture* draw_rt, GSTexture* draw_ds_clone, GSTexture* draw_ds,
 	const bool one_barrier, const bool full_barrier)
 {
-	const bool vs_expand = config.vs.expand != GSHWDrawConfig::VSExpand::None;
-	const bool vs_indexing = config.vs.UseVSExpandIndexBuffer();
-	const u32 vs_indexing_expansion = GetExpansionFactor(config.vs.expand);
-
-	auto Draw = [&](int offset, int count) {
-		if (vs_expand)
-		{
-			DrawIndexedPrimitiveVSExpand(offset, count, vs_indexing, vs_indexing_expansion);
-		}
-		else
-		{
-			DrawIndexedPrimitive(offset, count);
-		}
-	};
-
 	if (draw_rt_clone || draw_ds_clone)
 	{
 #ifdef PCSX2_DEVBUILD
@@ -3072,7 +3074,7 @@ void GSDevice11::SendHWDraw(const GSHWDrawConfig& config,
 				const GSVector4i original_bbox = (*config.drawlist_bbox)[n].rintersect(config.drawarea);
 				CopyAndBind(ProcessCopyArea(rtsize, original_bbox));
 
-				Draw(p, count);
+				Draw(config, p, count);
 				
 				p += count;
 			}
@@ -3084,7 +3086,7 @@ void GSDevice11::SendHWDraw(const GSHWDrawConfig& config,
 		CopyAndBind(ProcessCopyArea(rtsize, config.drawarea));
 	}
 
-	Draw(0, m_index.count);
+	Draw(config);
 }
 
 void GSDevice11::SetRenderHWShaderResources(const GSHWDrawConfig& config, GSTexture* primid_texture)

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -301,10 +301,15 @@ public:
 	bool SetGPUTimingEnabled(bool enabled) override;
 	float GetAndResetAccumulatedGPUTime() override;
 
+	// Helpers and utility draws.
 	void DrawPrimitive();
 	void DrawIndexedPrimitive();
 	void DrawIndexedPrimitive(int offset, int count);
-	void DrawIndexedPrimitiveVSExpand(int offset, int count, bool vs_indexing = false, int vs_indexing_expansion = 1);
+	void DrawIndexedPrimitiveVSExpand(int offset, int count, bool vs_indexing, int vs_indexing_expansion);
+
+	// Main GS primitive draws.
+	void Draw(const GSHWDrawConfig& config);
+	void Draw(const GSHWDrawConfig& config, int offset, int count);
 
 	void PushDebugGroup(const char* fmt, ...) override;
 	void PopDebugGroup() override;

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -1464,6 +1464,18 @@ void GSDevice12::DrawPrimitive()
 	GetCommandList().list4->DrawInstanced(m_vertex.count, 1, m_vertex.start, 0);
 }
 
+void GSDevice12::DrawIndexedPrimitive()
+{
+	DrawIndexedPrimitive(0, m_index.count);
+}
+
+void GSDevice12::DrawIndexedPrimitive(int offset, int count)
+{
+	pxAssert(offset + count <= (int)m_index.count);
+	g_perfmon.Put(GSPerfMon::DrawCalls, 1);
+	GetCommandList().list4->DrawIndexedInstanced(count, 1, m_index.start + offset, m_vertex.start, 0);
+}
+
 void GSDevice12::DrawIndexedPrimitiveVSExpand(int offset, int count, bool vs_indexing, int vs_indexing_expansion)
 {
 	g_perfmon.Put(GSPerfMon::DrawCalls, 1);
@@ -1479,17 +1491,23 @@ void GSDevice12::DrawIndexedPrimitiveVSExpand(int offset, int count, bool vs_ind
 	}
 }
 
-void GSDevice12::DrawIndexedPrimitive()
+void GSDevice12::Draw(const GSHWDrawConfig& config, int offset, int count)
 {
-	g_perfmon.Put(GSPerfMon::DrawCalls, 1);
-	GetCommandList().list4->DrawIndexedInstanced(m_index.count, 1, m_index.start, m_vertex.start, 0);
+	if (config.vs.expand != GSHWDrawConfig::VSExpand::None)
+	{
+		const bool vs_indexing = config.vs.UseVSExpandIndexBuffer();
+		const u32 vs_indexing_expansion = GetExpansionFactor(config.vs.expand);
+		DrawIndexedPrimitiveVSExpand(offset, count, vs_indexing, vs_indexing_expansion);
+	}
+	else
+	{
+		DrawIndexedPrimitive(offset, count);
+	}
 }
 
-void GSDevice12::DrawIndexedPrimitive(int offset, int count)
+void GSDevice12::Draw(const GSHWDrawConfig& config)
 {
-	pxAssert(offset + count <= (int)m_index.count);
-	g_perfmon.Put(GSPerfMon::DrawCalls, 1);
-	GetCommandList().list4->DrawIndexedInstanced(count, 1, m_index.start + offset, m_vertex.start, 0);
+	Draw(config, 0, m_index.count);
 }
 
 void GSDevice12::LookupNativeFormat(GSTexture::Format format, DXGI_FORMAT* d3d_format, DXGI_FORMAT* srv_format,
@@ -4138,7 +4156,7 @@ GSTexture12* GSDevice12::SetupPrimitiveTrackingDATE(GSHWDrawConfig& config, Pipe
 	init_pipe.ps.no_color = false;
 	init_pipe.ps.no_color1 = true;
 	if (BindDrawPipeline(init_pipe))
-		DrawIndexedPrimitive();
+		Draw(config);
 
 	// image is initialized/prepass is done, so finish up and get ready to do the "real" draw
 	EndRenderPass();
@@ -4458,7 +4476,7 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 		pipe.ps.blend_hw = config.blend_multi_pass.blend_hw;
 		pipe.ps.dither = config.blend_multi_pass.dither;
 		if (BindDrawPipeline(pipe))
-			DrawIndexedPrimitive();
+			Draw(config);
 	}
 
 	// and the alpha pass
@@ -4522,29 +4540,15 @@ void GSDevice12::SendHWDraw(const PipelineSelector& pipe, const GSHWDrawConfig& 
 	GSTexture12* draw_ds, const bool feedback_rt, const bool feedback_depth, const bool one_barrier,
 	const bool full_barrier)
 {
-	if (BindDrawPipeline(pipe) && !m_features.texture_barrier) [[unlikely]]
+	const int n_barriers = static_cast<int>(feedback_rt) + static_cast<int>(feedback_depth);
+
+	if (!m_features.texture_barrier) [[unlikely]]
 	{
-		DrawIndexedPrimitive();
+		if (BindDrawPipeline(pipe))
+			Draw(config);
 		return;
 	}
 
-	const int n_barriers = static_cast<int>(feedback_rt) + static_cast<int>(feedback_depth);
-
-	const bool vs_expand = config.vs.expand != GSHWDrawConfig::VSExpand::None;
-	const bool vs_indexing = config.vs.UseVSExpandIndexBuffer();
-	const u32 vs_indexing_expansion = GetExpansionFactor(config.vs.expand);
-
-	auto Draw = [&](int offset, int count) {
-		if (vs_expand)
-		{
-			DrawIndexedPrimitiveVSExpand(offset, count, vs_indexing, vs_indexing_expansion);
-		}
-		else
-		{
-			DrawIndexedPrimitive(offset, count);
-		}
-	};
-	
 	if (feedback_rt || feedback_depth)
 	{
 #ifdef PCSX2_DEVBUILD
@@ -4577,7 +4581,7 @@ void GSDevice12::SendHWDraw(const PipelineSelector& pipe, const GSHWDrawConfig& 
 					FeedbackBarrier(draw_ds);
 
 				if (BindDrawPipeline(pipe))
-					Draw(p, count);
+					Draw(config, p, count);
 				p += count;
 			}
 
@@ -4596,7 +4600,7 @@ void GSDevice12::SendHWDraw(const PipelineSelector& pipe, const GSHWDrawConfig& 
 	}
 
 	if (BindDrawPipeline(pipe))
-		Draw(0, m_index.count);
+		Draw(config);
 }
 
 void GSDevice12::UpdateHWPipelineSelector(GSHWDrawConfig& config)

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.h
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.h
@@ -463,10 +463,15 @@ public:
 	void PopDebugGroup() override;
 	void InsertDebugMessage(DebugMessageCategory category, const char* fmt, ...) override;
 
+	// Helpers and utility draws.
 	void DrawPrimitive();
 	void DrawIndexedPrimitive();
 	void DrawIndexedPrimitive(int offset, int count);
-	void DrawIndexedPrimitiveVSExpand(int offset, int count, bool vs_indexing = false, int vs_indexing_expansion = 1);
+	void DrawIndexedPrimitiveVSExpand(int offset, int count, bool vs_indexing, int vs_indexing_expansion);
+
+	// Main GS primitive draws.
+	void Draw(const GSHWDrawConfig& config);
+	void Draw(const GSHWDrawConfig& config, int offset, int count);
 
 	std::unique_ptr<GSDownloadTexture> CreateDownloadTexture(u32 width, u32 height, GSTexture::Format format) override;
 

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -1200,15 +1200,11 @@ void GSDeviceOGL::DrawPrimitive()
 
 void GSDeviceOGL::DrawIndexedPrimitive()
 {
-	g_perfmon.Put(GSPerfMon::DrawCalls, 1);
-	glDrawElementsBaseVertex(m_draw_topology, static_cast<u32>(m_index.count), GL_UNSIGNED_SHORT,
-		reinterpret_cast<void*>(static_cast<u32>(m_index.start) * sizeof(u16)), static_cast<GLint>(m_vertex.start));
+	DrawIndexedPrimitive(0, m_index.count);
 }
 
 void GSDeviceOGL::DrawIndexedPrimitive(int offset, int count)
 {
-	//ASSERT(offset + count <= (int)m_index.count);
-
 	g_perfmon.Put(GSPerfMon::DrawCalls, 1);
 	glDrawElementsBaseVertex(m_draw_topology, count, GL_UNSIGNED_SHORT,
 		reinterpret_cast<void*>((static_cast<u32>(m_index.start) + static_cast<u32>(offset)) * sizeof(u16)),
@@ -1217,8 +1213,6 @@ void GSDeviceOGL::DrawIndexedPrimitive(int offset, int count)
 
 void GSDeviceOGL::DrawIndexedPrimitiveVSExpand(int offset, int count, bool vs_indexing, int vs_indexing_expansion)
 {
-	//ASSERT(offset + count <= (int)m_index.count);
-
 	g_perfmon.Put(GSPerfMon::DrawCalls, 1);
 	if (vs_indexing)
 	{
@@ -1231,6 +1225,25 @@ void GSDeviceOGL::DrawIndexedPrimitiveVSExpand(int offset, int count, bool vs_in
 		glDrawElementsBaseVertex(m_draw_topology, count, GL_UNSIGNED_SHORT,
 			reinterpret_cast<void*>((static_cast<u32>(m_index.start) + static_cast<u32>(offset)) * sizeof(u16)), 0);
 	}
+}
+
+void GSDeviceOGL::Draw(const GSHWDrawConfig& config, int offset, int count)
+{
+	if (config.vs.expand != GSHWDrawConfig::VSExpand::None)
+	{
+		const bool vs_indexing = config.vs.UseVSExpandIndexBuffer();
+		const u32 vs_indexing_expansion = GetExpansionFactor(config.vs.expand);
+		DrawIndexedPrimitiveVSExpand(offset, count, vs_indexing, vs_indexing_expansion);
+	}
+	else
+	{
+		DrawIndexedPrimitive(offset, count);
+	}
+}
+
+void GSDeviceOGL::Draw(const GSHWDrawConfig& config)
+{
+	Draw(config, 0, m_index.count);
 }
 
 void GSDeviceOGL::CommitClear(GSTexture* t, bool use_write_fbo)
@@ -2898,7 +2911,7 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 		SetupOM(dss);
 
 		// Compute primitiveID max that pass the date test (Draw without barrier)
-		DrawIndexedPrimitive();
+		Draw(config);
 
 		psel.ps.date = 3;
 		config.alpha_second_pass.ps.date = 3;
@@ -3007,7 +3020,7 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 		psel.ps.blend_hw = config.blend_multi_pass.blend_hw;
 		psel.ps.dither = config.blend_multi_pass.dither;
 		SetupPipeline(psel);
-		DrawIndexedPrimitive();
+		Draw(config);
 	}
 
 	if (config.alpha_second_pass.enable)
@@ -3059,27 +3072,6 @@ void GSDeviceOGL::SendHWDraw(const GSHWDrawConfig& config,
 	GSTexture* draw_rt_clone, GSTexture* draw_rt, GSTexture* draw_ds_clone, GSTexture* draw_ds,
 	const bool one_barrier, const bool full_barrier)
 {
-	const bool vs_expand = config.vs.expand != GSHWDrawConfig::VSExpand::None;
-	const bool vs_indexing = config.vs.UseVSExpandIndexBuffer();
-	const u32 vs_indexing_expansion = GetExpansionFactor(config.vs.expand);
-
-	auto Draw = [&](int offset, int count) {
-		if (vs_expand)
-		{
-			DrawIndexedPrimitiveVSExpand(offset, count, vs_indexing, vs_indexing_expansion);
-		}
-		else
-		{
-			DrawIndexedPrimitive(offset, count);
-		}
-	};
-
-	if (!m_features.texture_barrier) [[unlikely]]
-	{
-		Draw(0, m_index.count);
-		return;
-	}
-
 #ifdef PCSX2_DEVBUILD
 	if ((one_barrier || full_barrier) && !(config.ps.IsFeedbackLoopRT() || config.ps.IsFeedbackLoopDepth())) [[unlikely]]
 		Console.Warning("OpenGL: Possible unnecessary barrier detected.");
@@ -3129,7 +3121,7 @@ void GSDeviceOGL::SendHWDraw(const GSHWDrawConfig& config,
 				CopyAndBind(ProcessCopyArea(rtsize, original_bbox));
 			}
 
-			Draw(p, count);
+			Draw(config, p, count);
 			p += count;
 		}
 
@@ -3150,7 +3142,7 @@ void GSDeviceOGL::SendHWDraw(const GSHWDrawConfig& config,
 		}
 	}
 
-	Draw(0, m_index.count);
+	Draw(config);
 }
 
 // Note: used as a callback of DebugMessageCallback. Don't change the signature

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -318,10 +318,15 @@ public:
 	bool SetGPUTimingEnabled(bool enabled) override;
 	float GetAndResetAccumulatedGPUTime() override;
 
+	// Helpers and utility draws.
 	void DrawPrimitive();
 	void DrawIndexedPrimitive();
 	void DrawIndexedPrimitive(int offset, int count);
-	void DrawIndexedPrimitiveVSExpand(int offset, int count, bool vs_indexing = false, int vs_indexing_expansion = 1);
+	void DrawIndexedPrimitiveVSExpand(int offset, int count, bool vs_indexing, int vs_indexing_expansion);
+
+	// Main GS primitive draws.
+	void Draw(const GSHWDrawConfig& config);
+	void Draw(const GSHWDrawConfig& config, int offset, int count);
 
 	std::unique_ptr<GSDownloadTexture> CreateDownloadTexture(u32 width, u32 height, GSTexture::Format format) override;
 

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -2767,8 +2767,7 @@ void GSDeviceVK::DrawPrimitive()
 
 void GSDeviceVK::DrawIndexedPrimitive()
 {
-	g_perfmon.Put(GSPerfMon::DrawCalls, 1);
-	vkCmdDrawIndexed(GetCurrentCommandBuffer(), m_index.count, 1, m_index.start, m_vertex.start, 0);
+	DrawIndexedPrimitive(0, m_index.count);
 }
 
 void GSDeviceVK::DrawIndexedPrimitive(int offset, int count)
@@ -2793,6 +2792,25 @@ void GSDeviceVK::DrawIndexedPrimitiveVSExpand(int offset, int count, bool vs_ind
 		SetVSPushConstants(m_vertex.start);
 		vkCmdDrawIndexed(GetCurrentCommandBuffer(), count, 1, m_index.start + offset, 0, 0);
 	}
+}
+
+void GSDeviceVK::Draw(const GSHWDrawConfig& config, int offset, int count)
+{
+	if (config.vs.expand != GSHWDrawConfig::VSExpand::None)
+	{
+		const bool vs_indexing = config.vs.UseVSExpandIndexBuffer();
+		const u32 vs_indexing_expansion = GetExpansionFactor(config.vs.expand);
+		DrawIndexedPrimitiveVSExpand(offset, count, vs_indexing, vs_indexing_expansion);
+	}
+	else
+	{
+		DrawIndexedPrimitive(offset, count);
+	}
+}
+
+void GSDeviceVK::Draw(const GSHWDrawConfig& config)
+{
+	Draw(config, 0, m_index.count);
 }
 
 VkFormat GSDeviceVK::LookupNativeFormat(GSTexture::Format format) const
@@ -5756,7 +5774,7 @@ GSTextureVK* GSDeviceVK::SetupPrimitiveTrackingDATE(GSHWDrawConfig& config)
 	pipe.ps.no_color = false;
 	pipe.ps.no_color1 = true;
 	if (BindDrawPipeline(pipe))
-		DrawIndexedPrimitive();
+		Draw(config);
 
 	// image is initialized/prepass is done, so finish up and get ready to do the "real" draw
 	EndRenderPass();
@@ -6105,7 +6123,7 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 		if (BindDrawPipeline(pipe))
 		{
 			// TODO: This probably should have barriers, in case we want to use it conditionally.
-			DrawIndexedPrimitive();
+			Draw(config);
 		}
 	}
 
@@ -6273,24 +6291,9 @@ VkDependencyFlags GSDeviceVK::GetFeedbackBarrierDependencyFlags() const
 void GSDeviceVK::SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt, GSTextureVK* draw_ds,
 	bool one_barrier, bool full_barrier)
 {
-	const bool vs_expand = config.vs.expand != GSHWDrawConfig::VSExpand::None;
-	const bool vs_indexing = config.vs.UseVSExpandIndexBuffer();
-	const u32 vs_indexing_expansion = GetExpansionFactor(config.vs.expand);
-
-	auto Draw = [&](int offset, int count) {
-		if (vs_expand)
-		{
-			DrawIndexedPrimitiveVSExpand(offset, count, vs_indexing, vs_indexing_expansion);
-		}
-		else
-		{
-			DrawIndexedPrimitive(offset, count);
-		}
-	};
-
 	if (!m_features.texture_barrier) [[unlikely]]
 	{
-		Draw(0, m_index.count);
+		Draw(config);
 		return;
 	}
 
@@ -6346,7 +6349,7 @@ void GSDeviceVK::SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt, 
 			IssueBarriers();
 
 			const u32 count = (*config.drawlist)[n] * indices_per_prim;
-			Draw(p, count);
+			Draw(config, p, count);
 			p += count;
 		}
 
@@ -6359,5 +6362,5 @@ void GSDeviceVK::SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt, 
 		IssueBarriers();
 	}
 
-	Draw(0, m_index.count);
+	Draw(config);
 }

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -533,10 +533,15 @@ public:
 	void PopDebugGroup() override;
 	void InsertDebugMessage(DebugMessageCategory category, const char* fmt, ...) override;
 
+	// Helpers and utility draws.
 	void DrawPrimitive();
 	void DrawIndexedPrimitive();
 	void DrawIndexedPrimitive(int offset, int count);
-	void DrawIndexedPrimitiveVSExpand(int offset, int count, bool vs_indexing = false, int vs_indexing_expansion = 1);
+	void DrawIndexedPrimitiveVSExpand(int offset, int count, bool vs_indexing, int vs_indexing_expansion);
+
+	// Main GS primitive draws.
+	void Draw(const GSHWDrawConfig& config);
+	void Draw(const GSHWDrawConfig& config, int offset, int count);
 
 	std::unique_ptr<GSDownloadTexture> CreateDownloadTexture(u32 width, u32 height, GSTexture::Format format) override;
 


### PR DESCRIPTION
### Description of Changes
Add a generic draw function for selecting the correct draw to use based on pipeline config.

Also some small refactors to DrawIndexedPrimitive().

### Rationale behind Changes
Fixes broken primid and blend multipass draws (regression from https://github.com/PCSX2/pcsx2/pull/13681).

That PR added a separate function for VS expand draws, but it was not correctly used in primid setup/blend multipass.

### Suggested Testing Steps
Disable texture barriers and test games to make sure nothing is broken (disabling texture barriers makes it more likely that primid date or blend multipass will be used). The renderers GL, VK, DX12, DX11 are affected.

### Did you use AI to help find, test, or implement this issue or feature?
No.