### PR TITLE
GS/HW: Fix flat shaded color in AA1 shader.

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -1729,6 +1729,11 @@ VS_OUTPUT vs_main_expand(uint vid : SV_VertexID)
 		}
 
 		vtx.interior = 0;
+
+		#if !VS_IIP
+			// Get the provoking vertex color (first vertex in DX)
+			vtx.c = i0 == 0 ? vtx.c : (i1 == 0 ? other.c : opposite.c);
+		#endif
 	}
 
 	return vtx;

--- a/bin/resources/shaders/opengl/tfx_vgs.glsl
+++ b/bin/resources/shaders/opengl/tfx_vgs.glsl
@@ -308,6 +308,11 @@ void main()
 		}
 
 		VSout.interior = 0;
+
+		#if !VS_IIP
+			// Get the provoking vertex color (last vertex in GL)
+			vtx.c = i0 == 2 ? vtx.c : (i1 == 2 ? other.c : opposite.c);
+		#endif
 	}
 
 #endif

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -316,6 +316,11 @@ void main()
 		}
 
 		vsOut.interior = 0;
+
+		#if !VS_IIP
+			// Get the provoking vertex color (last vertex in VK)
+			vtx.c = i0 == 2 ? vtx.c : (i1 == 2 ? other.c : opposite.c);
+		#endif
 	}
 
 #endif

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -396,6 +396,12 @@ vertex MainVSOut vs_main_expand(
 				}
 
 				out.interior = 0;
+
+				if (NOT_IIP)
+				{
+					// Get the provoking vertex color (first vertex in Metal)
+					out.fc = i0 == 0 ? out.fc : (i1 == 0 ? other.fc : opposite.fc);
+				}
 			}
 
 			return out;

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 92; // Last changed in PR 14399
+static constexpr u32 SHADER_CACHE_VERSION = 93; // Last changed in PR 14435


### PR DESCRIPTION
### Description of Changes
Make sure AA1 edges use the provoking color when flat shading.

### Rationale behind Changes
Fixes graphical corruption in DX in the attached dump.

Thanks @JordanTheToaster for identifying this.

### Suggested Testing Steps
Run the attached dump with AA1 enabled and DX11, DX12, or Metal.

Master (red on the coin looking thing)
<img width="640" height="256" alt="master" src="https://github.com/user-attachments/assets/6e82530b-7d3d-4f40-8f8c-c037146ab55e" />

PR
<img width="640" height="256" alt="pr" src="https://github.com/user-attachments/assets/4ab5ea53-0903-4538-892b-307e7d947e0c" />

### Did you use AI to help find, test, or implement this issue or feature?
Yes, to ask if Metal is first/last vertex provoking. Confirmed it by checking the source.