### PR TITLE
GS: Fix AA1 coverage regression on sw and cleanup.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -10473,6 +10473,5 @@ std::size_t GSRendererHW::ComputeDrawlistGetSize(float scale)
 
 bool GSRendererHW::IsCoverageAlphaSupported()
 {
-	return IsCoverageAlpha() && g_gs_device->Features().aa1 &&
-	       (m_vt.m_primclass == GS_LINE_CLASS || m_vt.m_primclass == GS_TRIANGLE_CLASS);
+	return IsCoverageAlpha() && g_gs_device->Features().aa1;
 }

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -1393,7 +1393,7 @@ bool GSRendererSW::GetScanlineGlobalData(SharedData* data)
 				gd.sel.pabe = 1;
 			}
 
-			if (PRIM->AA1 && (primclass == GS_LINE_CLASS || primclass == GS_TRIANGLE_CLASS))
+			if (IsCoverageAlpha())
 			{
 				gd.sel.aa1 = 1;
 			}
@@ -1521,6 +1521,11 @@ bool GSRendererSW::GetScanlineGlobalData(SharedData* data)
 	}
 
 	return true;
+}
+
+bool GSRendererSW::IsCoverageAlphaSupported()
+{
+	return IsCoverageAlpha();
 }
 
 GSRendererSW::SharedData::SharedData()

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.h
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.h
@@ -82,7 +82,7 @@ protected:
 	template <u32 primclass>
 	void RewriteVerticesIfSTOverflow();
 
-	bool IsCoverageAlphaSupported() override { return true; }
+	bool IsCoverageAlphaSupported() override;
 public:
 	GSRendererSW(int threads);
 	~GSRendererSW() override;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS: Fix AA1 coverage regression on sw and cleanup.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Regression fix from https://github.com/PCSX2/pcsx2/pull/13681

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test the Suffering on sw renderer, smoke test other games with aa1 on sw and hw.
[The Suffering Ties That Binnd.gs.xz.zip](https://github.com/user-attachments/files/27018742/The.Suffering.Ties.That.Binnd.gs.xz.zip)

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.