### PR TITLE
Qt: Automatically reflow settings check boxes

### DIFF
--- a/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/EmulationSettingsWidget.cpp
@@ -70,23 +70,9 @@ EmulationSettingsWidget::EmulationSettingsWidget(SettingsWindow* settings_dialog
 					std::clamp(Host::GetBaseIntSettingValue("EmuCore/Speedhacks", "EECycleRate", DEFAULT_EE_CYCLE_RATE) - MINIMUM_EE_CYCLE_RATE,
 						0, MAXIMUM_EE_CYCLE_RATE - MINIMUM_EE_CYCLE_RATE))));
 
-		// Disable cheats, use the cheats panel instead (move fastcvd up in its spot).
-		const int count = m_ui.systemSettingsLayout->count();
-		for (int i = 0; i < count; i++)
-		{
-			QLayoutItem* item = m_ui.systemSettingsLayout->itemAt(i);
-			if (item && item->widget() == m_ui.cheats)
-			{
-				int row, col, rowSpan, colSpan;
-				m_ui.systemSettingsLayout->getItemPosition(i, &row, &col, &rowSpan, &colSpan);
-				delete m_ui.systemSettingsLayout->takeAt(i);
-				m_ui.systemSettingsLayout->removeWidget(m_ui.fastCDVD);
-				m_ui.systemSettingsLayout->addWidget(m_ui.fastCDVD, row, col);
-				delete m_ui.cheats;
-				m_ui.cheats = nullptr;
-				break;
-			}
-		}
+		// Disable cheats, use the cheats panel instead
+		m_ui.systemSettingsLayout->removeWidget(m_ui.cheats);
+		m_ui.cheats->hide();
 	}
 	else
 	{
@@ -96,8 +82,10 @@ EmulationSettingsWidget::EmulationSettingsWidget(SettingsWindow* settings_dialog
 
 		// Allow for FastCDVD for per-game settings only
 		m_ui.systemSettingsLayout->removeWidget(m_ui.fastCDVD);
-		m_ui.fastCDVD->deleteLater();
+		m_ui.fastCDVD->hide();
 	}
+
+	reflowCheckBoxes(m_ui.systemSettingsLayout);
 
 	const std::optional<int> cycle_rate =
 		dialog()->getIntValue("EmuCore/Speedhacks", "EECycleRate", sif ? std::nullopt : std::optional<int>(DEFAULT_EE_CYCLE_RATE));

--- a/pcsx2-qt/Settings/SettingsWidget.cpp
+++ b/pcsx2-qt/Settings/SettingsWidget.cpp
@@ -3,6 +3,7 @@
 
 #include "SettingsWidget.h"
 
+#include <QtWidgets/QGridLayout>
 #include <QtWidgets/QScrollArea>
 #include <QtWidgets/QScrollBar>
 #include <QtWidgets/QTabBar>
@@ -112,6 +113,31 @@ void SettingsWidget::updateTabMargins(QScrollArea* scroll_area)
 	else
 	{
 		scroll_area->widget()->layout()->setContentsMargins(-1, -1, -1, -1);
+	}
+}
+
+void SettingsWidget::reflowCheckBoxes(QGridLayout* layout)
+{
+	std::vector<QWidget*> widgets;
+
+	for (int row = 0; row < layout->rowCount(); row++)
+	{
+		for (int column = 0; column < layout->columnCount(); column++)
+		{
+			QLayoutItem* item = layout->itemAtPosition(row, column);
+			if (item && item->widget())
+			{
+				widgets.push_back(item->widget());
+				layout->removeWidget(item->widget());
+			}
+		}
+	}
+
+	for (size_t i = 0; i < widgets.size(); i++)
+	{
+		int row = static_cast<int>(i / 2);
+		int column = static_cast<int>(i % 2);
+		layout->addWidget(widgets[i], row, column);
 	}
 }
 

--- a/pcsx2-qt/Settings/SettingsWidget.h
+++ b/pcsx2-qt/Settings/SettingsWidget.h
@@ -7,6 +7,7 @@
 
 #include <QtWidgets/QWidget>
 
+class QGridLayout;
 class QScrollArea;
 class QTabWidget;
 
@@ -44,6 +45,10 @@ protected:
 	void addPageHeader(QWidget* header, bool custom_margins = false);
 	QWidget* addTab(QString name, QWidget* contents, bool custom_margins = false);
 	void setTabVisible(QWidget* tab, bool is_visible, QWidget* switch_to = nullptr);
+
+	// Rearrange the checkboxes in a group so that there aren't any gaps. To be
+	// used if checkboxes have been hidden programmatically.
+	void reflowCheckBoxes(QGridLayout* layout);
 
 private:
 	void updateTabMargins(QScrollArea* scroll_area);


### PR DESCRIPTION
### Description of Changes
- Add a SettingsWidget::reflowCheckBoxes function that removes any gaps between check boxes.
- Use this function for the System Settings group on the emulation settings page.

### Rationale behind Changes
Remove some kludgy code that manually moves check boxes around depending on which should be visible.

### Suggested Testing Steps
Make sure all the check boxes in the System Settings group on the emulation page are still satisfactory.

### Did you use AI to help find, test, or implement this issue or feature?
No.
