### PR TITLE
GS: Check if current tex is valid before resizing.

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -718,7 +718,7 @@ void GSRenderer::VSync(u32 field, bool registers_written, bool idle_frame)
 			const GSTexture* current = g_gs_device->GetCurrent();
 			const GSVector2i internal_res = GetInternalResolution();
 
-			if (current->GetWidth() > internal_res.x || current->GetHeight() > internal_res.y)
+			if (current && (current->GetWidth() > internal_res.x || current->GetHeight() > internal_res.y))
 				g_gs_device->Resize(internal_res.x, internal_res.y);
 		}
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS: Check if current tex is valid before resizing.
When texture dumping is enabled or when trying to take a snapshot at the beginning with Bilinear sharp enabled on MC3 the current texture may be null so let's check it if it's valid.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Access violation crash, helps #14390, there is another crash related issue with achievements on that issue.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test #14390 with bilinear sharp enabled, take a ss/gs dump or enable tex dumping.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation how. -->
No.