### PR TITLE
Hotkeys: New Input profile swapping hotkey(s)

### DIFF
--- a/pcsx2/Hotkeys.cpp
+++ b/pcsx2/Hotkeys.cpp
@@ -12,6 +12,8 @@
 #include "SPU2/spu2.h"
 #include "VMManager.h"
 #include "SIO/Memcard/MemoryCardFile.h"
+#include "SIO/Pad/Pad.h"
+#include "INISettingsInterface.h"
 
 #include "common/Assertions.h"
 #include "common/Error.h"
@@ -115,6 +117,44 @@ static void HotkeySaveStateSlot(s32 slot)
 	VMManager::SaveStateToSlot(slot, true, [slot](const std::string& error) {
 		FullscreenUI::ReportStateSaveError(error, slot);
 	});
+}
+
+static void HotkeyCycleInputProfile(s32 amount)
+{
+	if (!VMManager::HasValidVM())
+		return;
+
+	const u32 crc = VMManager::GetCurrentCRC();
+	// Try the legacy format (crc.ini) first
+	std::string filename(VMManager::GetGameSettingsPath({}, crc));
+	if (!FileSystem::FileExists(filename.c_str()))
+		filename = VMManager::GetGameSettingsPath(VMManager::GetSerialForGameSettings(), crc);
+	const std::unique_ptr<INISettingsInterface> game_settings = std::make_unique<INISettingsInterface>(std::move(filename));
+	game_settings->Load();
+
+	const std::string current_profile = game_settings->GetStringValue("EmuCore", "InputProfileName");
+	const std::vector<std::string> profiles = Pad::GetInputProfileNames();
+	const s32 current_i = std::find(profiles.begin(), profiles.end(), current_profile) - profiles.begin();
+	// Calculate the array index of the new profile to load, or profiles.size() for the shared profile
+	s32 new_i = (current_i + amount) % (static_cast<s32>(profiles.size()) + 1);
+	while (new_i < 0)
+		new_i += profiles.size() + 1;
+
+	if (new_i < profiles.size())
+	{
+		game_settings->SetStringValue("EmuCore", "InputProfileName", profiles.at(new_i).c_str());
+		Host::AddIconOSDMessage("InputProfileChanged", ICON_FA_KEYBOARD,
+			fmt::format(TRANSLATE_FS("Hotkeys", "Game input profile switched to {}"), profiles.at(new_i)));
+	}
+	else
+	{
+		game_settings->DeleteValue("EmuCore", "InputProfileName");
+		Host::AddIconOSDMessage("InputProfileChanged", ICON_FA_KEYBOARD,
+			TRANSLATE_STR("Hotkeys", "Game input profile switched to Shared"));
+	}
+	game_settings->Save();
+
+	Host::RunOnCPUThread([]() { VMManager::ReloadGameSettings(); });
 }
 
 static bool CanPause()
@@ -354,5 +394,15 @@ DEFINE_HOTKEY("ToggleMouseLock", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_
 	[](s32 pressed) {
 		if (!pressed)
 			Host::SetMouseLock(!Host::GetBoolSettingValue("EmuCore", "EnableMouseLock"));
+	})
+DEFINE_HOTKEY("CycleInputProfileForwards", TRANSLATE_NOOP("Hotkeys", "Input"), TRANSLATE_NOOP("Hotkeys", "Cycle Game input profile forwards (alphabetically)"),
+	[](s32 pressed) {
+		if (!pressed)
+			HotkeyCycleInputProfile(1);
+	})
+DEFINE_HOTKEY("CycleInputProfileBackwards", TRANSLATE_NOOP("Hotkeys", "Input"), TRANSLATE_NOOP("Hotkeys", "Cycle Game input profile backwards (alphabetically)"),
+	[](s32 pressed) {
+		if (!pressed)
+			HotkeyCycleInputProfile(-1);
 	})
 END_HOTKEY_LIST()

--- a/pcsx2/Hotkeys.cpp
+++ b/pcsx2/Hotkeys.cpp
@@ -12,6 +12,8 @@
 #include "SPU2/spu2.h"
 #include "VMManager.h"
 #include "SIO/Memcard/MemoryCardFile.h"
+#include "SIO/Pad/Pad.h"
+#include "INISettingsInterface.h"
 
 #include "common/Assertions.h"
 #include "common/Error.h"
@@ -115,6 +117,45 @@ static void HotkeySaveStateSlot(s32 slot)
 	VMManager::SaveStateToSlot(slot, true, [slot](const std::string& error) {
 		FullscreenUI::ReportStateSaveError(error, slot);
 	});
+}
+
+static void HotkeyCycleInputProfile(s32 amount)
+{
+	if (!VMManager::HasValidVM())
+		return;
+
+	const u32 crc = VMManager::GetCurrentCRC();
+	// Try the legacy format (crc.ini) first
+	std::string filename(VMManager::GetGameSettingsPath({}, crc));
+	if (!FileSystem::FileExists(filename.c_str()))
+		filename = VMManager::GetGameSettingsPath(VMManager::GetSerialForGameSettings(), crc);
+	const std::unique_ptr<INISettingsInterface> game_settings = std::make_unique<INISettingsInterface>(std::move(filename));
+	game_settings->Load();
+
+	const std::string current_profile = game_settings->GetStringValue("EmuCore", "InputProfileName");
+	const std::vector<std::string> profiles = Pad::GetInputProfileNames();
+	const s32 current_i = std::find(profiles.begin(), profiles.end(), current_profile) - profiles.begin();
+	// Calculate the array index of the new profile to load, or profiles.size() for the shared profile
+	s32 new_i = (current_i + amount) % (static_cast<s32>(profiles.size()) + 1);
+	while (new_i < 0)
+		new_i += profiles.size() + 1;
+
+	if (new_i < profiles.size())
+	{
+		game_settings->SetStringValue("EmuCore", "InputProfileName", profiles.at(new_i).c_str());
+		Host::AddIconOSDMessage("InputProfileChanged", ICON_FA_KEYBOARD,
+			fmt::format(TRANSLATE_FS("Hotkeys", "Game input profile switched to {}"), profiles.at(new_i)));
+	}
+	else
+	{
+		game_settings->DeleteValue("EmuCore", "InputProfileName");
+		Host::AddIconOSDMessage("InputProfileChanged", ICON_FA_KEYBOARD,
+			TRANSLATE_STR("Hotkeys", "Game input profile switched to Shared"));
+	}
+	game_settings->Save();
+
+	Host::RunOnCPUThread([]() { VMManager::ReloadGameSettings(); });
+	Pad::ResetAllControllerInputs();
 }
 
 static bool CanPause()
@@ -354,5 +395,15 @@ DEFINE_HOTKEY("ToggleMouseLock", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_
 	[](s32 pressed) {
 		if (!pressed)
 			Host::SetMouseLock(!Host::GetBoolSettingValue("EmuCore", "EnableMouseLock"));
+	})
+DEFINE_HOTKEY("CycleInputProfileForwards", TRANSLATE_NOOP("Hotkeys", "Input"), TRANSLATE_NOOP("Hotkeys", "Cycle Game input profile forwards (alphabetically)"),
+	[](s32 pressed) {
+		if (!pressed)
+			HotkeyCycleInputProfile(1);
+	})
+DEFINE_HOTKEY("CycleInputProfileBackwards", TRANSLATE_NOOP("Hotkeys", "Input"), TRANSLATE_NOOP("Hotkeys", "Cycle Game input profile backwards (alphabetically)"),
+	[](s32 pressed) {
+		if (!pressed)
+			HotkeyCycleInputProfile(-1);
 	})
 END_HOTKEY_LIST()


### PR DESCRIPTION
### Description of Changes
Hotkeys: New Input profile swapping hotkey(s)

Two new Hotkeys to cycle the Input profile for a specific game forwards and backwards alphabetically between the Shared input profile and any custom ones. They are contained in a new section called "Input".
Changes get saved in the game settings INI file, so they persist after shutdown and don't override global Shared settings
When the hotkeys are used a notification is displayed with the name of the new Input profile

### Rationale behind Changes
Giving a way for users to rapidly change their Input profile without leaving the game window. This helps in games with sections/modes where the commands change wildly and might become uncomfortable to play with the same profile.
Closes #7325
- Note: While researching I found [this page](https://pcsx2.net/docs/configuration/controllers/#can-i-use-profiles-to-switch-mappings-while-playing) in the documentation which says this pull request shouldn't really be allowed, but then the Issue I mentioned was accepted so I guess this is fine...? Feel free to close this if it wasn't allowed

### Suggested Testing Steps
Assign a binding to the hotkeys from the Settings menu and then test them on any game (or the Padtest ELF) with any number of Input profiles created

### Did you use AI to help find, test, or implement this issue or feature?
No