### PR TITLE
GS/DX12/Debug: Enable dx12 support for debug purposes on Haswell.

### DIFF
--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -282,12 +282,19 @@ bool GSDevice12::CreateDevice(u32& vendor_id)
 		}
 	}
 
-	// Intel Haswell doesn't actually support DX12 even tho the device is created which results in a crash,
-	// to get around this check if device can be created using feature level 12 (skylake+).
-	const bool isIntel = (vendor_id == 0x163C || vendor_id == 0x8086 || vendor_id == 0x8087);
-
 	// Create the actual device.
+	// Intel Haswell DX12 support is specific:
+	// Newerest drivers have dx12 support disabled so the last driver to support dx12 is 15.40.42.5063.
+	// Shader cache must be also disabled, and make sure Debug Device option is disabled as well.
+	// Let's enable it on dev/debug for testing purposes so we don't have to change this all the time.
+	// TODO: Find out the status of Broadwell.
+#ifdef PCSX2_DEVBUILD
+	hr = D3D12CreateDevice(m_adapter.get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&m_device));
+#else
+	const bool isIntel = (vendor_id == 0x163C || vendor_id == 0x8086 || vendor_id == 0x8087);
 	hr = D3D12CreateDevice(m_adapter.get(), isIntel ? D3D_FEATURE_LEVEL_12_0 : D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&m_device));
+#endif
+
 	if (FAILED(hr))
 	{
 		Console.Error("D3D12: Failed to create device: %08X", hr);


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/DX12/Debug: Enable dx12 support for debug purposes on Haswell.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
This is intended for developers only for testing:
Newerest drivers have dx12 support disabled so the last driver to support dx12 is 15.40.42.5063.
Shader cache must be also disabled, and make sure Debug Device option is disabled as well.
Let's enable it on dev/debug for testing purposes so we don't have to change this all the time.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Specific conditions above to get dx12 working on dev/debug.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.