### PR TITLE
Fix build with libstdc++ 16

### DIFF
--- a/pcsx2/GS/GSUtil.h
+++ b/pcsx2/GS/GSUtil.h
@@ -6,6 +6,7 @@
 #include "GS.h"
 #include "GSRegs.h"
 #include "GSPerfMon.h"
+#include <climits>
 
 class GSUtil
 {

--- a/pcsx2/GS/Renderers/Common/GSDirtyRect.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDirtyRect.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0+
 
 #include "GSDirtyRect.h"
+#include <climits>
 #include <vector>
 
 GSDirtyRect::GSDirtyRect() :

--- a/pcsx2/GS/Renderers/Common/GSFastList.h
+++ b/pcsx2/GS/Renderers/Common/GSFastList.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "common/AlignedMalloc.h"
+#include <climits>
 
 template <class T>
 struct Element


### PR DESCRIPTION
### Description of Changes
Adds includes for climits

### Rationale behind Changes
They must have rearranged their includes so we don't pick up this transitively anymore.

### Suggested Testing Steps
No functional difference

### Did you use AI to help find, test, or implement this issue or feature?
No
