### PR TITLE
GS/TC: Update dirty target linked to source when dirty overlaps the read

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2261,20 +2261,34 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const bool is_color, const 
 			}
 		}
 
-		if (src->m_from_target && src->m_target_direct && src->m_region.HasEither())
+		if (src->m_from_target && src->m_target_direct)
 		{
-			if (src->m_from_target->m_TEX0.TBP0 == src->m_TEX0.TBP0)
+			GSVector4i req_rect = r;
+
+			// The read area might be offset but the start of the texture is at the beginning of the space.
+			req_rect.x = region.HasX() ? region.GetMinX() : 0;
+			req_rect.y = region.HasY() ? region.GetMinY() : 0;
+
+			const bool dirty_overlap = !src->m_from_target->m_dirty.GetTotalRect(src->m_from_target->m_TEX0, src->m_from_target->m_unscaled_size).rintersect(req_rect).rempty();
+
+			if (dirty_overlap)
+				src->m_from_target->Update();
+
+			if (src->m_region.HasEither())
 			{
-				src->m_region.bits = 0;
-				src->m_region.SetX(0, region.HasX() ? region.GetMaxX() : (1 << TEX0.TW));
-				src->m_region.SetY(0, region.HasY() ? region.GetMaxY() : (1 << TEX0.TH));
-			}
-			else if (src->m_TEX0.TBP0 > src->m_from_target->m_TEX0.TBP0)
-			{
-				GSVector4i dst_offset = TranslateAlignedRectByPage(src->m_from_target, src->m_TEX0.TBP0, src->m_TEX0.PSM, src->m_TEX0.TBW, GSVector4i(0, 0, 1, 1), false);
-				src->m_region.bits = 0;
-				src->m_region.SetX(dst_offset.x, dst_offset.x + (region.HasX() ? std::min(region.GetMaxX(), (1 << TEX0.TW)) : (1 << TEX0.TW)));
-				src->m_region.SetY(dst_offset.y, dst_offset.y + (region.HasY() ? std::min(region.GetMaxY(), (1 << TEX0.TH)) : (1 << TEX0.TH)));
+				if (src->m_from_target->m_TEX0.TBP0 == src->m_TEX0.TBP0)
+				{
+					src->m_region.bits = 0;
+					src->m_region.SetX(0, region.HasX() ? region.GetMaxX() : (1 << TEX0.TW));
+					src->m_region.SetY(0, region.HasY() ? region.GetMaxY() : (1 << TEX0.TH));
+				}
+				else if (src->m_TEX0.TBP0 > src->m_from_target->m_TEX0.TBP0)
+				{
+					GSVector4i dst_offset = TranslateAlignedRectByPage(src->m_from_target, src->m_TEX0.TBP0, src->m_TEX0.PSM, src->m_TEX0.TBW, GSVector4i(0, 0, 1, 1), false);
+					src->m_region.bits = 0;
+					src->m_region.SetX(dst_offset.x, dst_offset.x + (region.HasX() ? std::min(region.GetMaxX(), (1 << TEX0.TW)) : (1 << TEX0.TW)));
+					src->m_region.SetY(dst_offset.y, dst_offset.y + (region.HasY() ? std::min(region.GetMaxY(), (1 << TEX0.TH)) : (1 << TEX0.TH)));
+				}
 			}
 		}
 


### PR DESCRIPTION
### Description of Changes
Updates the target if linked to an existing source when the target is dirty and overlaps the requested source read.

### Rationale behind Changes
In the case there was already a target linked source, but that target was updated via an EE-GS upload, it would not update that target in the existing path, meaning the old source data got used.

### Suggested Testing Steps
Smoke test some games, but also check Pump It Up - Exceed and TOCA Race Driver 3

### Did you use AI to help find, test, or implement this issue or feature?
No

Fixes the first frame of the dump in TOCA Race Driver 3 (not sure how that translates ingame)
Fixes the bad arrow sprites in Pump It Up - Exceed

Pump It Up - Exceed:
Master:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/e699861c-bcbc-4c5e-8cac-0ab614caa8a1" />
PR:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/3aa66657-3fca-4994-bc21-70213c0893e3" />

TOCA Race Driver 3 (May not translate to anything ingame, only happens for 1 frame of dump):
Master:
<img width="681" height="511" alt="image" src="https://github.com/user-attachments/assets/af6122ef-30b5-455b-9c01-2b656fa1b78a" />
PR:
<img width="681" height="511" alt="image" src="https://github.com/user-attachments/assets/3ba3441d-9386-442b-888d-ccaf8b953c80" />


