### PR TITLE
GS: fix `GSDevice::SortMultiStretchRects` strict weak ordering

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <ostream>
 #include <fstream>
+#include <tuple>
 
 int SetDATMShader(SetDATM datm)
 {
@@ -814,7 +815,7 @@ void GSDevice::SortMultiStretchRects(MultiStretchRect* rects, u32 num_rects)
 {
 	// Depending on num_rects, insertion sort may be better here.
 	std::sort(rects, rects + num_rects, [](const MultiStretchRect& lhs, const MultiStretchRect& rhs) {
-		return lhs.src < rhs.src || lhs.linear < rhs.linear;
+		return std::tie(lhs.src, lhs.linear) < std::tie(rhs.src, rhs.linear);
 	});
 }
 

--- a/tests/ctest/core/CMakeLists.txt
+++ b/tests/ctest/core/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_pcsx2_test(core_test
+	GS/gs_device_tests.cpp
 	patch_tests.cpp
 	MockMemoryInterface.h
 	StubHost.cpp

--- a/tests/ctest/core/GS/gs_device_tests.cpp
+++ b/tests/ctest/core/GS/gs_device_tests.cpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "pcsx2/GS/Renderers/Common/GSDevice.h"
+
+#include <cstdint>
+#include <gtest/gtest.h>
+
+TEST(GSDevice, SortMultiStretchRectsSortsByTextureThenLinear)
+{
+	// The sort key only compares and batches source textures, it never dereferences them.
+	GSTexture* const low_texture = reinterpret_cast<GSTexture*>(static_cast<uintptr_t>(0x1000));
+	GSTexture* const high_texture = reinterpret_cast<GSTexture*>(static_cast<uintptr_t>(0x2000));
+	const GSDevice::MultiStretchRect expected[] = {
+		{GSVector4(), GSVector4(), low_texture, true, 0xf},
+		{GSVector4(), GSVector4(), high_texture, false, 0xf},
+	};
+	GSDevice::MultiStretchRect rects[][2] = {
+		{
+			expected[0],
+			expected[1],
+		},
+		{
+			expected[1],
+			expected[0],
+		},
+	};
+
+	for (GSDevice::MultiStretchRect(&rect_pair)[2] : rects)
+	{
+		GSDevice::SortMultiStretchRects(rect_pair, std::size(rect_pair));
+
+		EXPECT_EQ(rect_pair[0].src, expected[0].src);
+		EXPECT_EQ(rect_pair[0].linear, expected[0].linear);
+		EXPECT_EQ(rect_pair[1].src, expected[1].src);
+		EXPECT_EQ(rect_pair[1].linear, expected[1].linear);
+	}
+}
+
+TEST(GSDevice, SortMultiStretchRectsGroupsBatchableRectsTogether)
+{
+	// The sort key only compares and batches source textures, it never dereferences them.
+	GSTexture* const low_texture = reinterpret_cast<GSTexture*>(static_cast<uintptr_t>(0x1000));
+	GSTexture* const high_texture = reinterpret_cast<GSTexture*>(static_cast<uintptr_t>(0x2000));
+	const GSDevice::MultiStretchRect a = {GSVector4(), GSVector4(), low_texture, true, 0xf};
+	const GSDevice::MultiStretchRect b = {GSVector4(), GSVector4(), high_texture, false, 0xf};
+	const GSDevice::MultiStretchRect expected[] = {
+		a,
+		a,
+		a,
+		a,
+		b,
+		b,
+		b,
+		b,
+	};
+	GSDevice::MultiStretchRect rects[] = {
+		a,
+		b,
+		a,
+		b,
+		a,
+		b,
+		a,
+		b,
+	};
+
+	GSDevice::SortMultiStretchRects(rects, std::size(rects));
+
+	for (u32 i = 0; i < std::size(rects); i++)
+	{
+		EXPECT_EQ(rects[i].src, expected[i].src);
+		EXPECT_EQ(rects[i].linear, expected[i].linear);
+	}
+}


### PR DESCRIPTION
### Description of Changes

This changes the `GSDevice::SortMultiStretchRects()` comparator to use a simple lexicographic order with `std::tie(src, linear)`.

It also adds tests for the sort order, including a repeated pattern which should group batchable rectangles together.

### Rationale behind Changes

`std::sort` requires its comparator to satisfy the strict weak ordering contract. The old comparator:

https://github.com/PCSX2/pcsx2/blob/27736ef47f1c4a9b1112d3adf2c333f3cc620b54/pcsx2/GS/Renderers/Common/GSDevice.cpp#L813-L819

does not satisfy that requirement, so using it with `std::sort` is invalid.

In terms of the algorithm's contract, the comparator used by `std::sort` must induce a strict weak ordering. In particular:

```text
comp(a, b) && comp(b, c) implies comp(a, c)
equiv(a, b) && equiv(b, c) implies equiv(a, c)
```

Here, `equiv(a, b)` means `!comp(a, b) && !comp(b, a)`.

References:

- C++ draft, sorting requirement: https://eel.is/c++draft/alg.sorting.general
- C++ draft, strict weak order definition: https://eel.is/c++draft/concept.strictweakorder

Once the comparator violates that contract, the `std::sort` call is outside the algorithm's contract, so the standard no longer constrains the result. In practice, common C++ library implementations can then produce incorrect sorting results, and undefined behavior can also extend to out-of-bounds reads or writes.

This happens in `GSTextureCache::CreateMergedSource()`, which currently does:

https://github.com/PCSX2/pcsx2/blob/27736ef47f1c4a9b1112d3adf2c333f3cc620b54/pcsx2/GS/Renderers/HW/GSTextureCache.cpp#L6870-L6872

All `DrawMultiStretchRects()` backends split batches on contiguous runs of matching `src`, `linear`, and `wmask`.

For example, the DX11 backend batches only while adjacent rectangles keep the same `src`, `linear`, and `wmask`:

https://github.com/PCSX2/pcsx2/blob/27736ef47f1c4a9b1112d3adf2c333f3cc620b54/pcsx2/GS/Renderers/DX11/GSDevice11.cpp#L1606-L1612

In the sorted `copy_queue` path changed by this PR, the original comparator can fail to keep batchable rectangles contiguous, so `DrawMultiStretchRects()` may split what should be one batch into multiple smaller batches.

### Suggested Testing Steps

- Run the GS core tests and check that the new `gs_device_tests.cpp` cases pass.
- Confirm that `SortMultiStretchRectsSortsByTextureThenLinear` sorts by `src` first and `linear` second.
- Confirm that `SortMultiStretchRectsGroupsBatchableRectsTogether` turns the following input:

```cpp
A, B, A, B, A, B, A, B
```

into:

```cpp
A, A, A, A, B, B, B, B
```

where:

```cpp
const GSDevice::MultiStretchRect A = {GSVector4(), GSVector4(), low_address_texture, true, 0xf};
const GSDevice::MultiStretchRect B = {GSVector4(), GSVector4(), high_address_texture, false, 0xf};
```

- Check the test-only CI run in my local-fork repo here (Original Comparator Failed the Tests First): https://github.com/qwe854896/pcsx2/actions/runs/24952841788/job/73065906793#step:14:35
- Check the follow-up CI run in my local-fork repo with the comparator fix here (Fixed Comparator Passed the Tests): https://github.com/qwe854896/pcsx2/actions/runs/24953051163/job/73066458211#step:14:28

### Did you use AI to help find, test, or implement this issue or feature?

Yes.

- But I found the bug with a checker I wrote myself.
- I designed the testcase and the `std::tie` fix myself, and used AI to help refine the tests, implement them in a way that matches the repository's contribution/style requirements.
- I used AI to help draft this PR description. I manually revised the final wording.

### Side Notes

-  In the sorted `copy_queue` path this PR changes, `wmask` is always `0xf`, so `std::tie(src, linear)` keeps the current intended sort key while making the comparator valid for `std::sort`. It may still be worth discussing separately whether `wmask` should also be part of the compare key for completeness, but that is not included in this PR.
- The existing comment in `SortMultiStretchRects()` says `// Depending on num_rects, insertion sort may be better here.` That may not be worth doing manually unless profiling shows it matters. Common `std::sort` implementations already switch to insertion sort for small ranges internally, so this may already be handled well enough by the standard library.
  - One libstdc++ example is `__final_insertion_sort`, which uses `_S_threshold = 16` and falls back to insertion sort for small ranges:
  https://gcc.gnu.org/onlinedocs/libstdc%2B%2B/libstdc%2B%2B-html-USERS-4.4/a01347.html
- Existing backends using `DrawMultiStretchRects()` batching logic:
  - DX11: https://github.com/PCSX2/pcsx2/blob/27736ef47f1c4a9b1112d3adf2c333f3cc620b54/pcsx2/GS/Renderers/DX11/GSDevice11.cpp#L1606-L1612
  - DX12: https://github.com/PCSX2/pcsx2/blob/27736ef47f1c4a9b1112d3adf2c333f3cc620b54/pcsx2/GS/Renderers/DX12/GSDevice12.cpp#L1793-L1799
  - Vulkan: https://github.com/PCSX2/pcsx2/blob/27736ef47f1c4a9b1112d3adf2c333f3cc620b54/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp#L2976-L2982
  - OpenGL: https://github.com/PCSX2/pcsx2/blob/27736ef47f1c4a9b1112d3adf2c333f3cc620b54/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp#L1872-L1878
  - Metal: https://github.com/PCSX2/pcsx2/blob/27736ef47f1c4a9b1112d3adf2c333f3cc620b54/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm#L1771-L1777
