### PR TITLE
GS/HW: Reject malformed UVs in shader anisotropic filtering

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -263,6 +263,9 @@ float manual_lod(float uv_w)
 #if PS_ANISOTROPIC_FILTERING > 1
 float4 sample_c_af(float2 uv, float uv_w)
 {
+	// HW sampler will reject bad UVs, match that here.
+	uv = any(isnan(uv) | isinf(uv)) ? float2(0, 0) : uv;
+
 	// Below taken from https://microsoft.github.io/DirectX-Specs/d3d/archive/D3D11_3_FunctionalSpec.htm#7.18.11%20LOD%20Calculations
 	// With guidance from https://pema.dev/2025/05/09/mipmaps-too-much-detail/ 
 	float2 sz;

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -212,6 +212,9 @@ float manual_lod(float uv_w)
 #if PS_ANISOTROPIC_FILTERING > 1
 vec4 sample_c_af(vec2 uv, float uv_w)
 {
+	// HW sampler will reject bad UVs, match that here.
+	uv = (any(isnan(uv)) || any(isinf(uv))) ? vec2(0, 0) : uv;
+
 	// Below taken from https://microsoft.github.io/DirectX-Specs/d3d/archive/D3D11_3_FunctionalSpec.htm#7.18.11%20LOD%20Calculations
 	// With guidance from https://pema.dev/2025/05/09/mipmaps-too-much-detail/ 
 	vec2 sz = textureSize(TextureSampler, 0);

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -552,6 +552,9 @@ float manual_lod(float uv_w)
 #if PS_ANISOTROPIC_FILTERING > 1
 vec4 sample_c_af(vec2 uv, float uv_w)
 {
+	// HW sampler will reject bad UVs, match that here.
+	uv = (any(isnan(uv)) || any(isinf(uv))) ? vec2(0, 0) : uv;
+
 	// Below taken from https://microsoft.github.io/DirectX-Specs/d3d/archive/D3D11_3_FunctionalSpec.htm#7.18.11%20LOD%20Calculations
 	// With guidance from https://pema.dev/2025/05/09/mipmaps-too-much-detail/ 
 	vec2 sz = textureSize(Texture, 0);

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -461,6 +461,9 @@ struct PSMain
 
 	float4 sample_c_af(float2 uv, float uv_w)
 	{
+		// HW sampler will reject bad UVs, match that here.
+		uv = any(isnan(uv) | isinf(uv)) ? float2(0, 0) : uv;
+
 		// Below taken from https://microsoft.github.io/DirectX-Specs/d3d/archive/D3D11_3_FunctionalSpec.htm#7.18.11%20LOD%20Calculations
 		// With guidance from https://pema.dev/2025/05/09/mipmaps-too-much-detail/
 		float2 sz = float2(get_tex_dims());

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 90; // Last changed in PR 14349
+static constexpr u32 SHADER_CACHE_VERSION = 91; // Last changed in PR 14370


### PR DESCRIPTION
### Description of Changes
texture samplers (At least under DX) will replace any UVs containing either NaNs or Inf values with 0,0.
Replicate that with shader based anisotropic filtering.

### Rationale behind Changes
A dump of Star ocean 3 resulted in geometry, which among other issues. contained NaN texture coordinates.
The shader based anisotropic filtering would end up returning NaN colours due to NaN propagation in mathematic operations.

This was hidden when anisotropic filtering is disabled, as UV 0,0 the texture is transparent black.

### Suggested Testing Steps
Test renders with AF enabled.

### Did you use AI to help find, test, or implement this issue or feature?
No