### PR TITLE
GS/HW: Add two pass and three pass primid AA1.

### DIFF
--- a/bin/resources/shaders/dx11/convert.fx
+++ b/bin/resources/shaders/dx11/convert.fx
@@ -693,4 +693,11 @@ float ps_primid_image_init_3(PS_INPUT input) : SV_Target
 }
 #endif
 
+#if defined(__ps_primid_image_init_4__)
+float ps_primid_image_init_4(PS_INPUT input) : SV_Target
+{
+	return float(-1); // AA1 primid
+}
+#endif
+
 #endif // PIXEL_SHADER

--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -48,6 +48,8 @@
 #define PS_AA1_LINE 1
 #define PS_AA1_TRIANGLE 2
 #define PS_AA1_TRIANGLE_SW_Z 3
+#define PS_AA1_TRIANGLE_PRIMID 4
+#define PS_AA1_TRIANGLE_PRIMID_INIT 5
 #endif
 
 #ifndef PS_ROV_DEPTH_NONE
@@ -128,6 +130,8 @@
 #define VS_EXPAND_SPRITE 3
 #define VS_EXPAND_LINE_AA1 4
 #define VS_EXPAND_TRIANGLE_AA1 5
+#define VS_EXPAND_TRIANGLE_AA1_INTERIOR 6
+#define VS_EXPAND_TRIANGLE_AA1_EDGE 7
 #endif
 
 #define SW_BLEND (PS_BLEND_A || PS_BLEND_B || PS_BLEND_D)
@@ -139,11 +143,12 @@
 #define NEEDS_DEPTH_FOR_AA1 (PS_AA1 == PS_AA1_TRIANGLE_SW_Z)
 #define SW_DEPTH (NEEDS_DEPTH_FOR_AFAIL || NEEDS_DEPTH_FOR_ZTST || NEEDS_DEPTH_FOR_AA1)
 #define ZWRITE (PS_ZFLOOR || PS_ZCLAMP || SW_DEPTH)
+#define PRIMID_SETUP (PS_DATE == 1 || PS_DATE == 2 || PS_AA1 == PS_AA1_TRIANGLE_PRIMID_INIT)
 
 #define PS_RETURN_COLOR_ROV (!PS_NO_COLOR && PS_ROV_COLOR)
 #define PS_RETURN_COLOR (!PS_NO_COLOR && !PS_ROV_COLOR)
 #define PS_RETURN_DEPTH_ROV (PS_ROV_DEPTH == PS_ROV_DEPTH_READ_WRITE)
-#define PS_RETURN_DEPTH (ZWRITE && !PS_ROV_DEPTH)
+#define PS_RETURN_DEPTH (ZWRITE && !PS_ROV_DEPTH && !PRIMID_SETUP)
 #define PS_ROV_EARLYDEPTHSTENCIL (PS_ROV_COLOR && !PS_ROV_DEPTH && !ZWRITE)
 
 struct VS_INPUT
@@ -185,7 +190,8 @@ struct PS_INPUT
 #endif
 	float inv_cov : COLOR1; // We use the inverse to make it simpler to interpolate.
 	nointerpolation uint interior : COLOR2; // 1 for triangle interior; 0 for edge;
-#if (PS_DATE >= 1 && PS_DATE <= 3) || GS_FORWARD_PRIMID
+#if (PS_DATE >= 1 && PS_DATE <= 3) || (PS_AA1 == PS_AA1_TRIANGLE_PRIMID) || \
+	(PS_AA1 == PS_AA1_TRIANGLE_PRIMID_INIT) || GS_FORWARD_PRIMID
 	uint primid : SV_PrimitiveID;
 #endif
 };
@@ -206,7 +212,7 @@ struct PS_OUTPUT
 		#undef NUM_RTS
 		#define NUM_RTS 1
 		
-		#if !PS_NO_COLOR1
+		#if !PS_NO_COLOR1 && !PRIMID_SETUP
 			float4 c1 : SV_Target1;
 		#endif
 	#endif
@@ -1441,23 +1447,31 @@ if (bad)
 	discard;
 #endif
 
-#if PS_DATE == 3
-	// Note gl_PrimitiveID == stencil_ceil will be the primitive that will update
-	// the bad alpha value so we must keep it.
-	int stencil_ceil = int(PrimMinTexture.Load(int3(input.p.xy, 0)));
-	if (int(input.primid) > stencil_ceil)
-		discard;
-#endif
+#if PS_DATE == 3 || PS_AA1 == PS_AA1_TRIANGLE_PRIMID
+
+	int primid_limit = int(PrimMinTexture.Load(int3(input.p.xy, 0)));
+
+	#if PS_DATE == 3
+		// Note gl_PrimitiveID == primid_limit will be the primitive that will update
+		// the bad alpha value so we must keep it.
+		if (int(input.primid) > primid_limit)
+			discard;
+	#endif
+
+	#if PS_AA1 == PS_AA1_TRIANGLE_PRIMID
+		// Discard if this edge is under a previous triangle interior.
+		// Edge should never overlap with its own interior so < and <= should be the same here.
+		if (int(input.primid) <= primid_limit)
+			discard;
+	#endif
+
+#endif // primid DATE/AA1 discard
 
 	// Output values
 #if !PS_NO_COLOR
-	#if PS_DATE == 1 || PS_DATE == 2
-		float o_col0;
-	#else
-		float4 o_col0;
-		#if !PS_NO_COLOR1
-			float4 o_col1;
-		#endif
+	float4 o_col0;
+	#if !PS_NO_COLOR1 && !PRIMID_SETUP
+		float4 o_col1;
 	#endif
 #endif
 
@@ -1473,8 +1487,13 @@ if (bad)
 	// Pixel with alpha equal to 0 will failed (0-127)
 	o_col0 = (C.a < 127.5f) ? float(input.primid) : float(0x7FFFFFFF);
 
+#elif PS_AA1 == PS_AA1_TRIANGLE_PRIMID_INIT
+
+	// Multiply by 12 because there are 12x as many edge/cap triangles as interior triangles.
+	o_col0 = float(12 * input.primid);
+	
 #else
-	// Not primid DATE setup
+	// Not primid DATE/AA1 setup
 
 	ps_blend(C, alpha_blend, input.p.xy);
 
@@ -1541,7 +1560,7 @@ if (bad)
 
 	ps_fbmask(C, input.p.xy);
 
-#if (PS_AFAIL == AFAIL_RGB_ONLY_DSB) && !PS_NO_COLOR1
+#if (PS_AFAIL == AFAIL_RGB_ONLY_DSB) && !PS_NO_COLOR1 && !PRIMID_SETUP
 	// Use alpha blend factor to determine whether to update A.
 	alpha_blend.a = float(atst_pass);
 #endif
@@ -1550,7 +1569,7 @@ if (bad)
 #if !PS_NO_COLOR
 	o_col0.a = PS_RTA_CORRECTION ? C.a / 128.0f : C.a / 255.0f;
 	o_col0.rgb = PS_COLCLIP_HW ? float3(C.rgb / 65535.0f) : C.rgb / 255.0f;
-#if !PS_NO_COLOR1
+#if !PS_NO_COLOR1 && !PRIMID_SETUP
 	o_col1 = alpha_blend;
 #endif
 #endif // !PS_NO_COLOR
@@ -1590,7 +1609,7 @@ if (bad)
 	// Color write back
 #if PS_RETURN_COLOR
 	output.c0 = o_col0;
-	#if !PS_NO_COLOR1
+	#if !PS_NO_COLOR1 && !PRIMID_SETUP
 		output.c1 = o_col1;
 	#endif
 #elif PS_RETURN_COLOR_ROV
@@ -1920,7 +1939,7 @@ VS_OUTPUT vs_main_expand(uint vid : SV_VertexID)
 
 	return vtx;
 
-#elif VS_EXPAND == VS_EXPAND_TRIANGLE_AA1
+#elif (VS_EXPAND == VS_EXPAND_TRIANGLE_AA1 || VS_EXPAND == VS_EXPAND_TRIANGLE_AA1_INTERIOR || VS_EXPAND == VS_EXPAND_TRIANGLE_AA1_EDGE)
 
 	// Triangles with AA1 are expanded as follows:
 	// - Vertices 0-2: Interior of triangle (1 triangle).
@@ -1930,23 +1949,37 @@ VS_OUTPUT vs_main_expand(uint vid : SV_VertexID)
 	// - Vertices 21-26: First corner cap (2 triangles).
 	// - Vertices 27-32: Second corner cap (2 triangles).
 	// - Vertices 33-38: Third corner cap (2 triangles).
+	// With INTERIOR or EDGE the corresponding vertices are omitted.
 
+#if VS_EXPAND == VS_EXPAND_TRIANGLE_AA1
 	uint prim_id = vid / 39;
-	uint prim_offset = vid - 39 * prim_id; // range: 0-38
-	bool interior = prim_offset < 3;
-	bool edge = 3 <= prim_offset && prim_offset < 21;
+	uint prim_offset_interior = vid - 39 * prim_id; // used range: 0-2
+	uint prim_offset_edges = prim_offset_interior - 3; // used range: 0-17
+	uint prim_offset_caps = prim_offset_edges - 18; // used range: 0-17
+#elif VS_EXPAND == VS_EXPAND_TRIANGLE_AA1_INTERIOR
+	uint prim_id = vid / 3;
+	uint prim_offset_interior = vid - 3 * prim_id; // used range: 0-2
+	uint prim_offset_edges = -1; // unused
+	uint prim_offset_caps = -1; // unused
+#elif VS_EXPAND == VS_EXPAND_TRIANGLE_AA1_EDGE
+	uint prim_id = vid / 36;
+	uint prim_offset_interior = -1; // unused
+	uint prim_offset_edges = vid - 36 * prim_id; // used range: 0-17
+	uint prim_offset_caps = prim_offset_edges - 18; // used range: 0-17
+#endif
+	bool interior = 0 <= prim_offset_interior && prim_offset_interior < 3;
+	bool edge = 0 <= prim_offset_edges && prim_offset_edges < 18;
 
 	VS_OUTPUT vtx;
 	if (interior)
 	{
-		vtx = vs_main(load_vertex(load_index(3 * prim_id + prim_offset)));
+		vtx = vs_main(load_vertex(load_index(3 * prim_id + prim_offset_interior)));
 		vtx.inv_cov = 0.0f; // Full coverage
 		vtx.interior = 1;
 	}
 	else if (edge)
 	{
 		// Vertex indices for this edge. We need all 3 for determining exterior/interior.
-		uint prim_offset_edges = prim_offset - 3; // range: 0-17
 		uint i0 = prim_offset_edges / 6;
 		uint i1 = (i0 >= 2) ? i0 - 2 : i0 + 1;
 		uint i2 = (i0 >= 1) ? i0 - 1 : i0 + 2;
@@ -1975,11 +2008,10 @@ VS_OUTPUT vs_main_expand(uint vid : SV_VertexID)
 	else // Corner cap
 	{
 		// Vertex indices for this cap. We need all 3 for determining exterior/interior.
-		uint prim_offset_cap = prim_offset - 21; // range: 0-8
-		uint i0 = prim_offset_cap / 6;
+		uint i0 = prim_offset_caps / 6;
 		uint i1 = (i0 >= 2) ? i0 - 2 : i0 + 1;
 		uint i2 = (i0 >= 1) ? i0 - 1 : i0 + 2;
-		uint cap_offset = prim_offset_cap - 6 * i0; // range: 0-5
+		uint cap_offset = prim_offset_caps - 6 * i0; // range: 0-5
 
 		bool is_near_corner = cap_offset == 0 || cap_offset == 3;
 		bool is_far_corner = cap_offset == 2 || cap_offset == 5;

--- a/bin/resources/shaders/opengl/convert.glsl
+++ b/bin/resources/shaders/opengl/convert.glsl
@@ -18,10 +18,10 @@ void vs_main()
 	PSin_p = vec4(POSITION, 0.5f, 1.0f);
 	PSin_t = TEXCOORD0;
 	PSin_c = COLOR;
-	gl_Position = vec4(POSITION, 0.5f, 1.0f); // NOTE I don't know if it is possible to merge POSITION_OUT and gl_Position
+	gl_Position = vec4(POSITION, 0.5f, 1.0f);
 }
 
-#endif
+#endif // VERTEX_SHADER
 
 #ifdef FRAGMENT_SHADER
 
@@ -611,7 +611,9 @@ void ps_yuv()
 }
 #endif
 
-#if defined(ps_primid_image_init_0) || defined(ps_primid_image_init_1) || defined(ps_primid_image_init_2) || defined(ps_primid_image_init_3)
+#if defined(ps_primid_image_init_0) || defined(ps_primid_image_init_1) || \
+	defined(ps_primid_image_init_2) || defined(ps_primid_image_init_3) || \
+	defined(ps_primid_image_init_4)
 
 void main()
 {
@@ -633,7 +635,10 @@ void main()
 		if(sample_c().a < (254.5f / 255.0f)) // >= 0x80 pass
 			o_col0 = vec4(-1);
 	#endif
+	#ifdef ps_primid_image_init_4
+		o_col0 = vec4(-1); // AA1 primid
+	#endif
 }
 #endif
 
-#endif
+#endif // FRAGMENT_SHADER

--- a/bin/resources/shaders/opengl/tfx_fs.glsl
+++ b/bin/resources/shaders/opengl/tfx_fs.glsl
@@ -38,6 +38,8 @@
 #define PS_AA1_LINE 1
 #define PS_AA1_TRIANGLE 2
 #define PS_AA1_TRIANGLE_SW_Z 3
+#define PS_AA1_TRIANGLE_PRIMID 4
+#define PS_AA1_TRIANGLE_PRIMID_INIT 5
 #endif
 
 // TEX_COORD_DEBUG output the uv coordinate as color. It is useful
@@ -63,6 +65,7 @@
 #define NEEDS_TEX (PS_TFX != 4)
 #define SW_DEPTH (NEEDS_DEPTH_FOR_AFAIL || NEEDS_DEPTH_FOR_ZTST || NEEDS_DEPTH_FOR_AA1)
 #define ZWRITE (SW_DEPTH || PS_ZCLAMP || PS_ZFLOOR)
+#define PRIMID_SETUP (PS_DATE == 1 || PS_DATE == 2 || PS_AA1 == PS_AA1_TRIANGLE_PRIMID_INIT)
 
 layout(std140, binding = 0) uniform cb21
 {
@@ -134,7 +137,7 @@ in SHADER
 	#endif
 #endif
 
-#if !PS_NO_COLOR && !PS_NO_COLOR1
+#if !PS_NO_COLOR && !PS_NO_COLOR1 && !PRIMID_SETUP
 	// Same buffer but 2 colors for dual source blending
 	layout(location = 0, index = 0) TARGET_0_QUALIFIER vec4 o_col0;
 	layout(location = 0, index = 1) out vec4 o_col1;
@@ -144,7 +147,7 @@ in SHADER
 
 // Depth feedback mode 2 is for depth as color.
 // Use FB fetch for the feedback if it's available.
-#if SW_DEPTH && PS_NO_COLOR1 && (DEPTH_FEEDBACK_SUPPORT == 2)
+#if SW_DEPTH && PS_NO_COLOR1 && (DEPTH_FEEDBACK_SUPPORT == 2) && !PRIMID_SETUP
 	#if HAS_FRAMEBUFFER_FETCH
 		layout(location = 1) inout float o_col1;
 	#else
@@ -161,7 +164,7 @@ layout(binding = 1) uniform sampler2D PaletteSampler;
 layout(binding = 2) uniform sampler2D RtSampler; // note 2 already use by the image below
 #endif
 
-#if PS_DATE == 3
+#if PS_DATE == 3 || (PS_AA1 == PS_AA1_TRIANGLE_PRIMID)
 layout(binding = 3) uniform sampler2D img_prim_min;
 #endif
 
@@ -1240,17 +1243,28 @@ void ps_main()
 		discard;
 	}
 
-#endif
+#endif // PS_DATE >= 5
+
+#if PS_DATE == 3 || PS_AA1 == PS_AA1_TRIANGLE_PRIMID
+	int primid_limit = int(texelFetch(img_prim_min, ivec2(gl_FragCoord.xy), 0).r);
 
 #if PS_DATE == 3
-	int stencil_ceil = int(texelFetch(img_prim_min, ivec2(gl_FragCoord.xy), 0).r);
-	// Note gl_PrimitiveID == stencil_ceil will be the primitive that will update
+	// Note gl_PrimitiveID == primid_limit will be the primitive that will update
 	// the bad alpha value so we must keep it.
-
-	if (gl_PrimitiveID > stencil_ceil) {
+	if (gl_PrimitiveID > primid_limit) {
 		discard;
 	}
 #endif
+
+#if PS_AA1 == PS_AA1_TRIANGLE_PRIMID
+	// Discard if this edge is under a previous triangle interior.
+	// Edge should never overlap with its own interior so < and <= should be the same here.
+	if (gl_PrimitiveID <= primid_limit) {
+		discard;
+	}
+#endif
+
+#endif // primid DATE/AA1 discard
 
 	vec4 C = ps_color();
 
@@ -1310,6 +1324,10 @@ void ps_main()
 	// Pixel with alpha equal to 0 will failed (0-127)
 	o_col0 = (C.a < 127.5f) ? vec4(gl_PrimitiveID) : vec4(0x7FFFFFFF);
 	return;
+#elif PS_AA1 == PS_AA1_TRIANGLE_PRIMID_INIT
+	// Multiply by 12 because there are 12x as many edge triangles as interior triangles.
+	o_col0 = vec4(12 * gl_PrimitiveID);
+	return;
 #endif
 
 	ps_blend(C, alpha_blend);
@@ -1362,7 +1380,7 @@ void ps_main()
 
 	ps_fbmask(C);
 
-#if (PS_AFAIL == AFAIL_RGB_ONLY_DSB) && !PS_NO_COLOR1
+#if (PS_AFAIL == AFAIL_RGB_ONLY_DSB) && !PS_NO_COLOR1 && !PRIMID_SETUP
 	// Use alpha blend factor to determine whether to update A.
 	alpha_blend.a = float(atst_pass);
 #endif
@@ -1400,7 +1418,7 @@ void ps_main()
 	// FB fetch in sample_from_rt().
 	o_col0 = C;
 
-	#if !PS_NO_COLOR1
+	#if !PS_NO_COLOR1 && !PRIMID_SETUP
 		o_col1 = alpha_blend;
 	#endif
 #endif
@@ -1416,7 +1434,7 @@ void ps_main()
 
 // Writing back depth
 #if ZWRITE
-	#if SW_DEPTH && PS_NO_COLOR1 && (DEPTH_FEEDBACK_SUPPORT == 2)
+	#if SW_DEPTH && PS_NO_COLOR1 && (DEPTH_FEEDBACK_SUPPORT == 2) && !PRIMID_SETUP
 		// Depth as color write. For depth as color feedback we write to both
 		// color copy and real depth to avoid having to copy back to real depth.
 		// Warning: do not write o_col1 until the end since the value might

--- a/bin/resources/shaders/opengl/tfx_vgs.glsl
+++ b/bin/resources/shaders/opengl/tfx_vgs.glsl
@@ -26,6 +26,8 @@ layout(std140, binding = 1) uniform cb20
 #define VS_EXPAND_SPRITE 3
 #define VS_EXPAND_LINE_AA1 4
 #define VS_EXPAND_TRIANGLE_AA1 5
+#define VS_EXPAND_TRIANGLE_AA1_INTERIOR 6
+#define VS_EXPAND_TRIANGLE_AA1_EDGE 7
 #endif
 
 out SHADER
@@ -361,7 +363,7 @@ void main()
 	vtx.t_float.y = is_bottom ? lt.t_float.y : vtx.t_float.y;
 	vtx.t_int.yw = is_bottom ? lt.t_int.yw : vtx.t_int.yw;
 
-#elif VS_EXPAND == VS_EXPAND_TRIANGLE_AA1
+#elif (VS_EXPAND == VS_EXPAND_TRIANGLE_AA1 || VS_EXPAND == VS_EXPAND_TRIANGLE_AA1_INTERIOR || VS_EXPAND == VS_EXPAND_TRIANGLE_AA1_EDGE)
 
 	// Triangles with AA1 are expanded as follows:
 	// - Vertices 0-2: Interior of triangle (1 triangle).
@@ -371,22 +373,36 @@ void main()
 	// - Vertices 21-26: First corner cap (2 triangles).
 	// - Vertices 27-32: Second corner cap (2 triangles).
 	// - Vertices 33-38: Third corner cap (2 triangles).
+	// With INTERIOR or EDGE the corresponding vertices are omitted.
 
+#if VS_EXPAND == VS_EXPAND_TRIANGLE_AA1
 	uint prim_id = vid / 39;
-	uint prim_offset = vid - 39 * prim_id; // range: 0-38
-	bool interior = prim_offset < 3;
-	bool edge = 3 <= prim_offset && prim_offset < 21;
+	uint prim_offset_interior = vid - 39 * prim_id; // used range: 0-2
+	uint prim_offset_edges = prim_offset_interior - 3; // used range: 0-17
+	uint prim_offset_caps = prim_offset_edges - 18; // used range: 0-17
+#elif VS_EXPAND == VS_EXPAND_TRIANGLE_AA1_INTERIOR
+	uint prim_id = vid / 3;
+	uint prim_offset_interior = vid - 3 * prim_id; // used range: 0-2
+	uint prim_offset_edges = -1; // unused
+	uint prim_offset_caps = -1; // unused
+#elif VS_EXPAND == VS_EXPAND_TRIANGLE_AA1_EDGE
+	uint prim_id = vid / 36;
+	uint prim_offset_interior = -1; // unused
+	uint prim_offset_edges = vid - 36 * prim_id; // used range: 0-17
+	uint prim_offset_caps = prim_offset_edges - 18; // used range: 0-17
+#endif
+	bool interior = 0 <= prim_offset_interior && prim_offset_interior < 3;
+	bool edge = 0 <= prim_offset_edges && prim_offset_edges < 18;
 
 	if (interior)
 	{
-		vtx = load_vertex(load_index(3 * prim_id + prim_offset));
+		vtx = load_vertex(load_index(3 * prim_id + prim_offset_interior));
 		VSout.inv_cov = 0.0f; // Full coverage
 		VSout.interior = 1;
 	}
 	else if (edge)
 	{
 		// Vertex indices for this edge. We need all 3 for determining exterior/interior.
-		uint prim_offset_edges = prim_offset - 3; // range: 0-17
 		uint i0 = prim_offset_edges / 6;
 		uint i1 = (i0 >= 2) ? i0 - 2 : i0 + 1;
 		uint i2 = (i0 >= 1) ? i0 - 1 : i0 + 2;
@@ -415,11 +431,10 @@ void main()
 	else // Corner cap
 	{
 		// Vertex indices for this cap. We need all 3 for determining exterior/interior.
-		uint prim_offset_cap = prim_offset - 21; // range: 0-8
-		uint i0 = prim_offset_cap / 6;
+		uint i0 = prim_offset_caps / 6;
 		uint i1 = (i0 >= 2) ? i0 - 2 : i0 + 1;
 		uint i2 = (i0 >= 1) ? i0 - 1 : i0 + 2;
-		uint cap_offset = prim_offset_cap - 6 * i0; // range: 0-5
+		uint cap_offset = prim_offset_caps - 6 * i0; // range: 0-5
 
 		bool is_near_corner = cap_offset == 0 || cap_offset == 3;
 		bool is_far_corner = cap_offset == 2 || cap_offset == 5;

--- a/bin/resources/shaders/vulkan/convert.glsl
+++ b/bin/resources/shaders/vulkan/convert.glsl
@@ -624,7 +624,9 @@ void ps_yuv()
 }
 #endif
 
-#if defined(ps_primid_image_init_0) || defined(ps_primid_image_init_1) || defined(ps_primid_image_init_2) || defined(ps_primid_image_init_3)
+#if defined(ps_primid_image_init_0) || defined(ps_primid_image_init_1) || \
+	defined(ps_primid_image_init_2) || defined(ps_primid_image_init_3) || \
+	defined(ps_primid_image_init_4)
 
 void main()
 {
@@ -645,6 +647,9 @@ void main()
 	#ifdef ps_primid_image_init_3
 		if(sample_c(v_tex).a < (254.5f / 255.0f)) // >= 0x80 pass
 			o_col0 = vec4(-1);
+	#endif
+	#ifdef ps_primid_image_init_4
+		o_col0 = vec4(-1); // AA1 primid
 	#endif
 }
 #endif

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -14,6 +14,8 @@
 #define VS_EXPAND_SPRITE 3
 #define VS_EXPAND_LINE_AA1 4
 #define VS_EXPAND_TRIANGLE_AA1 5
+#define VS_EXPAND_TRIANGLE_AA1_INTERIOR 6
+#define VS_EXPAND_TRIANGLE_AA1_EDGE 7
 #endif
 
 layout(std140, set = 0, binding = 0) uniform cb0
@@ -356,7 +358,7 @@ void main()
 	vtx.t.y = is_bottom ? lt.t.y : vtx.t.y;
 	vtx.ti.yw = is_bottom ? lt.ti.yw : vtx.ti.yw;
 
-#elif VS_EXPAND == VS_EXPAND_TRIANGLE_AA1
+#elif (VS_EXPAND == VS_EXPAND_TRIANGLE_AA1 || VS_EXPAND == VS_EXPAND_TRIANGLE_AA1_INTERIOR || VS_EXPAND == VS_EXPAND_TRIANGLE_AA1_EDGE)
 
 	// Triangles with AA1 are expanded as follows:
 	// - Vertices 0-2: Interior of triangle (1 triangle).
@@ -366,22 +368,37 @@ void main()
 	// - Vertices 21-26: First corner cap (2 triangles).
 	// - Vertices 27-32: Second corner cap (2 triangles).
 	// - Vertices 33-38: Third corner cap (2 triangles).
+	// With INTERIOR or EDGE the corresponding vertices are omitted.
 
+#if VS_EXPAND == VS_EXPAND_TRIANGLE_AA1
 	uint prim_id = vid / 39;
-	uint prim_offset = vid - 39 * prim_id; // range: 0-38
-	bool interior = prim_offset < 3;
-	bool edge = 3 <= prim_offset && prim_offset < 21;
+	uint prim_offset_interior = vid - 39 * prim_id; // used range: 0-2
+	uint prim_offset_edges = prim_offset_interior - 3; // used range: 0-17
+	uint prim_offset_caps = prim_offset_edges - 18; // used range: 0-17
+#elif VS_EXPAND == VS_EXPAND_TRIANGLE_AA1_INTERIOR
+	uint prim_id = vid / 3;
+	uint prim_offset_interior = vid - 3 * prim_id; // used range: 0-2
+	uint prim_offset_edges = -1; // unused
+	uint prim_offset_caps = -1; // unused
+#elif VS_EXPAND == VS_EXPAND_TRIANGLE_AA1_EDGE
+	uint prim_id = vid / 36;
+	uint prim_offset_interior = -1; // unused
+	uint prim_offset_edges = vid - 36 * prim_id; // used range: 0-17
+	uint prim_offset_caps = prim_offset_edges - 18; // used range: 0-17
+#endif
+	bool interior = 0 <= prim_offset_interior && prim_offset_interior < 3;
+	bool edge = 0 <= prim_offset_edges && prim_offset_edges < 18;
 
 	if (interior)
 	{
-		vtx = load_vertex(load_index(3 * prim_id + prim_offset));
+		vtx = load_vertex(load_index(3 * prim_id + prim_offset_interior));
 		vsOut.inv_cov = 0.0f; // Full coverage
 		vsOut.interior = 1;
 	}
 	else if (edge)
 	{
 		// Vertex indices for this edge. We need all 3 for determining exterior/interior.
-		uint prim_offset_edges = prim_offset - 3; // range: 0-17
+		
 		uint i0 = prim_offset_edges / 6;
 		uint i1 = (i0 >= 2) ? i0 - 2 : i0 + 1;
 		uint i2 = (i0 >= 1) ? i0 - 1 : i0 + 2;
@@ -410,11 +427,10 @@ void main()
 	else // Corner cap
 	{
 		// Vertex indices for this cap. We need all 3 for determining exterior/interior.
-		uint prim_offset_cap = prim_offset - 21; // range: 0-8
-		uint i0 = prim_offset_cap / 6;
+		uint i0 = prim_offset_caps / 6;
 		uint i1 = (i0 >= 2) ? i0 - 2 : i0 + 1;
 		uint i2 = (i0 >= 1) ? i0 - 1 : i0 + 2;
-		uint cap_offset = prim_offset_cap - 6 * i0; // range: 0-5
+		uint cap_offset = prim_offset_caps - 6 * i0; // range: 0-5
 
 		bool is_near_corner = cap_offset == 0 || cap_offset == 3;
 		bool is_far_corner = cap_offset == 2 || cap_offset == 5;
@@ -513,6 +529,8 @@ void main()
 #define PS_AA1_LINE 1
 #define PS_AA1_TRIANGLE 2
 #define PS_AA1_TRIANGLE_SW_Z 3
+#define PS_AA1_TRIANGLE_PRIMID 4
+#define PS_AA1_TRIANGLE_PRIMID_INIT 5
 #endif
 
 #ifndef PS_ROV_DEPTH_NONE
@@ -588,11 +606,12 @@ void main()
 #define PS_FEEDBACK_LOOP_IS_NEEDED_RT (PS_TEX_IS_FB == 1 || AFAIL_NEEDS_RT || PS_FBMASK || SW_BLEND_NEEDS_RT || SW_AD_TO_HW || (PS_DATE >= 5))
 #define PS_FEEDBACK_LOOP_IS_NEEDED_DEPTH (AFAIL_NEEDS_DEPTH || ZTST_NEEDS_DEPTH || AA1_NEEDS_DEPTH)
 #define ZWRITE (PS_ZCLAMP || PS_ZFLOOR || SW_DEPTH || PS_FEEDBACK_LOOP_IS_NEEDED_DEPTH)
+#define PRIMID_SETUP (PS_DATE == 1 || PS_DATE == 2 || PS_AA1 == PS_AA1_TRIANGLE_PRIMID_INIT)
 
 #define PS_RETURN_COLOR_ROV (!PS_NO_COLOR && PS_ROV_COLOR)
 #define PS_RETURN_COLOR (!PS_NO_COLOR && !PS_ROV_COLOR)
 #define PS_RETURN_DEPTH_ROV (PS_ROV_DEPTH == PS_ROV_DEPTH_READ_WRITE)
-#define PS_RETURN_DEPTH (ZWRITE && !PS_ROV_DEPTH)
+#define PS_RETURN_DEPTH (ZWRITE && !PS_ROV_DEPTH && !PRIMID_SETUP)
 #define PS_ROV_EARLYDEPTHSTENCIL (PS_ROV_COLOR && !PS_ROV_DEPTH && !ZWRITE)
 
 #define NEEDS_TEX (PS_TFX != 4)
@@ -639,7 +658,7 @@ layout(location = 0) in VSOutput
 } vsIn;
 
 #if PS_RETURN_COLOR
-	#if !PS_NO_COLOR1
+	#if !PS_NO_COLOR1 && !PRIMID_SETUP
 		layout(location = 0, index = 0) out vec4 o_col0;
 		layout(location = 0, index = 1) out vec4 o_col1;
 	#elif !PS_NO_COLOR
@@ -693,7 +712,7 @@ layout(set = 1, binding = 1) uniform texture2D Palette;
 	#endif
 #endif
 
-#if PS_DATE > 0
+#if PS_DATE > 0 || (PS_AA1 == PS_AA1_TRIANGLE_PRIMID)
 layout(set = 1, binding = 3) uniform texture2D PrimMinTexture;
 #endif
 
@@ -1763,6 +1782,7 @@ void main()
 	if ((int(gl_FragCoord.y) & 1) == (PS_SCANMSK & 1))
 		DISCARD;
 #endif
+
 #if PS_DATE >= 5
 
 #if PS_WRITE_RG == 1
@@ -1792,17 +1812,28 @@ void main()
 		DISCARD;
 	}
 
-#endif		// PS_DATE >= 5
+#endif // PS_DATE >= 5
+
+#if PS_DATE == 3 || PS_AA1 == PS_AA1_TRIANGLE_PRIMID
+	int primid_limit = int(texelFetch(PrimMinTexture, ivec2(gl_FragCoord.xy), 0).r);
 
 #if PS_DATE == 3
-	int stencil_ceil = int(texelFetch(PrimMinTexture, ivec2(gl_FragCoord.xy), 0).r);
-	// Note gl_PrimitiveID == stencil_ceil will be the primitive that will update
+	// Note gl_PrimitiveID == primid_limit will be the primitive that will update
 	// the bad alpha value so we must keep it.
-
-	if (gl_PrimitiveID > stencil_ceil) {
+	if (gl_PrimitiveID > primid_limit) {
 		DISCARD;
 	}
 #endif
+
+#if PS_AA1 == PS_AA1_TRIANGLE_PRIMID
+	// Discard if this edge is under a previous triangle interior.
+	// Edge should never overlap with its own interior so < and <= should be the same here.
+	if (gl_PrimitiveID <= primid_limit) {
+		discard;
+	}
+#endif
+
+#endif // primid DATE/AA1 discard
 
 	vec4 C = ps_color();
 
@@ -1865,7 +1896,14 @@ void main()
 	// Pixel with alpha equal to 0 will failed (0-127)
 	o_col0 = (C.a < 127.5f) ? vec4(gl_PrimitiveID) : vec4(0x7FFFFFFF);
 
+#elif PS_AA1 == PS_AA1_TRIANGLE_PRIMID_INIT
+
+	// Multiply by 12 because there are 12x as many edge triangles as interior triangles.
+	o_col0 = vec4(12 * gl_PrimitiveID);
+
 #else
+	// Not primid DATE/AA1 setup
+
 	ps_blend(C, alpha_blend);
 
 	#if PS_SHUFFLE
@@ -1916,7 +1954,7 @@ void main()
 
 	ps_fbmask(C);
 
-	#if (PS_AFAIL == AFAIL_RGB_ONLY_DSB) && !PS_NO_COLOR1
+	#if (PS_AFAIL == AFAIL_RGB_ONLY_DSB) && !PS_NO_COLOR1 && !PRIMID_SETUP
 		// Use alpha blend factor to determine whether to update A.
 		alpha_blend.a = float(atst_pass);
 	#endif
@@ -1933,7 +1971,7 @@ void main()
 		#else
 			o_col0.rgb = C.rgb / 255.0f;
 		#endif
-		#if !PS_NO_COLOR1
+		#if !PS_NO_COLOR1 && !PRIMID_SETUP
 			o_col1 = alpha_blend;
 		#endif
 

--- a/pcsx2-qt/Settings/GraphicsHardwareRenderingSettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsHardwareRenderingSettingsTab.ui
@@ -48,7 +48,7 @@
      </item>
     </widget>
    </item>
-   <item row="6" column="0" colspan="2">
+   <item row="7" column="0" colspan="2">
     <layout class="QGridLayout" name="hardwareRenderingOptionsLayout">
      <item row="0" column="1">
       <widget class="QCheckBox" name="accurateAlphaTest">
@@ -65,20 +65,13 @@
       </widget>
      </item>
      <item row="1" column="0">
-      <widget class="QCheckBox" name="hwAA1">
-       <property name="text">
-        <string>AA1</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
       <widget class="QCheckBox" name="rov">
         <property name="text">
          <string>Rasterizer Ordered View</string>
         </property>
       </widget>
      </item>
-     <item row="2" column="0">
+     <item row="1" column="1">
       <widget class="QCheckBox" name="enableHWFixes">
        <property name="text">
         <string>Manual Hardware Renderer Fixes</string>
@@ -147,6 +140,16 @@
      </property>
     </widget>
    </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="blendingLabel">
+     <property name="text">
+      <string>Blending Accuracy:</string>
+     </property>
+     <property name="buddy">
+      <cstring>blending</cstring>
+     </property>
+    </widget>
+   </item>
    <item row="5" column="1">
     <widget class="QComboBox" name="blending">
      <item>
@@ -181,6 +184,45 @@
      </item>
     </widget>
    </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="hwAA1Label">
+     <property name="text">
+      <string>AA1 Accuracy:</string>
+     </property>
+     <property name="buddy">
+      <cstring>hwAA1</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1">
+    <widget class="QComboBox" name="hwAA1">
+     <item>
+      <property name="text">
+       <string>Off (Default)</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Lines Only</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Low</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Medium (Slow)</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>High (Very Slow)</string>
+      </property>
+     </item>
+    </widget>
+   </item>
    <item row="2" column="1">
     <widget class="QComboBox" name="trilinearFiltering">
      <item>
@@ -205,16 +247,6 @@
      </item>
     </widget>
    </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="blendingLabel">
-     <property name="text">
-      <string>Blending Accuracy:</string>
-     </property>
-     <property name="buddy">
-      <cstring>blending</cstring>
-     </property>
-    </widget>
-   </item>
    <item row="2" column="0">
     <widget class="QLabel" name="trilinearFilterLabel">
      <property name="text">
@@ -225,7 +257,7 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="0">
+   <item row="8" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Orientation::Vertical</enum>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -112,10 +112,11 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_hw.dithering, "EmuCore/GS", "dithering_ps2", 2);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_hw.mipmapping, "EmuCore/GS", "hw_mipmap", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_hw.accurateAlphaTest, "EmuCore/GS", "HWAccurateAlphaTest", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_hw.hwAA1, "EmuCore/GS", "HWAA1", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_hw.rov, "EmuCore/GS", "HWROV", false);
 	SettingWidgetBinder::BindWidgetToIntSetting(
 		sif, m_hw.blending, "EmuCore/GS", "accurate_blending_unit", static_cast<int>(AccBlendLevel::Basic));
+	SettingWidgetBinder::BindWidgetToIntSetting(
+		sif, m_hw.hwAA1, "EmuCore/GS", "HWAA1", static_cast<int>(GSHWAA1Level::LinesOnly));
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_hw.enableHWFixes, "EmuCore/GS", "UserHacks", false);
 	connect(m_hw.upscaleMultiplier, &QComboBox::currentIndexChanged, this,
 		&GraphicsSettingsWidget::onUpscaleMultiplierChanged);
@@ -497,9 +498,6 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 			m_hw.accurateAlphaTest, tr("Accurate Alpha Test"), tr("Unchecked"), tr("Enables accurate alpha testing, which some games require to render correctly. This may require more draw calls and result in a speed penalty."));
 
 		dialog()->registerWidgetHelp(
-			m_hw.hwAA1, tr("AA1"), tr("Unchecked"), tr("Enables AA1 (PS2 antialiasing), which some games require to render correctly. This may result in a heavy performance penalty."));
-
-		dialog()->registerWidgetHelp(
 			m_hw.rov, tr("Rasterizer Ordered View"), tr("Unchecked"), tr("Enables Rasterizer Ordered View (ROV), which allows feedback loops to be executed with fewer draw calls. Can improve performance in feedback heavy games with higher accuracy settings."));
 
 		dialog()->registerWidgetHelp(
@@ -529,6 +527,10 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 		dialog()->registerWidgetHelp(m_hw.blending, tr("Blending Accuracy"), tr("Basic (Recommended)"),
 			tr("Control the accuracy level of the GS blending unit emulation.<br> "
 			   "The higher the setting, the more blending is emulated in the shader accurately, and the higher the speed penalty will be."));
+
+		dialog()->registerWidgetHelp(m_hw.hwAA1, tr("AA1 Accuracy"), tr("Off (Default)"),
+			tr("Control the accuracy level of AA1 (PS2 antialiasing).<br> "
+			   "The higher the setting, the more AA1 is emulated in the shader accurately, and the higher the speed penalty will be."));
 
 		dialog()->registerWidgetHelp(m_advanced.texturePreloading, tr("Texture Preloading"), tr("Full (Hash Cache)"),
 			tr("Uploads entire textures at once instead of in small pieces, avoiding redundant uploads when possible. "

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -477,6 +477,15 @@ enum class GSDepthFeedbackMode : u8
 	DepthAsRT = 3,
 };
 
+enum class GSHWAA1Level : u8
+{
+	Off       = 0,
+	LinesOnly = 1,
+	Low       = 2,
+	Medium    = 3,
+	High      = 4,
+};
+
 enum class AchievementOverlayPosition : u8
 {
 	TopLeft,
@@ -726,6 +735,7 @@ struct Pcsx2Config
 		static constexpr AccBlendLevel DEFAULT_BLENDING_ACCURACY = AccBlendLevel::Basic;
 		static constexpr BiFiltering DEFAULT_TEXTURE_FILTERING_MODE = BiFiltering::PS2;
 		static constexpr TriFiltering DEFAULT_TRILINEAR_FILTERING_MODE = TriFiltering::Automatic;
+		static constexpr GSHWAA1Level DEFAULT_AA1_LEVEL = GSHWAA1Level::Off;
 
 		static constexpr float DEFAULT_OSD_SCALE = 100.0f;
 		static constexpr float DEFAULT_OSD_MARGIN = 10.0f;
@@ -794,7 +804,6 @@ struct Pcsx2Config
 					Mipmap : 1,
 					HWMipmap : 1,
 					HWAccurateAlphaTest : 1,
-					HWAA1 : 1,
 					HWROV : 1,
 					HWROVLogging : 1,
 					HWROVBarriersVK : 1,
@@ -895,6 +904,7 @@ struct Pcsx2Config
 		TriFiltering TriFilter = DEFAULT_TRILINEAR_FILTERING_MODE;
 		s8 OverrideTextureBarriers = -1;
 		GSDepthFeedbackMode DepthFeedbackMode = GSDepthFeedbackMode::Auto;
+		GSHWAA1Level HWAA1 = DEFAULT_AA1_LEVEL;
 
 		u8 CAS_Sharpness = 50;
 		u8 ShadeBoost_Brightness = DEFAULT_SHADEBOOST_BRIGHTNESS;

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -6497,32 +6497,41 @@ void GSState::CalcAlphaMinMax(const int tex_alpha_min, const int tex_alpha_max)
 
 	m_vt.m_alpha.min = min;
 	m_vt.m_alpha.max = max;
-	m_vt.m_alpha.depth_min = min;
-	m_vt.m_alpha.depth_max = max;
+	m_vt.m_alpha.interior_min = min;
+	m_vt.m_alpha.interior_max = max;
+	m_vt.m_alpha.edge_min = min;
+	m_vt.m_alpha.edge_max = max;
 	m_vt.m_alpha.valid = true;
 
 	if (IsCoverageAlphaSupported())
 	{
-		// Expand the alpha range depending on what the AA1 can do to the alpha.
-		
+		// Separate handling for edges and interior to allow AA1 optimizations.
 		if (PRIM->ABE)
 		{
-			// ABE==1: Coverage is used for alpha only used when incoming alpha is exactly 128.
-			// If 128 is in the incoming range, expand it down to 0, since edges could be 0-127.
-			// Don't change depth min, since depth isn't written on the edges.
+			// ABE==1: Coverage is used for alpha on edges only when incoming alpha is exactly 128.
 			if (min <= 128 && 128 <= max)
 			{
-				m_vt.m_alpha.min = std::min(0, min);
+				m_vt.m_alpha.edge_min = 0;
+				m_vt.m_alpha.edge_max = (min == 128 && max == 128) ? 127 : max;
 			}
 		}
 		else
 		{
-			// ABE==0: Coverage is always used for alpha, so assume exactly 0-128.
-			// Assume exactly 128 for depth, since depth isn't written on the edges.
-			m_vt.m_alpha.min = 0;
-			m_vt.m_alpha.max = 128;
-			m_vt.m_alpha.depth_min = 128;
-			m_vt.m_alpha.depth_max = 128;
+			// ABE==0: Coverage is always used for alpha.
+			m_vt.m_alpha.interior_min = 128;
+			m_vt.m_alpha.interior_max = 128;
+			m_vt.m_alpha.edge_min = 0;
+			m_vt.m_alpha.edge_max = 127;
+		}
+
+		// Update main range to reflect AA1 interiors/edges.
+		m_vt.m_alpha.min = m_vt.m_alpha.edge_min;
+		m_vt.m_alpha.max = m_vt.m_alpha.edge_max;
+		if (m_vt.m_primclass == GS_TRIANGLE_CLASS)
+		{
+			// Only triangles have an interior.
+			m_vt.m_alpha.min = std::min(m_vt.m_alpha.min, m_vt.m_alpha.interior_min);
+			m_vt.m_alpha.max = std::max(m_vt.m_alpha.max, m_vt.m_alpha.interior_max);
 		}
 	}
 }
@@ -6562,7 +6571,7 @@ void GSState::CorrectATEAlphaMinMax(const u32 atst, const int aref)
 	m_vt.m_alpha.max = amax;
 }
 
-bool GSState::TryAlphaTest(u32& fm, u32& zm)
+bool GSState::TryAlphaTest(u32& fm, u32& zm, TryAlphaTestRegion region)
 {
 	// Shortcut for the easy case
 	if (m_context->TEST.ATST == ATST_ALWAYS)
@@ -6601,13 +6610,14 @@ bool GSState::TryAlphaTest(u32& fm, u32& zm)
 		ALL_FAIL,
 	};
 
-	AlphaTestResult result, depth_result;
+	AlphaTestResult result = UNKNOWN, interior_result = UNKNOWN, edge_result = UNKNOWN;
 
 	if (m_context->TEST.ATST == ATST_NEVER)
 	{
 		// Shortcut for NEVER to avoid GetAlphaMinMax below.
 		result = ALL_FAIL;
-		depth_result = ALL_FAIL;
+		interior_result = ALL_FAIL;
+		edge_result = ALL_FAIL;
 	}
 	else
 	{
@@ -6683,11 +6693,24 @@ bool GSState::TryAlphaTest(u32& fm, u32& zm)
 		};
 
 		result = GetResult(aminmax.min, aminmax.max);
-		depth_result = (result != UNKNOWN) ? result : GetResult(aminmax.depth_min, aminmax.depth_max);
+		interior_result = (result != UNKNOWN) ? result : GetResult(aminmax.interior_min, aminmax.interior_max);
+		edge_result = (result != UNKNOWN) ? result : GetResult(aminmax.edge_min, aminmax.edge_max);
+		
+		switch (region)
+		{
+			case TryAlphaTestRegion::INTERIOR:
+				result = interior_result;
+				break;
+			case TryAlphaTestRegion::EDGE:
+				result = edge_result;
+				break;
+			default:
+				break;
+		}
 	}
 
 	const u32 fail_fm = (result == ALL_FAIL) ? 0xffffffff : 0x0;
-	const u32 fail_zm = (depth_result == ALL_FAIL) ? 0xffffffff : 0x0;
+	const u32 fail_zm = (interior_result == ALL_FAIL) ? 0xffffffff : 0x0; // Depth only written in interiors.
 
 	switch (fail_type)
 	{

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -215,8 +215,18 @@ protected:
 		GSVector4i coverage; ///< Part of the texture used
 		u8 uses_boundary;    ///< Whether or not the usage touches the left, top, right, or bottom edge (and therefore needs wrap modes preserved)
 	};
+
+	// For optimizing alpha separately on AA1 triangle edges/interiors.
+	// For all other cases only ALL is used.
+	enum class TryAlphaTestRegion
+	{
+		ALL,
+		INTERIOR,
+		EDGE,
+	};
+
 	TextureMinMaxResult GetTextureMinMax(GIFRegTEX0 TEX0, GIFRegCLAMP CLAMP, bool linear, bool clamp_to_tsize);
-	bool TryAlphaTest(u32& fm, u32& zm);
+	bool TryAlphaTest(u32& fm, u32& zm, TryAlphaTestRegion region = TryAlphaTestRegion::ALL);
 	bool IsFlatShaded();
 	bool IsOpaque();
 	bool IsMipMapDraw();

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -1272,12 +1272,15 @@ static const char* GetVSExpandName(GSHWDrawConfig::VSExpand vsexpand)
 {
 	switch (vsexpand)
 	{
-		case GSHWDrawConfig::VSExpand::None:        return "None";
-		case GSHWDrawConfig::VSExpand::Point:       return "Point";
-		case GSHWDrawConfig::VSExpand::Line:        return "Line";
-		case GSHWDrawConfig::VSExpand::Sprite:      return "Sprite";
-		case GSHWDrawConfig::VSExpand::LineAA1:     return "LineAA1";
-		case GSHWDrawConfig::VSExpand::TriangleAA1: return "TriangleAA1";
+		case GSHWDrawConfig::VSExpand::None:                return "None";
+		case GSHWDrawConfig::VSExpand::Point:               return "Point";
+		case GSHWDrawConfig::VSExpand::Line:                return "Line";
+		case GSHWDrawConfig::VSExpand::Sprite:              return "Sprite";
+		case GSHWDrawConfig::VSExpand::LineAA1:             return "LineAA1";
+		case GSHWDrawConfig::VSExpand::TriangleAA1:         return "TriangleAA1";
+		case GSHWDrawConfig::VSExpand::TriangleAA1Interior: return "TriangleAA1Interior";
+		case GSHWDrawConfig::VSExpand::TriangleAA1Edge:     return "TriangleAA1Edge";
+		default: break;
 	}
 	return "Unknown";
 }
@@ -1494,6 +1497,20 @@ static const char* GetDestinationAlphaModeName(GSHWDrawConfig::DestinationAlphaM
 	return "Unknown";
 }
 
+static const char* GetAA1ModeName(GSHWDrawConfig::AA1Mode datm)
+{
+	switch (datm)
+	{
+		case GSHWDrawConfig::AA1Mode::Off:             return "Off";
+		case GSHWDrawConfig::AA1Mode::OnePass:         return "OnePass";
+		case GSHWDrawConfig::AA1Mode::TwoPass:         return "TwoPass";
+		case GSHWDrawConfig::AA1Mode::ThreePassPrimid: return "ThreePassPrimid";
+		case GSHWDrawConfig::AA1Mode::DepthFeedback:   return "DepthFeedback";
+	}
+	return "Unknown";
+}
+
+
 static const char* GetColClipModeName(GSHWDrawConfig::ColClipMode ccmode)
 {
 	switch (ccmode)
@@ -1646,7 +1663,7 @@ static void DumpBlendState(DrawConfigWriter& out, const GSHWDrawConfig::BlendSta
 	DumpBlendEquation(out, "equation_alpha", GSDevice::OP_ADD, bs.src_factor_alpha, bs.dst_factor_alpha);
 }
 
-static void DumpDepthStencilSelctor(DrawConfigWriter& out, const GSHWDrawConfig::DepthStencilSelector& dss)
+static void DumpDepthStencilSelector(DrawConfigWriter& out, const GSHWDrawConfig::DepthStencilSelector& dss)
 {
 	out.WriteLn("ztst: {} ({})", GSUtil::GetZTSTName(dss.ztst), dss.ztst);
 	out.WriteLn("zwe: {}", dss.zwe);
@@ -1675,7 +1692,7 @@ static void DumpAlphaPass(DrawConfigWriter& out, const GSHWDrawConfig::AlphaPass
 	DumpPSSelector(out.WithIndent(), ap.ps);
 
 	out.WriteLn("dss:");
-	DumpDepthStencilSelctor(out.WithIndent(), ap.depth);
+	DumpDepthStencilSelector(out.WithIndent(), ap.depth);
 }
 
 static void DumpBlendMultipass(DrawConfigWriter& out, const GSHWDrawConfig::BlendMultiPass& bmp)
@@ -1687,6 +1704,25 @@ static void DumpBlendMultipass(DrawConfigWriter& out, const GSHWDrawConfig::Blen
 
 	out.WriteLn("blend:");
 	DumpBlendState(out.WithIndent(), bmp.blend);
+}
+
+static void DumpAA1Pass(DrawConfigWriter& out, const GSHWDrawConfig::AA1Pass& ap)
+{
+	out.WriteLn("enable: {}", ap.enable);
+	out.WriteLn("colormask: {:x}", ap.colormask.wrgba);
+	out.WriteLn("ps_aref: {}", ap.ps_aref);
+
+	out.WriteLn("vs:");
+	DumpVSSelector(out.WithIndent(), ap.vs);
+
+	out.WriteLn("ps:");
+	DumpPSSelector(out.WithIndent(), ap.ps);
+
+	out.WriteLn("dss:");
+	DumpDepthStencilSelector(out.WithIndent(), ap.depth);
+
+	out.WriteLn("blend:");
+	DumpBlendState(out.WithIndent(), ap.blend);
 }
 
 template<typename T, typename U = int>
@@ -1735,7 +1771,7 @@ static void DumpVSConstantBuffer(DrawConfigWriter& out, const GSHWDrawConfig::VS
 }
 
 static void DumpConfig(DrawConfigWriter& out, const GSHWDrawConfig& conf,
-	bool ps, bool vs, bool bs, bool dss, bool ss, bool asp, bool bmp, bool cbvs, bool cbps)
+	bool ps, bool vs, bool bs, bool dss, bool ss, bool asp, bool bmp, bool aa1mp, bool cbvs, bool cbps)
 {
 	out.WriteLn("topology: {} ({})", GetTopologyName(conf.topology), static_cast<u32>(conf.topology));
 	out.WriteLn("require_one_barrier: {}", conf.require_one_barrier);
@@ -1748,6 +1784,8 @@ static void DumpConfig(DrawConfigWriter& out, const GSHWDrawConfig& conf,
 	out.WriteLn("datm: {} ({})", GetSetDATMName(conf.datm), static_cast<u32>(conf.datm));
 	out.WriteLn("line_expand: {}", conf.line_expand);
 	out.WriteLn("colormask: {:x}", conf.colormask.wrgba);
+
+	out.WriteLn("aa1_mode: {} ({})", GetAA1ModeName(conf.aa1_mode), static_cast<u32>(conf.aa1_mode));
 
 	if (ps)
 	{
@@ -1776,7 +1814,7 @@ static void DumpConfig(DrawConfigWriter& out, const GSHWDrawConfig& conf,
 	if (dss)
 	{
 		out.WriteLn("depth:");
-		DumpDepthStencilSelctor(out.WithIndent(), conf.depth);
+		DumpDepthStencilSelector(out.WithIndent(), conf.depth);
 	}
 	
 	if (asp)
@@ -1789,6 +1827,12 @@ static void DumpConfig(DrawConfigWriter& out, const GSHWDrawConfig& conf,
 	{
 		out.WriteLn("blend_multi_pass:");
 		DumpBlendMultipass(out.WithIndent(), conf.blend_multi_pass);
+	}
+
+	if (aa1mp)
+	{
+		out.WriteLn("aa1_multi_pass:");
+		DumpAA1Pass(out.WithIndent(), conf.aa1_multi_pass);
 	}
 
 	if (cbvs)
@@ -1805,12 +1849,12 @@ static void DumpConfig(DrawConfigWriter& out, const GSHWDrawConfig& conf,
 }
 
 void GSHWDrawConfig::DumpConfig(const std::string& path, const GSHWDrawConfig& conf,
-	bool ps, bool vs, bool bs, bool dss, bool ss, bool asp, bool bmp, bool cbvs, bool cbps)
+	bool ps, bool vs, bool bs, bool dss, bool ss, bool asp, bool bmp, bool aa1mp, bool cbvs, bool cbps)
 {
 	if (FileSystem::ManagedCFilePtr file = FileSystem::OpenManagedCFile(path.c_str(), "w"))
 	{
 		DrawConfigWriter writer;
-		::DumpConfig(writer, conf, ps, vs, bs, dss, ss, asp, bmp, cbvs, cbps);
+		::DumpConfig(writer, conf, ps, vs, bs, dss, ss, asp, bmp, aa1mp, cbvs, cbps);
 		fwrite(writer.buffer.data(), 1, writer.buffer.size(), file.get());
 	}
 }

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -696,7 +696,7 @@ struct alignas(16) GSHWDrawConfig
 		__fi bool UseFixedExpandIndexBuffer() const { return (expand == VSExpand::Point || expand == VSExpand::Sprite); }
 		
 		/// Return true if the index buffer should be bound as a vertex shader resource.
-		__fi bool UseVSExpandIndexBuffer() const { return (expand == VSExpand::TriangleAA1); }
+		__fi bool UseVSExpandIndexBuffer() const { return (expand >= VSExpand::TriangleAA1 && expand <= VSExpand::TriangleAA1Edge); }
 	};
 	static_assert(sizeof(VSSelector) == 1, "VSSelector is a single byte");
 
@@ -788,7 +788,7 @@ struct alignas(16) GSHWDrawConfig
 				u32 scanmsk : 2;
 
 				// AA1
-				PS_AA1 aa1 : 2; // Pixel shader AA1 primitive. Must be used in conjunction with VS AA1 expand.
+				PS_AA1 aa1 : 3; // Pixel shader AA1 primitive. Must be used in conjunction with VS AA1 expand.
 				u32 abe : 1; // Alpha blend enabled. Currently only used for emulating AA1/ABE interaction.
 
 				// Anisotropic filtering
@@ -905,6 +905,12 @@ struct alignas(16) GSHWDrawConfig
 		__fi bool HasDepthROVWrite() const
 		{
 			return rov_depth == PS_ROV_DEPTH::READ_WRITE;
+		}
+
+		__fi void DisableAlphaTest()
+		{
+			atst = PS_ATST::NONE;
+			afail = PS_AFAIL::KEEP;
 		}
 	};
 	static_assert(sizeof(PSSelector) == 16, "PSSelector is 12 bytes");
@@ -1228,6 +1234,20 @@ struct alignas(16) GSHWDrawConfig
 		Full,           ///< Full emulation (using barriers / ROV)
 	};
 
+	enum class AA1Mode : u8
+	{
+		Off,             ///< No AA1
+		OnePass,         ///< Lines or triangles without depth write
+		TwoPass,         ///< Two passes: interiors then edges
+		ThreePassPrimid, ///< Three passes: primid setup, interiors, then edges (with primid discard)
+		DepthFeedback,   ///< Full emulation (using depth feedback barriers)
+	};
+
+	static constexpr bool IsAA1MultiPass(AA1Mode mode)
+	{
+		return mode == AA1Mode::TwoPass || mode == AA1Mode::ThreePassPrimid;
+	}
+
 	enum class ColClipMode : u8
 	{
 		NoModify = 0,
@@ -1272,6 +1292,8 @@ struct alignas(16) GSHWDrawConfig
 	} tex_hazard;
 
 	AlphaTestMode alpha_test;
+	
+	AA1Mode aa1_mode;
 
 	DestinationAlphaMode destination_alpha;
 	SetDATM datm;
@@ -1303,6 +1325,19 @@ struct alignas(16) GSHWDrawConfig
 
 	BlendMultiPass blend_multi_pass;
 
+	struct AA1Pass
+	{
+		alignas(8) VSSelector vs;
+		alignas(8) PSSelector ps;
+		bool enable : 1;
+		ColorMaskSelector colormask;
+		DepthStencilSelector depth;
+		BlendState blend;
+		float ps_aref;
+	};
+
+	AA1Pass aa1_multi_pass;
+
 	VSConstantBuffer cb_vs;
 	PSConstantBuffer cb_ps;
 	
@@ -1325,11 +1360,119 @@ struct alignas(16) GSHWDrawConfig
 	{
 		return blend.enable || blend_multi_pass.enable || ps.IsSWBlending();
 	}
+	
+	// Draw pass selectors
+	enum class DrawPass
+	{
+		Main,
+		AlphaSecond,
+		AA1Second,
+		PrimID,
+		Blend,
+	};
+
+	bool GetFullBarrier(DrawPass pass) const
+	{
+		switch (pass)
+		{
+			default:
+			case DrawPass::Main: return require_full_barrier;
+			case DrawPass::AlphaSecond: return alpha_second_pass.require_full_barrier;
+			case DrawPass::AA1Second: return require_full_barrier;
+			case DrawPass::PrimID: return false;
+			case DrawPass::Blend: return false;
+		}
+	}
+
+	bool GetOneBarrier(DrawPass pass) const
+	{
+		switch (pass)
+		{
+			default:
+			case DrawPass::Main: return require_one_barrier;
+			case DrawPass::AlphaSecond: return alpha_second_pass.require_one_barrier;
+			case DrawPass::AA1Second: return require_one_barrier;
+			case DrawPass::PrimID: return false;
+			case DrawPass::Blend: return false;
+		}
+	}
+
+	const VSSelector& GetVS(DrawPass pass) const
+	{
+		switch (pass)
+		{
+			default:
+			case DrawPass::Main: return vs;
+			case DrawPass::AlphaSecond: return vs;
+			case DrawPass::AA1Second: return aa1_multi_pass.vs;
+			case DrawPass::Blend: return vs;
+			case DrawPass::PrimID: return vs;
+		}
+	}
+
+	const PSSelector& GetPS(DrawPass pass) const
+	{
+		switch (pass)
+		{
+			default:
+			case DrawPass::Main: return ps;
+			case DrawPass::AlphaSecond: return alpha_second_pass.ps;
+			case DrawPass::AA1Second: return aa1_multi_pass.ps;
+			case DrawPass::Blend: return ps;
+			case DrawPass::PrimID: return ps;
+		}
+	}
+
+	ColorMaskSelector GetColorMask(DrawPass pass) const
+	{
+		switch (pass)
+		{
+			default:
+			case DrawPass::Main: return colormask;
+			case DrawPass::AlphaSecond: return alpha_second_pass.colormask;
+			case DrawPass::AA1Second: return aa1_multi_pass.colormask;
+			case DrawPass::Blend: return colormask;
+			case DrawPass::PrimID: return GSHWDrawConfig::ColorMaskSelector(1);
+		}
+	}
+
+	DepthStencilSelector GetDepth(DrawPass pass) const
+	{
+		switch (pass)
+		{
+			default:
+			case DrawPass::Main: return depth;
+			case DrawPass::AlphaSecond: return alpha_second_pass.depth;
+			case DrawPass::AA1Second: return aa1_multi_pass.depth;
+			case DrawPass::Blend: return depth;
+			case DrawPass::PrimID:
+			{
+				DepthStencilSelector primid_depth = depth;
+				primid_depth.zwe = false;
+				return primid_depth;
+			}
+		}
+	}
+
+	bool IsAA1Enabled() const
+	{
+		return aa1_mode != AA1Mode::Off;
+	}
+
+	// Disables all AA1 config EXCEPT for vertex shader, which cannot be disabled without additional info.
+	void DisableAA1()
+	{
+		aa1_mode = AA1Mode::Off;
+		aa1_multi_pass.enable = false;
+		ps.aa1 = PS_AA1::NONE;
+		if (alpha_second_pass.enable)
+			ps.aa1 = PS_AA1::NONE;
+	}
 
 	// Dumping
 	static void DumpConfig(const std::string& path, const GSHWDrawConfig& conf,
 		bool ps = true, bool vs = true, bool bs = true, bool dss = true, bool ss = true, bool asp = true, bool bmp = true,
-		bool cbvs = true, bool cbps = true);
+		bool aa1mp = true, bool cbvs = true, bool cbps = true);
 };
 
 static inline u32 GetExpansionFactor(GSHWDrawConfig::VSExpand expand)
@@ -1344,6 +1487,10 @@ static inline u32 GetExpansionFactor(GSHWDrawConfig::VSExpand expand)
 			return 2;
 		case GSHWDrawConfig::VSExpand::TriangleAA1:
 			return 13;
+		case GSHWDrawConfig::VSExpand::TriangleAA1Interior:
+			return 1;
+		case GSHWDrawConfig::VSExpand::TriangleAA1Edge:
+			return 12;
 		default:
 			return 1;
 	}

--- a/pcsx2/GS/Renderers/Common/GSShaderEnums.h
+++ b/pcsx2/GS/Renderers/Common/GSShaderEnums.h
@@ -11,12 +11,15 @@ namespace GSShader {
 
 enum class VSExpand : uint8_t
 {
-	None        = 0,
-	Point       = 1,
-	Line        = 2,
-	Sprite      = 3,
-	LineAA1     = 4,
-	TriangleAA1 = 5,
+	None                = 0,
+	Point               = 1,
+	Line                = 2,
+	Sprite              = 3,
+	LineAA1             = 4,
+	TriangleAA1         = 5,
+	TriangleAA1Interior = 6,
+	TriangleAA1Edge     = 7,
+	Count               = 8,
 };
 
 enum class PS_ATST : uint32_t
@@ -50,10 +53,12 @@ enum class ZTST : uint32_t
 
 enum class PS_AA1 : uint32_t
 {
-	NONE          = 0, ///< No AA1
-	LINE          = 1, ///< AA1 lines
-	TRIANGLE      = 2, ///< AA1 triangles
-	TRIANGLE_SW_Z = 3, ///< AA1 triangles with software Z discard
+	NONE                 = 0, ///< No AA1
+	LINE                 = 1, ///< AA1 lines
+	TRIANGLE             = 2, ///< AA1 triangles
+	TRIANGLE_SW_Z        = 3, ///< AA1 triangles with software Z discard
+	TRIANGLE_PRIMID      = 4, ///< AA1 triangle edges with primid discard
+	TRIANGLE_PRIMID_INIT = 5, ///< AA1 triangle interiors primid init
 };
 
 enum class PS_ROV_DEPTH : uint32_t

--- a/pcsx2/GS/Renderers/Common/GSVertexTrace.h
+++ b/pcsx2/GS/Renderers/Common/GSVertexTrace.h
@@ -31,8 +31,9 @@ public:
 	{
 		int min, max;
 
-		// Separate inference for depth if using AA1 coverage alpha, since edges don't write depth.
-		int depth_min, depth_max;
+		// Separate inference for interior/edges if using AA1 coverage alpha.
+		int interior_min, interior_max;
+		int edge_min, edge_max;
 
 		bool valid;
 	};

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -714,7 +714,7 @@ void GSDevice11::SetFeatures(IDXGIAdapter1* adapter)
 	m_features.cas_sharpening = (m_feature_level >= D3D_FEATURE_LEVEL_11_0);
 	m_features.test_and_sample_depth = (m_feature_level >= D3D_FEATURE_LEVEL_11_0);
 	m_features.depth_feedback = m_features.multidraw_fb_copy && GSConfig.DepthFeedbackMode == GSDepthFeedbackMode::Depth;
-	m_features.aa1 = GSConfig.HWAA1 && m_features.vs_expand && m_features.feedback_loops();
+	m_features.aa1 = GSConfig.HWAA1 != GSHWAA1Level::Off && m_features.vs_expand && m_features.feedback_loops();
 
 	m_max_texture_size = (m_feature_level >= D3D_FEATURE_LEVEL_11_0) ?
 	                         D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION :
@@ -1380,12 +1380,13 @@ void GSDevice11::DrawIndexedPrimitiveVSExpand(int offset, int count, bool vs_ind
 	}
 }
 
-void GSDevice11::Draw(const GSHWDrawConfig& config, int offset, int count)
+void GSDevice11::Draw(const GSHWDrawConfig& config, const GSHWDrawConfig::DrawPass pass, int offset, int count)
 {
-	if (config.vs.expand != GSHWDrawConfig::VSExpand::None)
+	const VSSelector& vs = config.GetVS(pass);
+	if (vs.expand != GSHWDrawConfig::VSExpand::None)
 	{
-		const bool vs_indexing = config.vs.UseVSExpandIndexBuffer();
-		const u32 vs_indexing_expansion = GetExpansionFactor(config.vs.expand);
+		const bool vs_indexing = vs.UseVSExpandIndexBuffer();
+		const u32 vs_indexing_expansion = GetExpansionFactor(vs.expand);
 		DrawIndexedPrimitiveVSExpand(offset, count, vs_indexing, vs_indexing_expansion);
 	}
 	else
@@ -1394,9 +1395,9 @@ void GSDevice11::Draw(const GSHWDrawConfig& config, int offset, int count)
 	}
 }
 
-void GSDevice11::Draw(const GSHWDrawConfig& config)
+void GSDevice11::Draw(const GSHWDrawConfig& config, const GSHWDrawConfig::DrawPass pass)
 {
-	Draw(config, 0, m_index.count);
+	Draw(config, pass, 0, m_index.count);
 }
 
 void GSDevice11::CommitClear(GSTexture* t)
@@ -1581,9 +1582,10 @@ void GSDevice11::DoStretchRect(GSTexture* sTex, const GSVector4& sRect, GSTextur
 
 void GSDevice11::DoStretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, ID3D11PixelShader* ps, ID3D11Buffer* ps_cb, ID3D11BlendState* bs, Filter filter)
 {
-	g_perfmon.Put(GSPerfMon::TextureCopies, 1);
+	g_perfmon.Put(GSPerfMon::TextureCopies, sTex ? 1 : 0); // only count as a copy if there's a source
 
-	CommitClear(sTex);
+	if (sTex)
+		CommitClear(sTex);
 
 	const bool draw_in_depth = dTex && dTex->IsDepthStencil();
 
@@ -1997,7 +1999,7 @@ void GSDevice11::SetupVS(VSSelector sel, const GSHWDrawConfig::VSConstantBuffer*
 		i = m_vs.try_emplace(sel.key, std::move(vs)).first;
 	}
 
-	if (m_vs_cb_cache.Update(*cb))
+	if (cb && m_vs_cb_cache.Update(*cb))
 	{
 		m_ctx->UpdateSubresource(m_vs_cb.get(), 0, NULL, cb, 0, 0);
 	}
@@ -3108,21 +3110,33 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 		draw_rt = colclip_rt ? colclip_rt : draw_rt;
 	}
 
-	// Destination Alpha Setup
+	// Destination Alpha / AA1 primid Setup
 	const bool need_barrier = config.require_one_barrier || (config.require_full_barrier && m_features.multidraw_fb_copy);
-	if (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking)
+	if (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking ||
+		config.aa1_mode == GSHWDrawConfig::AA1Mode::ThreePassPrimid)
 	{
 		primid_texture = CreateRenderTarget(rtsize.x, rtsize.y, GSTexture::Format::PrimID, false);
 		if (!primid_texture)
 		{
-			Console.Warning("D3D11: Failed to allocate DATE image, aborting draw.");
+			Console.Warning("D3D11: Failed to allocate primid image, aborting draw.");
 			return;
 		}
 
-		DoStretchRect(colclip_rt ? colclip_rt : config.rt, GSVector4(config.drawarea) / GSVector4(rtsize).xyxy(),
-			primid_texture, GSVector4(config.drawarea), m_date.primid_init_ps[static_cast<u8>(config.datm)].get(), nullptr, Nearest);
+		if (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking)
+		{
+			DoStretchRect(colclip_rt ? colclip_rt : config.rt, GSVector4(config.drawarea) / GSVector4(rtsize).xyxy(),
+				primid_texture, GSVector4(config.drawarea), m_date.primid_init_ps[static_cast<u8>(config.datm)].get(), nullptr, Nearest);
+		}
+		else
+		{
+			// AA1
+			DoStretchRect(nullptr, GSVector4(config.drawarea) / GSVector4(rtsize).xyxy(),
+				primid_texture, GSVector4(config.drawarea), m_date.primid_init_ps[4].get(), nullptr, Nearest);
+		}
 	}
-	else if (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::Stencil ||
+	
+	// Destination Alpha stencil setup
+	if (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::Stencil ||
 			 (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::StencilOne && !need_barrier))
 		SetupDATE(colclip_rt ? colclip_rt : config.rt, config.ds, config.datm, config.drawarea);
 
@@ -3186,17 +3200,30 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 
 	if (primid_texture)
 	{
+		const bool date = (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking);
+		const bool aa1 = (config.aa1_mode == GSHWDrawConfig::AA1Mode::ThreePassPrimid);
+		pxAssert(date != aa1); // exactly one must be true
+
 		OMDepthStencilSelector dss = config.depth;
 		dss.zwe = 0;
+		const u8 blend_op = date ? 3 /* MIN */ : 0 /* ADD */;
 		const OMBlendSelector blend(GSHWDrawConfig::ColorMaskSelector(1),
-			GSHWDrawConfig::BlendState(true, CONST_ONE, CONST_ONE, 3 /* MIN */, CONST_ONE, CONST_ZERO, false, 0));
+			GSHWDrawConfig::BlendState(true, CONST_ONE, CONST_ONE, blend_op, CONST_ONE, CONST_ZERO, false, 0));
 		SetupOM(dss, blend, 0);
 		OMSetRenderTargets(primid_texture, nullptr, config.ds, nullptr, nullptr, &config.scissor, read_only_dsv);
 		SetRenderHWShaderResources(config, nullptr);
-		Draw(config);
+		Draw(config, GSHWDrawConfig::DrawPass::PrimID);
 
-		config.ps.date = 3;
-		config.alpha_second_pass.ps.date = 3;
+		if (date)
+		{
+			config.ps.date = 3;
+			config.alpha_second_pass.ps.date = 3;
+			config.aa1_multi_pass.ps.date = 3;
+		}
+		else
+		{
+			config.ps.aa1 = GSHWDrawConfig::PS_AA1::TRIANGLE;
+		}
 		SetupPS(config.ps, nullptr, config.sampler);
 	}
 
@@ -3222,8 +3249,9 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 
 	const bool rt_feedbackloop_pass1 = config.IsFeedbackLoopRT(config.ps);
 	const bool rt_feedbackloop_pass2 = config.IsFeedbackLoopRT(config.alpha_second_pass.ps);
+	const bool rt_feedbackloop_pass3 = config.IsFeedbackLoopRT(config.aa1_multi_pass.ps);
 	if (draw_rt && !draw_rt_rov && (((config.require_one_barrier || (config.require_full_barrier && m_features.multidraw_fb_copy)) &&
-		(rt_feedbackloop_pass1 || rt_feedbackloop_pass2))))
+		(rt_feedbackloop_pass1 || rt_feedbackloop_pass2 || rt_feedbackloop_pass3))))
 	{
 		// Requires a copy of the RT.
 		draw_rt_clone = CreateTexture(rtsize.x, rtsize.y, 1, draw_rt->GetFormat(), true);
@@ -3234,8 +3262,9 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 
 	const bool ds_feedbackloop_pass1 = config.IsFeedbackLoopDepth(config.ps);
 	const bool ds_feedbackloop_pass2 = config.IsFeedbackLoopDepth(config.alpha_second_pass.ps);
+	const bool ds_feedbackloop_pass3 = config.IsFeedbackLoopDepth(config.aa1_multi_pass.ps);
 	if (draw_ds && !draw_ds_rov && (config.require_one_barrier || (config.require_full_barrier && m_features.multidraw_fb_copy)) &&
-		(ds_feedbackloop_pass1 || ds_feedbackloop_pass2))
+		(ds_feedbackloop_pass1 || ds_feedbackloop_pass2 || ds_feedbackloop_pass3))
 	{
 		// Requires a copy of the DS.
 		draw_ds_clone = CreateTexture(rtsize.x, rtsize.y, 1, (draw_ds_as_rt ? draw_ds_as_rt : draw_ds)->GetFormat(), true);
@@ -3252,8 +3281,7 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 	if (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::StencilOne && need_barrier)
 		m_ctx->ClearDepthStencilView(*static_cast<GSTexture11*>(draw_ds), D3D11_CLEAR_STENCIL, 0.0f, 1);
 
-	SendHWDraw(config, rt_feedbackloop_pass1 ? draw_rt_clone : nullptr, draw_rt, ds_feedbackloop_pass1 ? draw_ds_clone : nullptr, draw_ds_as_rt ? draw_ds_as_rt : draw_ds,
-		config.require_one_barrier, config.require_full_barrier, rtsize);
+	SendHWDraw(config, GSHWDrawConfig::DrawPass::Main, rt_feedbackloop_pass1 ? draw_rt_clone : nullptr, draw_rt, ds_feedbackloop_pass1 ? draw_ds_clone : nullptr, draw_ds_as_rt ? draw_ds_as_rt : draw_ds, rtsize);
 
 	if (config.blend_multi_pass.enable)
 	{
@@ -3262,7 +3290,7 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 		config.ps.dither = config.blend_multi_pass.dither;
 		SetupPS(config.ps, &config.cb_ps, config.sampler);
 		SetupOM(config.depth, OMBlendSelector(config.colormask, config.blend_multi_pass.blend), config.blend_multi_pass.blend.constant);
-		Draw(config);
+		Draw(config, GSHWDrawConfig::DrawPass::Blend);
 	}
 
 	if (config.alpha_second_pass.enable)
@@ -3278,10 +3306,29 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 			SetupPS(config.alpha_second_pass.ps, nullptr, config.sampler);
 		}
 
-		const bool one_barrier = config.alpha_second_pass.require_one_barrier && m_features.multidraw_fb_copy;
 		SetupOM(config.alpha_second_pass.depth, OMBlendSelector(config.alpha_second_pass.colormask, config.blend), config.blend.constant);
-		SendHWDraw(config, rt_feedbackloop_pass2 ? draw_rt_clone : nullptr, draw_rt, ds_feedbackloop_pass2 ? draw_ds_clone : nullptr, draw_ds_as_rt ? draw_ds_as_rt : draw_ds,
-			one_barrier, config.alpha_second_pass.require_full_barrier, rtsize);
+		SendHWDraw(config, GSHWDrawConfig::DrawPass::AlphaSecond, rt_feedbackloop_pass2 ? draw_rt_clone : nullptr, draw_rt, ds_feedbackloop_pass2 ? draw_ds_clone : nullptr, draw_ds_as_rt ? draw_ds_as_rt : draw_ds, rtsize);
+	}
+
+	if (config.aa1_multi_pass.enable)
+	{
+		SetupVS(config.aa1_multi_pass.vs, nullptr);
+
+		if (config.cb_ps.FogColor_AREF.a != config.aa1_multi_pass.ps_aref)
+		{
+			config.cb_ps.FogColor_AREF.a = config.aa1_multi_pass.ps_aref;
+			SetupPS(config.aa1_multi_pass.ps, &config.cb_ps, config.sampler);
+		}
+		else
+		{
+			// ps cbuffer hasn't changed, so don't bother checking
+			SetupPS(config.aa1_multi_pass.ps, nullptr, config.sampler);
+		}
+
+		SetupOM(config.aa1_multi_pass.depth, OMBlendSelector(config.aa1_multi_pass.colormask, config.aa1_multi_pass.blend),
+			config.aa1_multi_pass.blend.constant);
+		SendHWDraw(config, GSHWDrawConfig::DrawPass::AA1Second, rt_feedbackloop_pass3 ? draw_rt_clone : nullptr, draw_rt,
+			ds_feedbackloop_pass3 ? draw_ds_clone : nullptr, draw_ds_as_rt ? draw_ds_as_rt : draw_ds, rtsize);
 	}
 
 	if (colclip_rt)
@@ -3351,12 +3398,14 @@ void GSDevice11::FeedbackCopyAndBind(const GSHWDrawConfig& config,
 		// No RT hazards so just need the draw area (or full area for DS).
 		FeedbackCopyAndBind(config, rt, rt_clone, ds, ds_clone, ProcessCopyArea(rtsize, config.drawarea));
 	}
-};
+}
 
-void GSDevice11::SendHWDraw(const GSHWDrawConfig& config,
-	GSTexture* draw_rt_clone, GSTexture* draw_rt, GSTexture* draw_ds_clone, GSTexture* draw_ds,
-	const bool one_barrier, const bool full_barrier, GSVector2i rtsize)
+void GSDevice11::SendHWDraw(const GSHWDrawConfig& config, GSHWDrawConfig::DrawPass pass,
+	GSTexture* draw_rt_clone, GSTexture* draw_rt, GSTexture* draw_ds_clone, GSTexture* draw_ds, GSVector2i rtsize)
 {
+	const bool full_barrier = config.GetFullBarrier(pass);
+	const bool one_barrier = config.GetOneBarrier(pass);
+
 #ifdef PCSX2_DEVBUILD
 	if ((one_barrier || full_barrier) && !(config.IsFeedbackLoopRT(config.ps) || config.IsFeedbackLoopDepth(config.ps))) [[unlikely]]
 		Console.Warning("D3D11: Possible unnecessary copy detected.");
@@ -3381,7 +3430,7 @@ void GSDevice11::SendHWDraw(const GSHWDrawConfig& config,
 
 			FeedbackCopyAndBind(config, draw_rt, draw_rt_clone, draw_ds, draw_ds_clone, bbox);
 
-			Draw(config, p, count);
+			Draw(config, pass, p, count);
 
 			p += count;
 		}
@@ -3394,7 +3443,7 @@ void GSDevice11::SendHWDraw(const GSHWDrawConfig& config,
 		FeedbackCopyAndBind(config, draw_rt, draw_rt_clone, draw_ds, draw_ds_clone, config.drawarea, config.samplearea);
 	}
 
-	Draw(config);
+	Draw(config, pass);
 
 	if (config.ps.HasColorROV() || config.ps.HasDepthROV())
 		g_perfmon.Put(GSPerfMon::DrawCallsROV, 1);

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -265,7 +265,7 @@ private:
 	{
 		wil::com_ptr_nothrow<ID3D11DepthStencilState> dss;
 		wil::com_ptr_nothrow<ID3D11BlendState> bs;
-		wil::com_ptr_nothrow<ID3D11PixelShader> primid_init_ps[4];
+		wil::com_ptr_nothrow<ID3D11PixelShader> primid_init_ps[5];
 	} m_date;
 
 	struct
@@ -349,8 +349,8 @@ public:
 	void DrawIndexedPrimitiveVSExpand(int offset, int count, bool vs_indexing, int vs_indexing_expansion);
 
 	// Main GS primitive draws.
-	void Draw(const GSHWDrawConfig& config);
-	void Draw(const GSHWDrawConfig& config, int offset, int count);
+	void Draw(const GSHWDrawConfig& config, GSHWDrawConfig::DrawPass pass);
+	void Draw(const GSHWDrawConfig& config, GSHWDrawConfig::DrawPass pass, int offset, int count);
 
 	void PushDebugGroup(const char* fmt, ...) override;
 	void PopDebugGroup() override;
@@ -420,9 +420,8 @@ public:
 	void FeedbackCopyAndBind(const GSHWDrawConfig& config,
 		GSTexture* rt, GSTexture* rt_clone, GSTexture* ds, GSTexture* ds_clone,
 		const GSVector4i& copyarea, const GSVector4i& samplearea);
-	void SendHWDraw(const GSHWDrawConfig& config,
-		GSTexture* draw_rt_clone, GSTexture* draw_rt, GSTexture* draw_ds_clone, GSTexture* draw_ds,
-		const bool one_barrier, const bool full_barrier, GSVector2i rtsize);
+	void SendHWDraw(const GSHWDrawConfig& config, GSHWDrawConfig::DrawPass pass,
+		GSTexture* draw_rt_clone, GSTexture* draw_rt, GSTexture* draw_ds_clone, GSTexture* draw_ds, GSVector2i rtsize);
 	void SetRenderHWShaderResources(const GSHWDrawConfig& config, GSTexture* primid_texture);
 
 	void ClearSamplerCache() override;

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -1503,7 +1503,7 @@ bool GSDevice12::CheckFeatures(const u32& vendor_id)
 	m_features.test_and_sample_depth = true;
 	m_features.vs_expand = !GSConfig.DisableVertexShaderExpand;
 	m_features.depth_feedback = false;
-	m_features.aa1 = GSConfig.HWAA1 && m_features.vs_expand && m_features.feedback_loops();
+	m_features.aa1 = GSConfig.HWAA1 != GSHWAA1Level::Off && m_features.vs_expand && m_features.feedback_loops();
 
 	m_features.dxt_textures = SupportsTextureFormat(DXGI_FORMAT_BC1_UNORM) &&
 	                          SupportsTextureFormat(DXGI_FORMAT_BC2_UNORM) &&
@@ -1594,12 +1594,13 @@ void GSDevice12::DrawIndexedPrimitiveVSExpand(int offset, int count, bool vs_ind
 	}
 }
 
-void GSDevice12::Draw(const GSHWDrawConfig& config, int offset, int count)
+void GSDevice12::Draw(const GSHWDrawConfig& config, GSHWDrawConfig::DrawPass pass, int offset, int count)
 {
-	if (config.vs.expand != GSHWDrawConfig::VSExpand::None)
+	const GSHWDrawConfig::VSSelector& vs = config.GetVS(pass);
+	if (vs.expand != GSHWDrawConfig::VSExpand::None)
 	{
-		const bool vs_indexing = config.vs.UseVSExpandIndexBuffer();
-		const u32 vs_indexing_expansion = GetExpansionFactor(config.vs.expand);
+		const bool vs_indexing = vs.UseVSExpandIndexBuffer();
+		const u32 vs_indexing_expansion = GetExpansionFactor(vs.expand);
 		DrawIndexedPrimitiveVSExpand(offset, count, vs_indexing, vs_indexing_expansion);
 	}
 	else
@@ -1608,9 +1609,9 @@ void GSDevice12::Draw(const GSHWDrawConfig& config, int offset, int count)
 	}
 }
 
-void GSDevice12::Draw(const GSHWDrawConfig& config)
+void GSDevice12::Draw(const GSHWDrawConfig& config, GSHWDrawConfig::DrawPass pass)
 {
-	Draw(config, 0, m_index.count);
+	Draw(config, pass, 0, m_index.count);
 }
 
 void GSDevice12::LookupNativeFormat(GSTexture::Format format, DXGI_FORMAT* d3d_format, DXGI_FORMAT* srv_format,
@@ -2922,9 +2923,9 @@ bool GSDevice12::CompileConvertPipelines()
 		}
 	}
 
-	for (u32 datm = 0; datm < 4; datm++)
+	for (u32 i = 0; i < 5; i++)
 	{
-		const std::string entry_point(StringUtil::StdStringFromFormat("ps_primid_image_init_%d", datm));
+		const std::string entry_point(StringUtil::StdStringFromFormat("ps_primid_image_init_%d", i));
 
 		const std::string entry_point_macro = WrapEntryPointMacro(entry_point);
 
@@ -2947,12 +2948,20 @@ bool GSDevice12::CompileConvertPipelines()
 		for (u32 ds = 0; ds < 2; ds++)
 		{
 			gpb.SetDepthStencilFormat(ds ? DXGI_FORMAT_D32_FLOAT_S8X24_UINT : DXGI_FORMAT_UNKNOWN);
-			m_primid_image_setup_pipelines[ds][datm] = gpb.Create(m_device.get(), m_shader_cache, false);
-			if (!m_primid_image_setup_pipelines[ds][datm])
+			m_primid_image_setup_pipelines[ds][i] = gpb.Create(m_device.get(), m_shader_cache, false);
+			if (!m_primid_image_setup_pipelines[ds][i])
 				return false;
 
-			D3D12::SetObjectName(m_primid_image_setup_pipelines[ds][datm].get(),
-				TinyString::from_format("DATE image clear pipeline (ds={}, datm={})", ds, (datm == 1 || datm == 3)));
+			if (i < 4)
+			{
+				D3D12::SetObjectName(m_primid_image_setup_pipelines[ds][i].get(),
+					TinyString::from_format("DATE primid image clear pipeline (ds={}, datm={})", ds, (i == 1 || i == 3)));
+			}
+			else
+			{
+				D3D12::SetObjectName(m_primid_image_setup_pipelines[ds][i].get(),
+					TinyString::from_format("AA1 primid image clear pipeline"));
+			}
 		}
 	}
 
@@ -3335,9 +3344,10 @@ GSDevice12::ComPtr<ID3D12PipelineState> GSDevice12::CreateTFXPipeline(const Pipe
 	u32 num_rts = 0;
 	if (p.rt)
 	{
-		const GSTexture::Format format = IsDATEModePrimIDInit(p.ps.date) ?
-			GSTexture::Format::PrimID :
-			(p.ps.colclip_hw ? GSTexture::Format::ColorClip : GSTexture::Format::Color);
+		const GSTexture::Format format =
+			(IsDATEModePrimIDInit(p.ps.date) || p.ps.aa1 == GSHWDrawConfig::PS_AA1::TRIANGLE_PRIMID_INIT) ?
+				GSTexture::Format::PrimID :
+				(p.ps.colclip_hw ? GSTexture::Format::ColorClip : GSTexture::Format::Color);
 
 		DXGI_FORMAT native_format;
 		LookupNativeFormat(format, nullptr, nullptr, &native_format, nullptr, nullptr);
@@ -4266,16 +4276,27 @@ void GSDevice12::SetupDATE(GSTexture* rt, GSTexture* ds, SetDATM datm, const GSV
 	EndRenderPass();
 }
 
-GSTexture12* GSDevice12::SetupPrimitiveTrackingDATE(GSHWDrawConfig& config, PipelineSelector& pipe)
+GSTexture12* GSDevice12::SetupPrimitiveTracking(GSHWDrawConfig& config)
 {
-	g_perfmon.Put(GSPerfMon::TextureCopies, 1);
+	const bool date = (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking);
+	const bool aa1 = (config.aa1_mode == GSHWDrawConfig::AA1Mode::ThreePassPrimid);
+	pxAssert(date != aa1); // exactly one must be true
 
-	// How this is done:
+	g_perfmon.Put(GSPerfMon::TextureCopies, date ? 1 : 0); // Only a copy if it's DATE; AA1 doesn't sample RT.
+
+	// How DATE is done:
 	// - can't put a barrier for the image in the middle of the normal render pass, so that's out
 	// - so, instead of just filling the int texture with INT_MAX, we sample the RT and use -1 for failing values
 	// - then, instead of sampling the RT with DATE=1/2, we just do a min() without it, the -1 gets preserved
 	// - then, the DATE=3 draw is done as normal
-	GL_INS("Setup DATE Primitive ID Image for {%d,%d}-{%d,%d}", config.drawarea.left, config.drawarea.top,
+
+	// How AA1 is done:
+	// - Initialize the primid texture to -1 (allow everything).
+	// - Write the primid of the interior triangles.
+	// - In the edge pass, discard edge pixels that are overlapped by an interior in primid order.
+
+	GL_INS("Setup %s Primitive ID Image for {%d,%d}-{%d,%d}", date ? "DATE" : "AA1",
+		config.drawarea.left, config.drawarea.top,
 		config.drawarea.right, config.drawarea.bottom);
 
 	const GSVector2i rtsize(config.rt->GetSize());
@@ -4286,17 +4307,22 @@ GSTexture12* GSDevice12::SetupPrimitiveTrackingDATE(GSHWDrawConfig& config, Pipe
 
 	EndRenderPass();
 
-	// setup the fill quad to prefill with existing alpha values
-	SetUtilityTexture(config.rt, m_point_sampler_cpu);
+	// setup the fill quad to prefill with init values
+	if (date)
+		SetUtilityTexture(config.rt, m_point_sampler_cpu);
+	else
+		SetUtilityTexture(m_null_texture.get(), m_point_sampler_cpu);
 	OMSetRenderTargets(image, nullptr, config.ds, config.drawarea);
+
+	const u32 ds = (config.ds ? 1 : 0);
 
 	// if the depth target has been cleared, we need to preserve that clear
 	BeginRenderPass(D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_DISCARD, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE,
-		config.ds ? GetLoadOpForTexture(static_cast<GSTexture12*>(config.ds)) :
+		ds ? GetLoadOpForTexture(static_cast<GSTexture12*>(config.ds)) :
 					D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS,
-		config.ds ? D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE : D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
+		ds ? D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE : D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
 		D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS, D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
-		GSVector4::zero(), config.ds ? config.ds->GetClearDepth() : 0.0f);
+		GSVector4::zero(), ds ? config.ds->GetClearDepth() : 0.0f);
 
 	// draw the quad to prefill the image
 	const GSVector4 src = GSVector4(config.drawarea) / GSVector4(rtsize).xyxy();
@@ -4309,7 +4335,7 @@ GSTexture12* GSDevice12::SetupPrimitiveTrackingDATE(GSHWDrawConfig& config, Pipe
 	};
 	SetUtilityRootSignature();
 	SetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-	SetPipeline(m_primid_image_setup_pipelines[pipe.ds][static_cast<u8>(config.datm)].get());
+	SetPipeline(m_primid_image_setup_pipelines[ds][aa1 ? 4 : static_cast<u8>(config.datm)].get());
 	IASetVertexBuffer(vertices, sizeof(vertices[0]), std::size(vertices));
 	if (ApplyUtilityState())
 		DrawPrimitive();
@@ -4319,23 +4345,33 @@ GSTexture12* GSDevice12::SetupPrimitiveTrackingDATE(GSHWDrawConfig& config, Pipe
 	UploadHWDrawVerticesAndIndices(config);
 
 	// cut down the configuration for the prepass, we don't need blending or any feedback loop
-	PipelineSelector init_pipe(m_pipeline_selector);
-	init_pipe.dss.zwe = false;
-	init_pipe.cms.wrgba = 0;
-	init_pipe.bs = {};
-	init_pipe.rt = true;
-	init_pipe.ps.blend_a = init_pipe.ps.blend_b = init_pipe.ps.blend_c = init_pipe.ps.blend_d = false;
-	init_pipe.ps.no_color = false;
-	init_pipe.ps.no_color1 = true;
-	if (BindDrawPipeline(init_pipe))
-		Draw(config);
+	UpdateHWPipelineSelector(config);
+	PipelineSelector& pipe = m_pipeline_selector;
+	pipe.dss.zwe = false;
+	pipe.cms = GSHWDrawConfig::ColorMaskSelector();
+	pipe.bs = {};
+	pipe.rt = true;
+	pipe.ps.blend_a = pipe.ps.blend_b = pipe.ps.blend_c = pipe.ps.blend_d = false;
+	pipe.ps.no_color = false;
+	pipe.ps.no_color1 = true;
+	if (BindDrawPipeline(pipe))
+		Draw(config, GSHWDrawConfig::DrawPass::PrimID);
 
 	// image is initialized/prepass is done, so finish up and get ready to do the "real" draw
 	EndRenderPass();
 
-	// .. by setting it to DATE=3
-	pipe.ps.date = 3;
-	config.alpha_second_pass.ps.date = 3;
+	if (date)
+	{
+		// set DATE=3 for the real draw
+		config.ps.date = 3;
+		config.alpha_second_pass.ps.date = 3;
+		config.aa1_multi_pass.ps.date = 3;
+	}
+	else
+	{
+		// set triangle interiors for the real draw
+		config.ps.aa1 = GSHWDrawConfig::PS_AA1::TRIANGLE;
+	}
 
 	// and bind the image to the primitive sampler
 	image->TransitionToState(GSTexture12::ResourceState::PixelShaderResource);
@@ -4378,14 +4414,42 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 	GSTexture12* draw_ds_rov = config.ps.HasDepthROV() ? static_cast<GSTexture12*>(config.ds) : nullptr;
 	GSTexture12* draw_rt_clone = nullptr;
 
-	const bool feedback = draw_rt && (config.require_one_barrier || (config.require_full_barrier && m_features.texture_barrier) || (config.tex && config.tex == config.rt));
-
-	// Align the render area to 128x128, hopefully avoiding render pass restarts for small render area changes (e.g. Ratchet and Clank).
 	const GSVector2i rtsize(config.rt ? config.rt->GetSize() : config.ds->GetSize());
 
-	PipelineSelector& pipe = m_pipeline_selector;
+	// stream buffer in first, in case we need to exec
+	SetVSConstantBuffer(config.cb_vs);
+	SetPSConstantBuffer(config.cb_ps);
+
+	// bind textures before checking the render pass, in case we need to transition them
+	if (config.tex)
+	{
+		PSSetShaderResource(0, config.tex, config.tex != config.rt && config.tex != config.ds);
+		PSSetSampler(config.sampler);
+	}
+	if (config.pal)
+		PSSetShaderResource(1, config.pal, true);
+
+	if (config.blend.constant_enable)
+		SetBlendConstants(config.blend.constant);
+
+	// Primitive ID tracking DATE/AA1 setup.
+	GSTexture12* date_image = nullptr;
+	if (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking ||
+		config.aa1_mode == GSHWDrawConfig::AA1Mode::ThreePassPrimid)
+	{
+		GSTexture* backup_rt = config.rt;
+		config.rt = draw_rt;
+		date_image = SetupPrimitiveTracking(config);
+		config.rt = backup_rt;
+		if (!date_image)
+		{
+			Console.Warning("D3D12: Failed to allocate DATE image, aborting draw.");
+			return;
+		}
+	}
 
 	// figure out the pipeline
+	PipelineSelector& pipe = m_pipeline_selector;
 	UpdateHWPipelineSelector(config);
 
 	// now blit the colclip texture back to the original target
@@ -4426,59 +4490,13 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 		}
 	}
 
-	// Destination Alpha Setup
+	// Destination Alpha Stencil Setup
 	const bool need_barrier = config.require_one_barrier || (config.require_full_barrier && m_features.texture_barrier);
-	switch (config.destination_alpha)
+	if (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::Stencil ||
+		(config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::StencilOne && !need_barrier))
 	{
-		case GSHWDrawConfig::DestinationAlphaMode::Off: // No setup
-		case GSHWDrawConfig::DestinationAlphaMode::Full: // No setup
-		case GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking: // Setup is done below
-			break;
-		case GSHWDrawConfig::DestinationAlphaMode::StencilOne: // setup is done below
-		{
-			// we only need to do the setup here if we don't have barriers, in which case do full DATE.
-			if (!need_barrier)
-			{
-				SetupDATE(draw_rt, config.ds, config.datm, config.drawarea);
-				config.destination_alpha = GSHWDrawConfig::DestinationAlphaMode::Stencil;
-			}
-		}
-		break;
-
-		case GSHWDrawConfig::DestinationAlphaMode::Stencil:
-			SetupDATE(draw_rt, config.ds, config.datm, config.drawarea);
-			break;
-	}
-
-	// stream buffer in first, in case we need to exec
-	SetVSConstantBuffer(config.cb_vs);
-	SetPSConstantBuffer(config.cb_ps);
-
-	// bind textures before checking the render pass, in case we need to transition them
-	if (config.tex)
-	{
-		PSSetShaderResource(TEXTURE_TEXTURE, config.tex, config.tex != config.rt && config.tex != config.ds);
-		PSSetSampler(config.sampler);
-	}
-	if (config.pal)
-		PSSetShaderResource(TEXTURE_PALETTE, config.pal, true);
-
-	if (config.blend.constant_enable)
-		SetBlendConstants(config.blend.constant);
-
-	// Primitive ID tracking DATE setup.
-	GSTexture12* date_image = nullptr;
-	if (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking)
-	{
-		GSTexture* backup_rt = config.rt;
-		config.rt = draw_rt;
-		date_image = SetupPrimitiveTrackingDATE(config, pipe);
-		config.rt = backup_rt;
-		if (!date_image)
-		{
-			Console.Warning("D3D12: Failed to allocate DATE image, aborting draw.");
-			return;
-		}
+		SetupDATE(draw_rt, config.ds, config.datm, config.drawarea);
+			config.destination_alpha = GSHWDrawConfig::DestinationAlphaMode::Stencil;
 	}
 
 	// Switch to colclip target for colclip hw rendering
@@ -4546,7 +4564,7 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 	GSTexture12* draw_ds_as_rt = static_cast<GSTexture12*>(m_ds_as_rt);
 
 	const bool feedback_rt = draw_rt && (((config.require_one_barrier || (config.require_full_barrier && m_features.texture_barrier)) && (config.IsFeedbackLoopRT(config.ps) ||
-		config.IsFeedbackLoopRT(config.alpha_second_pass.ps))));
+		config.IsFeedbackLoopRT(config.alpha_second_pass.ps) || config.IsFeedbackLoopRT(config.aa1_multi_pass.ps))));
 	const bool feedback_depth = draw_ds_as_rt != nullptr;
 
 	if (feedback_rt && !m_features.texture_barrier)
@@ -4660,8 +4678,7 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 		UploadHWDrawVerticesAndIndices(config);
 
 	// now we can do the actual draw
-	SendHWDraw(pipe, config, draw_rt, draw_ds_as_rt, draw_rt_rov, draw_ds_rov,
-		feedback_rt, feedback_depth, config.require_one_barrier, config.require_full_barrier);
+	SendHWDraw(pipe, config, GSHWDrawConfig::DrawPass::Main, draw_rt, draw_ds_as_rt, draw_rt_rov, draw_ds_rov, feedback_rt, feedback_depth);
 
 	// blend second pass
 	if (config.blend_multi_pass.enable)
@@ -4674,7 +4691,7 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 		pipe.ps.blend_hw = config.blend_multi_pass.blend_hw;
 		pipe.ps.dither = config.blend_multi_pass.dither;
 		if (BindDrawPipeline(pipe))
-			Draw(config);
+			Draw(config, GSHWDrawConfig::DrawPass::Blend);
 	}
 
 	// and the alpha pass
@@ -4691,9 +4708,27 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 		pipe.cms = config.alpha_second_pass.colormask;
 		pipe.dss = config.alpha_second_pass.depth;
 		pipe.bs = config.blend;
-		SendHWDraw(pipe, config, draw_rt, draw_ds_as_rt, draw_rt_rov, draw_ds_rov,
-			feedback_rt, feedback_depth, config.alpha_second_pass.require_one_barrier,
-			config.alpha_second_pass.require_full_barrier);
+		SendHWDraw(pipe, config, GSHWDrawConfig::DrawPass::AlphaSecond, draw_rt, draw_ds_as_rt, draw_rt_rov, draw_ds_rov,
+			feedback_rt, feedback_depth);
+	}
+
+	// and the AA1 pass
+	if (config.aa1_multi_pass.enable)
+	{
+		// cbuffer will definitely be dirty if aref changes, no need to check it
+		if (config.cb_ps.FogColor_AREF.a != config.aa1_multi_pass.ps_aref)
+		{
+			config.cb_ps.FogColor_AREF.a = config.aa1_multi_pass.ps_aref;
+			SetPSConstantBuffer(config.cb_ps);
+		}
+
+		pipe.vs = config.aa1_multi_pass.vs;
+		pipe.ps = config.aa1_multi_pass.ps;
+		pipe.cms = config.aa1_multi_pass.colormask;
+		pipe.dss = config.aa1_multi_pass.depth;
+		pipe.bs = config.aa1_multi_pass.blend;
+		SendHWDraw(pipe, config, GSHWDrawConfig::DrawPass::AA1Second, draw_rt, draw_ds_as_rt, draw_rt_rov, draw_ds_rov,
+			feedback_rt, feedback_depth);
 	}
 
 	if (date_image)
@@ -4735,11 +4770,13 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 	}
 }
 
-void GSDevice12::SendHWDraw(const PipelineSelector& pipe, const GSHWDrawConfig& config, GSTexture12* draw_rt,
-	GSTexture12* draw_ds, GSTexture12* draw_rt_rov, GSTexture12* draw_ds_rov,
-	const bool feedback_rt, const bool feedback_depth,
-	const bool one_barrier, const bool full_barrier)
+void GSDevice12::SendHWDraw(const PipelineSelector& pipe, const GSHWDrawConfig& config, GSHWDrawConfig::DrawPass pass,
+	GSTexture12* draw_rt, GSTexture12* draw_ds, GSTexture12* draw_rt_rov, GSTexture12* draw_ds_rov,
+	const bool feedback_rt, const bool feedback_depth)
 {
+	const bool full_barrier = config.GetFullBarrier(pass);
+	const bool one_barrier = config.GetOneBarrier(pass);
+
 	// Should not be mixing ROVs with barriers.
 	pxAssert(!(draw_rt_rov || draw_ds_rov) || !(one_barrier || full_barrier));
 	
@@ -4748,7 +4785,7 @@ void GSDevice12::SendHWDraw(const PipelineSelector& pipe, const GSHWDrawConfig& 
 	if (!m_features.texture_barrier) [[unlikely]]
 	{
 		if (BindDrawPipeline(pipe))
-			Draw(config);
+			Draw(config, pass);
 		return;
 	}
 
@@ -4784,7 +4821,7 @@ void GSDevice12::SendHWDraw(const PipelineSelector& pipe, const GSHWDrawConfig& 
 					FeedbackBarrier(draw_ds);
 
 				if (BindDrawPipeline(pipe))
-					Draw(config, p, count);
+					Draw(config, pass, p, count);
 				p += count;
 			}
 
@@ -4803,7 +4840,7 @@ void GSDevice12::SendHWDraw(const PipelineSelector& pipe, const GSHWDrawConfig& 
 	}
 
 	if (BindDrawPipeline(pipe))
-		Draw(config);
+		Draw(config, pass);
 
 	if (config.ps.HasColorROV() || config.ps.HasDepthROV())
 		g_perfmon.Put(GSPerfMon::DrawCallsROV, 1);

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.h
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.h
@@ -409,7 +409,7 @@ private:
 	std::array<ComPtr<ID3D12PipelineState>, NUM_INTERLACE_SHADERS> m_interlace{};
 	std::array<ComPtr<ID3D12PipelineState>, 2> m_colclip_setup_pipelines{}; // [depth]
 	std::array<ComPtr<ID3D12PipelineState>, 2> m_colclip_finish_pipelines{}; // [depth]
-	std::array<std::array<ComPtr<ID3D12PipelineState>, 4>, 2> m_primid_image_setup_pipelines{}; // [depth][datm]
+	std::array<std::array<ComPtr<ID3D12PipelineState>, 5>, 2> m_primid_image_setup_pipelines{}; // [depth][datm]
 	ComPtr<ID3D12PipelineState> m_fxaa_pipeline;
 	ComPtr<ID3D12PipelineState> m_shadeboost_pipeline;
 	ComPtr<ID3D12PipelineState> m_imgui_pipeline;
@@ -540,8 +540,8 @@ public:
 	void DrawIndexedPrimitiveVSExpand(int offset, int count, bool vs_indexing, int vs_indexing_expansion);
 
 	// Main GS primitive draws.
-	void Draw(const GSHWDrawConfig& config);
-	void Draw(const GSHWDrawConfig& config, int offset, int count);
+	void Draw(const GSHWDrawConfig& config, GSHWDrawConfig::DrawPass pass);
+	void Draw(const GSHWDrawConfig& config, GSHWDrawConfig::DrawPass pass, int offset, int count);
 
 	std::unique_ptr<GSDownloadTexture> CreateDownloadTexture(u32 width, u32 height, GSTexture::Format format) override;
 
@@ -566,7 +566,7 @@ public:
 	void DrawStretchRect(const GSVector4& sRect, const GSVector4& dRect, const GSVector2i& ds);
 
 	void SetupDATE(GSTexture* rt, GSTexture* ds, SetDATM datm, const GSVector4i& bbox);
-	GSTexture12* SetupPrimitiveTrackingDATE(GSHWDrawConfig& config, PipelineSelector& pipe);
+	GSTexture12* SetupPrimitiveTracking(GSHWDrawConfig& config);
 
 	void IASetVertexBuffer(const void* vertex, size_t stride, size_t count);
 	void IASetIndexBuffer(const void* index, size_t count);
@@ -585,9 +585,8 @@ public:
 	bool BindDrawPipeline(const PipelineSelector& p);
 
 	void RenderHW(GSHWDrawConfig& config) override;
-	void SendHWDraw(const PipelineSelector& pipe, const GSHWDrawConfig& config, GSTexture12* draw_rt,
-		GSTexture12* draw_ds, GSTexture12* draw_rt_rov, GSTexture12* draw_ds_rov,
-		const bool feedback_rt, const bool feedback_depth, const bool one_barrier, const bool full_barrier);
+	void SendHWDraw(const PipelineSelector& pipe, const GSHWDrawConfig& config, GSHWDrawConfig::DrawPass pass, GSTexture12* draw_rt,
+		GSTexture12* draw_ds, GSTexture12* draw_rt_rov, GSTexture12* draw_ds_rov, bool feedback_rt, const bool feedback_depth);
 
 	void UpdateHWPipelineSelector(GSHWDrawConfig& config);
 	void UploadHWDrawVerticesAndIndices(GSHWDrawConfig& config);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5417,7 +5417,7 @@ void GSRendererHW::SetupIA(float target_scale, float sx, float sy, bool req_vert
 
 	const bool unscale_pt_ln = !GSConfig.UserHacks_DisableSafeFeatures && (target_scale != 1.0f);
 	const GSDevice::FeatureSupport features = g_gs_device->Features();
-	const bool draw_aa1 = !no_rt && PRIM->AA1 && features.aa1;
+	const bool draw_aa1 = m_conf.IsAA1Enabled();
 
 	pxAssert(VerifyIndices());
 
@@ -5551,10 +5551,20 @@ void GSRendererHW::SetupIA(float target_scale, float sx, float sy, bool req_vert
 				if (draw_aa1)
 				{
 					GL_INS("HW: AA1 triangle expand.");
-					m_conf.vs.expand = GSHWDrawConfig::VSExpand::TriangleAA1;
 					m_conf.cb_vs.point_size = GSVector2(16.0f * sx, 16.0f * sy);
 					m_conf.topology = GSHWDrawConfig::Topology::Triangle;
 					m_conf.indices_per_prim = 3;
+
+					if (GSHWDrawConfig::IsAA1MultiPass(m_conf.aa1_mode))
+					{
+						// Main pass handles triangle interiors, second pass does edges.
+						m_conf.vs.expand = GSHWDrawConfig::VSExpand::TriangleAA1Interior;
+						m_conf.aa1_multi_pass.vs.expand = GSHWDrawConfig::VSExpand::TriangleAA1Edge;
+					}
+					else
+					{
+						m_conf.vs.expand = GSHWDrawConfig::VSExpand::TriangleAA1;
+					}
 				}
 				else
 				{
@@ -5848,46 +5858,127 @@ void GSRendererHW::DetermineAlphaScaling(GSTextureCache::Target* rt, GSTextureCa
 	}
 }
 
+void GSRendererHW::OptimizeAlphaTestAndMasks(TryAlphaTestRegion region, GIFRegTEST& test, GSHWDrawConfig::ColorMaskSelector& colormask, bool& zwe)
+{
+	u32 fm = 0, zm = 0;
+	u32 atst = test.ATST;
+	u32 afail = test.AFAIL;
+
+	test.ATE &= !TryAlphaTest(fm, zm, region);
+	colormask.wr &= ((0x000000FF & ~fm) != 0);
+	colormask.wg &= ((0x0000FF00 & ~fm) != 0);
+	colormask.wb &= ((0x00FF0000 & ~fm) != 0);
+	colormask.wa &= ((0xFF000000 & ~fm) != 0);
+	zwe &= (zm == 0);
+
+	if (test.ATE)
+	{
+		SimplifyAlphaTest(colormask, m_interior_depth_write, atst, afail);
+		test = m_cached_ctx.TEST;
+		test.ATST = atst;
+		test.AFAIL = afail;
+		test.ATE &= (atst != ATST_ALWAYS);
+	}
+}
+
 void GSRendererHW::EmulateAA1()
 {
 	pxAssert(!g_gs_device->Features().aa1 || g_gs_device->Features().feedback_loops());
 
-	if (IsCoverageAlphaSupported())
+	if (!IsCoverageAlphaSupported() || !m_conf.rt || m_conf.colormask.wrgba == 0 ) // No AA1 if there's no color output.
 	{
-		m_conf.ps.abe = PRIM->ABE; // ABE flag determines how coverage is used for alpha.
+		m_conf.aa1_mode = GSHWDrawConfig::AA1Mode::Off;
+		return;
+	}
 
-		if (m_vt.m_primclass == GS_LINE_CLASS)
+	// Optimize alpha tests on interiors and/or edges.
+	m_interior_test = m_cached_ctx.TEST;
+	m_interior_mask = m_conf.colormask;
+	m_interior_depth_write = m_cached_ctx.DepthWrite();
+	m_edge_test = m_cached_ctx.TEST;
+	m_edge_mask = m_conf.colormask;
+	if (m_cached_ctx.TEST.ATE)
+	{
+		OptimizeAlphaTestAndMasks(TryAlphaTestRegion::INTERIOR, m_interior_test, m_interior_mask, m_interior_depth_write);
+
+		bool edge_depth_write = false; // edges always don't write depth.
+		OptimizeAlphaTestAndMasks(TryAlphaTestRegion::EDGE, m_edge_test, m_edge_mask, edge_depth_write);
+	}
+
+	if (!m_edge_mask.wrgba)
+	{
+		GL_INS("HW: No write on edges, AA1 disabled.");
+		m_conf.aa1_mode = GSHWDrawConfig::AA1Mode::Off;
+		return;
+	}
+
+	m_conf.ps.abe = PRIM->ABE; // ABE flag determines how coverage is used for alpha.
+
+	if (m_vt.m_primclass == GS_LINE_CLASS) // All AA1 levels supports lines.
+	{
+		GL_INS("HW: AA1 lines. No depth write.");
+
+		// AA1: Z is not written on lines since coverage is always less than 0x80.
+		m_conf.depth.zwe = false;
+		m_cached_ctx.ZBUF.ZMSK = 1;
+
+		m_conf.ps.aa1 = GSHWDrawConfig::PS_AA1::LINE;
+		m_conf.aa1_mode = GSHWDrawConfig::AA1Mode::OnePass;
+	}
+	else if (m_vt.m_primclass == GS_TRIANGLE_CLASS)
+	{
+		if (m_cached_ctx.DepthWrite())
 		{
-			GL_INS("HW: AA1 lines. No depth write.");
-
-			// AA1: Z is not written on lines since coverage is always less than 0x80.
-			m_conf.depth.zwe = false;
-			m_cached_ctx.ZBUF.ZMSK = 1;
-
-			m_conf.ps.aa1 = GSHWDrawConfig::PS_AA1::LINE;
-		}
-		else if (m_vt.m_primclass == GS_TRIANGLE_CLASS)
-		{
-			// Force SW depth so that Z writes can be prevented for edge pixels.
-			if (m_cached_ctx.DepthWrite())
+			if (GSConfig.HWAA1 == GSHWAA1Level::High ||
+				(GSConfig.HWAA1 == GSHWAA1Level::Medium && m_cached_ctx.TEST.DATE) || // Avoid primid with DATE.
+				// Barriers performs better than 3 pass primid on Metal.
+				(GSConfig.HWAA1 == GSHWAA1Level::Medium && GSGetCurrentRenderer() == GSRendererType::Metal) ||
+				GSConfig.HWROV || g_gs_device->Features().framebuffer_fetch) // Depth feedback is preferable to either two/three pass.
 			{
+				// Depth feedback AA1, most accurate/expensive.
+				// Force SW depth so that Z writes can be prevented for edge pixels.
 				GL_INS("HW: AA1 triangles with depth feedback.");
 
 				m_conf.ps.aa1 = GSHWDrawConfig::PS_AA1::TRIANGLE_SW_Z; // Allows discarding depth on edge pixels.
+				m_conf.aa1_mode = GSHWDrawConfig::AA1Mode::DepthFeedback;
 
 				ConfigureDepthFeedback(); // Enable barriers/SW depth test.
 			}
-			else
+			else if (GSConfig.HWAA1 == GSHWAA1Level::Medium)
 			{
-				GL_INS("HW: AA1 triangles with no depth write.");
+				// Three pass primid AA1, middle accurate/expensive.
+				// First draw triangle interiors, then edges with depth masked.
+				// Discard edge pixels if they are covered by interiors (determine with primid).
+				GL_INS("HW: AA1 triangles primid 3 pass.");
+
+				m_conf.ps.aa1 = GSHWDrawConfig::PS_AA1::TRIANGLE_PRIMID_INIT; // Setup for init pass.
+				m_conf.aa1_mode = GSHWDrawConfig::AA1Mode::ThreePassPrimid;
+			}
+			else if (GSConfig.HWAA1 == GSHWAA1Level::Low)
+			{
+				// Two pass AA1, least accurate/expensive.
+				// First draw triangle interiors, then edges with depth masked.
+				GL_INS("HW: AA1 triangles 2 pass.");
 
 				m_conf.ps.aa1 = GSHWDrawConfig::PS_AA1::TRIANGLE; // No special depth handling.
+				m_conf.aa1_mode = GSHWDrawConfig::AA1Mode::TwoPass;
+			}
+			else
+			{
+				pxFailRel("Impossible");
 			}
 		}
 		else
 		{
-			pxFail("Unsupported primclass for AA1"); // Impossible
+			GL_INS("HW: AA1 triangles with no depth write.");
+
+			m_conf.ps.aa1 = GSHWDrawConfig::PS_AA1::TRIANGLE; // No special depth handling.
+			m_conf.aa1_mode = GSHWDrawConfig::AA1Mode::OnePass;
 		}
+	}
+	else
+	{
+		pxFail("Unsupported primclass for AA1"); // Impossible
 	}
 }
 
@@ -5952,11 +6043,11 @@ void GSRendererHW::EmulateDATESelectMethod(DATEOptions& date_options, GSTextureC
 		date_options.barrier = true;
 		m_conf.require_full_barrier = true;
 	}
-	else if (features.feedback_loops() && IsCoverageAlphaSupported())
+	else if (features.feedback_loops() && m_conf.aa1_mode > GSHWDrawConfig::AA1Mode::OnePass)
 	{
-		// We're using AA1 for this draw so use only full barrier DATE, to avoid the complications
-		// with stencil/primid setup with AA1 vertex shaders. AA1 triangles usually require full barriers anyway.
-		GL_PERF("DATE: Accurate with IsCoverageAlphaSupported");
+		// We're using multipass AA1 for this draw so use only full barrier DATE, to avoid the complications
+		// with stencil/primid setup with AA1 vertex shaders. AA1 with depth feedback should be used (setup later).
+		GL_PERF("DATE: Accurate with multipass AA1");
 		date_options.barrier = true;
 		m_conf.require_full_barrier = true;
 	}
@@ -6019,7 +6110,7 @@ void GSRendererHW::EmulateDATESelectMethod(DATEOptions& date_options, GSTextureC
 			m_conf.require_full_barrier = true;
 			date_options.barrier = true;
 		}
-		else if (features.primitive_id)
+		else if (features.primitive_id && m_conf.aa1_mode <= GSHWDrawConfig::AA1Mode::OnePass)
 		{
 			GL_PERF("DATE: Accurate with alpha %d-%d", GetAlphaMinMax().min, GetAlphaMinMax().max);
 			date_options.primid = true;
@@ -8868,59 +8959,70 @@ void GSRendererHW::GetAlphaTestConfigPS(const u32 atst, const u8 aref, const boo
 	}
 }
 
+void GSRendererHW::SimplifyAlphaTest(const GSHWDrawConfig::ColorMaskSelector& colormask, const bool zwe, u32& atst, u32& afail)
+{
+	if (afail == AFAIL_RGB_ONLY && !colormask.wa)
+		afail = AFAIL_FB_ONLY;
+
+	if (!zwe && !colormask.wrgba)
+		atst = ATST_NEVER;
+
+	if ((afail == AFAIL_FB_ONLY && !zwe) ||
+		(afail == AFAIL_RGB_ONLY && !colormask.wa && !zwe) ||
+		(afail == AFAIL_ZB_ONLY && !colormask.wrgba))
+	{
+		// Failing alpha test is a NOP.
+		atst = ATST_ALWAYS;
+	}
+
+	if ((afail == AFAIL_FB_ONLY && !colormask.wrgba) ||
+		(afail == AFAIL_RGB_ONLY && !(colormask.wrgba & 7)) ||
+		(afail == AFAIL_ZB_ONLY && !zwe))
+	{
+		// Failing alpha test discards both color/depth.
+		afail = AFAIL_KEEP;
+	}
+}
+
 void GSRendererHW::EmulateAlphaTest(DATEOptions& date_options)
 {
 	const GSDevice::FeatureSupport& features = g_gs_device->Features();
 
-	if (!m_cached_ctx.TEST.ATE)
+	// If doing two pass AA1, optimize alpha test based on interiors only.
+	// Alpha test on edges is handled later.
+	const bool aa1_multipass = GSHWDrawConfig::IsAA1MultiPass(m_conf.aa1_mode);
+	GIFRegTEST& test = aa1_multipass ? m_interior_test : m_cached_ctx.TEST;
+	const bool zwe = aa1_multipass ? m_interior_depth_write : m_cached_ctx.DepthWrite();
+	const GSHWDrawConfig::ColorMaskSelector& colormask = aa1_multipass ? m_interior_mask : m_conf.colormask;
+
+	if (!test.ATE)
 	{
 		GL_INS("HW: Alpha test disabled");
 		m_conf.alpha_test = GSHWDrawConfig::AlphaTestMode::NONE;
 		return;
 	}
 
-	GL_PUSH("HW: Alpha test config (1)");
+	GL_PUSH("HW: Alpha test config (1st pass)");
 
 	// Temp pixel shader constants for the setup.
 	PS_ATST ps_atst;
 	float ps_aref;
 
-	u32 atst = m_cached_ctx.TEST.ATST;
-	u32 afail = m_cached_ctx.TEST.GetAFAIL(m_cached_ctx.FRAME.PSM);
-	u8 aref = m_cached_ctx.TEST.AREF;
-	const bool zwe = m_cached_ctx.DepthWrite();
+	u32 atst = test.ATST;
+	u32 afail = test.GetAFAIL(m_cached_ctx.FRAME.PSM);
+	u8 aref = test.AREF;
 
 	// First make some simplifications.
-	if (afail == AFAIL_RGB_ONLY && !m_conf.colormask.wa)
-		afail = AFAIL_FB_ONLY;
+	SimplifyAlphaTest(colormask, zwe, atst, afail);
 
-	if (!zwe && !m_conf.colormask.wrgba)
-		atst = ATST_NEVER;
-
-	if ((afail == AFAIL_FB_ONLY && !zwe) ||
-		(afail == AFAIL_RGB_ONLY && !m_conf.colormask.wa && !zwe) ||
-		(afail == AFAIL_ZB_ONLY && !m_conf.colormask.wrgba))
-	{
-		// Failing alpha test is a NOP.
-		atst = ATST_ALWAYS;
-	}
-
-	if ((afail == AFAIL_FB_ONLY && !m_conf.colormask.wrgba) ||
-		(afail == AFAIL_RGB_ONLY && (!(m_conf.colormask.wrgba & 7))) ||
-		(afail == AFAIL_ZB_ONLY && !zwe))
-	{
-		// Failing alpha test discards both color/depth.
-		afail = AFAIL_KEEP;
-	}
-
-	m_cached_ctx.TEST.ATST = atst;
-	m_cached_ctx.TEST.AFAIL = afail;
+	test.ATST = atst;
+	test.AFAIL = afail;
 	GL_INS("Using: ATST = %s, AFAIL = %s", GSUtil::GetATSTName(atst), GSUtil::GetAFAILName(afail));
 
 	if (atst == ATST_ALWAYS)
 	{
 		GL_INS("Alpha test: ALWAYS (disable)");
-		m_cached_ctx.TEST.ATE = false;
+		test.ATE = false;
 		m_conf.alpha_test = GSHWDrawConfig::AlphaTestMode::NONE;
 		return;
 	}
@@ -8975,6 +9077,11 @@ void GSRendererHW::EmulateAlphaTest(DATEOptions& date_options)
 		features.feedback_loops() &&
 		(!afail_needs_depth || m_conf.ps.IsFeedbackLoopDepth());
 
+	// Don't want to do 3-4 passes, all with color barriers. Better to just do depth feedback.
+	const bool possible_3_pass_barrier =
+		m_conf.require_full_barrier && features.feedback_loops() &&
+		(afail != AFAIL_KEEP) && aa1_multipass;
+
 	// Determine if we can use FB-fetch for color only feedback.
 	const bool free_fbfetch_feedback = features.framebuffer_fetch && !afail_needs_depth;
 
@@ -8986,7 +9093,7 @@ void GSRendererHW::EmulateAlphaTest(DATEOptions& date_options)
 
 	// Prefer feedback method only if it's free (color only feedback) or enabled.
 	const bool prefer_feedback = free_barrier_feedback || free_fbfetch_feedback ||
-	                             GSConfig.HWAccurateAlphaTest;
+	                             possible_3_pass_barrier || GSConfig.HWAccurateAlphaTest;
 
 	// The simple cases can be handle accurately in two passes so no point
 	// in requiring barriers if they are not already required.
@@ -9057,7 +9164,6 @@ void GSRendererHW::EmulateAlphaTest(DATEOptions& date_options)
 		}
 
 		// The actual blend setup will be done later after determining blending.
-
 		m_conf.alpha_test = GSHWDrawConfig::AlphaTestMode::SIMPLE_RGB_ONLY;
 	}
 	else
@@ -9074,26 +9180,50 @@ void GSRendererHW::EmulateAlphaTest(DATEOptions& date_options)
 	}
 }
 
+// Set up dual source blend so that we can do conditional alpha discard in the shader by manipulating the blend factors.
+void GSRendererHW::GetAlphaTestRGBOnlyDSBConfig(GSHWDrawConfig::BlendState& blend, GSHWDrawConfig::BlendMultiPass* blend_multi_pass)
+{
+	if (!blend.enable)
+	{
+		blend = GSHWDrawConfig::BlendState(true, GSDevice::CONST_ONE, GSDevice::CONST_ZERO,
+			GSDevice::OP_ADD, GSDevice::SRC1_ALPHA, GSDevice::INV_SRC1_ALPHA, false, 0);
+	}
+	else
+	{
+		if (blend_multi_pass && blend_multi_pass->enable)
+		{
+			blend_multi_pass->blend.src_factor_alpha = GSDevice::SRC1_ALPHA;
+			blend_multi_pass->blend.dst_factor_alpha = GSDevice::INV_SRC1_ALPHA;
+		}
+		else
+		{
+			blend.src_factor_alpha = GSDevice::SRC1_ALPHA;
+			blend.dst_factor_alpha = GSDevice::INV_SRC1_ALPHA;
+		}
+	}
+}
+
 void GSRendererHW::EmulateAlphaTestSecondPass()
 {
 	if (!GSHWDrawConfig::HasAlphaTestSecondPass(m_conf.alpha_test))
-	{
 		return;
-	}
 
-	GL_PUSH("HW: Alpha test config (2)");
-
-	const u32 atst = m_cached_ctx.TEST.ATST;
-	const u32 afail = m_cached_ctx.TEST.AFAIL;
-	const u32 aref = m_cached_ctx.TEST.AREF;
-
-	// Temp variables for PS config.
-	PS_ATST ps_atst;
-	float ps_aref;
+	GL_INS("HW: Alpha test config (2nd pass)");
 
 	std::memcpy(&m_conf.alpha_second_pass.ps, &m_conf.ps, sizeof(m_conf.ps));
 	std::memcpy(&m_conf.alpha_second_pass.colormask, &m_conf.colormask, sizeof(m_conf.colormask));
 	std::memcpy(&m_conf.alpha_second_pass.depth, &m_conf.depth, sizeof(m_conf.depth));
+	m_conf.alpha_second_pass.ps_aref = m_conf.cb_ps.FogColor_AREF.a;
+
+	const GIFRegTEST& test = GSHWDrawConfig::IsAA1MultiPass(m_conf.aa1_mode) ? m_interior_test : m_cached_ctx.TEST;
+
+	const u32 atst = test.ATST;
+	const u32 afail = test.AFAIL;
+	const u32 aref = test.AREF;
+
+	// Temp variables for PS config.
+	PS_ATST ps_atst;
+	float ps_aref;
 
 	if (m_conf.alpha_test == GSHWDrawConfig::AlphaTestMode::SIMPLE_FB_ONLY ||
 		m_conf.alpha_test == GSHWDrawConfig::AlphaTestMode::SIMPLE_RGB_ONLY)
@@ -9102,7 +9232,7 @@ void GSRendererHW::EmulateAlphaTestSecondPass()
 
 		m_conf.depth.zwe = false; // Disable Z write on first pass
 
-		m_conf.alpha_second_pass.colormask.wrgba = false; // Disable color write on second pass
+		m_conf.alpha_second_pass.colormask.wrgba = 0; // Disable color write on second pass
 
 		// Only need a second pass if Z is written.
 		if (m_conf.alpha_second_pass.depth.zwe)
@@ -9119,24 +9249,7 @@ void GSRendererHW::EmulateAlphaTestSecondPass()
 		if (m_conf.alpha_test == GSHWDrawConfig::AlphaTestMode::SIMPLE_RGB_ONLY)
 		{
 			pxAssert(!m_conf.ps.no_color1); // Make sure dual source blend didn't accidentally get disabled.
-			if (!m_conf.blend.enable)
-			{
-				m_conf.blend = GSHWDrawConfig::BlendState(true, GSDevice::CONST_ONE, GSDevice::CONST_ZERO,
-					GSDevice::OP_ADD, GSDevice::SRC1_ALPHA, GSDevice::INV_SRC1_ALPHA, false, 0);
-			}
-			else
-			{
-				if (m_conf.blend_multi_pass.enable)
-				{
-					m_conf.blend_multi_pass.blend.src_factor_alpha = GSDevice::SRC1_ALPHA;
-					m_conf.blend_multi_pass.blend.dst_factor_alpha = GSDevice::INV_SRC1_ALPHA;
-				}
-				else
-				{
-					m_conf.blend.src_factor_alpha = GSDevice::SRC1_ALPHA;
-					m_conf.blend.dst_factor_alpha = GSDevice::INV_SRC1_ALPHA;
-				}
-			}
+			GetAlphaTestRGBOnlyDSBConfig(m_conf.blend, &m_conf.blend_multi_pass);
 		}
 	}
 	else
@@ -9213,6 +9326,89 @@ void GSRendererHW::EmulateAlphaTestSecondPass()
 	// If the alpha test prevents all writes, abort the draw.
 	if (!(m_conf.colormask.wrgba || m_conf.depth.zwe))
 		m_conf.alpha_test = GSHWDrawConfig::AlphaTestMode::ABORT_DRAW;
+}
+
+void GSRendererHW::EmulateAA1MultiPass()
+{
+	if (!GSHWDrawConfig::IsAA1MultiPass(m_conf.aa1_mode))
+		return;
+
+	// Only triangles can have AA1 multipass.
+	pxAssert(m_vt.m_primclass == GS_TRIANGLE_CLASS);
+
+	// We cannot do AA1 primid and DATE primid simultaneously.
+	pxAssert(!(m_conf.aa1_mode == GSHWDrawConfig::AA1Mode::ThreePassPrimid &&
+		m_conf.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking));
+
+	// The primid method is not compatible with barriers.
+	const bool barriers_with_primid = m_conf.require_full_barrier &&
+		(m_conf.aa1_mode == GSHWDrawConfig::AA1Mode::ThreePassPrimid);
+
+	// If we are already using depth feedback, just use it for AA1 also.
+	const bool depth_feedback_enabled = m_conf.require_full_barrier && m_conf.ps.IsFeedbackLoopDepth();
+
+	if (barriers_with_primid || depth_feedback_enabled)
+	{
+		// Cancel 2/3 pass method and use accurate path.
+		GL_INS("HW: Using depth feedback, cancel AA1 2nd pass.");
+		m_conf.ps.aa1 = GSHWDrawConfig::PS_AA1::TRIANGLE_SW_Z;
+		m_conf.aa1_mode = GSHWDrawConfig::AA1Mode::DepthFeedback;
+		ConfigureDepthFeedback();
+		return;
+	}
+
+	GL_INS("HW: AA1 config (2nd/3rd pass).");
+
+	// Initialize AA1 multi pass.
+	m_conf.aa1_multi_pass.enable = true;
+
+	std::memcpy(&m_conf.aa1_multi_pass.ps, &m_conf.ps, sizeof(m_conf.ps));
+	std::memcpy(&m_conf.aa1_multi_pass.vs, &m_conf.vs, sizeof(m_conf.vs));
+	std::memcpy(&m_conf.aa1_multi_pass.colormask, &m_conf.colormask, sizeof(m_conf.colormask));
+	std::memcpy(&m_conf.aa1_multi_pass.depth, &m_conf.depth, sizeof(m_conf.depth));
+	std::memcpy(&m_conf.aa1_multi_pass.blend, &m_conf.blend, sizeof(m_conf.blend));
+	m_conf.aa1_multi_pass.ps_aref = m_conf.cb_ps.FogColor_AREF.a;
+
+	m_conf.aa1_multi_pass.ps.aa1 =
+		m_conf.aa1_mode == GSHWDrawConfig::AA1Mode::ThreePassPrimid ?
+			GSHWDrawConfig::PS_AA1::TRIANGLE_PRIMID:
+			GSHWDrawConfig::PS_AA1::TRIANGLE;
+
+	m_conf.aa1_multi_pass.depth.zwe = false; // Draws edge without depth.
+	m_conf.aa1_multi_pass.ps.DisableDepthOutput();
+
+	// Setup alpha test for the edges.
+	if (m_edge_test.ATE)
+	{
+		const auto ConfigureAlphaTest = [&]() {
+			GSHWDrawConfig::PS_ATST ps_atst;
+			float ps_aref;
+			GetAlphaTestConfigPS(m_edge_test.ATST, m_edge_test.AREF, false, ps_atst, ps_aref);
+			m_conf.aa1_multi_pass.ps.atst = ps_atst;
+			m_conf.aa1_multi_pass.ps_aref = ps_aref;
+		};
+		
+		if (m_edge_test.AFAIL == AFAIL_FB_ONLY)
+		{
+			// Depth is not written so alpha test is a NOP.
+			m_conf.aa1_multi_pass.ps.DisableAlphaTest();
+		}
+		// Depth is not written so alpha fail ZB_ONLY is the same as KEEP.
+		else if (m_edge_test.AFAIL == AFAIL_KEEP || m_edge_test.AFAIL == AFAIL_ZB_ONLY)
+		{
+			ConfigureAlphaTest();
+			m_conf.aa1_multi_pass.ps.afail = PS_AFAIL::KEEP;
+		}
+		else if (m_edge_test.AFAIL == AFAIL_RGB_ONLY)
+		{
+			// Use the dual source blend method for conditionally discarding alpha.
+			pxAssert(!m_conf.ps.no_color1); // Make sure dual source blend didn't accidentally get disabled.
+			
+			ConfigureAlphaTest();
+			m_conf.aa1_multi_pass.ps.afail = PS_AFAIL::RGB_ONLY_DSB;
+			GetAlphaTestRGBOnlyDSBConfig(m_conf.aa1_multi_pass.blend);
+		}
+	}
 }
 
 // Setup barriers and/or SW depth testing for depth feedback.
@@ -9305,9 +9501,6 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 
 	m_prim_overlap = PrimitiveOverlap(false);
 
-	// Do AA1 setup early so we can mask depth if possible.
-	EmulateAA1();
-
 	if (rt)
 	{
 		EmulateTextureShuffleAndFbmask(rt, tex);
@@ -9317,6 +9510,11 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 			return;
 		}
 	}
+
+	// Do AA1 setup early so we can mask depth if possible and optimize alpha test further.
+	// This must come AFTER the color mask is determined in EmulateTextureShuffleAndFbmask(),
+	// and BEFORE the alpha range is corrected in CorrectATEAlphaMinMax().
+	EmulateAA1();
 
 	if (EmulateDATEEarlyFail(date_options, rt))
 		return;
@@ -9481,8 +9679,16 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 	// This also computes the drawlist if needed.
 	DetermineBarriers(rt, tex);
 
-	// Perform second pass setup here once barriers are determined.
+	// Perform alpha second pass setup here once barriers are determined.
 	EmulateAlphaTestSecondPass();
+
+	// Perform AA1 second pass setup here once barriers are determined.
+	EmulateAA1MultiPass();
+	if (m_conf.IsAA1Enabled() && (!m_conf.rt || m_conf.colormask.wrgba == 0))
+	{
+		GL_INS("HW: No color write, disable AA1.");
+		m_conf.DisableAA1();
+	}
 
 	if (m_conf.alpha_test == GSHWDrawConfig::AlphaTestMode::ABORT_DRAW)
 	{
@@ -10979,6 +11185,8 @@ GSHWDrawConfig& GSRendererHW::BeginHLEHardwareDraw(
 	config.datm = SetDATM::DATM0;
 	config.line_expand = false;
 	config.alpha_second_pass.enable = false;
+	config.aa1_multi_pass.enable = false;
+	config.blend_multi_pass.enable = false;
 	config.vs.key = 0;
 	config.vs.tme = tex != nullptr;
 	config.vs.iip = true;
@@ -11070,5 +11278,8 @@ std::size_t GSRendererHW::ComputeDrawlistGetSize(float scale)
 
 bool GSRendererHW::IsCoverageAlphaSupported()
 {
-	return IsCoverageAlpha() && IsRTWritten() && g_gs_device->Features().aa1;
+	const bool check_level =
+		GSConfig.HWAA1 >= GSHWAA1Level::Low ||
+		(GSConfig.HWAA1 == GSHWAA1Level::LinesOnly && m_vt.m_primclass == GS_LINE_CLASS);
+	return IsCoverageAlpha() && IsRTWritten() && g_gs_device->Features().aa1 && check_level;
 }

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -233,7 +233,11 @@ private:
 
 	void EmulateZbuffer(const GSTextureCache::Target* ds);
 	void EmulateAA1();
+	void EmulateAA1MultiPass();
+	static void SimplifyAlphaTest(const GSHWDrawConfig::ColorMaskSelector& colormask, const bool zwe, u32& atst, u32& afail);
+	void OptimizeAlphaTestAndMasks(TryAlphaTestRegion region, GIFRegTEST& test, GSHWDrawConfig::ColorMaskSelector& colormask, bool& zwe);
 	static void GetAlphaTestConfigPS(const u32 atst, const u8 aref, const bool invert_test, PS_ATST& ps_atst_out, float& aref_out);
+	static void GetAlphaTestRGBOnlyDSBConfig(GSHWDrawConfig::BlendState& bs, GSHWDrawConfig::BlendMultiPass* blend_multi_mass = nullptr);
 	void EmulateAlphaTest(DATEOptions& date_options);
 	void EmulateAlphaTestSecondPass();
 	void ConfigureDepthFeedback(bool rov_depth = false);
@@ -340,6 +344,13 @@ private:
 
 	GSHWDrawConfig m_conf = {};
 	HWCachedCtx m_cached_ctx;
+
+	// For AA1 alpha test optimizations.
+	GIFRegTEST m_interior_test = {};
+	GIFRegTEST m_edge_test = {};
+	GSHWDrawConfig::ColorMaskSelector m_interior_mask = 0;
+	GSHWDrawConfig::ColorMaskSelector m_edge_mask = 0;
+	bool m_interior_depth_write = 0;
 
 	// software sprite renderer state
 	std::vector<GSVertexSW> m_sw_vertex_buffer;

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
@@ -256,7 +256,7 @@ public:
 	MRCOwned<id<MTLRenderPipelineState>> m_datm_pipeline[4];
 	MRCOwned<id<MTLRenderPipelineState>> m_clut_pipeline[2];
 	MRCOwned<id<MTLRenderPipelineState>> m_stencil_clear_pipeline;
-	MRCOwned<id<MTLRenderPipelineState>> m_primid_init_pipeline[2][4];
+	MRCOwned<id<MTLRenderPipelineState>> m_primid_init_pipeline[2][5];
 	MRCOwned<id<MTLRenderPipelineState>> m_colclip_init_pipeline;
 	MRCOwned<id<MTLRenderPipelineState>> m_colclip_clear_pipeline;
 	MRCOwned<id<MTLRenderPipelineState>> m_colclip_resolve_pipeline;
@@ -274,7 +274,7 @@ public:
 		return m_convert_pipeline[ShaderConvertSelector(shader).Index()];
 	}
 
-	MRCOwned<id<MTLFunction>> m_hw_vs[6 << 3];
+	MRCOwned<id<MTLFunction>> m_hw_vs[static_cast<u32>(GSShader::VSExpand::Count) << 3];
 	std::unordered_map<PSSelector, MRCOwned<id<MTLFunction>>> m_hw_ps;
 	std::unordered_map<PipelineSelectorMTL, MRCOwned<id<MTLRenderPipelineState>>> m_hw_pipeline;
 
@@ -467,8 +467,7 @@ public:
 	void SetupDestinationAlpha(GSTexture* rt, GSTexture* ds, const GSVector4i& r, SetDATM datm);
 	void PrepareROVTexture(GSTexture** ptex);
 	void RenderHW(GSHWDrawConfig& config) override;
-	void SendHWDraw(GSHWDrawConfig& config, id<MTLRenderCommandEncoder> enc, id<MTLBuffer> buffer, size_t off,
-		bool one_barrier, bool full_barrier);
+	void SendHWDraw(GSHWDrawConfig& config, GSHWDrawConfig::DrawPass pass, id<MTLRenderCommandEncoder> enc, id<MTLBuffer> buffer, size_t off);
 
 	// MARK: Debug
 

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -1067,7 +1067,7 @@ bool GSDeviceMTL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 	m_features.cas_sharpening = true;
 	m_features.test_and_sample_depth = true;
 	m_features.depth_feedback = getDepthFeedback(m_dev, m_features.framebuffer_fetch);
-	m_features.aa1 = GSConfig.HWAA1 && m_features.vs_expand;
+	m_features.aa1 = GSConfig.HWAA1 != GSHWAA1Level::Off && m_features.vs_expand;
 	m_features.rov = m_dev.features.rov && !m_features.framebuffer_fetch;
 	m_max_texture_size = m_dev.features.max_texsize;
 
@@ -1251,11 +1251,13 @@ bool GSDeviceMTL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 	m_primid_init_pipeline[1][1] = MakePipeline(pdesc, fs_triangle, LoadShader(@"ps_primid_init_datm1"), @"PrimID DATM1 Clear");
 	m_primid_init_pipeline[1][2] = MakePipeline(pdesc, fs_triangle, LoadShader(@"ps_primid_rta_init_datm0"), @"PrimID DATM0 RTA Clear");
 	m_primid_init_pipeline[1][3] = MakePipeline(pdesc, fs_triangle, LoadShader(@"ps_primid_rta_init_datm1"), @"PrimID DATM1 RTA Clear");
+	m_primid_init_pipeline[1][4] = MakePipeline(pdesc, fs_triangle, LoadShader(@"ps_primid_init_aa1"), @"PrimID AA1 Clear");
 	pdesc.depthAttachmentPixelFormat = MTLPixelFormatInvalid;
 	m_primid_init_pipeline[0][0] = MakePipeline(pdesc, fs_triangle, LoadShader(@"ps_primid_init_datm0"), @"PrimID DATM0 Clear");
 	m_primid_init_pipeline[0][1] = MakePipeline(pdesc, fs_triangle, LoadShader(@"ps_primid_init_datm1"), @"PrimID DATM1 Clear");
 	m_primid_init_pipeline[0][2] = MakePipeline(pdesc, fs_triangle, LoadShader(@"ps_primid_rta_init_datm0"), @"PrimID DATM0 RTA Clear");
 	m_primid_init_pipeline[0][3] = MakePipeline(pdesc, fs_triangle, LoadShader(@"ps_primid_rta_init_datm1"), @"PrimID DATM1 RTA Clear");
+	m_primid_init_pipeline[0][4] = MakePipeline(pdesc, fs_triangle, LoadShader(@"ps_primid_init_aa1"), @"PrimID AA1 Clear");
 
 	pdesc.colorAttachments[0].pixelFormat = ConvertPixelFormat(GSTexture::Format::Color);
 	applyAttribute(pdesc.vertexDescriptor, 0, MTLVertexFormatFloat2, offsetof(ConvertShaderVertex, pos),    0);
@@ -1735,9 +1737,11 @@ void GSDeviceMTL::RenderCopy(GSTexture* sTex, id<MTLRenderPipelineState> pipelin
 	// FS Triangle encoder uses vertex ID alone to make a FS triangle, which we then scissor to the desired rectangle
 	MRESetScissor(rect);
 	MRESetPipeline(pipeline);
-	MRESetTexture(sTex, GSMTLTextureIndexNonHW);
+	if (sTex)
+		MRESetTexture(sTex, GSMTLTextureIndexNonHW);
 	[m_current_render.encoder drawPrimitives:MTLPrimitiveTypeTriangle vertexStart:0 vertexCount:3];
-	g_perfmon.Put(GSPerfMon::TextureCopies, 1);
+	if (sTex)
+		g_perfmon.Put(GSPerfMon::TextureCopies, 1);
 	g_perfmon.Put(GSPerfMon::DrawCalls, 1);
 }
 
@@ -2360,14 +2364,7 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 	if (!config.vs.UseFixedExpandIndexBuffer())
 	{
 		memcpy(static_cast<u8*>(allocation.cpu_buffer) + vertsize, config.indices, idxsize);
-		if (config.vs.UseVSExpandIndexBuffer())
-		{
-			// VS expand index buffer is bound to the VS instead of the input assembler
-			u32 expand = GetExpansionFactor(config.vs.expand);
-			config.nindices *= expand;
-			config.indices_per_prim *= expand;
-		}
-		else
+		if (!config.vs.UseVSExpandIndexBuffer())
 		{
 			index_buffer = allocation.gpu_buffer;
 			index_buffer_offset = allocation.gpu_offset + vertsize;
@@ -2446,27 +2443,7 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 		case GSHWDrawConfig::DestinationAlphaMode::Full:
 			break; // No setup
 		case GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking:
-		{
-			FlushClears(rt);
-			GSVector2i size = rt->GetSize();
-			primid_tex = CreateRenderTarget(size.x, size.y, GSTexture::Format::PrimID);
-			DepthStencilSelector dsel = config.depth;
-			dsel.zwe = 0;
-			GSTexture* depth = dsel.key == DepthStencilSelector::NoDepth().key ? nullptr : config.ds;
-			BeginRenderPass(@"PrimID Destination Alpha Init", primid_tex, MTLLoadActionDontCare, depth, MTLLoadActionLoad);
-			RenderCopy(rt, m_primid_init_pipeline[static_cast<bool>(depth)][static_cast<u8>(config.datm)], config.drawarea);
-			MRESetDSS(dsel);
-			pxAssert(config.ps.date == 1 || config.ps.date == 2);
-			if (config.ps.tex_is_fb)
-				MRESetTexture(rt, GSMTLTextureIndexRenderTarget);
-			config.require_one_barrier = false; // Ending render pass is our barrier
-			pxAssert(config.require_full_barrier == false && config.drawlist == nullptr);
-			MRESetHWPipelineState(config.vs, config.ps, {}, {});
-			MREInitHWDraw(config, allocation);
-			SendHWDraw(config, m_current_render.encoder, index_buffer, index_buffer_offset, false, false);
-			config.ps.date = 3;
-			break;
-		}
+			break; // Done below
 		case GSHWDrawConfig::DestinationAlphaMode::StencilOne:
 			BeginRenderPass(@"Destination Alpha Stencil Clear", nullptr, MTLLoadActionDontCare, nullptr, MTLLoadActionDontCare, config.ds, MTLLoadActionDontCare);
 			[m_current_render.encoder setStencilReferenceValue:1];
@@ -2478,6 +2455,39 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 			SetupDestinationAlpha(rt, config.ds, config.drawarea, config.datm);
 			stencil = config.ds;
 			break;
+	}
+
+	// Destination alpha / AA1 primid setup
+	if (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking ||
+		config.aa1_mode == GSHWDrawConfig::AA1Mode::ThreePassPrimid)
+	{
+		const bool date = (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking);
+		const bool aa1 = (config.aa1_mode == GSHWDrawConfig::AA1Mode::ThreePassPrimid);
+		pxAssert(date != aa1); // exactly one must be true
+		FlushClears(rt);
+		GSVector2i size = rt->GetSize();
+		primid_tex = CreateRenderTarget(size.x, size.y, GSTexture::Format::PrimID);
+		DepthStencilSelector dsel = config.depth;
+		dsel.zwe = 0;
+		GSTexture* depth = dsel.key == DepthStencilSelector::NoDepth().key ? nullptr : config.ds;
+		BeginRenderPass(date ? @"PrimID Destination Alpha Init" : @"PrimID AA1 Init", primid_tex, MTLLoadActionDontCare, depth, MTLLoadActionLoad);
+		if (date)
+			RenderCopy(rt, m_primid_init_pipeline[static_cast<bool>(depth)][static_cast<u8>(config.datm)], config.drawarea);
+		else
+			RenderCopy(nullptr, m_primid_init_pipeline[static_cast<bool>(depth)][4], config.drawarea);
+		MRESetDSS(dsel);
+		pxAssert(config.ps.date == 1 || config.ps.date == 2);
+		if (config.ps.tex_is_fb)
+			MRESetTexture(rt, GSMTLTextureIndexRenderTarget);
+		config.require_one_barrier = false; // Ending render pass is our barrier
+		pxAssert(config.require_full_barrier == false && config.drawlist == nullptr);
+		MRESetHWPipelineState(config.vs, config.ps, {}, {});
+		MREInitHWDraw(config, allocation);
+		SendHWDraw(config, GSHWDrawConfig::DrawPass::PrimID, m_current_render.encoder, index_buffer, index_buffer_offset);
+		if (date)
+			config.ps.date = 3;
+		else
+			config.ps.aa1 = GSHWDrawConfig::PS_AA1::TRIANGLE;
 	}
 
 	// Try to reduce render pass restarts
@@ -2531,7 +2541,7 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 	MRESetHWPipelineState(config.vs, config.ps, config.blend, config.colormask);
 	MRESetDSS(config.depth);
 
-	SendHWDraw(config, mtlenc, index_buffer, index_buffer_offset, config.require_one_barrier, config.require_full_barrier);
+	SendHWDraw(config, GSHWDrawConfig::DrawPass::Main, mtlenc, index_buffer, index_buffer_offset);
 
 	if (config.alpha_second_pass.enable)
 	{
@@ -2542,7 +2552,19 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 		}
 		MRESetHWPipelineState(config.vs, config.alpha_second_pass.ps, config.blend, config.alpha_second_pass.colormask);
 		MRESetDSS(config.alpha_second_pass.depth);
-		SendHWDraw(config, mtlenc, index_buffer, index_buffer_offset, config.alpha_second_pass.require_one_barrier, config.alpha_second_pass.require_full_barrier);
+		SendHWDraw(config, GSHWDrawConfig::DrawPass::AlphaSecond, mtlenc, index_buffer, index_buffer_offset);
+	}
+
+	if (config.aa1_multi_pass.enable)
+	{
+		if (config.aa1_multi_pass.ps_aref != config.cb_ps.FogColor_AREF.a)
+		{
+			config.cb_ps.FogColor_AREF.a = config.aa1_multi_pass.ps_aref;
+			MRESetCB(config.cb_ps);
+		}
+		MRESetHWPipelineState(config.aa1_multi_pass.vs, config.aa1_multi_pass.ps, config.aa1_multi_pass.blend, config.aa1_multi_pass.colormask);
+		MRESetDSS(config.aa1_multi_pass.depth);
+		SendHWDraw(config, GSHWDrawConfig::DrawPass::AA1Second, mtlenc, index_buffer, index_buffer_offset);
 	}
 
 	if (colclip_rt)
@@ -2582,7 +2604,7 @@ static void EncodeDraw(id<MTLRenderCommandEncoder> enc, MTLPrimitiveType topolog
 	}
 }
 
-void GSDeviceMTL::SendHWDraw(GSHWDrawConfig& config, id<MTLRenderCommandEncoder> enc, id<MTLBuffer> buffer, size_t off, bool one_barrier, bool full_barrier)
+void GSDeviceMTL::SendHWDraw(GSHWDrawConfig& config, GSHWDrawConfig::DrawPass pass, id<MTLRenderCommandEncoder> enc, id<MTLBuffer> buffer, size_t off)
 {
 	MTLPrimitiveType topology;
 	switch (config.topology)
@@ -2592,19 +2614,35 @@ void GSDeviceMTL::SendHWDraw(GSHWDrawConfig& config, id<MTLRenderCommandEncoder>
 		case GSHWDrawConfig::Topology::Triangle: topology = MTLPrimitiveTypeTriangle; break;
 	}
 
+	u32 nindices = config.nindices;
+	u32 indices_per_prim = config.indices_per_prim;
+	
+	// VS expand index buffer is bound to the VS instead of the input assembler.
+	// Do the index expansion here as this the only type of expansion that may
+	// vary between different passes.
+	const GSHWDrawConfig::VSSelector& vs = config.GetVS(pass);
+	if (vs.UseVSExpandIndexBuffer())
+	{
+		u32 expand = GetExpansionFactor(vs.expand);
+		nindices *= expand;
+		indices_per_prim *= expand;
+	}
+
 	if (!m_features.texture_barrier) [[unlikely]]
 	{
-		EncodeDraw(enc, topology, config.nindices, buffer, off, 0);
+		EncodeDraw(enc, topology, nindices, buffer, off, 0);
 		g_perfmon.Put(GSPerfMon::DrawCalls, 1);
 		return;
 	}
 
+	const bool full_barrier = config.GetFullBarrier(pass);
+	const bool one_barrier = config.GetOneBarrier(pass);
 
 	if (full_barrier)
 	{
 		pxAssert(config.drawlist && !config.drawlist->empty());
 
-		[enc pushDebugGroup:[NSString stringWithFormat:@"Full barrier split draw (%d primitives in %zu groups)", config.nindices / config.indices_per_prim, config.drawlist->size()]];
+		[enc pushDebugGroup:[NSString stringWithFormat:@"Full barrier split draw (%d primitives in %zu groups)", nindices / indices_per_prim, config.drawlist->size()]];
 #if defined(_DEBUG)
 		// Check how draw call is split.
 		std::map<size_t, size_t> frequency;
@@ -2616,14 +2654,13 @@ void GSDeviceMTL::SendHWDraw(GSHWDrawConfig& config, id<MTLRenderCommandEncoder>
 			message += " " + std::to_string(it.first) + "(" + std::to_string(it.second) + ")";
 
 		[enc insertDebugSignpost:[NSString stringWithFormat:@"Split single draw (%d primitives) into %zu draws: consecutive draws(frequency):%s",
-			config.nindices / config.indices_per_prim, config.drawlist->size(), message.c_str()]];
+			nindices / indices_per_prim, config.drawlist->size(), message.c_str()]];
 #endif
 
 
 		g_perfmon.Put(GSPerfMon::DrawCalls, config.drawlist->size());
 		g_perfmon.Put(GSPerfMon::Barriers, config.drawlist->size());
 
-		const u32 indices_per_prim = config.indices_per_prim;
 		const u32 draw_list_size = static_cast<u32>(config.drawlist->size());
 
 		for (u32 n = 0, p = 0; n < draw_list_size; n++)
@@ -2644,7 +2681,7 @@ void GSDeviceMTL::SendHWDraw(GSHWDrawConfig& config, id<MTLRenderCommandEncoder>
 		g_perfmon.Put(GSPerfMon::Barriers, 1);
 	}
 
-	EncodeDraw(enc, topology, config.nindices, buffer, off, 0);
+	EncodeDraw(enc, topology, nindices, buffer, off, 0);
 	g_perfmon.Put(GSPerfMon::DrawCalls, 1);
 }
 

--- a/pcsx2/GS/Renderers/Metal/convert.metal
+++ b/pcsx2/GS/Renderers/Metal/convert.metal
@@ -130,6 +130,11 @@ fragment float4 ps_primid_rta_init_datm0(float4 p [[position]], DirectReadTextur
 	return tex.read(p).a > (254.5f / 255.f) ? -1 : FLT_MAX;
 }
 
+fragment float4 ps_primid_init_aa1()
+{
+	return -1;
+}
+
 fragment float4 ps_rta_correction(ConvertShaderData data [[stage_in]], ConvertPSRes res)
 {
 	float4 in = res.sample(data.t);

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -104,8 +104,8 @@ constant ROV_DEPTH PS_ROV_DEPTH = static_cast<ROV_DEPTH>(PS_ROV_DEPTH_RAW);
 	#define FBFETCH_SUPPORT 0
 #endif
 
-constant bool PS_PRIM_CHECKING_INIT = PS_DATE == 1 || PS_DATE == 2;
-constant bool PS_PRIM_CHECKING_READ = PS_DATE == 3;
+constant bool PS_PRIM_CHECKING_INIT = PS_DATE == 1 || PS_DATE == 2 || PS_AA1 == AA1::TRIANGLE_PRIMID_INIT;
+constant bool PS_PRIM_CHECKING_READ = PS_DATE == 3 || PS_AA1 == AA1::TRIANGLE_PRIMID;
 #if PRIMID_SUPPORT
 constant bool NEEDS_PRIMID = PS_PRIM_CHECKING_INIT || PS_PRIM_CHECKING_READ;
 #endif
@@ -130,11 +130,12 @@ constant bool PS_ZOUTPUT = (PS_ZCLAMP || PS_ZFLOOR || SW_DEPTH) && PS_ROV_DEPTH 
 constant bool PS_ZOUTPUT_LESS = PS_ZOUTPUT && !SW_DEPTH;
 constant bool PS_ZOUTPUT_ANY  = PS_ZOUTPUT && SW_DEPTH;
 constant bool PS_ZOUTPUT_COLOR = PS_ZOUTPUT_ANY && !DEPTH_FEEDBACK;
-constant bool VS_NEEDS_INDEX_BUFFER = VS_EXPAND_TYPE == VSExpand::TriangleAA1;
-constant bool VS_COVERAGE = VS_EXPAND_TYPE == VSExpand::LineAA1 || VS_EXPAND_TYPE == VSExpand::TriangleAA1;
-constant bool VS_INTERIOR = VS_EXPAND_TYPE == VSExpand::TriangleAA1;
+constant bool VS_TRIANGLE_AA1 = VS_EXPAND_TYPE >= VSExpand::TriangleAA1 && VS_EXPAND_TYPE <= VSExpand::TriangleAA1Edge;
+constant bool VS_NEEDS_INDEX_BUFFER = VS_TRIANGLE_AA1;
+constant bool VS_COVERAGE = VS_EXPAND_TYPE == VSExpand::LineAA1 || VS_TRIANGLE_AA1;
+constant bool VS_INTERIOR = VS_TRIANGLE_AA1;
 constant bool PS_COVERAGE = PS_AA1 != AA1::NONE;
-constant bool PS_INTERIOR = PS_AA1 == AA1::TRIANGLE_SW_Z;
+constant bool PS_INTERIOR = PS_AA1 >= AA1::TRIANGLE && PS_AA1 <= AA1::TRIANGLE_PRIMID_INIT;
 
 struct MainVSIn
 {
@@ -390,6 +391,7 @@ vertex MainVSOut vs_main_expand(
 {
 	switch (VS_EXPAND_TYPE)
 	{
+		case VSExpand::Count:
 		case VSExpand::None:
 			return vs_main_run(load_vertex(vertices[vid]), cb);
 		case VSExpand::Point:
@@ -462,6 +464,8 @@ vertex MainVSOut vs_main_expand(
 			return out;
 		}
 		case VSExpand::TriangleAA1:
+		case VSExpand::TriangleAA1Interior:
+		case VSExpand::TriangleAA1Edge:
 		{
 			// Triangles with AA1 are expanded as follows:
 			// - Vertices 0-2: Interior of triangle (1 triangle).
@@ -471,26 +475,51 @@ vertex MainVSOut vs_main_expand(
 			// - Vertices 21-26: First corner cap (2 triangles).
 			// - Vertices 27-32: Second corner cap (2 triangles).
 			// - Vertices 33-38: Third corner cap (2 triangles).
+			// With Interior or Edge the corresponding vertices are omitted.
 
-			uint prim_id = vid / 39;
-			uint prim_offset = vid - 39 * prim_id; // range: 0-38
-			bool interior = prim_offset < 3;
-			bool edge = 3 <= prim_offset && prim_offset < 21;
+			uint prim_id, prim_offset_interior, prim_offset_edges, prim_offset_caps;
+			switch (VS_EXPAND_TYPE)
+			{
+				default:
+				case VSExpand::TriangleAA1:
+					prim_id = vid / 39;
+					prim_offset_interior = vid - 39 * prim_id; // used range: 0-2
+					prim_offset_edges = prim_offset_interior - 3; // used range: 0-17
+					prim_offset_caps = prim_offset_edges - 18; // used range: 0-17
+					break;
+				case VSExpand::TriangleAA1Interior:
+					prim_id = vid / 3;
+					prim_offset_interior = vid - 3 * prim_id; // used range: 0-2
+					prim_offset_edges = -1; // unused
+					prim_offset_caps = -1; // unused
+					break;
+				case VSExpand::TriangleAA1Edge:
+					prim_id = vid / 36;
+					prim_offset_interior = -1; // unused
+					prim_offset_edges = vid - 36 * prim_id; // used range: 0-17
+					prim_offset_caps = prim_offset_edges - 18; // used range: 0-17
+					break;
+			}
 
-			MainVSOut out;
+			bool interior = 0 <= prim_offset_interior && prim_offset_interior < 3;
+			bool edge = 0 <= prim_offset_edges && prim_offset_edges < 18;
+
+			// Vertex indices for this edge. We need all 3 for determining exterior/interior.
+			uint i0 = interior ? prim_offset_interior : (edge ? prim_offset_edges / 6 : prim_offset_caps / 6);
+			uint i1 = (i0 >= 2) ? i0 - 2 : i0 + 1;
+			uint i2 = (i0 >= 1) ? i0 - 1 : i0 + 2;
+			MainVSOut out      = vs_main_run(load_vertex(vertices[indices[3 * prim_id + i0]]), cb);
+			MainVSOut other    = vs_main_run(load_vertex(vertices[indices[3 * prim_id + i1]]), cb);
+			MainVSOut opposite = vs_main_run(load_vertex(vertices[indices[3 * prim_id + i2]]), cb);
+			
 			if (interior)
 			{
-				out = vs_main_run(load_vertex(vertices[indices[3 * prim_id + prim_offset]]), cb);
+				out = vs_main_run(load_vertex(vertices[indices[3 * prim_id + prim_offset_interior]]), cb);
 				out.inv_cov = 0.f;
 				out.interior = 1;
 			}
 			else if (edge)
 			{
-				// Vertex indices for this edge. We need all 3 for determining exterior/interior.
-				uint prim_offset_edges = prim_offset - 3; // range: 0-17
-				uint i0 = prim_offset_edges / 6;
-				uint i1 = (i0 >= 2) ? i0 - 2 : i0 + 1;
-				uint i2 = (i0 >= 1) ? i0 - 1 : i0 + 2;
 				uint edge_offset = prim_offset_edges - 6 * i0; // range: 0-5
 
 				// Note: order of top/bottom, inside/outside is arbitrary,
@@ -516,11 +545,10 @@ vertex MainVSOut vs_main_expand(
 			else // Corner cap
 			{
 				// Vertex indices for this cap. We need all 3 for determining exterior/interior.
-				uint prim_offset_cap = prim_offset - 21; // range: 0-8
-				uint i0 = prim_offset_cap / 6;
+				uint i0 = prim_offset_caps / 6;
 				uint i1 = (i0 >= 2) ? i0 - 2 : i0 + 1;
 				uint i2 = (i0 >= 1) ? i0 - 1 : i0 + 2;
-				uint cap_offset = prim_offset_cap - 6 * i0; // range: 0-5
+				uint cap_offset = prim_offset_caps - 6 * i0; // range: 0-5
 
 				bool is_near_corner = cap_offset == 0 || cap_offset == 3;
 				bool is_far_corner = cap_offset == 2 || cap_offset == 5;
@@ -1521,13 +1549,25 @@ struct PSMain
 				discard();
 		}
 
-		if (PS_DATE == 3)
+		if (PS_DATE == 3 || PS_AA1 == AA1::TRIANGLE_PRIMID)
 		{
-			float stencil_ceil = prim_id_tex.read(uint2(in.p.xy)).r;
-			// Note prim_id == stencil_ceil will be the primitive that will update
-			// the bad alpha value so we must keep it.
-			if (float(prim_id) > stencil_ceil)
-				discard();
+			float primid_limit = prim_id_tex.read(uint2(in.p.xy)).r;
+
+			if (PS_DATE == 3)
+			{
+				// Note prim_id == primid_limit will be the primitive that will update
+				// the bad alpha value so we must keep it.
+				if (float(prim_id) > primid_limit)
+					discard();
+			}
+
+			if (PS_AA1 == AA1::TRIANGLE_PRIMID)
+			{
+				// Discard if this edge is under a previous triangle interior.
+				// Edge should never overlap with its own interior so < and <= should be the same here.
+				if (float(prim_id) <= primid_limit)
+					discard();
+			}
 		}
 
 		float4 C = ps_color();
@@ -1584,6 +1624,14 @@ struct PSMain
 		{
 			// DATM == 1, Pixel with alpha equal to 0 will failed (0-127)
 			out.c0 = C.a < 127.5f ? float(prim_id) : FLT_MAX;
+			return out;
+		}
+
+		// Get the last primitive whose interior overlaps the pixel.
+		if (PS_AA1 == AA1::TRIANGLE_PRIMID_INIT)
+		{
+			// Multiply by 12 because there are 12x as many edge triangles as interior triangles.
+			out.c0 = float(12 * prim_id);
 			return out;
 		}
 

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -910,7 +910,7 @@ bool GSDeviceOGL::CheckFeatures()
 		Console.Warning("GLAD_GL_ARB_conservative_depth is not supported. This will reduce performance.");
 	}
 	
-	m_features.aa1 = GSConfig.HWAA1 && m_features.vs_expand && m_features.feedback_loops();
+	m_features.aa1 = GSConfig.HWAA1 != GSHWAA1Level::Off && m_features.vs_expand && m_features.feedback_loops();
 	
 	return true;
 }
@@ -1330,12 +1330,13 @@ void GSDeviceOGL::DrawIndexedPrimitiveVSExpand(int offset, int count, bool vs_in
 	}
 }
 
-void GSDeviceOGL::Draw(const GSHWDrawConfig& config, int offset, int count)
+void GSDeviceOGL::Draw(const GSHWDrawConfig& config, GSHWDrawConfig::DrawPass pass, int offset, int count)
 {
-	if (config.vs.expand != GSHWDrawConfig::VSExpand::None)
+	const GSHWDrawConfig::VSSelector& vs = config.GetVS(pass);
+	if (vs.expand != GSHWDrawConfig::VSExpand::None)
 	{
-		const bool vs_indexing = config.vs.UseVSExpandIndexBuffer();
-		const u32 vs_indexing_expansion = GetExpansionFactor(config.vs.expand);
+		const bool vs_indexing = vs.UseVSExpandIndexBuffer();
+		const u32 vs_indexing_expansion = GetExpansionFactor(vs.expand);
 		DrawIndexedPrimitiveVSExpand(offset, count, vs_indexing, vs_indexing_expansion);
 	}
 	else
@@ -1344,9 +1345,9 @@ void GSDeviceOGL::Draw(const GSHWDrawConfig& config, int offset, int count)
 	}
 }
 
-void GSDeviceOGL::Draw(const GSHWDrawConfig& config)
+void GSDeviceOGL::Draw(const GSHWDrawConfig& config, GSHWDrawConfig::DrawPass pass)
 {
-	Draw(config, 0, m_index.count);
+	Draw(config, pass, 0, m_index.count);
 }
 
 void GSDeviceOGL::CommitClear(GSTexture* t, bool use_write_fbo)
@@ -1528,16 +1529,14 @@ GSDepthStencilOGL* GSDeviceOGL::CreateDepthStencil(OMDepthStencilSelector dssel)
 	return dss;
 }
 
-GSTexture* GSDeviceOGL::InitPrimDateTexture(GSTexture* rt, const GSVector4i& area, SetDATM datm)
+GSTexture* GSDeviceOGL::InitPrimIDTexture(GSTexture* rt, const GSVector2i& rtsize, const GSVector4i& area, u8 shader)
 {
-	const GSVector2i& rtsize = rt->GetSize();
-
 	GSTexture* tex = CreateRenderTarget(rtsize.x, rtsize.y, GSTexture::Format::PrimID, false);
 	if (!tex)
 		return nullptr;
 
 	GL_PUSH("PrimID Destination Alpha Clear");
-	DoStretchRect(rt, GSVector4(area) / GSVector4(rtsize).xyxy(), tex, GSVector4(area), m_date.primid_ps[static_cast<u8>(datm)], Nearest);
+	DoStretchRect(rt, GSVector4(area) / GSVector4(rtsize).xyxy(), tex, GSVector4(area), m_date.primid_ps[shader], Nearest);
 	return tex;
 }
 
@@ -1834,7 +1833,8 @@ void GSDeviceOGL::DoStretchRect(GSTexture* sTex, const GSVector4& sRect, GSTextu
 void GSDeviceOGL::DoStretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect,
 	const GLProgram& ps, bool alpha_blend, OMColorMaskSelector cms, Filter filter)
 {
-	CommitClear(sTex, true);
+	if (sTex)
+		CommitClear(sTex, true);
 
 	const bool draw_in_depth = dTex->IsDepthStencil();
 
@@ -1842,7 +1842,7 @@ void GSDeviceOGL::DoStretchRect(GSTexture* sTex, const GSVector4& sRect, GSTextu
 	// Init
 	// ************************************
 
-	GL_PUSH("StretchRect from %d to %d", static_cast<GSTextureOGL*>(sTex)->GetID(), static_cast<GSTextureOGL*>(dTex)->GetID());
+	GL_PUSH("StretchRect from %d to %d", sTex ? static_cast<GSTextureOGL*>(sTex)->GetID() : -1, static_cast<GSTextureOGL*>(dTex)->GetID());
 	if (draw_in_depth)
 		OMSetRenderTargets(nullptr, nullptr, dTex);
 	else
@@ -1872,7 +1872,7 @@ void GSDeviceOGL::DoStretchRect(GSTexture* sTex, const GSVector4& sRect, GSTextu
 	// ************************************
 	// Draw
 	// ************************************
-	DrawStretchRect(sRect, dRect, dTex->GetSize());
+	DrawStretchRect(sRect, dRect, dTex->GetSize(), sTex != nullptr);
 }
 
 void GSDeviceOGL::PresentRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, PresentShader shader, float shaderTime, Filter filter)
@@ -1983,9 +1983,9 @@ void GSDeviceOGL::FilteredDownsampleTexture(GSTexture* sTex, GSTexture* dTex, u3
 	DrawStretchRect(GSVector4::zero(), dRect, dTex->GetSize());
 }
 
-void GSDeviceOGL::DrawStretchRect(const GSVector4& sRect, const GSVector4& dRect, const GSVector2i& ds)
+void GSDeviceOGL::DrawStretchRect(const GSVector4& sRect, const GSVector4& dRect, const GSVector2i& ds, bool has_src)
 {
-	g_perfmon.Put(GSPerfMon::TextureCopies, 1);
+	g_perfmon.Put(GSPerfMon::TextureCopies, has_src ? 1 : 0); // only count as a copy if there's a source
 
 	const float inv_x = 2.0f / ds.x;
 	const float inv_y = 2.0f / ds.y;
@@ -2913,31 +2913,26 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 		draw_rt = colclip_rt ? colclip_rt : config.rt;
 	}
 
-	// Destination Alpha Setup
 	const bool need_barrier = config.require_one_barrier || (config.require_full_barrier && m_features.feedback_loops());
-	switch (config.destination_alpha)
+	
+	// Destination Alpha stencil setup
+	if (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::Stencil ||
+		(config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::StencilOne && !need_barrier))
+		SetupDATE(colclip_rt ? colclip_rt : config.rt, config.ds, config.datm, config.drawarea);
+
+	// Destination alpha / AA1 primid setup
+	if (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking ||
+		config.aa1_mode == GSHWDrawConfig::AA1Mode::ThreePassPrimid)
 	{
-		case GSHWDrawConfig::DestinationAlphaMode::Off:
-		case GSHWDrawConfig::DestinationAlphaMode::Full:
-			break; // No setup
-		case GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking:
-			primid_texture = InitPrimDateTexture(colclip_rt ? colclip_rt : config.rt, config.drawarea, config.datm);
-			if (!primid_texture)
-			{
-				Console.Warning("GL: Failed to allocate DATE image, aborting draw.");
-				return;
-			}
-			break;
-		case GSHWDrawConfig::DestinationAlphaMode::StencilOne:
-			if (need_barrier)
-			{
-				// Cleared after RT bind.
-				break;
-			}
-			[[fallthrough]];
-		case GSHWDrawConfig::DestinationAlphaMode::Stencil:
-			SetupDATE(colclip_rt ? colclip_rt : config.rt, config.ds, config.datm, config.drawarea);
-			break;
+		if (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking)
+			primid_texture = InitPrimIDTexture(colclip_rt ? colclip_rt : config.rt, rtsize, config.drawarea, static_cast<u8>(config.datm));
+		else
+			primid_texture = InitPrimIDTexture(nullptr, rtsize, config.drawarea, 4); // AA1
+		if (!primid_texture)
+		{
+			Console.Warning("GL: Failed to allocate primid image, aborting draw.");
+			return;
+		}
 	}
 
 	IASetVertexBuffer(config.verts, config.nverts, GetVertexAlignment(config.vs.expand));
@@ -3027,23 +3022,36 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 
 	if (primid_texture)
 	{
-		GL_PUSH("Destination Alpha PrimID Init");
+		const bool date = (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking);
+		const bool aa1 = (config.aa1_mode == GSHWDrawConfig::AA1Mode::ThreePassPrimid);
+		pxAssert(date != aa1); // exactly one must be true
+
+		GL_PUSH("%s PrimID Init", date ? "DATE" : "AA1");
 
 		OMSetRenderTargets(primid_texture, nullptr, config.ds, &config.scissor);
 		OMColorMaskSelector mask;
 		mask.wrgba = 0;
 		mask.wr = true;
 		OMSetColorMaskState(mask);
-		OMSetBlendState(true, GL_ONE, GL_ONE, GL_MIN);
+		OMSetBlendState(true, GL_ONE, GL_ONE, date ? GL_MIN : GL_FUNC_ADD);
 		OMDepthStencilSelector dss = config.depth;
 		dss.zwe = 0; // Don't write depth
 		SetupOM(dss);
 
-		// Compute primitiveID max that pass the date test (Draw without barrier)
-		Draw(config);
+		// DATE: Compute primitiveID max that pass (Draw without barrier)
+		// AA1: Compute primitiveID max of interior triangles
+		Draw(config, GSHWDrawConfig::DrawPass::PrimID);
 
-		psel.ps.date = 3;
-		config.alpha_second_pass.ps.date = 3;
+		if (date)
+		{
+			psel.ps.date = 3;
+			config.alpha_second_pass.ps.date = 3;
+			config.aa1_multi_pass.ps.date = 3;
+		}
+		else
+		{
+			psel.ps.aa1 = GSHWDrawConfig::PS_AA1::TRIANGLE;
+		}
 		SetupPipeline(psel);
 		PSSetShaderResource(TEXTURE_PRIMID, primid_texture);
 	}
@@ -3096,8 +3104,9 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 
 	const bool rt_feedbackloop_pass1 = config.IsFeedbackLoopRT(config.ps);
 	const bool rt_feedbackloop_pass2 = config.IsFeedbackLoopRT(config.alpha_second_pass.ps);
+	const bool rt_feedbackloop_pass3 = config.IsFeedbackLoopRT(config.aa1_multi_pass.ps);
 	if (draw_rt && !m_features.texture_barrier && (((config.require_one_barrier || (config.require_full_barrier && m_features.multidraw_fb_copy)) &&
-		(rt_feedbackloop_pass1 || rt_feedbackloop_pass2))))
+		(rt_feedbackloop_pass1 || rt_feedbackloop_pass2 || rt_feedbackloop_pass3))))
 	{
 		// Requires a copy of the RT.
 		draw_rt_clone = CreateTexture(rtsize.x, rtsize.y, 1, draw_rt->GetFormat(), true);
@@ -3108,8 +3117,9 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 
 	const bool ds_feedbackloop_pass1 = config.ps.IsFeedbackLoopDepth();
 	const bool ds_feedbackloop_pass2 = config.alpha_second_pass.ps.IsFeedbackLoopDepth();
+	const bool ds_feedbackloop_pass3 = config.aa1_multi_pass.ps.IsFeedbackLoopDepth();
 	if (draw_ds && !m_features.texture_barrier && m_features.depth_feedback &&
-		(config.require_one_barrier || (config.require_full_barrier && m_features.multidraw_fb_copy)) && (ds_feedbackloop_pass1 || ds_feedbackloop_pass2))
+		(config.require_one_barrier || (config.require_full_barrier && m_features.multidraw_fb_copy)) && (ds_feedbackloop_pass1 || ds_feedbackloop_pass2 || ds_feedbackloop_pass3))
 	{
 		// Requires a copy of the DS.
 		draw_ds_clone = CreateTexture(rtsize.x, rtsize.y, 1, draw_ds->GetFormat(), true);
@@ -3129,8 +3139,7 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 		glClearBufferiv(GL_STENCIL, 0, &clear_color);
 	}
 
-	SendHWDraw(config, rt_feedbackloop_pass1 ? draw_rt_clone : nullptr, draw_rt, ds_feedbackloop_pass1 ? draw_ds_clone : nullptr, draw_ds,
-		config.require_one_barrier, config.require_full_barrier);
+	SendHWDraw(config, GSHWDrawConfig::DrawPass::Main, rt_feedbackloop_pass1 ? draw_rt_clone : nullptr, draw_rt, ds_feedbackloop_pass1 ? draw_ds_clone : nullptr, draw_ds);
 
 	if (config.blend_multi_pass.enable)
 	{
@@ -3149,7 +3158,7 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 		psel.ps.blend_hw = config.blend_multi_pass.blend_hw;
 		psel.ps.dither = config.blend_multi_pass.dither;
 		SetupPipeline(psel);
-		Draw(config);
+		Draw(config, GSHWDrawConfig::DrawPass::Blend);
 	}
 
 	if (config.alpha_second_pass.enable)
@@ -3175,10 +3184,40 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 		{
 			OMSetBlendState();
 		}
-		const bool one_barrier = config.alpha_second_pass.require_one_barrier && m_features.feedback_loops();
+		
 		SetupOM(config.alpha_second_pass.depth);
-		SendHWDraw(config, rt_feedbackloop_pass2 ? draw_rt_clone : nullptr, draw_rt, ds_feedbackloop_pass2 ? draw_ds_clone : nullptr, draw_ds,
-			one_barrier, config.alpha_second_pass.require_full_barrier);
+		SendHWDraw(config, GSHWDrawConfig::DrawPass::AlphaSecond, rt_feedbackloop_pass2 ? draw_rt_clone : nullptr, draw_rt, ds_feedbackloop_pass2 ? draw_ds_clone : nullptr, draw_ds);
+	}
+
+	if (config.aa1_multi_pass.enable)
+	{
+		// cbuffer will definitely be dirty if aref changes, no need to check it
+		if (config.cb_ps.FogColor_AREF.a != config.aa1_multi_pass.ps_aref)
+		{
+			config.cb_ps.FogColor_AREF.a = config.aa1_multi_pass.ps_aref;
+			PSSetUniformBuffer(config.cb_ps);
+		}
+
+		psel.vs = config.aa1_multi_pass.vs;
+		psel.ps = config.aa1_multi_pass.ps;
+		SetupPipeline(psel);
+		OMSetColorMaskState(config.aa1_multi_pass.colormask);
+		const GSHWDrawConfig::BlendState& blend_aa1 = config.aa1_multi_pass.blend;
+		if (blend_aa1.IsEffective(config.aa1_multi_pass.colormask))
+		{
+			OMSetBlendState(blend_aa1.enable, s_gl_blend_factors[blend_aa1.src_factor],
+				s_gl_blend_factors[blend_aa1.dst_factor], s_gl_blend_ops[blend_aa1.op],
+				s_gl_blend_factors[blend_aa1.src_factor_alpha], s_gl_blend_factors[blend_aa1.dst_factor_alpha],
+				blend_aa1.constant_enable, blend_aa1.constant);
+		}
+		else
+		{
+			OMSetBlendState();
+		}
+
+		SetupOM(config.aa1_multi_pass.depth);
+		SendHWDraw(config, GSHWDrawConfig::DrawPass::AA1Second, rt_feedbackloop_pass3 ? draw_rt_clone : nullptr, draw_rt,
+			ds_feedbackloop_pass3 ? draw_ds_clone : nullptr, draw_ds);
 	}
 
 	if (colclip_rt)
@@ -3249,10 +3288,12 @@ void GSDeviceOGL::FeedbackCopyAndBind(const GSHWDrawConfig& config,
 	}
 }
 
-void GSDeviceOGL::SendHWDraw(const GSHWDrawConfig& config,
-	GSTexture* draw_rt_clone, GSTexture* draw_rt, GSTexture* draw_ds_clone, GSTexture* draw_ds,
-	const bool one_barrier, const bool full_barrier)
+void GSDeviceOGL::SendHWDraw(const GSHWDrawConfig& config, GSHWDrawConfig::DrawPass pass,
+	GSTexture* draw_rt_clone, GSTexture* draw_rt, GSTexture* draw_ds_clone, GSTexture* draw_ds)
 {
+	const bool full_barrier = config.GetFullBarrier(pass);
+	const bool one_barrier = config.GetOneBarrier(pass);
+
 #ifdef PCSX2_DEVBUILD
 	if ((one_barrier || full_barrier) && !(config.IsFeedbackLoopRT(config.ps) || config.IsFeedbackLoopDepth(config.ps))) [[unlikely]]
 		Console.Warning("OpenGL: Possible unnecessary barrier detected.");
@@ -3287,7 +3328,7 @@ void GSDeviceOGL::SendHWDraw(const GSHWDrawConfig& config,
 				FeedbackCopyAndBind(config, draw_rt, draw_rt_clone, draw_ds, draw_ds_clone, bbox);
 			}
 
-			Draw(config, p, count);
+			Draw(config, pass, p, count);
 			p += count;
 		}
 
@@ -3308,7 +3349,7 @@ void GSDeviceOGL::SendHWDraw(const GSHWDrawConfig& config,
 		}
 	}
 
-	Draw(config);
+	Draw(config, pass);
 }
 
 // Note: used as a callback of DebugMessageCallback. Don't change the signature

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -220,7 +220,7 @@ private:
 	struct
 	{
 		GSDepthStencilOGL* dss = nullptr;
-		GLProgram primid_ps[4];
+		GLProgram primid_ps[5];
 	} m_date;
 
 	struct
@@ -309,7 +309,7 @@ private:
 	void OMAttachDs(GSTexture* ds = nullptr);
 	void OMSetFBO(GLuint fbo);
 
-	void DrawStretchRect(const GSVector4& sRect, const GSVector4& dRect, const GSVector2i& ds);
+	void DrawStretchRect(const GSVector4& sRect, const GSVector4& dRect, const GSVector2i& ds, bool has_src = true);
 
 	void SetIndexBuffer(std::unique_ptr<GLStreamBuffer>& buffer, const void* index, size_t count);
 
@@ -363,12 +363,12 @@ public:
 	void DrawIndexedPrimitiveVSExpand(int offset, int count, bool vs_indexing, int vs_indexing_expansion);
 
 	// Main GS primitive draws.
-	void Draw(const GSHWDrawConfig& config);
-	void Draw(const GSHWDrawConfig& config, int offset, int count);
+	void Draw(const GSHWDrawConfig& config, GSHWDrawConfig::DrawPass pass);
+	void Draw(const GSHWDrawConfig& config, GSHWDrawConfig::DrawPass pass, int offset, int count);
 
 	std::unique_ptr<GSDownloadTexture> CreateDownloadTexture(u32 width, u32 height, GSTexture::Format format) override;
 
-	GSTexture* InitPrimDateTexture(GSTexture* rt, const GSVector4i& area, SetDATM datm);
+	GSTexture* InitPrimIDTexture(GSTexture* rt, const GSVector2i& rtsize, const GSVector4i& area, u8 shader);
 
 	void CopyRect(GSTexture* sTex, GSTexture* dTex, const GSVector4i& r, u32 destX, u32 destY) override;
 
@@ -395,9 +395,8 @@ public:
 	void FeedbackCopyAndBind(const GSHWDrawConfig& config,
 		GSTexture* rt, GSTexture* rt_clone, GSTexture* ds, GSTexture* ds_clone,
 		const GSVector4i& copyarea, const GSVector4i& samplearea);
-	void SendHWDraw(const GSHWDrawConfig& config,
-		GSTexture* draw_rt_clone, GSTexture* draw_rt, GSTexture* draw_ds_clone, GSTexture* draw_ds,
-		const bool one_barrier, const bool full_barrier);
+	void SendHWDraw(const GSHWDrawConfig& config, GSHWDrawConfig::DrawPass pass,
+		GSTexture* draw_rt_clone, GSTexture* draw_rt, GSTexture* draw_ds_clone, GSTexture* draw_ds);
 	void SetupDATE(GSTexture* rt, GSTexture* ds, SetDATM datm, const GSVector4i& bbox);
 
 	void VSSetUniformBuffer(GSHWDrawConfig::VSConstantBuffer& cb);

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -2798,7 +2798,7 @@ bool GSDeviceVK::CheckFeatures()
 		(m_device_features.wideLines && limits.lineWidthRange[0] <= f_upscale && limits.lineWidthRange[1] >= f_upscale);
 
 	m_features.depth_feedback = m_features.feedback_loops();
-	m_features.aa1 = GSConfig.HWAA1 && m_features.vs_expand && m_features.feedback_loops();
+	m_features.aa1 = GSConfig.HWAA1 != GSHWAA1Level::Off && m_features.vs_expand && m_features.feedback_loops();
 
 	DevCon.WriteLn("Optional features:%s%s%s%s%s", m_features.primitive_id ? " primitive_id" : "",
 		m_features.texture_barrier ? " texture_barrier" : "", m_features.framebuffer_fetch ? " framebuffer_fetch" : "",
@@ -2893,12 +2893,13 @@ void GSDeviceVK::DrawIndexedPrimitiveVSExpand(int offset, int count, bool vs_ind
 	}
 }
 
-void GSDeviceVK::Draw(const GSHWDrawConfig& config, int offset, int count)
+void GSDeviceVK::Draw(const GSHWDrawConfig& config, GSHWDrawConfig::DrawPass pass, int offset, int count)
 {
-	if (config.vs.expand != GSHWDrawConfig::VSExpand::None)
+	const GSHWDrawConfig::VSSelector& vs = config.GetVS(pass);
+	if (vs.expand != GSHWDrawConfig::VSExpand::None)
 	{
-		const bool vs_indexing = config.vs.UseVSExpandIndexBuffer();
-		const u32 vs_indexing_expansion = GetExpansionFactor(config.vs.expand);
+		const bool vs_indexing = vs.UseVSExpandIndexBuffer();
+		const u32 vs_indexing_expansion = GetExpansionFactor(vs.expand);
 		DrawIndexedPrimitiveVSExpand(offset, count, vs_indexing, vs_indexing_expansion);
 	}
 	else
@@ -2907,9 +2908,9 @@ void GSDeviceVK::Draw(const GSHWDrawConfig& config, int offset, int count)
 	}
 }
 
-void GSDeviceVK::Draw(const GSHWDrawConfig& config)
+void GSDeviceVK::Draw(const GSHWDrawConfig& config, GSHWDrawConfig::DrawPass pass)
 {
-	Draw(config, 0, m_index.count);
+	Draw(config, pass, 0, m_index.count);
 }
 
 VkFormat GSDeviceVK::LookupNativeFormat(GSTexture::Format format) const
@@ -4258,9 +4259,9 @@ bool GSDeviceVK::CompileConvertPipelines()
 		}
 	}
 
-	for (u32 datm = 0; datm < 4; datm++)
+	for (u32 i = 0; i < 5; i++)
 	{
-		const std::string entry_point(StringUtil::StdStringFromFormat("ps_primid_image_init_%d", datm));
+		const std::string entry_point(StringUtil::StdStringFromFormat("ps_primid_image_init_%d", i));
 		VkShaderModule ps =
 			GetUtilityFragmentShader(*source, entry_point.c_str());
 		if (ps == VK_NULL_HANDLE)
@@ -4278,13 +4279,21 @@ bool GSDeviceVK::CompileConvertPipelines()
 		for (u32 ds = 0; ds < 2; ds++)
 		{
 			gpb.SetRenderPass(m_primid_image_setup_render_passes[ds][0], 0);
-			m_primid_image_setup_pipelines[ds][datm] =
+			m_primid_image_setup_pipelines[ds][i] =
 				gpb.Create(m_device, g_vulkan_shader_cache->GetPipelineCache(true), false);
-			if (!m_primid_image_setup_pipelines[ds][datm])
+			if (!m_primid_image_setup_pipelines[ds][i])
 				return false;
 
-			Vulkan::SetObjectName(m_device, m_primid_image_setup_pipelines[ds][datm],
-				"DATE image clear pipeline (ds=%u, datm=%u)", ds, (datm == 1 || datm == 3));
+			if (i < 4)
+			{
+				Vulkan::SetObjectName(m_device, m_primid_image_setup_pipelines[ds][i],
+					"DATE primid image clear pipeline (ds=%u, datm=%u)", ds, (i == 1 || i == 3));
+			}
+			else
+			{
+				Vulkan::SetObjectName(m_device, m_primid_image_setup_pipelines[ds][i],
+					"AA1 primid image clear pipeline (ds=%u)", ds);
+			}
 		}
 	}
 
@@ -4810,7 +4819,7 @@ void GSDeviceVK::DestroyResources()
 	}
 	for (u32 ds = 0; ds < 2; ds++)
 	{
-		for (u32 datm = 0; datm < 4; datm++)
+		for (u32 datm = 0; datm < 5; datm++)
 		{
 			if (m_primid_image_setup_pipelines[ds][datm] != VK_NULL_HANDLE)
 				vkDestroyPipeline(m_device, m_primid_image_setup_pipelines[ds][datm], nullptr);
@@ -5038,9 +5047,9 @@ VkPipeline GSDeviceVK::CreateTFXPipeline(const PipelineSelector& p)
 
 	// Common state
 	gpb.SetPipelineLayout(m_tfx_pipeline_layout);
-	if (IsDATEModePrimIDInit(p.ps.date))
+	if (IsDATEModePrimIDInit(p.ps.date) || p.ps.aa1 == GSHWDrawConfig::PS_AA1::TRIANGLE_PRIMID_INIT)
 	{
-		// DATE image prepass
+		// DATE or AA1 image prepass
 		gpb.SetRenderPass(m_primid_image_setup_render_passes[p.ds][0], 0);
 	}
 	else
@@ -5886,16 +5895,27 @@ void GSDeviceVK::SetupDATE(GSTexture* rt, GSTexture* ds, SetDATM datm, const GSV
 	EndRenderPass();
 }
 
-GSTextureVK* GSDeviceVK::SetupPrimitiveTrackingDATE(GSHWDrawConfig& config)
+GSTextureVK* GSDeviceVK::SetupPrimitiveTracking(GSHWDrawConfig& config)
 {
-	g_perfmon.Put(GSPerfMon::TextureCopies, 1);
+	const bool date = (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking);
+	const bool aa1 = (config.aa1_mode == GSHWDrawConfig::AA1Mode::ThreePassPrimid);
+	pxAssert(date != aa1); // exactly one must be true
 
-	// How this is done:
+	g_perfmon.Put(GSPerfMon::TextureCopies, date ? 1 : 0); // Only a copy if it's DATE; AA1 doesn't sample RT.
+
+	// How DATE is done:
 	// - can't put a barrier for the image in the middle of the normal render pass, so that's out
 	// - so, instead of just filling the int texture with INT_MAX, we sample the RT and use -1 for failing values
 	// - then, instead of sampling the RT with DATE=1/2, we just do a min() without it, the -1 gets preserved
 	// - then, the DATE=3 draw is done as normal
-	GL_INS("Setup DATE Primitive ID Image for {%d,%d}-{%d,%d}", config.drawarea.left, config.drawarea.top,
+
+	// How AA1 is done:
+	// - Initialize the primid texture to -1 (allow everything).
+	// - Write the primid of the interior triangles.
+	// - In the edge pass, discard edge pixels that are overlapped by an interior in primid order.
+
+	GL_INS("Setup %s Primitive ID Image for {%d,%d}-{%d,%d}", date ? "DATE": "AA1",
+		config.drawarea.left, config.drawarea.top,
 		config.drawarea.right, config.drawarea.bottom);
 
 	const GSVector2i rtsize(config.rt->GetSize());
@@ -5906,8 +5926,11 @@ GSTextureVK* GSDeviceVK::SetupPrimitiveTrackingDATE(GSHWDrawConfig& config)
 
 	EndRenderPass();
 
-	// setup the fill quad to prefill with existing alpha values
-	SetUtilityTexture(config.rt, m_point_sampler);
+	// setup the fill quad to prefill with init values
+	if (date)
+		SetUtilityTexture(config.rt, m_point_sampler);
+	else
+		SetUtilityTexture(m_null_texture.get(), m_point_sampler);
 	OMSetRenderTargets(image, config.ds, config.drawarea);
 
 	// if the depth target has been cleared, we need to preserve that clear
@@ -5935,7 +5958,7 @@ GSTextureVK* GSDeviceVK::SetupPrimitiveTrackingDATE(GSHWDrawConfig& config)
 		{GSVector4(dst.x, -dst.w, 0.5f, 1.0f), GSVector2(src.x, src.w)},
 		{GSVector4(dst.z, -dst.w, 0.5f, 1.0f), GSVector2(src.z, src.w)},
 	};
-	const VkPipeline pipeline = m_primid_image_setup_pipelines[ds][static_cast<u8>(config.datm)];
+	const VkPipeline pipeline = m_primid_image_setup_pipelines[ds][aa1 ? 4 : static_cast<u8>(config.datm)];
 	SetPipeline(pipeline);
 	IASetVertexBuffer(vertices, sizeof(vertices[0]), std::size(vertices));
 	if (ApplyUtilityState())
@@ -5945,13 +5968,13 @@ GSTextureVK* GSDeviceVK::SetupPrimitiveTrackingDATE(GSHWDrawConfig& config)
 	UploadHWDrawVerticesAndIndices(config);
 
 	// primid texture will get re-bound, so clear it since we're using push descriptors
-	PSSetShaderResource(3, m_null_texture.get(), false);
+	PSSetShaderResource(TFX_TEXTURE_PRIMID, m_null_texture.get(), false);
 
 	// cut down the configuration for the prepass, we don't need blending or any feedback loop
 	PipelineSelector& pipe = m_pipeline_selector;
 	UpdateHWPipelineSelector(config, pipe);
 	pipe.dss.zwe = false;
-	pipe.cms.wrgba = 0;
+	pipe.cms = GSHWDrawConfig::ColorMaskSelector();
 	pipe.bs = {};
 	pipe.feedback_loop_flags = FeedbackLoopFlag_None;
 	pipe.rt = true;
@@ -5959,18 +5982,27 @@ GSTextureVK* GSDeviceVK::SetupPrimitiveTrackingDATE(GSHWDrawConfig& config)
 	pipe.ps.no_color = false;
 	pipe.ps.no_color1 = true;
 	if (BindDrawPipeline(pipe))
-		Draw(config);
+		Draw(config, GSHWDrawConfig::DrawPass::PrimID);
 
 	// image is initialized/prepass is done, so finish up and get ready to do the "real" draw
 	EndRenderPass();
 
-	// .. by setting it to DATE=3
-	config.ps.date = 3;
-	config.alpha_second_pass.ps.date = 3;
+	if (date)
+	{
+		// set DATE=3 for the real draw
+		config.ps.date = 3;
+		config.alpha_second_pass.ps.date = 3;
+		config.aa1_multi_pass.ps.date = 3;
+	}
+	else
+	{
+		// set triangle interiors for the real draw
+		config.ps.aa1 = GSHWDrawConfig::PS_AA1::TRIANGLE;
+	}
 
 	// and bind the image to the primitive sampler
 	image->TransitionToLayout(GSTextureVK::Layout::ShaderReadOnly);
-	PSSetShaderResource(3, image, false);
+	PSSetShaderResource(TFX_TEXTURE_PRIMID, image, false);
 	return image;
 }
 
@@ -6003,10 +6035,10 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 	if (config.topology == GSHWDrawConfig::Topology::Line)
 		SetLineWidth(config.line_expand ? config.cb_ps.ScaleFactor.z : 1.0f);
 
-	// Primitive ID tracking DATE setup.
-	// Needs to be done before
+	// Primitive ID tracking DATE/AA1 setup.
 	GSTextureVK* date_image = nullptr;
-	if (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking)
+	if (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking ||
+		config.aa1_mode == GSHWDrawConfig::AA1Mode::ThreePassPrimid)
 	{
 		// If we have a colclip in progress, we need to use the colclip texture, but we can't check this later as there's a chicken/egg problem with the pipe setup.
 		GSTexture* backup_rt = config.rt;
@@ -6014,10 +6046,10 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 		if (colclip_rt)
 			config.rt = colclip_rt;
 
-		date_image = SetupPrimitiveTrackingDATE(config);
+		date_image = SetupPrimitiveTracking(config);
 		if (!date_image)
 		{
-			Console.Warning("VK: Failed to allocate DATE image, aborting draw.");
+			Console.Warning("VK: Failed to allocate primid image, aborting draw.");
 			return;
 		}
 
@@ -6083,28 +6115,14 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 		}
 	}
 
-	// Destination Alpha Setup
 	const bool need_barrier = config.require_one_barrier || (config.require_full_barrier && m_features.texture_barrier);
-	switch (config.destination_alpha)
-	{
-		case GSHWDrawConfig::DestinationAlphaMode::Off: // No setup
-		case GSHWDrawConfig::DestinationAlphaMode::Full: // No setup
-		case GSHWDrawConfig::DestinationAlphaMode::PrimIDTracking: // Setup is done below
-			break;
-		case GSHWDrawConfig::DestinationAlphaMode::StencilOne: // setup is done below
-		{
-			// we only need to do the setup here if we don't have barriers, in which case do full DATE.
-			if (!need_barrier)
-			{
-				SetupDATE(draw_rt, config.ds, config.datm, config.drawarea);
-				config.destination_alpha = GSHWDrawConfig::DestinationAlphaMode::Stencil;
-			}
-		}
-		break;
 
-		case GSHWDrawConfig::DestinationAlphaMode::Stencil:
-			SetupDATE(draw_rt, config.ds, config.datm, config.drawarea);
-			break;
+	// Destination Alpha stencil setup
+	if (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::Stencil ||
+		(config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::StencilOne && !need_barrier))
+	{
+		SetupDATE(draw_rt, config.ds, config.datm, config.drawarea);
+		config.destination_alpha = GSHWDrawConfig::DestinationAlphaMode::Stencil;
 	}
 
 	// Switch to colclip target for colclip hw rendering
@@ -6190,7 +6208,7 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 				(FeedbackLoopFlag_ReadAndWriteDepth | FeedbackLoopFlag_ReadDepth));
 	}
 
-	if (draw_rt && ((config.require_one_barrier && (config.IsFeedbackLoopRT(config.ps) || config.IsFeedbackLoopRT(config.alpha_second_pass.ps)))) && !m_features.texture_barrier)
+	if (draw_rt && ((config.require_one_barrier && (config.IsFeedbackLoopRT(config.ps) || config.IsFeedbackLoopRT(config.alpha_second_pass.ps) || config.IsFeedbackLoopRT(config.aa1_multi_pass.ps)))) && !m_features.texture_barrier)
 	{
 		// Requires a copy of the RT.
 		draw_rt_clone = static_cast<GSTextureVK*>(CreateTexture(rtsize.x, rtsize.y, 1, draw_rt->GetFormat(), true));
@@ -6346,8 +6364,7 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 
 	// now we can do the actual draw
 	if (BindDrawPipeline(pipe))
-		SendHWDraw(config, pipe.IsRTFeedbackLoop() ? draw_rt : nullptr, pipe.IsDepthFeedbackLoop() ? draw_ds : nullptr,
-			config.require_one_barrier, config.require_full_barrier);
+		SendHWDraw(config, GSHWDrawConfig::DrawPass::Main, pipe.IsRTFeedbackLoop() ? draw_rt : nullptr, pipe.IsDepthFeedbackLoop() ? draw_ds : nullptr);
 
 	// blend second pass
 	if (config.blend_multi_pass.enable)
@@ -6362,7 +6379,7 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 		if (BindDrawPipeline(pipe))
 		{
 			// TODO: This probably should have barriers, in case we want to use it conditionally.
-			Draw(config);
+			Draw(config, GSHWDrawConfig::DrawPass::Blend);
 		}
 	}
 
@@ -6382,8 +6399,29 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 		pipe.bs = config.blend;
 		if (BindDrawPipeline(pipe))
 		{
-			SendHWDraw(config, pipe.IsRTFeedbackLoop() ? draw_rt : nullptr, pipe.IsDepthFeedbackLoop() ? draw_ds : nullptr,
-				config.alpha_second_pass.require_one_barrier, config.alpha_second_pass.require_full_barrier);
+			SendHWDraw(config, GSHWDrawConfig::DrawPass::AlphaSecond, pipe.IsRTFeedbackLoop() ? draw_rt : nullptr, pipe.IsDepthFeedbackLoop() ? draw_ds : nullptr);
+		}
+	}
+
+	// and the AA1 pass
+	if (config.aa1_multi_pass.enable)
+	{
+		// cbuffer will definitely be dirty if aref changes, no need to check it
+		if (config.cb_ps.FogColor_AREF.a != config.aa1_multi_pass.ps_aref)
+		{
+			config.cb_ps.FogColor_AREF.a = config.aa1_multi_pass.ps_aref;
+			SetPSConstantBuffer(config.cb_ps);
+		}
+
+		pipe.vs = config.aa1_multi_pass.vs;
+		pipe.ps = config.aa1_multi_pass.ps;
+		pipe.cms = config.aa1_multi_pass.colormask;
+		pipe.dss = config.aa1_multi_pass.depth;
+		pipe.bs = config.aa1_multi_pass.blend;
+		if (BindDrawPipeline(pipe))
+		{
+			SendHWDraw(config, GSHWDrawConfig::DrawPass::AA1Second, pipe.IsRTFeedbackLoop() ? draw_rt : nullptr,
+				pipe.IsDepthFeedbackLoop() ? draw_ds : nullptr);
 		}
 	}
 
@@ -6527,14 +6565,16 @@ VkDependencyFlags GSDeviceVK::GetFeedbackBarrierDependencyFlags() const
 	                                 VK_DEPENDENCY_BY_REGION_BIT;
 }
 
-void GSDeviceVK::SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt, GSTextureVK* draw_ds,
-	bool one_barrier, bool full_barrier)
+void GSDeviceVK::SendHWDraw(const GSHWDrawConfig& config, GSHWDrawConfig::DrawPass pass, GSTextureVK* draw_rt, GSTextureVK* draw_ds)
 {
 	if (!m_features.texture_barrier) [[unlikely]]
 	{
-		Draw(config);
+		Draw(config, pass);
 		return;
 	}
+
+	const bool full_barrier = config.GetFullBarrier(pass);
+	const bool one_barrier = config.GetOneBarrier(pass);
 
 #ifdef PCSX2_DEVBUILD
 	if ((one_barrier || full_barrier) && !(config.IsFeedbackLoopRT(m_pipeline_selector.ps) || config.IsFeedbackLoopDepth(m_pipeline_selector.ps))) [[unlikely]]
@@ -6588,7 +6628,7 @@ void GSDeviceVK::SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt, 
 			IssueBarriers();
 
 			const u32 count = config.drawlist->at(n) * indices_per_prim;
-			Draw(config, p, count);
+			Draw(config, pass, p, count);
 			p += count;
 		}
 
@@ -6601,7 +6641,7 @@ void GSDeviceVK::SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt, 
 		IssueBarriers();
 	}
 
-	Draw(config);
+	Draw(config, pass);
 
 	if (config.ps.HasColorROV() || config.ps.HasDepthROV())
 		g_perfmon.Put(GSPerfMon::DrawCallsROV, 1);

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -443,7 +443,7 @@ private:
 	VkPipeline m_colclip_setup_pipelines[2][2] = {}; // [depth][feedback_loop]
 	VkPipeline m_colclip_finish_pipelines[2][2] = {}; // [depth][feedback_loop]
 	VkRenderPass m_primid_image_setup_render_passes[2][2] = {}; // [depth][clear]
-	VkPipeline m_primid_image_setup_pipelines[2][4] = {}; // [depth][datm]
+	VkPipeline m_primid_image_setup_pipelines[2][5] = {}; // [depth][datm]
 	VkPipeline m_fxaa_pipeline = {};
 	VkPipeline m_shadeboost_pipeline = {};
 
@@ -591,8 +591,8 @@ public:
 	void DrawIndexedPrimitiveVSExpand(int offset, int count, bool vs_indexing, int vs_indexing_expansion);
 
 	// Main GS primitive draws.
-	void Draw(const GSHWDrawConfig& config);
-	void Draw(const GSHWDrawConfig& config, int offset, int count);
+	void Draw(const GSHWDrawConfig& config, GSHWDrawConfig::DrawPass pass);
+	void Draw(const GSHWDrawConfig& config, GSHWDrawConfig::DrawPass pass, int offset, int count);
 
 	std::unique_ptr<GSDownloadTexture> CreateDownloadTexture(u32 width, u32 height, GSTexture::Format format) override;
 
@@ -620,7 +620,7 @@ public:
 	void FilteredDownsampleTexture(GSTexture* sTex, GSTexture* dTex, u32 downsample_factor, const GSVector2i& clamp_min, const GSVector4& dRect) override;
 
 	void SetupDATE(GSTexture* rt, GSTexture* ds, SetDATM datm, const GSVector4i& bbox);
-	GSTextureVK* SetupPrimitiveTrackingDATE(GSHWDrawConfig& config);
+	GSTextureVK* SetupPrimitiveTracking(GSHWDrawConfig& config);
 
 	void IASetVertexBuffer(const void* vertex, size_t stride, size_t count, size_t align_multiplier = 1);
 	void IASetIndexBuffer(const void* index, size_t count);
@@ -644,8 +644,7 @@ public:
 	VkImageMemoryBarrier GetColorBufferFeedbackBarrier(GSTextureVK* rt) const;
 	VkImageMemoryBarrier GetDepthStencilBufferFeedbackBarrier(GSTextureVK* ds) const;
 	VkDependencyFlags GetFeedbackBarrierDependencyFlags() const;
-	void SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt, GSTextureVK* draw_ds,
-		bool one_barrier, bool full_barrier);
+	void SendHWDraw(const GSHWDrawConfig& config, GSHWDrawConfig::DrawPass pass, GSTextureVK* draw_rt, GSTextureVK* draw_ds);
 
 	//////////////////////////////////////////////////////////////////////////
 	// Vulkan State

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -952,9 +952,9 @@ __ri void ImGuiManager::DrawSettingsOverlay(float scale, float margin, float spa
 
 		if (GSConfig.HWAccurateAlphaTest)
 			APPEND("AAT ");
-
-		if (GSConfig.HWAA1)
-			APPEND("AA1 ");
+		
+		if (GSConfig.HWAA1 != GSHWAA1Level::Off)
+			APPEND("AA1={} ", static_cast<unsigned>(GSConfig.HWAA1));
 
 		if (GSConfig.HWROV)
 			APPEND("ROV ");

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -754,11 +754,11 @@ Pcsx2Config::GSOptions::GSOptions()
 	Mipmap = true;
 	HWMipmap = true;
 	HWAccurateAlphaTest = false;
-	HWAA1 = false;
 	UseDebugBlend = false;
 	HWROV = false;
 	HWROVLogging = false;
 	HWROVBarriersVK = false;
+	HWAA1 = DEFAULT_AA1_LEVEL;
 
 	ManualUserHacks = false;
 	UserHacks_AlignSpriteX = false;
@@ -862,6 +862,7 @@ bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 		OpEqu(UserHacks_BilinearHack) &&
 		OpEqu(OverrideTextureBarriers) &&
 		OpEqu(DepthFeedbackMode) &&
+		OpEqu(HWAA1) &&
 
 		OpEqu(CAS_Sharpness) &&
 		OpEqu(ShadeBoost_Brightness) &&
@@ -914,7 +915,7 @@ bool Pcsx2Config::GSOptions::RestartOptionsAreEqual(const GSOptions& right) cons
 		   OpEqu(DisableVertexShaderExpand) &&
 		   OpEqu(OverrideTextureBarriers) &&
 		   OpEqu(DepthFeedbackMode) &&
-		   OpEqu(HWAA1) &&
+		   ((HWAA1 == GSHWAA1Level::Off) == (right.HWAA1 == GSHWAA1Level::Off)) &&
 		   OpEqu(ExclusiveFullscreenControl);
 }
 
@@ -1046,11 +1047,11 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 
 	SettingsWrapBitBoolEx(HWMipmap, "hw_mipmap");
 	SettingsWrapBitBool(HWAccurateAlphaTest);
-	SettingsWrapBitBool(HWAA1);
 	SettingsWrapBitBool(UseDebugBlend);
 	SettingsWrapBitBool(HWROV);
 	SettingsWrapBitBool(HWROVLogging);
 	SettingsWrapBitBool(HWROVBarriersVK);
+	SettingsWrapIntEnumEx(HWAA1, "HWAA1");
 	SettingsWrapIntEnumEx(AccurateBlendingUnit, "accurate_blending_unit");
 	SettingsWrapIntEnumEx(TextureFiltering, "filter");
 	SettingsWrapIntEnumEx(TexturePreloading, "texture_preloading");

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 108; // Last changed in PR 14688
+static constexpr u32 SHADER_CACHE_VERSION = 109; // Last changed in PR 14429

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -3284,7 +3284,7 @@ void VMManager::WarnAboutUnsafeSettings()
 			append(ICON_FA_IMAGES,
 				TRANSLATE_SV("VMManager", "Accurate Alpha Test is enabled, this may reduce performance."));
 		}
-		if (EmuConfig.GS.HWAA1)
+		if (EmuConfig.GS.HWAA1 != GSHWAA1Level::Off)
 		{
 			append(ICON_FA_CIRCLE_EXCLAMATION,
 				TRANSLATE_SV("VMManager", "AA1 is enabled, this may severely degrade performance."));


### PR DESCRIPTION
### Description of Changes
Adds lower accuracy/cost AA1 alternatives to depth feedback:
- Two pass: first draw interiors, then draw edges on top (with depth masked).
- Three pass primid: first get interior primids; then draws interiors; then draw edges on top (with depth masked and discard edge pixels overlapped by interior pixels in primid order).

The AA1 setting is changed to an oridinal setting with the following values:
- Off.
- Lines Only: Enabled for lines only.
- Low: Do triangles with either two pass or one pass (the latter when depth is masked).
- Medium: Prefer three pass primid triangles.
- High: Prefer depth feedback triangles.

In some cases, two or three pass will be promoted to depth feedback (e.g. if depth feedback, barriers, or DATE is already used in the same draw).

Thanks to @refractionpcsx2 for discussions and feedback on these methods.

### Rationale behind Changes
AA1 with depth feedback is heavy, especially for its often small visual impact. This gives lighter alternatives where accurate AA1 is not required.

So far I haven't found any examples where three pass primid looks significantly different from depth feedback. Two pass can look significantly worse (example below).

### Suggested Testing Steps

Use the 'AA1 Accuracy' drop down in Settings>Graphics>Rendering. Recommended to use basic blend and turn off accurate alpha test so that AA1 with depth feedback is not forced on.

Performance comparison would be helpful to make sure the assumed performance ordering actually holds (e.g. three pass is more performant than depth feedback). Three pass may increase render passes significantly, while depth feedback may increase barriers significantly.

On Metal, the performance of three pass seems to be worse than depth feedback, possibly due to the increased render passes. Thanks @kamfretoz and @SternXD for the Metal tests.

### Comparison

Example where two pass has significant inaccuracies.

[Booting PS2 BIOS... _20220901235528.gs.xz.zip](https://github.com/user-attachments/files/27573953/Booting.PS2.BIOS._20220901235528.gs.xz.zip)

Low AA1 + basic blend + 2x (edges of boxes look bad)
<img width="1280" height="512" alt="00716_f00002_fr1_00000_C_32" src="https://github.com/user-attachments/assets/8019a9d7-0929-4798-b290-294368314529" />

Medium AA1 + basic blend + 2x
<img width="1280" height="512" alt="00716_f00002_fr1_00000_C_32" src="https://github.com/user-attachments/assets/7e59aa2d-edc4-4fcd-bbb0-6b3838e000a1" />

High AA1 + basic blend + 2x
<img width="1280" height="512" alt="00716_f00002_fr1_00000_C_32" src="https://github.com/user-attachments/assets/91f91c95-9ea9-49c6-b501-3e275ae5f71b" />

Low AA1 stats (6 frames)
```
Draw Calls: 1794 (avg 299)
Render Passes: 566 (avg 95)
Barriers: 0 (avg 0)
Copies: 15 (avg 3)
```

Medium AA1 stats (6 frames)
```
Draw Calls: 2532 (avg 422)
Render Passes: 998 (avg 167)
Barriers: 0 (avg 0)
Copies: 15 (avg 3)
```

High AA1 stats (6 frames)
```
Draw Calls: 4782 (avg 797)
Render Passes: 566 (avg 95)
Barriers: 7452 (avg 1242)
Copies: 15 (avg 3)
```

### Sources of inaccuracy

The two methods seem to have opposite sources of inaccuracy:
- Two pass: can incorrectly draw edge fragments on top of interior fragments.
- Three pass: can incorrectly reject fragments that should be drawn on top interior fragments. This can happen because the primid setup pass does not write to the depth buffer, so the written primids may reflect interior fragments that should have failed the depth test.

### Did you use AI to help find, test, or implement this issue or feature?
I use AI as a reference, so may have asked relevant questions while developing this.