### PR TITLE
GS/HW: Correct buffered rect size of corrected EE->GS transfers

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2403,7 +2403,7 @@ void GSState::FlushWrite()
 
 			if (m_draw_transfers.size() > 0 && m_tr.m_blit.DBP == m_draw_transfers.back().blit.DBP)
 			{
-				m_draw_transfers.back().rect = r;
+				m_draw_transfers.back().rect = m_draw_transfers.back().rect.runion(r);
 			}
 		}
 	}


### PR DESCRIPTION
### Description of Changes
Fixes transfer buffer rect when adjusting the size of the transferred rect on subsequent transfers to be more accurate to the data that is incoming.

### Rationale behind Changes
Bug was introduced in #13902 where I was checking for existing transfers to the same address then overwriting the rect instead of joining them together, so when this got used later to work out the target size, it was getting a completely incorrect value.

### Suggested Testing Steps
Test Mercenaries and make sure the loading screen shows properly, maybe smoke test Star Wars - The Clone Wars (but dump run + manual check of gs dump seems ok)

### Did you use AI to help find, test, or implement this issue or feature?
No

Fixes #14380

Mercenaries:

Master:
<img width="596" height="447" alt="image" src="https://github.com/user-attachments/assets/c3920439-0df0-43de-8dbd-69a1a7b76aff" />

PR:
<img width="596" height="447" alt="image" src="https://github.com/user-attachments/assets/90387da1-3b23-4543-a714-a98e72f697ec" />

