### PR TITLE
GSRunner: Add -debugdevice command line parameter.

### DIFF
--- a/pcsx2-gsrunner/Main.cpp
+++ b/pcsx2-gsrunner/Main.cpp
@@ -799,6 +799,12 @@ bool GSRunner::ParseCommandLineArgs(int argc, char* argv[], VMBootParameters& pa
 				s_perf_enable = true;
 				continue;
 			}
+			else if (CHECK_ARG("-debugdevice"))
+			{
+				Console.WriteLn("Enable debug device");
+				s_settings_interface.SetBoolValue("EmuCore/GS", "UseDebugDevice", true);
+				continue;
+			}
 			else if (CHECK_ARG("--"))
 			{
 				no_more_args = true;


### PR DESCRIPTION
### Description of Changes
Adds a -debugdevice command line parameter to GSRunner to enable device debugging.

### Rationale behind Changes
Makes debugging with the GSRunner more convenient, instead of changing the setting in the INI.

### Suggested Testing Steps
Run the GSRunner in renderdoc with/without the setting to see if it works.

### Did you use AI to help find, test, or implement this issue or feature?
No.
