### PR TITLE
GS/HW: Clamp large UVs in shader anisotropic filtering

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -266,6 +266,10 @@ float4 sample_c_af(float2 uv, float uv_w)
 	// HW sampler will reject bad UVs, match that here.
 	uv = any(isnan(uv) | isinf(uv)) ? float2(0, 0) : uv;
 
+	// Large floating point values risk NaN/Inf values.
+	// Above this value floats lose decimal precision, so seems a resonable limit for UVs.
+	uv = clamp(uv, -8388608.0f, 8388608.0f);
+
 	// Below taken from https://microsoft.github.io/DirectX-Specs/d3d/archive/D3D11_3_FunctionalSpec.htm#7.18.11%20LOD%20Calculations
 	// With guidance from https://pema.dev/2025/05/09/mipmaps-too-much-detail/ 
 	float2 sz;

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -215,6 +215,10 @@ vec4 sample_c_af(vec2 uv, float uv_w)
 	// HW sampler will reject bad UVs, match that here.
 	uv = (any(isnan(uv)) || any(isinf(uv))) ? vec2(0, 0) : uv;
 
+	// Large floating point values risk NaN/Inf values.
+	// Above this value floats lose decimal precision, so seems a resonable limit for UVs.
+	uv = clamp(uv, -8388608.0f, 8388608.0f);
+
 	// Below taken from https://microsoft.github.io/DirectX-Specs/d3d/archive/D3D11_3_FunctionalSpec.htm#7.18.11%20LOD%20Calculations
 	// With guidance from https://pema.dev/2025/05/09/mipmaps-too-much-detail/ 
 	vec2 sz = textureSize(TextureSampler, 0);

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -555,6 +555,10 @@ vec4 sample_c_af(vec2 uv, float uv_w)
 	// HW sampler will reject bad UVs, match that here.
 	uv = (any(isnan(uv)) || any(isinf(uv))) ? vec2(0, 0) : uv;
 
+	// Large floating point values risk NaN/Inf values.
+	// Above this value floats lose decimal precision, so seems a resonable limit for UVs.
+	uv = clamp(uv, -8388608.0f, 8388608.0f);
+
 	// Below taken from https://microsoft.github.io/DirectX-Specs/d3d/archive/D3D11_3_FunctionalSpec.htm#7.18.11%20LOD%20Calculations
 	// With guidance from https://pema.dev/2025/05/09/mipmaps-too-much-detail/ 
 	vec2 sz = textureSize(Texture, 0);

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -464,6 +464,10 @@ struct PSMain
 		// HW sampler will reject bad UVs, match that here.
 		uv = any(isnan(uv) | isinf(uv)) ? float2(0, 0) : uv;
 
+		// Large floating point values risk NaN/Inf values.
+		// Above this value floats lose decimal precision, so seems a resonable limit for UVs.
+		uv = clamp(uv, -8388608.0f, 8388608.0f);
+
 		// Below taken from https://microsoft.github.io/DirectX-Specs/d3d/archive/D3D11_3_FunctionalSpec.htm#7.18.11%20LOD%20Calculations
 		// With guidance from https://pema.dev/2025/05/09/mipmaps-too-much-detail/
 		float2 sz = float2(get_tex_dims());

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 91; // Last changed in PR 14370
+static constexpr u32 SHADER_CACHE_VERSION = 92; // Last changed in PR 14399


### PR DESCRIPTION
### Description of Changes
Clamps large UVs before performing anisotropic filtering.

### Rationale behind Changes
Large UV values can result in Inf/NaN values.
Floating point values above 8388608 are unable to represent decimal values, so clamping them seems safe.
A side effect of this is that we don't detect anisotropy beyond that range, so anisotropic filtering stops being effective at high UV values.

### Suggested Testing Steps
Test anisotropic filtering on the menu of DreamWorks Over the hedge.
Test anisotropic filtering in other games/locations.

### Did you use AI to help find, test, or implement this issue or feature?
No
