### PR TITLE
Qt: Fix crash when interacting with per-game achievement settings

### DIFF
--- a/pcsx2-qt/Settings/AchievementSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AchievementSettingsWidget.cpp
@@ -90,17 +90,15 @@ AchievementSettingsWidget::AchievementSettingsWidget(SettingsWindow* settings_di
 	}
 	else
 	{
-		// remove login and game info, not relevant for per-game
+		// hide login and game info, not relevant for per-game
 		m_ui.verticalLayout->removeWidget(m_ui.gameInfoBox);
-		m_ui.gameInfoBox->deleteLater();
-		m_ui.gameInfoBox = nullptr;
+		m_ui.gameInfoBox->hide();
 		m_ui.verticalLayout->removeWidget(m_ui.loginBox);
-		m_ui.loginBox->deleteLater();
-		m_ui.loginBox = nullptr;
+		m_ui.loginBox->hide();
 
 		// sound effects
 		m_ui.verticalLayout->removeWidget(m_ui.soundEffectsBox);
-		m_ui.soundEffectsBox->deleteLater();
+		m_ui.soundEffectsBox->hide();
 		m_ui.soundEffectsBox = nullptr;
 	}
 
@@ -120,9 +118,6 @@ void AchievementSettingsWidget::updateEnableState()
 	const bool info = enabled && sound && dialog()->getEffectiveBoolValue("Achievements", "InfoSound", true);
 	const bool unlock = enabled && sound && dialog()->getEffectiveBoolValue("Achievements", "UnlockSound", true);
 	const bool lbsound = enabled && sound && dialog()->getEffectiveBoolValue("Achievements", "LBSubmitSound", true);
-
-	m_ui.viewProfile->setEnabled(enabled);
-	m_ui.loginButton->setEnabled(enabled);
 
 	m_ui.hardcoreMode->setEnabled(enabled);
 	m_ui.achievementNotifications->setEnabled(enabled);

--- a/pcsx2-qt/Settings/AchievementSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AchievementSettingsWidget.ui
@@ -12,38 +12,49 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <widget class="QLabel" name="rcheevosDisclaimer">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;justify&quot;&gt;PCSX2 uses RetroAchievements as an achievement database and for tracking progress. To use achievements, please sign up for an account at &lt;a href=&quot;https://retroachievements.org/&quot;&gt;retroachievements.org&lt;/a&gt;.&lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;To view the achievement list in-game, press the hotkey for &lt;span style=&quot; font-weight:600;&quot;&gt;Open Pause Menu&lt;/span&gt; and select &lt;span style=&quot; font-weight:600;&quot;&gt;Achievements&lt;/span&gt; from the menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::TextFormat::RichText</enum>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="margin">
+      <number>8</number>
+     </property>
+     <property name="openExternalLinks">
+      <bool>true</bool>
+     </property>
+     <property name="buddy">
+      <cstring>enable</cstring>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="loginBox">
      <property name="title">
       <string>Account</string>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0">
       <item>
-       <layout class="QGridLayout" name="acccountLayout">
-        <item row="0" column="0">
-         <widget class="QCheckBox" name="enable">
-          <property name="text">
-           <string>Enable Achievements</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="loginStatus">
-          <property name="text">
-           <string>Username:
+       <widget class="QLabel" name="loginStatus">
+        <property name="text">
+         <string>Username:
 Login token generated at:</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
-          </property>
-          <property name="textInteractionFlags">
-           <set>Qt::TextInteractionFlag::TextBrowserInteraction</set>
-          </property>
-          <property name="buddy">
-           <cstring>viewProfile</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::TextInteractionFlag::TextBrowserInteraction</set>
+        </property>
+        <property name="buddy">
+         <cstring>viewProfile</cstring>
+        </property>
+       </widget>
       </item>
       <item>
        <layout class="QHBoxLayout" name="achievementButtons">
@@ -95,58 +106,43 @@ Login token generated at:</string>
     </widget>
    </item>
    <item>
-    <widget class="QLabel" name="rcheevosDisclaimer">
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;justify&quot;&gt;PCSX2 uses RetroAchievements as an achievement database and for tracking progress. To use achievements, please sign up for an account at &lt;a href=&quot;https://retroachievements.org/&quot;&gt;retroachievements.org&lt;/a&gt;.&lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;To view the achievement list in-game, press the hotkey for &lt;span style=&quot; font-weight:600;&quot;&gt;Open Pause Menu&lt;/span&gt; and select &lt;span style=&quot; font-weight:600;&quot;&gt;Achievements&lt;/span&gt; from the menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="textFormat">
-      <enum>Qt::TextFormat::RichText</enum>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-     <property name="margin">
-      <number>8</number>
-     </property>
-     <property name="openExternalLinks">
-      <bool>true</bool>
-     </property>
-     <property name="buddy">
-      <cstring>enable</cstring>
-     </property>
-    </widget>
-   </item>
-   <item>
     <widget class="QGroupBox" name="settingsBox">
      <property name="title">
       <string>Settings</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_5">
-      <item row="1" column="1">
-       <widget class="QCheckBox" name="unofficialAchievements">
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="enable">
         <property name="text">
-         <string>Test Unofficial Achievements</string>
+         <string>Enable Achievements</string>
         </property>
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QCheckBox" name="spectatorMode">
-        <property name="text">
-         <string>Enable Spectator Mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
        <widget class="QCheckBox" name="hardcoreMode">
         <property name="text">
          <string>Enable Hardcore Mode</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="spectatorMode">
+        <property name="text">
+         <string>Enable Spectator Mode</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
        <widget class="QCheckBox" name="encoreMode">
         <property name="text">
          <string>Enable Encore Mode</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="unofficialAchievements">
+        <property name="text">
+         <string>Test Unofficial Achievements</string>
         </property>
        </widget>
       </item>
@@ -537,9 +533,9 @@ Login token generated at:</string>
   </layout>
  </widget>
  <tabstops>
-  <tabstop>enable</tabstop>
   <tabstop>viewProfile</tabstop>
   <tabstop>loginButton</tabstop>
+  <tabstop>enable</tabstop>
   <tabstop>hardcoreMode</tabstop>
   <tabstop>spectatorMode</tabstop>
   <tabstop>encoreMode</tabstop>


### PR DESCRIPTION
### Description of Changes
- Move the "Enable Achievements" checkbox back to the Settings group.
- Don't disable the login button when the "Enable Achievements" checkbox is unchecked.
- Move the text explaining what RetroAchievements is to the top.

### Rationale behind Changes
Fixes two regressions from #14364:
- Moving the "Enable Achievements" checkbox made it impossible to access the setting from the per-game settings dialog.
- When changing settings, we would attempt to access widgets that were deleted, causing a crash. In addition to fixing this directly, I've made it so we just hide those widgets instead. We don't leak memory since the widgets are still owned by their parents, and it's less error prone.

I think disabling the login button was confusing. It prompts you to enable achievements after logging in anyway. I also think having the text at the top looks better than having it in the middle, so I thought I may as well do that at the same time.

Closes #14436.

### Suggested Testing Steps
Make sure the per-game and global achievements settings pages work.

### Did you use AI to help find, test, or implement this issue or feature?
No.
