### PR TITLE
GHActions: Don't automatically undraft stable releases

### DIFF
--- a/.github/workflows/release_cut_new.yml
+++ b/.github/workflows/release_cut_new.yml
@@ -209,6 +209,7 @@ jobs:
           gh release upload "${TAG_VAL}" ${{ github.WORKSPACE }}/ci-artifacts/out/*  --repo PCSX2/pcsx2 --clobber
 
       - name: Publish Release
+        if: github.event_name != 'workflow_dispatch' || inputs.is_prerelease == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
### Description of Changes
When the release is a stable release, don't automatically undraft

### Rationale behind Changes
When we create a new stable, I have to manually add the installer to the release.
We are looking into locking (immutability) releases (so they can't be modified later) to make the updating system safer for our users. 
This makes it so when the release is no longer drafted, I can not add the installer :(

### Suggested Testing Steps
See if CI works

### Did you use AI to help find, test, or implement this issue or feature?
nuh
