### PR TITLE
DEV9: Isolate raw PCAP packet I/O

### DIFF
--- a/pcsx2/DEV9/pcap_io.cpp
+++ b/pcsx2/DEV9/pcap_io.cpp
@@ -118,30 +118,12 @@ bool PCAPAdapter::recv(NetPacket* pkt)
 	if (!blocking && NetAdapter::recv(pkt))
 		return true;
 
-	pcap_pkthdr* header;
-	const u_char* pkt_data;
-
-	// pcap bridged will pick up packets not intended for us, returning false on those packets will incur a 1ms wait.
-	// This delays getting packets we need, so instead loop untill a valid packet, or no packet, is returned from pcap_next_ex.
-	while (pcap_next_ex(hpcap, &header, &pkt_data) > 0)
+	while (RecvPCAPPacket(pkt))
 	{
-		// 1518 is the largest Ethernet frame we can get using an MTU of 1500 (assuming no VLAN tagging).
-		// This includes the FCS, which should be trimmed (PS2 SDK dosn't allow extra space for this).
-		if (header->len > 1518)
-		{
-			Console.Error("DEV9: Dropped jumbo frame of size: %u", header->len);
-			continue;
-		}
-
-		pxAssert(header->len == header->caplen);
-
-		memcpy(pkt->buffer, pkt_data, header->len);
-		pkt->size = static_cast<int>(header->len);
-
 		if (!switched)
 			SetMACBridgedRecv(pkt);
 
-		if (VerifyPkt(pkt, header->len))
+		if (VerifyPkt(pkt, pkt->size))
 		{
 			HandleFrameCheckSequence(pkt);
 
@@ -173,10 +155,39 @@ bool PCAPAdapter::send(NetPacket* pkt)
 	if (!switched)
 		SetMACBridgedSend(pkt);
 
-	if (pcap_sendpacket(hpcap, (u_char*)pkt->buffer, pkt->size))
-		return false;
-	else
+	return SendPCAPPacket(pkt);
+}
+
+bool PCAPAdapter::RecvPCAPPacket(NetPacket* pkt)
+{
+	pcap_pkthdr* header;
+	const u_char* pkt_data;
+
+	// pcap bridged will pick up packets not intended for us, returning false on those packets will incur a 1ms wait.
+	// This delays getting packets we need, so instead loop untill a valid packet, or no packet, is returned from pcap_next_ex.
+	while (pcap_next_ex(hpcap, &header, &pkt_data) > 0)
+	{
+		// 1518 is the largest Ethernet frame we can get using an MTU of 1500 (assuming no VLAN tagging).
+		// This includes the FCS, which should be trimmed (PS2 SDK dosn't allow extra space for this).
+		if (header->len > 1518)
+		{
+			Console.Error("DEV9: Dropped jumbo frame of size: %u", header->len);
+			continue;
+		}
+
+		pxAssert(header->len == header->caplen);
+
+		memcpy(pkt->buffer, pkt_data, header->len);
+		pkt->size = static_cast<int>(header->len);
 		return true;
+	}
+
+	return false;
+}
+
+bool PCAPAdapter::SendPCAPPacket(const NetPacket* pkt)
+{
+	return pcap_sendpacket(hpcap, reinterpret_cast<const u_char*>(pkt->buffer), pkt->size) == 0;
 }
 
 void PCAPAdapter::reloadSettings()

--- a/pcsx2/DEV9/pcap_io.h
+++ b/pcsx2/DEV9/pcap_io.h
@@ -39,6 +39,9 @@ private:
 	bool InitPCAP(const std::string& adapter, bool promiscuous);
 	bool SetMACSwitchedFilter(PacketReader::MAC_Address mac);
 
+	bool RecvPCAPPacket(NetPacket* pkt);
+	bool SendPCAPPacket(const NetPacket* pkt);
+
 	void SetMACBridgedRecv(NetPacket* pkt);
 	void SetMACBridgedSend(NetPacket* pkt);
 


### PR DESCRIPTION
### Description of Changes

Splits raw libpcap packet receive/send calls out of `PCAPAdapter::recv()` and `PCAPAdapter::send()` into small helper methods:

- `RecvPCAPPacket()`
- `SendPCAPPacket()`

The existing DEV9 packet handling remains in the same emulator-facing flow, including bridged MAC rewriting, packet verification, frame check sequence handling, internal server handling, and switched/bridged behavior.

### Rationale behind Changes

`PCAPAdapter::recv()` currently mixes raw libpcap packet access with DEV9 packet semantics. Separating the raw PCAP calls makes the code easier to follow and keeps adapter packet handling distinct from packet capture I/O.

This is intended to be behavior-preserving.

### Suggested Testing Steps

Tested locally:

- `clang-format -i pcsx2/DEV9/pcap_io.cpp pcsx2/DEV9/pcap_io.h`
- `cmake --build build --parallel`
- `cmake --build build --target unittests --parallel`

Unit tests: 2/2 passed.

Suggested review/testing:

- Smoke-test PCAP Bridged and PCAP Switched against a real adapter.
- Confirm packet receive/send behavior is unchanged.

### Did you use AI to help find, test, or implement this issue or feature?

AI was used to help create the build chain in my environment and to help familiarize myself with relevant parts of the code base. AI was also used as a review tool. It suggested a cleaner signature for `RecvPCAPPacket`, and after considering it, I agreed.
