### PR TITLE
GS/DX: Specify shader model directly instead of via feature level

### DIFF
--- a/pcsx2/GS/Renderers/DX11/D3D.cpp
+++ b/pcsx2/GS/Renderers/DX11/D3D.cpp
@@ -466,28 +466,52 @@ GSRendererType D3D::GetPreferredRenderer()
 	}
 }
 
-wil::com_ptr_nothrow<ID3DBlob> D3D::CompileShader(D3D::ShaderType type, D3D_FEATURE_LEVEL feature_level, bool debug,
+const char* D3D::ShaderModelToCacheString(D3D::ShaderModel shader_model)
+{
+	switch (shader_model)
+	{
+		case ShaderModel::SM40:
+			return "sm40";
+		case ShaderModel::SM41:
+			return "sm41";
+		case ShaderModel::SM50:
+			return "sm50";
+		case ShaderModel::SM51:
+			return "sm51";
+		default:
+			return "unk";
+	}
+}
+
+wil::com_ptr_nothrow<ID3DBlob> D3D::CompileShader(D3D::ShaderType type, D3D::ShaderModel shader_model, bool debug,
 	const std::string_view code, const D3D_SHADER_MACRO* macros /* = nullptr */,
 	const char* entry_point /* = "main" */)
 {
 	const char* target;
-	switch (feature_level)
+	switch (shader_model)
 	{
-		case D3D_FEATURE_LEVEL_10_0:
+		case ShaderModel::SM40:
 		{
 			static constexpr std::array<const char*, 4> targets = {{"vs_4_0", "ps_4_0", "cs_4_0"}};
 			target = targets[static_cast<int>(type)];
 		}
 		break;
 
-		case D3D_FEATURE_LEVEL_11_0:
+		case ShaderModel::SM41:
+		{
+			static constexpr std::array<const char*, 4> targets = {{"vs_4_1", "ps_4_1", "cs_4_1"}};
+			target = targets[static_cast<int>(type)];
+		}
+		break;
+
+		case ShaderModel::SM50:
 		{
 			static constexpr std::array<const char*, 4> targets = {{"vs_5_0", "ps_5_0", "cs_5_0"}};
 			target = targets[static_cast<int>(type)];
 		}
 		break;
 
-		case D3D_FEATURE_LEVEL_11_1:
+		case ShaderModel::SM51:
 		default:
 		{
 			static constexpr std::array<const char*, 4> targets = {{"vs_5_1", "ps_5_1", "cs_5_1"}};

--- a/pcsx2/GS/Renderers/DX11/D3D.h
+++ b/pcsx2/GS/Renderers/DX11/D3D.h
@@ -63,6 +63,16 @@ namespace D3D
 		Compute
 	};
 
-	wil::com_ptr_nothrow<ID3DBlob> CompileShader(ShaderType type, D3D_FEATURE_LEVEL feature_level, bool debug,
+	enum class ShaderModel
+	{
+		SM40 = 0x40, // DX11 FL 10_0
+		SM41 = 0x41, // DX11 FL 10_1
+		SM50 = 0x50, // DX11 FL 11_0
+		SM51 = 0x51, // DX12
+	};
+
+	const char* ShaderModelToCacheString(ShaderModel shader_model);
+
+	wil::com_ptr_nothrow<ID3DBlob> CompileShader(ShaderType type, ShaderModel shader_model, bool debug,
 		const std::string_view code, const D3D_SHADER_MACRO* macros = nullptr, const char* entry_point = "main");
 }; // namespace D3D

--- a/pcsx2/GS/Renderers/DX11/D3D11ShaderCache.cpp
+++ b/pcsx2/GS/Renderers/DX11/D3D11ShaderCache.cpp
@@ -56,12 +56,27 @@ bool D3D11ShaderCache::CacheIndexKey::operator!=(const CacheIndexKey& key) const
 
 bool D3D11ShaderCache::Open(D3D_FEATURE_LEVEL feature_level, bool debug)
 {
-	m_feature_level = feature_level;
+	switch (feature_level)
+	{
+		case D3D_FEATURE_LEVEL_10_0:
+			m_shader_model = D3D::ShaderModel::SM40;
+			break;
+		case D3D_FEATURE_LEVEL_10_1:
+			m_shader_model = D3D::ShaderModel::SM41;
+			break;
+		case D3D_FEATURE_LEVEL_11_0:
+			m_shader_model = D3D::ShaderModel::SM50;
+			break;
+		default:
+			pxAssert(false);
+			return false;
+	}
+
 	m_debug = debug;
 
 	if (!GSConfig.DisableShaderCache)
 	{
-		const std::string base_filename = GetCacheBaseFileName(feature_level, debug);
+		const std::string base_filename = GetCacheBaseFileName(m_shader_model, debug);
 		const std::string index_filename = base_filename + ".idx";
 		const std::string blob_filename = base_filename + ".bin";
 
@@ -198,19 +213,10 @@ bool D3D11ShaderCache::ReadExisting(const std::string& index_filename, const std
 	return true;
 }
 
-std::string D3D11ShaderCache::GetCacheBaseFileName(D3D_FEATURE_LEVEL feature_level, bool debug)
+std::string D3D11ShaderCache::GetCacheBaseFileName(D3D::ShaderModel shader_model, bool debug)
 {
 	std::string base_filename = "d3d_shaders_";
-
-	switch (feature_level)
-	{
-		case D3D_FEATURE_LEVEL_11_0:
-			base_filename += "sm50";
-			break;
-		default:
-			base_filename += "unk";
-			break;
-	}
+	base_filename += D3D::ShaderModelToCacheString(shader_model);
 
 	if (debug)
 		base_filename += "_debug";
@@ -400,7 +406,7 @@ wil::com_ptr_nothrow<ID3DBlob> D3D11ShaderCache::CompileAndAddShaderBlob(const C
 	const std::string_view shader_code, const D3D_SHADER_MACRO* macros, const char* entry_point)
 {
 	wil::com_ptr_nothrow<ID3DBlob> blob =
-		D3D::CompileShader(key.shader_type, m_feature_level, m_debug, shader_code, macros, entry_point);
+		D3D::CompileShader(key.shader_type, m_shader_model, m_debug, shader_code, macros, entry_point);
 	if (!blob)
 		return {};
 

--- a/pcsx2/GS/Renderers/DX11/D3D11ShaderCache.h
+++ b/pcsx2/GS/Renderers/DX11/D3D11ShaderCache.h
@@ -16,7 +16,6 @@ public:
 	D3D11ShaderCache();
 	~D3D11ShaderCache();
 
-	D3D_FEATURE_LEVEL GetFeatureLevel() const { return m_feature_level; }
 	bool UsingDebugShaders() const { return m_debug; }
 
 	bool Open(D3D_FEATURE_LEVEL feature_level, bool debug);
@@ -74,7 +73,7 @@ private:
 
 	using CacheIndex = std::unordered_map<CacheIndexKey, CacheIndexData, CacheIndexEntryHasher>;
 
-	static std::string GetCacheBaseFileName(D3D_FEATURE_LEVEL feature_level, bool debug);
+	static std::string GetCacheBaseFileName(D3D::ShaderModel shader_mode, bool debug);
 	static CacheIndexKey GetCacheKey(D3D::ShaderType type, const std::string_view shader_code,
 		const D3D_SHADER_MACRO* macros, const char* entry_point);
 
@@ -89,6 +88,6 @@ private:
 
 	CacheIndex m_index;
 
-	D3D_FEATURE_LEVEL m_feature_level = D3D_FEATURE_LEVEL_11_0;
+	D3D::ShaderModel m_shader_model = D3D::ShaderModel::SM50;
 	bool m_debug = false;
 };

--- a/pcsx2/GS/Renderers/DX12/D3D12ShaderCache.cpp
+++ b/pcsx2/GS/Renderers/DX12/D3D12ShaderCache.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0+
 
 #include "GS/Renderers/DX12/D3D12ShaderCache.h"
-#include "GS/Renderers/DX11/D3D.h"
 #include "GS/GS.h"
 
 #include "Config.h"
@@ -54,16 +53,18 @@ bool D3D12ShaderCache::CacheIndexKey::operator!=(const CacheIndexKey& key) const
 			source_length != key.source_length);
 }
 
-bool D3D12ShaderCache::Open(D3D_FEATURE_LEVEL feature_level, bool debug)
+bool D3D12ShaderCache::Open(D3D::ShaderModel shader_model, bool debug)
 {
-	m_feature_level = feature_level;
+	// Only support SM5.1 for now, which is the minimum for D3D12.
+	pxAssert(shader_model >= D3D::ShaderModel::SM51);
+	m_shader_model = shader_model;
 	m_debug = debug;
 
 	bool result = true;
 
 	if (!GSConfig.DisableShaderCache)
 	{
-		const std::string base_shader_filename = GetCacheBaseFileName("shaders", feature_level, debug);
+		const std::string base_shader_filename = GetCacheBaseFileName("shaders", m_shader_model, debug);
 		const std::string shader_index_filename = base_shader_filename + ".idx";
 		const std::string shader_blob_filename = base_shader_filename + ".bin";
 
@@ -75,7 +76,7 @@ bool D3D12ShaderCache::Open(D3D_FEATURE_LEVEL feature_level, bool debug)
 
 		if (result)
 		{
-			const std::string base_pipelines_filename = GetCacheBaseFileName("pipelines", feature_level, debug);
+			const std::string base_pipelines_filename = GetCacheBaseFileName("pipelines", m_shader_model, debug);
 			const std::string pipelines_index_filename = base_pipelines_filename + ".idx";
 			const std::string pipelines_blob_filename = base_pipelines_filename + ".bin";
 
@@ -133,7 +134,7 @@ void D3D12ShaderCache::InvalidatePipelineCache()
 	if (GSConfig.DisableShaderCache)
 		return;
 
-	const std::string base_pipelines_filename = GetCacheBaseFileName("pipelines", m_feature_level, m_debug);
+	const std::string base_pipelines_filename = GetCacheBaseFileName("pipelines", m_shader_model, m_debug);
 	const std::string pipelines_index_filename = base_pipelines_filename + ".idx";
 	const std::string pipelines_blob_filename = base_pipelines_filename + ".bin";
 	CreateNew(pipelines_index_filename, pipelines_blob_filename, m_pipeline_index_file, m_pipeline_blob_file);
@@ -253,21 +254,12 @@ bool D3D12ShaderCache::ReadExisting(const std::string& index_filename, const std
 	return true;
 }
 
-std::string D3D12ShaderCache::GetCacheBaseFileName(const std::string_view type, D3D_FEATURE_LEVEL feature_level, bool debug)
+std::string D3D12ShaderCache::GetCacheBaseFileName(const std::string_view type, D3D::ShaderModel shader_model, bool debug)
 {
 	std::string base_filename = "d3d12_";
 	base_filename += type;
 	base_filename += "_";
-
-	switch (feature_level)
-	{
-		case D3D_FEATURE_LEVEL_11_0:
-			base_filename += "sm50";
-			break;
-		default:
-			base_filename += "unk";
-			break;
-	}
+	base_filename += D3D::ShaderModelToCacheString(shader_model);
 
 	if (debug)
 		base_filename += "_debug";
@@ -497,15 +489,15 @@ D3D12ShaderCache::ComPtr<ID3DBlob> D3D12ShaderCache::CompileAndAddShaderBlob(
 	{
 		case EntryType::VertexShader:
 			blob =
-				D3D::CompileShader(D3D::ShaderType::Vertex, m_feature_level, m_debug, shader_code, macros, entry_point);
+				D3D::CompileShader(D3D::ShaderType::Vertex, m_shader_model, m_debug, shader_code, macros, entry_point);
 			break;
 		case EntryType::PixelShader:
 			blob =
-				D3D::CompileShader(D3D::ShaderType::Pixel, m_feature_level, m_debug, shader_code, macros, entry_point);
+				D3D::CompileShader(D3D::ShaderType::Pixel, m_shader_model, m_debug, shader_code, macros, entry_point);
 			break;
 		case EntryType::ComputeShader:
-			blob = D3D::CompileShader(
-				D3D::ShaderType::Compute, m_feature_level, m_debug, shader_code, macros, entry_point);
+			blob =
+				D3D::CompileShader(D3D::ShaderType::Compute, m_shader_model, m_debug, shader_code, macros, entry_point);
 			break;
 		default:
 			break;

--- a/pcsx2/GS/Renderers/DX12/D3D12ShaderCache.h
+++ b/pcsx2/GS/Renderers/DX12/D3D12ShaderCache.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0+
 
 #pragma once
+#include "GS/Renderers/DX11/D3D.h"
 
 #include "common/Pcsx2Defs.h"
 #include "common/HashCombine.h"
@@ -32,10 +33,9 @@ public:
 	D3D12ShaderCache();
 	~D3D12ShaderCache();
 
-	__fi D3D_FEATURE_LEVEL GetFeatureLevel() const { return m_feature_level; }
 	__fi bool UsingDebugShaders() const { return m_debug; }
 
-	bool Open(D3D_FEATURE_LEVEL feature_level, bool debug);
+	bool Open(D3D::ShaderModel shader_model, bool debug);
 	void Close();
 
 	__fi ComPtr<ID3DBlob> GetVertexShader(
@@ -95,7 +95,7 @@ private:
 
 	using CacheIndex = std::unordered_map<CacheIndexKey, CacheIndexData, CacheIndexEntryHasher>;
 
-	static std::string GetCacheBaseFileName(const std::string_view type, D3D_FEATURE_LEVEL feature_level, bool debug);
+	static std::string GetCacheBaseFileName(const std::string_view type, D3D::ShaderModel shader_model, bool debug);
 	static CacheIndexKey GetShaderCacheKey(
 		EntryType type, const std::string_view shader_code, const D3D_SHADER_MACRO* macros, const char* entry_point);
 	static CacheIndexKey GetPipelineCacheKey(const D3D12_GRAPHICS_PIPELINE_STATE_DESC& gpdesc);
@@ -123,6 +123,6 @@ private:
 	std::FILE* m_pipeline_blob_file = nullptr;
 	CacheIndex m_pipeline_index;
 
-	D3D_FEATURE_LEVEL m_feature_level = D3D_FEATURE_LEVEL_11_0;
+	D3D::ShaderModel m_shader_model = D3D::ShaderModel::SM51;
 	bool m_debug = false;
 };

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -892,7 +892,7 @@ bool GSDevice12::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 		m_tfx_source = std::move(*shader);
 	}
 
-	if (!m_shader_cache.Open(m_feature_level, GSConfig.UseDebugDevice))
+	if (!m_shader_cache.Open(D3D::ShaderModel::SM51, GSConfig.UseDebugDevice))
 		Console.Warning("D3D12: Shader cache failed to open.");
 
 	if (!CreateRootSignatures())


### PR DESCRIPTION
### Description of Changes
Specify the shader model directly, instead of passing a feature level to our compiler wrapper.
Always use SM5.1 on DX12.
Add the ability to compile SM4.1 (currently unused).

### Rationale behind Changes
DX12 doesn’t directly tie shader model support to a feature level (A FL11.0 GPU exists that supports SM6.8 and a FL12.0 that only supports 6.5).
it should be _slightly_ easier to add support for newer shader models if so desired.

We where previously compiling SM5.0* for DX12, yet all DX12 devices support SM5.1.
*On Intel Graphics Gen9 or newer, we would already compile for SM5.1.

Our DX11 backend is capable of falling back to FL10.0 (SM4.0).
We currently don't bother checking for FL10.1 support, if we do so in future than we can compile SM4.1 shaders for it.

### Suggested Testing Steps
Test DX11/DX12 Backend.

### Did you use AI to help find, test, or implement this issue or feature?
Yes (VS2022 AI assisted autocomplete).
