### PR TITLE
Debugger: Call QWidget::update instead of QWidget::repaint

### DIFF
--- a/pcsx2-qt/Debugger/DebuggerWindow.cpp
+++ b/pcsx2-qt/Debugger/DebuggerWindow.cpp
@@ -450,7 +450,7 @@ void DebuggerWindow::onStepInto()
 		cpu->resumeCpu();
 	});
 
-	repaint();
+	update();
 }
 
 void DebuggerWindow::onStepOver()
@@ -500,7 +500,7 @@ void DebuggerWindow::onStepOver()
 		cpu->resumeCpu();
 	});
 
-	this->repaint();
+	update();
 }
 
 void DebuggerWindow::onStepOut()
@@ -541,7 +541,7 @@ void DebuggerWindow::onStepOut()
 		cpu->resumeCpu();
 	});
 
-	this->repaint();
+	update();
 }
 
 void DebuggerWindow::changeEvent(QEvent* event)

--- a/pcsx2-qt/Debugger/DisassemblyView.cpp
+++ b/pcsx2-qt/Debugger/DisassemblyView.cpp
@@ -86,7 +86,7 @@ bool DisassemblyView::fromJson(const JsonValueWrapper& json)
 	if (show_instruction_bytes != json.value().MemberEnd() && show_instruction_bytes->value.IsBool())
 		m_showInstructionBytes = show_instruction_bytes->value.GetBool();
 
-	repaint();
+	update();
 
 	return true;
 }
@@ -222,7 +222,7 @@ void DisassemblyView::contextRunToCursor()
 void DisassemblyView::contextJumpToCursor()
 {
 	cpu().setPc(m_selectedAddressStart);
-	this->repaint();
+	update();
 }
 
 void DisassemblyView::contextToggleBreakpoint()
@@ -378,7 +378,7 @@ void DisassemblyView::contextRestoreFunction()
 void DisassemblyView::contextShowInstructionBytes()
 {
 	m_showInstructionBytes = !m_showInstructionBytes;
-	this->repaint();
+	update();
 }
 
 QString DisassemblyView::GetLineDisasm(u32 address)
@@ -610,7 +610,7 @@ void DisassemblyView::mousePressEvent(QMouseEvent* event)
 				m_selectedAddressEnd = selectedAddress;
 			}
 		}
-		this->repaint();
+		update();
 	}
 }
 
@@ -637,7 +637,7 @@ void DisassemblyView::wheelEvent(QWheelEvent* event)
 	{
 		m_visibleStart -= 4;
 	}
-	this->repaint();
+	update();
 }
 
 void DisassemblyView::keyPressEvent(QKeyEvent* event)
@@ -709,7 +709,7 @@ void DisassemblyView::keyPressEvent(QKeyEvent* event)
 			break;
 	}
 
-	this->repaint();
+	update();
 }
 
 void DisassemblyView::openContextMenu(QPoint pos)
@@ -1014,9 +1014,9 @@ void DisassemblyView::gotoAddress(u32 address, bool should_set_focus)
 	m_selectedAddressStart = destAddress;
 	m_selectedAddressEnd = destAddress;
 
-	this->repaint();
+	update();
 	if (should_set_focus)
-		this->setFocus();
+		setFocus();
 }
 
 void DisassemblyView::toggleBreakpoint(u32 address)
@@ -1034,7 +1034,7 @@ void DisassemblyView::toggleBreakpoint(u32 address)
 		QtHost::RunOnUIThread([view, cpu]() {
 			BreakpointModel::getInstance(*cpu)->refreshData();
 			if (view)
-				view->repaint();
+				view->update();
 		});
 	});
 }

--- a/pcsx2-qt/Debugger/Memory/MemorySearchView.cpp
+++ b/pcsx2-qt/Debugger/Memory/MemorySearchView.cpp
@@ -27,7 +27,6 @@ MemorySearchView::MemorySearchView(const DebuggerViewParameters& parameters)
 	: DebuggerView(parameters, MONOSPACE_FONT)
 {
 	m_ui.setupUi(this);
-	this->repaint();
 
 	m_ui.listSearchResults->setContextMenuPolicy(Qt::CustomContextMenu);
 	connect(m_ui.btnSearch, &QPushButton::clicked, this, &MemorySearchView::onSearchButtonClicked);

--- a/pcsx2-qt/Debugger/Memory/MemoryView.cpp
+++ b/pcsx2-qt/Debugger/Memory/MemoryView.cpp
@@ -741,7 +741,7 @@ bool MemoryView::fromJson(const JsonValueWrapper& json)
 	if (little_endian != json.value().MemberEnd() && little_endian->value.IsBool())
 		m_table.SetLittleEndian(little_endian->value.GetBool());
 
-	repaint();
+	update();
 
 	return true;
 }
@@ -764,7 +764,7 @@ void MemoryView::mousePressEvent(QMouseEvent* event)
 		return;
 
 	m_table.SelectAt(event->pos());
-	repaint();
+	update();
 }
 
 void MemoryView::openContextMenu(QPoint pos)
@@ -859,7 +859,7 @@ void MemoryView::openContextMenu(QPoint pos)
 
 	menu->popup(this->mapToGlobal(pos));
 
-	this->repaint();
+	update();
 	return;
 }
 
@@ -934,7 +934,7 @@ void MemoryView::wheelEvent(QWheelEvent* event)
 	{
 		m_table.UpdateStartAddress(m_table.startAddress - 0x10);
 	}
-	this->repaint();
+	update();
 }
 
 void MemoryView::keyPressEvent(QKeyEvent* event)
@@ -954,7 +954,7 @@ void MemoryView::keyPressEvent(QKeyEvent* event)
 				break;
 		}
 	}
-	this->repaint();
+	update();
 	DebuggerView::broadcastEvent(DebuggerEvents::VMUpdate());
 }
 
@@ -962,8 +962,8 @@ void MemoryView::gotoAddress(u32 address)
 {
 	m_table.UpdateStartAddress(address & ~0xF);
 	m_table.selectedAddress = address;
-	this->repaint();
-	this->setFocus();
+	update();
+	setFocus();
 }
 
 #include "moc_MemoryView.cpp"

--- a/pcsx2-qt/Debugger/RegisterView.cpp
+++ b/pcsx2-qt/Debugger/RegisterView.cpp
@@ -36,7 +36,7 @@ RegisterView::RegisterView(const DebuggerViewParameters& parameters)
 		ui.registerTabs->addTab(cpu().getRegisterCategoryName(i));
 	}
 
-	connect(ui.registerTabs, &QTabBar::currentChanged, [this]() { this->repaint(); });
+	connect(ui.registerTabs, &QTabBar::currentChanged, [this]() { update(); });
 
 	receiveEvent<DebuggerEvents::Refresh>([this](const DebuggerEvents::Refresh& event) -> bool {
 		update();
@@ -69,7 +69,7 @@ bool RegisterView::fromJson(const JsonValueWrapper& json)
 	if (show_fpr_float != json.value().MemberEnd() && show_fpr_float->value.IsBool())
 		m_showFPRFloat = show_fpr_float->value.GetBool();
 
-	repaint();
+	update();
 
 	return true;
 }
@@ -209,7 +209,8 @@ void RegisterView::mousePressEvent(QMouseEvent* event)
 			}
 		}
 	}
-	this->repaint();
+
+	update();
 }
 
 void RegisterView::wheelEvent(QWheelEvent* event)
@@ -223,7 +224,7 @@ void RegisterView::wheelEvent(QWheelEvent* event)
 		m_rowStart -= 1;
 	}
 
-	this->repaint();
+	update();
 }
 
 void RegisterView::mouseDoubleClickEvent(QMouseEvent* event)
@@ -259,7 +260,7 @@ void RegisterView::customMenuRequested(QPoint pos)
 		action->setChecked(m_showFPRFloat);
 		connect(action, &QAction::triggered, this, [this]() {
 			m_showFPRFloat = !m_showFPRFloat;
-			repaint();
+			update();
 		});
 
 		menu->addSeparator();
@@ -272,7 +273,7 @@ void RegisterView::customMenuRequested(QPoint pos)
 		action->setChecked(m_showVU0FFloat);
 		connect(action, &QAction::triggered, this, [this]() {
 			m_showVU0FFloat = !m_showVU0FFloat;
-			repaint();
+			update();
 		});
 
 		menu->addSeparator();


### PR DESCRIPTION
### Description of Changes
Call QWidget::update instead of QWidget::repaint when a widget in the debugger has to be repainted.

### Rationale behind Changes
This way, we schedule the event to run later, so if there's two update calls in a row it doesn't actually repaint the widget twice. I think this is slightly nicer so should be encouraged.

### Suggested Testing Steps
Make sure the modified widgets in the debugger are still responsive.

### Did you use AI to help find, test, or implement this issue or feature?
No.
