### PR TITLE
GS/VK: Update ImGui when resizing the swap chain

### DIFF
--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -13,6 +13,7 @@
 
 #include "BuildVersion.h"
 #include "Host.h"
+#include "ImGui/ImGuiManager.h"
 
 #include "common/Console.h"
 #include "common/BitUtils.h"
@@ -2353,6 +2354,7 @@ GSDevice::PresentResult GSDeviceVK::BeginPresent(bool frame_skip)
 		if (res == VK_SUBOPTIMAL_KHR || res == VK_ERROR_OUT_OF_DATE_KHR)
 		{
 			ResizeWindow(0, 0, m_window_info.surface_scale);
+			ImGuiManager::WindowResized();
 			res = m_swap_chain->AcquireNextImage();
 		}
 		else if (res == VK_ERROR_SURFACE_LOST_KHR)


### PR DESCRIPTION
### Description of Changes
Builds on/superseding #13648 by adding the same behavior to the other renderers. 

Ensures ImGui resize events are triggered during swap chain resize, allowing the OSD and BPM to remain in sync during heavy resizing.

### Rationale behind Changes
Closes https://github.com/PCSX2/pcsx2/pull/13648
Smoother resize

### Suggested Testing Steps
Resize with the BPM, the OSD or other ImGui related events in Vulkan.

### Did you use AI to help find, test, or implement this issue or feature?
No