### PR TITLE
GameDB: fixes wrong title for SLPM-65496 - Hyper Street Fighter II - The Anniversary Edition

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -44042,7 +44042,7 @@ SLPM-65495:
 SLPM-65496:
   name: "ハイパーストリートファイターⅡ アニバーサリーエディション"
   name-sort: "はいぱーすとりーとふぁいたー2 あにばーさりーえでぃしょん"
-  name-en: "Hyper Street Fighter"
+  name-en: "Hyper Street Fighter II - The Anniversary Edition"
   region: "NTSC-J"
 SLPM-65497:
   name: "ワールドサッカーウイニングイレブン7 インターナショナル プレミアムパッケージ supported by アディダス"


### PR DESCRIPTION
### Description of Changes
Fix "Hyper Street Fighter II - The Anniversary Edition" Japanese entry

### Rationale behind Changes
The original japanese release of Hyper Street Fighter II - The Anniversary Edition was named "Hyper Street Fighter" while the CapKore and EU editions were correctly named.

### Did you use AI to help find, test, or implement this issue or feature?
No
