### PR TITLE
Qt: Add MainWindowFullscreen to ini for human readable fullscreen override

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -873,6 +873,16 @@ void MainWindow::saveStateToConfig()
 		changed = true;
 	}
 
+	if (Host::ContainsBaseSettingValue("UI", "MainWindowMaximized"))
+	{
+		const bool maximized = Host::GetBaseBoolSettingValue("UI", "MainWindowMaximized");
+		if (maximized != isMaximized())
+		{
+			Host::SetBaseBoolSettingValue("UI", "MainWindowMaximized", isMaximized());
+			changed = true;
+		}
+	}
+
 	if (Host::ContainsBaseSettingValue("UI", "MainWindowFullscreen"))
 	{
 		const bool fullscreen = Host::GetBaseBoolSettingValue("UI", "MainWindowFullscreen");
@@ -909,6 +919,15 @@ void MainWindow::restoreStateFromConfig()
 		{
 			QSignalBlocker sb(m_ui.actionViewStatusBar);
 			m_ui.actionViewStatusBar->setChecked(!m_ui.statusBar->isHidden());
+		}
+	}
+
+	{
+		if (Host::ContainsBaseSettingValue("UI", "MainWindowMaximized"))
+		{
+			const bool maximized = Host::GetBaseBoolSettingValue("UI", "MainWindowMaximized");
+			if (maximized)
+				showMaximized();
 		}
 	}
 

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -873,6 +873,16 @@ void MainWindow::saveStateToConfig()
 		changed = true;
 	}
 
+	if (Host::ContainsBaseSettingValue("UI", "MainWindowFullscreen"))
+	{
+		const bool fullscreen = Host::GetBaseBoolSettingValue("UI", "MainWindowFullscreen");
+		if (fullscreen != isFullScreen())
+		{
+			Host::SetBaseBoolSettingValue("UI", "MainWindowFullscreen", isFullScreen());
+			changed = true;
+		}
+	}
+
 	if (changed)
 		Host::CommitBaseSettingChanges();
 }
@@ -899,6 +909,15 @@ void MainWindow::restoreStateFromConfig()
 		{
 			QSignalBlocker sb(m_ui.actionViewStatusBar);
 			m_ui.actionViewStatusBar->setChecked(!m_ui.statusBar->isHidden());
+		}
+	}
+
+	{
+		if (Host::ContainsBaseSettingValue("UI", "MainWindowFullscreen"))
+		{
+			const bool fullscreen = Host::GetBaseBoolSettingValue("UI", "MainWindowFullscreen");
+			if (fullscreen)
+				showFullScreen();
 		}
 	}
 }


### PR DESCRIPTION
### Description of Changes
Add an optional parameter in the settings ini that allows you to override the fullscreen state in a human readable manner.

### Rationale behind Changes
Resolves #13249

### Suggested Testing Steps
1. Override enable
	- Main window not fullscreen
	- Close PCSX2
	- Add `MainWindowFullscreen = true`
	- Open PCSX2
	- See if the window opens fullscreen

2. Override disable
	- Don't have `MainWindowFullscreen` in the ini
	- Main window fullscreen
	- Close PCSX2
	- Add `MainWindowFullscreen = false`
	- Open PCSX2
	- See if the window opens in fullscreen (it should not)

3. Setting persistence
	- Add `MainWindowFullscreen = whatever`
	- Change the fullscreen state
	- Close PCSX2
	- See if the `MainWindowFullscreen` value changes accordingly

### Did you use AI to help find, test, or implement this issue or feature?
no