### PR TITLE
DEV9: Warn about Linux PCAP capability side effects

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1438,7 +1438,8 @@ function(setup_main_executable target)
 	endif()
 
 	if(ENABLE_SETCAP AND UNIX AND NOT APPLE)
-		message(WARNING "Networking capabilities enabled, building will require temporary root elevation.")
+		message(WARNING "Networking capabilities enabled on the main executable, building will require temporary root elevation.")
+		message(WARNING "File capabilities can disable LD_PRELOAD-based integrations such as the Steam overlay and Steam Input.")
 		add_custom_target(
 			pcsx2-enable-setcap
 			ALL

--- a/pcsx2/DEV9/pcap_io.cpp
+++ b/pcsx2/DEV9/pcap_io.cpp
@@ -280,6 +280,12 @@ bool PCAPAdapter::InitPCAP(const std::string& adapter, bool promiscuous)
 			 )) == nullptr)
 	{
 		Console.Error("DEV9: %s", errbuf);
+#if defined(__linux__)
+		Console.Error("DEV9: PCAP on Linux requires CAP_NET_RAW and CAP_NET_ADMIN capabilities.");
+		Console.Error("DEV9: Flatpak: raw packet capture is not supported; use the Sockets backend instead.");
+		Console.Error("DEV9: AppImage: extract the image first (--appimage-extract), then run setcap on the extracted binary.");
+		Console.Error("DEV9: Note: applying file capabilities to the main PCSX2 executable breaks Steam overlay/Input.");
+#endif
 		Console.Error("DEV9: Unable to open the adapter. %s is not supported by pcap", adapter.c_str());
 		return false;
 	}


### PR DESCRIPTION
### Description of Changes

Clarifies Linux PCAP diagnostics and the `ENABLE_SETCAP` build warning.

When `pcap_open_live()` fails on Linux, DEV9 now logs that PCAP normally requires `CAP_NET_RAW`/`CAP_NET_ADMIN` or equivalent packet-capture permissions. The CMake warning for `ENABLE_SETCAP` also now states that the capability is being applied to the main executable and may interfere with `LD_PRELOAD`-based integrations such as the Steam overlay/Input.

### Rationale behind Changes

Linux PCAP failures are currently easy to misread as adapter support problems, even when the actual issue is missing packet-capture permission.

This makes the existing permission requirement and build-time tradeoff more visible without changing PCSX2 networking behavior.

### Suggested Testing Steps

Tested locally:

- `clang-format -i pcsx2/DEV9/pcap_io.cpp`
- `cmake --preset clang-devel -DENABLE_SETCAP=OFF -DCMAKE_PREFIX_PATH="/home/sean/.local/pcsx2-deps"`
- `cmake --build build --parallel`
- `cmake --build build --target unittests --parallel`

Unit tests: 2/2 passed.

Suggested review/testing:

- Build with `ENABLE_SETCAP=ON` on Linux and confirm the updated warning is shown.
- Run PCAP without sufficient packet-capture permissions and confirm the additional DEV9 error text is logged.

### Did you use AI to help find, test, or implement this issue or feature?

AI was used to match the build chain on my local environment with PCSX2's conventions (for testing). It was also used, in addition to searching, to familiarize myself with how PSCX2's code base is generally laid out, which helped me find the right files to modify for this change.