### PR TITLE
GameDB: Fixes for SLES-52674 & SLES-52563

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -20778,6 +20778,9 @@ SLES-52563:
     nativeScaling: 1 # Fixes misaligned bloom.
     cpuSpriteRenderBW: 2 # Fixes player outfit rendering.
     cpuSpriteRenderLevel: 2 # Needed for above.
+  memcardFilters: # Football Fusion with Total Club Manager 2005
+    - "SLES-52674"
+    - "SLES-52563"
 SLES-52567:
   name: "Catwoman"
   region: "PAL-M7"
@@ -21172,10 +21175,13 @@ SLES-52673:
   name: "NHL 2005"
   region: "PAL-M5"
 SLES-52674:
-  name: "Fussball Manager 2005"
+  name: "Total Club Manager 2005"
   region: "PAL-M5"
   clampModes:
     vu1ClampMode: 3 # Fixes 3D rendering.
+  memcardFilters: # Football Fusion with Total Club Manager 2005
+    - "SLES-52674"
+    - "SLES-52563"
 SLES-52675:
   name: "Hugo - Cannon Cruise"
   region: "PAL-Unk"


### PR DESCRIPTION
### Description of Changes
Enable memcardFilters for SLES-52674 & SLES-52563 as well as change name of SLES-52674.

### Rationale behind Changes
The two 2005 releases, like their 2004 versions, have a cross-save feature allowing you to manage team in TCM and play matches in FIFA. This has been made available via memcardFilters for FolderMC users. The name for SLES-52674 has also been changed from its German name to its English name as it is PAL-M5.

### Suggested Testing Steps
I've tested by starting a game in TCM2005, exporting a match to football fusion, playing it in FIFA 2005, and importing it back to TCM2005 using the same FolderMC.

### Did you use AI to help find, test, or implement this issue or feature?
No
