### PR TITLE
GS/HW: More AA1 fixes and optimizations.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5362,7 +5362,7 @@ void GSRendererHW::HandleProvokingVertexFirst()
 	}
 }
 
-void GSRendererHW::SetupIA(float target_scale, float sx, float sy, bool req_vert_backup)
+void GSRendererHW::SetupIA(float target_scale, float sx, float sy, bool req_vert_backup, const bool no_rt)
 {
 	GL_PUSH("HW: IA");
 
@@ -5376,6 +5376,7 @@ void GSRendererHW::SetupIA(float target_scale, float sx, float sy, bool req_vert
 
 	const bool unscale_pt_ln = !GSConfig.UserHacks_DisableSafeFeatures && (target_scale != 1.0f);
 	const GSDevice::FeatureSupport features = g_gs_device->Features();
+	const bool draw_aa1 = !no_rt && PRIM->AA1 && features.aa1;
 
 	pxAssert(VerifyIndices());
 
@@ -5419,7 +5420,7 @@ void GSRendererHW::SetupIA(float target_scale, float sx, float sy, bool req_vert
 			{
 				m_conf.topology = GSHWDrawConfig::Topology::Line;
 				m_conf.indices_per_prim = 2;
-				if (PRIM->AA1 && features.aa1)
+				if (draw_aa1)
 				{
 					// AA1 expansion uses a similar path as upscale expansion but it is used
 					// for both upscaling and native resolution drawing.
@@ -5487,7 +5488,7 @@ void GSRendererHW::SetupIA(float target_scale, float sx, float sy, bool req_vert
 
 		case GS_TRIANGLE_CLASS:
 			{
-				if (PRIM->AA1 && features.aa1)
+				if (draw_aa1)
 				{
 					GL_INS("HW: AA1 triangle expand.");
 					m_conf.vs.expand = GSHWDrawConfig::VSExpand::TriangleAA1;
@@ -8943,7 +8944,7 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 
 	HandleProvokingVertexFirst();
 
-	SetupIA(rtscale, vs_scale_x, vs_scale_y, m_channel_shuffle_width != 0);
+	SetupIA(rtscale, vs_scale_x, vs_scale_y, m_channel_shuffle_width != 0, no_rt);
 
 	if (m_conf.ds && m_conf.ps.IsFeedbackLoopDepth() && !g_gs_device->Features().depth_feedback)
 	{
@@ -10493,5 +10494,5 @@ std::size_t GSRendererHW::ComputeDrawlistGetSize(float scale)
 
 bool GSRendererHW::IsCoverageAlphaSupported()
 {
-	return IsCoverageAlpha() && g_gs_device->Features().aa1;
+	return IsCoverageAlpha() && IsRTWritten() && g_gs_device->Features().aa1;
 }

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -210,7 +210,7 @@ private:
 
 	void ResetStates();
 	void HandleProvokingVertexFirst();
-	void SetupIA(float target_scale, float sx, float sy, bool req_vert_backup);
+	void SetupIA(float target_scale, float sx, float sy, bool req_vert_backup, const bool no_rt);
 	void EmulateTextureShuffleAndFbmask(GSTextureCache::Target* rt, GSTextureCache::Source* tex);
 	u32 EmulateChannelShuffle(GSTextureCache::Target* src, bool test_only, GSTextureCache::Target* rt = nullptr);
 	void EmulateBlending(int rt_alpha_min, int rt_alpha_max, DATEOptions& date_options, GSTextureCache::Target* rt,


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/HW: More AA1 fixes and optimizations.

Do not enable AA1 if we aren't drawing to the RT.
Check if RT is written for IsCoverageAlphaSupported().

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Fixes Driv3r crashing with aa1 option enabled.
Optimizations, bugfixes.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test if Driv3r crashes with aa1 enabled, test performance on various aa1 hw dumps.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.