### PR TITLE
Qt: Fix crash when closing OSD font picker dialog

### DIFF
--- a/pcsx2-qt/Settings/OSDSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/OSDSettingsWidget.cpp
@@ -184,10 +184,6 @@ void OSDSettingsWidget::onBrowseOsdFontPathClicked()
 		saveOsdFontPathSetting(QDir::toNativeSeparators(selected));
 	});
 
-	connect(m_font_picker, &QObject::destroyed, this, [this]() {
-		m_font_picker = nullptr;
-	});
-
 	m_font_picker->show();
 }
 


### PR DESCRIPTION
### Description of Changes
Remove a broken connect call.

### Rationale behind Changes
This fixes a crash that would happen when the settings dialog was closed with the OSD font picker dialog open. The QObject::destroyed signal would fire while inside of the OSDSettingsWidget destructor, so we would end up accessing an already destructed object.

This connect call was unnecessary anyway, since QPointer is a guarded pointer. It automatically becomes null when the object it's pointing to is destroyed, so we don't need to do it manually.

### Suggested Testing Steps
Try the following (tested on Linux):
- Open a settings dialog (global or per-game).
- Open the OSD font picker dialog.
- Perform an action that would result in the settings dialog being closed:
  - Close the settings dialog using the X button (this one only seems to happen with the per-game settings dialog).
  - Close PCSX2.
  - Toggle "Show Advanced Settings".
  - Etc.

On master, PCSX2 may crash in some unrelated code that runs shortly after. Since it's heap memory corruption, symptoms may vary depending on the platform.

### Did you use AI to help find, test, or implement this issue or feature?
No.
