### PR TITLE
GH: Use VS 2026 runners

### DIFF
--- a/.github/workflows/windows_build_matrix.yml
+++ b/.github/workflows/windows_build_matrix.yml
@@ -13,7 +13,7 @@ jobs:
   lint_vs_proj_files:
     name: Lint VS Project Files
     if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6

--- a/.github/workflows/windows_build_qt.yml
+++ b/.github/workflows/windows_build_qt.yml
@@ -12,7 +12,7 @@ on:
       os:
         required: false
         type: string
-        default: windows-2025
+        default: windows-2025-vs2026
       platform:
         required: false
         type: string


### PR DESCRIPTION
### Description of Changes
Switches the Windows runners to use the VS 2026 image.

### Rationale behind Changes
They are going to be forced onto VS 2026 anyway so might as well do it ourselves.

### Suggested Testing Steps
Make sure the MSVC and Clang builds don't break in any new exciting ways.

### Did you use AI to help find, test, or implement this issue or feature?
No
