### PR TITLE
GS:Metal: Fix depth feedback on cleared depth

### DIFF
--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -492,7 +492,10 @@ void GSDeviceMTL::BeginRenderPass(NSString* name, GSTexture* color, MTLLoadActio
 	if (rt1)
 	{
 		pxAssert(md);
-		desc.colorAttachments[1].texture = GetRT1DepthTexture(md);
+		MTLRenderPassColorAttachmentDescriptor* color1 = desc.colorAttachments[1];
+		color1.texture = GetRT1DepthTexture(md);
+		if (m_features.framebuffer_fetch)
+			color1.clearColor = MTLClearColorMake(depth_load == MTLLoadActionClear ? depth_clear : -1, 0, 0, 0);
 	}
 
 	EndRenderPass();
@@ -1031,15 +1034,7 @@ bool GSDeviceMTL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 		{
 			MTLRenderPassColorAttachmentDescriptor* color1 = [[desc colorAttachments] objectAtIndexedSubscript:1];
 			[color1 setStoreAction:MTLStoreActionDontCare];
-			if (m_features.framebuffer_fetch)
-			{
-				[color1 setLoadAction:MTLLoadActionClear];
-				[color1 setClearColor:MTLClearColorMake(-1, 0, 0, 0)];
-			}
-			else
-			{
-				[color1 setLoadAction:MTLLoadActionLoad];
-			}
+			[color1 setLoadAction:m_features.framebuffer_fetch ? MTLLoadActionClear : MTLLoadActionLoad];
 		}
 		m_render_pass_desc[i] = desc;
 	}


### PR DESCRIPTION
### Description of Changes
The Metal fbfetch depth feedback implementation uses a hybrid system where it binds the real depth texture as a resource and clears the fbfetch texture to -1, then only reads the real texture if the fbfetch texture contains -1.  This is supposed to make sure that it never attempts to read a pixel that has already been written by the current render pass, since once that happens the fbfetch depth will contain a value other than -1.

Turns out I forgot to handle load actions, so if the real depth texture was cleared by a clear load action, the fbfetch texture was still cleared to -1, resulting in us reading the pre-clear depth data from the depth texture.  Fixes it to clear both textures if the depth texture is cleared.

### Rationale behind Changes
Fixes #14372

### Suggested Testing Steps
Test the gsdump from #14372

<img width="896" height="700" alt="image" src="https://github.com/user-attachments/assets/13144d0d-f52c-407b-a522-d149548f8a79" />

### Did you use AI to help find, test, or implement this issue or feature?
No
