### PR TITLE
GS/HW: Fix brackets in texture shuffle detection.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -834,7 +834,7 @@ void GSRendererHW::DetectTextureShuffleSecondPass(GSTextureCache::Target* rt, GS
 		// path helps to maintain correct sizes in the texture cache. Occurs in NFS Most Wanted.
 
 		if (PRIM->TME &&
-			(m_vt.m_primclass == GS_SPRITE_CLASS || m_vt.m_primclass == GS_TRIANGLE_CLASS && TrianglesAreQuads(true)) &&
+			((m_vt.m_primclass == GS_SPRITE_CLASS || m_vt.m_primclass == GS_TRIANGLE_CLASS) && TrianglesAreQuads(true)) &&
 			(tex_psm.bpp == 16) && (frame_psm.bpp == 16) && rt->m_32_bits_fmt && tex->m_32_bits_fmt)
 		{
 			GL_INS("HW: Texture shuffle detection (2): Passed (HACK: reinterpreting both source/RT as 16 bit).");


### PR DESCRIPTION
### Description of Changes
Fix brackets in a logical expression in texture shuffle detection.

### Rationale behind Changes
Prevent bugs due to incorrect logic.

### Suggested Testing Steps
Shouldn't really require testing.

I smoke tested several NFS Most Wanted dumps (as per the comment), though the path was never hit in these.

### Did you use AI to help find, test, or implement this issue or feature?
No.
