### PR TITLE
StackWalker: Fix bugs.

### DIFF
--- a/pcsx2/DebugTools/MipsStackWalk.cpp
+++ b/pcsx2/DebugTools/MipsStackWalk.cpp
@@ -103,7 +103,10 @@ namespace MipsStackWalk
 		// TODO: Check if found entry is in the same symbol?  Might be wrong sometimes...
 
 		int ra_offset = -1;
-		const u32 start = frame.pc;
+
+		// The instruction pointed to by pc hasn't been executed yet,
+		// so we don't want to consider it here
+		const u32 start = frame.pc - 4;
 		u32 stop = entry;
 
 		if (entry == INVALIDTARGET)


### PR DESCRIPTION
### Description of Changes
When stack tracing, don't look at the instruction pointed to by PC, it hasn't executed yet.

### Rationale behind Changes
Fixes incorrect stack tracing in cases where we are stoppen on certain instructions.

### Suggested Testing Steps
Make sure debugger still works as expected.

### Did you use AI to help find, test, or implement this issue or feature?
No
