### PR TITLE
Achievements: Fix crash in WinHTTP timeout

### DIFF
--- a/common/HTTPDownloaderWinHTTP.cpp
+++ b/common/HTTPDownloaderWinHTTP.cpp
@@ -56,6 +56,11 @@ bool HTTPDownloaderWinHttp::Initialize(std::string user_agent)
 		return false;
 	}
 
+	DWORD timeout_ms = 15000;
+	WinHttpSetOption(m_hSession, WINHTTP_OPTION_CONNECT_TIMEOUT, &timeout_ms, sizeof(timeout_ms));
+	WinHttpSetOption(m_hSession, WINHTTP_OPTION_SEND_TIMEOUT, &timeout_ms, sizeof(timeout_ms));
+	WinHttpSetOption(m_hSession, WINHTTP_OPTION_RECEIVE_TIMEOUT, &timeout_ms, sizeof(timeout_ms));
+
 	return true;
 }
 
@@ -290,10 +295,13 @@ bool HTTPDownloaderWinHttp::StartRequest(HTTPDownloader::Request* request)
 		req->status_code = HTTP_STATUS_ERROR;
 		req->state.store(Request::State::Complete);
 	}
+	else
+	{
+		DevCon.WriteLn("Started HTTP request for '%s'", req->url.c_str());
+		req->state = Request::State::Started;
+		req->start_time = Common::Timer::GetCurrentValue();
+	}
 
-	DevCon.WriteLn("Started HTTP request for '%s'", req->url.c_str());
-	req->state = Request::State::Started;
-	req->start_time = Common::Timer::GetCurrentValue();
 	return true;
 }
 

--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -745,11 +745,18 @@ void Achievements::ClientServerCall(
 {
 	HTTPDownloader::Request::Callback hd_callback = [callback, callback_data](s32 status_code, const std::string& content_type, HTTPDownloader::Request::Data data)
 	{
+		const bool is_error = (status_code <= 0);
+		const bool is_retryable =
+			is_error && (status_code == HTTPDownloader::HTTP_STATUS_TIMEOUT);
+
 		rc_api_server_response_t rr;
-		rr.http_status_code = (status_code <= 0) ? (status_code == HTTPDownloader::HTTP_STATUS_CANCELLED ?
-		                                                   RC_API_SERVER_RESPONSE_CLIENT_ERROR :
-		                                                   RC_API_SERVER_RESPONSE_RETRYABLE_CLIENT_ERROR)
-		                                         : status_code;
+		rr.http_status_code =
+			is_error
+			? (is_retryable
+				? RC_API_SERVER_RESPONSE_RETRYABLE_CLIENT_ERROR
+				: RC_API_SERVER_RESPONSE_CLIENT_ERROR)
+			: status_code;
+
 		rr.body_length = data.size();
 		rr.body = reinterpret_cast<const char*>(data.data());
 


### PR DESCRIPTION
### Description of Changes
Fixup / formatting of #14311 since the author hasn't responded

### Rationale behind Changes
Crashing when timing out is bad
Fixes https://github.com/PCSX2/pcsx2/issues/14277
Closes https://github.com/PCSX2/pcsx2/pull/14311

### Suggested Testing Steps
Cause a timeout during an achievement request and see if PCSX2 crashed

### Did you use AI to help find, test, or implement this issue or feature?
No, this is work based off of the original PR.
