### PR TITLE
GS/HW/COLCLIP: Check tex mapping is enabled when checking for recursion

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2995,7 +2995,7 @@ void GSRendererHW::Draw()
 	// I hate that I have to do this, but some games (like Pac-Man World Rally) troll us by causing a flush with degenerate triangles, so we don't have all available information about the next draw.
 	// So we have to check when the next draw happens if our frame has changed or if it's become recursive.
 	const bool has_colclip_texture = g_gs_device->GetColorClipTexture() != nullptr;
-	if (!no_rt && has_colclip_texture && (m_conf.colclip_frame.FBP != m_cached_ctx.FRAME.FBP || m_conf.colclip_frame.Block() == m_cached_ctx.TEX0.TBP0))
+	if (!no_rt && has_colclip_texture && (m_conf.colclip_frame.FBP != m_cached_ctx.FRAME.FBP || (PRIM->TME && m_conf.colclip_frame.Block() == m_cached_ctx.TEX0.TBP0)))
 	{
 		GIFRegTEX0 FRAME;
 		FRAME.TBP0 = m_conf.colclip_frame.Block();


### PR DESCRIPTION
### Description of Changes
Checks that texture mapping is enabled before checking if a recursive draw is about to happen.

### Rationale behind Changes
This wasn't checked before, but some games (Cowboy Bebop and Detective Conan) will set the texture address to the same as the Frame, even though it's not using it, and this was confusing the code, causing it to resolve COLCLIP HDR (not that HDR) a lot of times which would cause massive slowdown. So now it explicitly checks for texture mapping being enabled.

### Suggested Testing Steps
Check the games listed below for performance.

### Did you use AI to help find, test, or implement this issue or feature?
No

Changes from GS Dump

```
Cowboy Bebop - Tsuioku no Serenade_SLPS-25551_20250407134557 ['Draw Calls: -1262 [4434=>3172]', 'Render Passes: -1589 [1604=>15]', 'Barriers: -502 [502=>0]', 'Copies: -1261 [1265=>4]']
Detective Conan MENU Graphics Bug Multi Frame ['Draw Calls: -376 [1599=>1223]', 'Render Passes: -460 [471=>11]', 'Barriers: -168 [176=>8]', 'Copies: -376 [380=>4]']
Disney's PK - Out of the Shadows_SLUS-20478_20250214232922 ['Draw Calls: -2 [85=>83]', 'Render Passes: -2 [23=>21]', 'Copies: -2 [9=>7]']
Rayman 3 - Hoodlum Havoc_SLES-51222_20220814004038 ['Draw Calls: -6 [210=>204]', 'Render Passes: -5 [64=>59]', 'Copies: -6 [34=>28]']
```
