### PR TITLE
GameDB: Enable Instant DMA Hack for Samurai Complete Edition (SLPM-74405)

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -54509,6 +54509,7 @@ SLPM-74405:
   region: "NTSC-J"
   gameFixes:
     - EETimingHack # Stops crash after intro movie.
+    - InstantDMAHack # Stops hang when entering Sword Select screen.
 SLPM-74406:
   name: "WRC ～WORLD RALLY CHAMPIONSHIP～ [PlayStation2 the Best]"
   name-sort: "WRC ～わーるど らりー ちゃんぴおんしっぷ～ [PlayStation2 the Best]"


### PR DESCRIPTION
### Description of Changes
Enables Instant DMA Hack for SLPM-74405 (侍 ～完全版～/Samurai Complete Edition).

### Rationale behind Changes
The game hangs when entering the Sword Select screen unless Instant DMA Hack is enabled.

For reference, I also tested the original Japanese release (SLPS-20178) and the North American release (SLUS-20407) and they don't need this hack. I assume it has something to do with how they changed the pause menu. In the earlier versions, pressing Start takes you straight to the Sword Select screen. In Complete Edition, pressing Start opens a pause menu with the options "Sword Select screen" and "Continue Game", and choosing "Sword Select screen" hangs without the hack enabled.

### Suggested Testing Steps
Press Start while in game and choose "Sword Select screen." Without the hack enabled, the game should hang. With the hack enabled, you should successfully enter the Sword Select screen.

### Did you use AI to help find, test, or implement this issue or feature?
No.
