### PR TITLE
USB: Additional commands for MSAC-US1

### DIFF
--- a/pcsx2/USB/usb-msd/usb-msd.cpp
+++ b/pcsx2/USB/usb-msd/usb-msd.cpp
@@ -1034,6 +1034,16 @@ namespace usb_msd
 			case ClassInterfaceOutRequest:
 				switch (data[0])
 				{
+					case TEST_UNIT_READY:
+					case START_STOP:
+					case SEND_DIAGNOSTIC:
+						break;
+					case MODE_SENSE_10:
+						s->f.mode = USB_MSDM_CBW;
+						s->f.data_len = 0x08;
+						memset(s->f.buf, 0, s->f.data_len);
+						s->f.buf[1] = 0x06;
+						break;
 					case REQUEST_SENSE:
 					{
 						s->f.mode = USB_MSDM_CBW;


### PR DESCRIPTION
### Description of Changes
Support additional commands for Sony MSAC-US1 storage device

### Rationale behind Changes
Replicate the real device more accurately and enable picture viewing on PSX:
| <img width="350" src="https://github.com/user-attachments/assets/ddf46281-ea69-47f1-8b1a-c4e1c182c297" /> | <img width="350" src="https://github.com/user-attachments/assets/769c29dc-596d-4e5f-b594-09da1a82f7c7" /> |
|-|-|

### Suggested Testing Steps
none