### PR TITLE
GS: Add shader compile indicator

### DIFF
--- a/pcsx2/GS/GSShaderCompileIndicator.h
+++ b/pcsx2/GS/GSShaderCompileIndicator.h
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+
+namespace GSShaderCompileIndicator
+{
+	inline constexpr std::uint64_t OSD_RECENT_COMPILE_NS = 500'000'000ULL;
+
+	inline std::atomic<std::uint32_t> s_active_compilations{0};
+	inline std::atomic<std::uint64_t> s_last_compile_activity_ns{0};
+
+	namespace detail
+	{
+		inline std::uint64_t steady_now_ns()
+		{
+			return static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(
+				std::chrono::steady_clock::now().time_since_epoch())
+					.count());
+		}
+	} // namespace detail
+
+	inline void TouchCompileActivity()
+	{
+		s_last_compile_activity_ns.store(detail::steady_now_ns(), std::memory_order_relaxed);
+	}
+
+	inline void BeginCompilation()
+	{
+		TouchCompileActivity();
+		s_active_compilations.fetch_add(1, std::memory_order_relaxed);
+	}
+
+	inline void EndCompilation()
+	{
+		s_active_compilations.fetch_sub(1, std::memory_order_relaxed);
+		TouchCompileActivity();
+	}
+
+	inline std::uint32_t GetActiveCompilationCount()
+	{
+		return s_active_compilations.load(std::memory_order_relaxed);
+	}
+
+	inline bool ShouldShowOnOSD(std::uint64_t hold_ns = OSD_RECENT_COMPILE_NS)
+	{
+		if (GetActiveCompilationCount() != 0)
+			return true;
+
+		const std::uint64_t last = s_last_compile_activity_ns.load(std::memory_order_relaxed);
+		if (last == 0)
+			return false;
+
+		const std::uint64_t now = detail::steady_now_ns();
+		return now > last && (now - last) < hold_ns;
+	}
+
+	inline float GetPostCompileFadeAlpha(std::uint64_t hold_ns = OSD_RECENT_COMPILE_NS)
+	{
+		if (GetActiveCompilationCount() != 0)
+			return 1.0f;
+
+		const std::uint64_t last = s_last_compile_activity_ns.load(std::memory_order_relaxed);
+		if (last == 0)
+			return 0.0f;
+
+		const std::uint64_t now = detail::steady_now_ns();
+		if (now <= last)
+			return 1.0f;
+
+		const std::uint64_t elapsed = now - last;
+		if (elapsed >= hold_ns)
+			return 0.0f;
+
+		return 1.0f - static_cast<float>(elapsed) / static_cast<float>(hold_ns);
+	}
+
+	struct ScopedCompilation
+	{
+		ScopedCompilation() { BeginCompilation(); }
+		~ScopedCompilation() { EndCompilation(); }
+		ScopedCompilation(const ScopedCompilation&) = delete;
+		ScopedCompilation& operator=(const ScopedCompilation&) = delete;
+	};
+} // namespace GSShaderCompileIndicator

--- a/pcsx2/GS/Renderers/DX11/D3D.cpp
+++ b/pcsx2/GS/Renderers/DX11/D3D.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0+
 
 #include "Config.h"
+#include "GS/GSShaderCompileIndicator.h"
 #include "GS/Renderers/Common/GSDevice.h"
 #include "GS/Renderers/DX11/D3D.h"
 #include "GS/GSExtra.h"
@@ -487,6 +488,8 @@ wil::com_ptr_nothrow<ID3DBlob> D3D::CompileShader(D3D::ShaderType type, D3D::Sha
 	const std::string_view code, const D3D_SHADER_MACRO* macros /* = nullptr */,
 	const char* entry_point /* = "main" */)
 {
+	const GSShaderCompileIndicator::ScopedCompilation compiling;
+
 	const char* target;
 	switch (shader_model)
 	{

--- a/pcsx2/GS/Renderers/DX12/D3D12ShaderCache.cpp
+++ b/pcsx2/GS/Renderers/DX12/D3D12ShaderCache.cpp
@@ -3,6 +3,7 @@
 
 #include "GS/Renderers/DX12/D3D12ShaderCache.h"
 #include "GS/GS.h"
+#include "GS/GSShaderCompileIndicator.h"
 
 #include "Config.h"
 #include "ShaderCacheVersion.h"
@@ -540,6 +541,8 @@ D3D12ShaderCache::ComPtr<ID3DBlob> D3D12ShaderCache::CompileAndAddShaderBlob(
 D3D12ShaderCache::ComPtr<ID3D12PipelineState> D3D12ShaderCache::CompileAndAddPipeline(
 	ID3D12Device* device, const CacheIndexKey& key, const D3D12_GRAPHICS_PIPELINE_STATE_DESC& gpdesc)
 {
+	const GSShaderCompileIndicator::ScopedCompilation compiling;
+
 	ComPtr<ID3D12PipelineState> pso;
 	HRESULT hr = device->CreateGraphicsPipelineState(&gpdesc, IID_PPV_ARGS(pso.put()));
 	if (FAILED(hr))
@@ -555,6 +558,8 @@ D3D12ShaderCache::ComPtr<ID3D12PipelineState> D3D12ShaderCache::CompileAndAddPip
 D3D12ShaderCache::ComPtr<ID3D12PipelineState> D3D12ShaderCache::CompileAndAddPipeline(
 	ID3D12Device* device, const CacheIndexKey& key, const D3D12_COMPUTE_PIPELINE_STATE_DESC& gpdesc)
 {
+	const GSShaderCompileIndicator::ScopedCompilation compiling;
+
 	ComPtr<ID3D12PipelineState> pso;
 	HRESULT hr = device->CreateComputePipelineState(&gpdesc, IID_PPV_ARGS(pso.put()));
 	if (FAILED(hr))

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -7,6 +7,7 @@
 #include "GS/Renderers/Metal/GSDeviceMTL.h"
 #include "GS/Renderers/Metal/GSTextureMTL.h"
 #include "GS/GSPerfMon.h"
+#include "GS/GSShaderCompileIndicator.h"
 
 #include "common/Console.h"
 #include "common/HostSys.h"
@@ -712,6 +713,7 @@ MRCOwned<id<MTLFunction>> GSDeviceMTL::LoadShader(NSString* name)
 
 MRCOwned<id<MTLRenderPipelineState>> GSDeviceMTL::MakePipeline(MTLRenderPipelineDescriptor* desc, id<MTLFunction> vertex, id<MTLFunction> fragment, NSString* name)
 {
+	const GSShaderCompileIndicator::ScopedCompilation compiling;
 	[desc setLabel:name];
 	[desc setVertexFunction:vertex];
 	[desc setFragmentFunction:fragment];
@@ -728,6 +730,7 @@ MRCOwned<id<MTLRenderPipelineState>> GSDeviceMTL::MakePipeline(MTLRenderPipeline
 
 MRCOwned<id<MTLComputePipelineState>> GSDeviceMTL::MakeComputePipeline(id<MTLFunction> compute, NSString* name)
 {
+	const GSShaderCompileIndicator::ScopedCompilation compiling;
 	MRCOwned<MTLComputePipelineDescriptor*> desc = MRCTransfer([MTLComputePipelineDescriptor new]);
 	[desc setLabel:name];
 	[desc setComputeFunction:compute];

--- a/pcsx2/GS/Renderers/Metal/GSMTLDeviceInfo.mm
+++ b/pcsx2/GS/Renderers/Metal/GSMTLDeviceInfo.mm
@@ -3,6 +3,7 @@
 
 #include "GSMTLDeviceInfo.h"
 #include "GS/GS.h"
+#include "GS/GSShaderCompileIndicator.h"
 #include "common/Console.h"
 #include "common/Path.h"
 
@@ -56,7 +57,10 @@ static bool detectPrimIDSupport(id<MTLDevice> dev, id<MTLLibrary> lib)
 	[desc setFragmentFunction:MRCTransfer([lib newFunctionWithName:@"primid_test"])];
 	[[desc colorAttachments][0] setPixelFormat:MTLPixelFormatR8Uint];
 	NSError* err;
-	[[dev newRenderPipelineStateWithDescriptor:desc error:&err] release];
+	{
+		const GSShaderCompileIndicator::ScopedCompilation compiling;
+		[[dev newRenderPipelineStateWithDescriptor:desc error:&err] release];
+	}
 	return !err;
 }
 
@@ -88,7 +92,11 @@ static DetectionResult detectIntelGPU(id<MTLDevice> dev, id<MTLLibrary> lib)
 	[pdesc setVertexFunction:MRCTransfer([lib newFunctionWithName:@"fs_triangle"])];
 	[pdesc setFragmentFunction:MRCTransfer([lib newFunctionWithName:@"fbfetch_test"])];
 	[[pdesc colorAttachments][0] setPixelFormat:MTLPixelFormatRGBA8Unorm];
-	auto pipe = MRCTransfer([dev newRenderPipelineStateWithDescriptor:pdesc error:nil]);
+	MRCOwned<id<MTLRenderPipelineState>> pipe;
+	{
+		const GSShaderCompileIndicator::ScopedCompilation compiling;
+		pipe = MRCTransfer([dev newRenderPipelineStateWithDescriptor:pdesc error:nil]);
+	}
 	if (!pipe)
 		return DetectionResult::HaswellOrNotIntel;
 	auto buf = MRCTransfer([dev newBufferWithLength:4 options:MTLResourceStorageModeShared]);

--- a/pcsx2/GS/Renderers/OpenGL/GLShaderCache.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GLShaderCache.cpp
@@ -3,6 +3,7 @@
 
 #include "GS/Renderers/OpenGL/GLShaderCache.h"
 #include "GS/GS.h"
+#include "GS/GSShaderCompileIndicator.h"
 
 #include "Config.h"
 #include "ShaderCacheVersion.h"
@@ -366,6 +367,8 @@ bool GLShaderCache::WriteToBlobFile(const CacheIndexKey& key, const std::vector<
 std::optional<GLProgram> GLShaderCache::CompileProgram(const std::string_view vertex_shader,
 	const std::string_view fragment_shader, const PreLinkCallback& callback, bool set_retrievable)
 {
+	const GSShaderCompileIndicator::ScopedCompilation compiling;
+
 	GLProgram prog;
 	if (!prog.Compile(vertex_shader, fragment_shader))
 		return std::nullopt;
@@ -385,6 +388,8 @@ std::optional<GLProgram> GLShaderCache::CompileProgram(const std::string_view ve
 std::optional<GLProgram> GLShaderCache::CompileComputeProgram(
 	const std::string_view glsl, const PreLinkCallback& callback, bool set_retrievable)
 {
+	const GSShaderCompileIndicator::ScopedCompilation compiling;
+
 	GLProgram prog;
 	if (!prog.CompileCompute(glsl))
 		return std::nullopt;

--- a/pcsx2/GS/Renderers/Vulkan/VKBuilders.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/VKBuilders.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0+
 
 #include "GS/Renderers/Vulkan/VKBuilders.h"
+#include "GS/GSShaderCompileIndicator.h"
 
 #include "common/Assertions.h"
 #include "common/Console.h"
@@ -279,6 +280,8 @@ void Vulkan::GraphicsPipelineBuilder::Clear()
 VkPipeline Vulkan::GraphicsPipelineBuilder::Create(
 	VkDevice device, VkPipelineCache pipeline_cache, bool clear /* = true */)
 {
+	const GSShaderCompileIndicator::ScopedCompilation compiling;
+
 	VkPipeline pipeline;
 	VkResult res = vkCreateGraphicsPipelines(device, pipeline_cache, 1, &m_ci, nullptr, &pipeline);
 	if (res != VK_SUCCESS)
@@ -588,6 +591,8 @@ void Vulkan::ComputePipelineBuilder::Clear()
 VkPipeline Vulkan::ComputePipelineBuilder::Create(
 	VkDevice device, VkPipelineCache pipeline_cache /*= VK_NULL_HANDLE*/, bool clear /*= true*/)
 {
+	const GSShaderCompileIndicator::ScopedCompilation compiling;
+
 	VkPipeline pipeline;
 	VkResult res = vkCreateComputePipelines(device, pipeline_cache, 1, &m_ci, nullptr, &pipeline);
 	if (res != VK_SUCCESS)

--- a/pcsx2/GS/Renderers/Vulkan/VKShaderCache.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/VKShaderCache.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
 // SPDX-License-Identifier: GPL-3.0+
 
+#include "GS/GSShaderCompileIndicator.h"
 #include "GS/GS.h"
 #include "GS/Renderers/Vulkan/GSDeviceVK.h"
 #include "GS/Renderers/Vulkan/VKBuilders.h"
@@ -229,6 +230,8 @@ std::optional<VKShaderCache::SPIRVCodeVector> VKShaderCache::CompileShaderToSPV(
 	std::optional<VKShaderCache::SPIRVCodeVector> ret;
 	if (!dyn_shaderc::Open())
 		return ret;
+
+	const GSShaderCompileIndicator::ScopedCompilation compiling;
 
 	shaderc_compile_options_t options = dyn_shaderc::shaderc_compile_options_initialize();
 	pxAssertRel(options, "shaderc_compile_options_initialize() failed");

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -5,6 +5,7 @@
 #include "Config.h"
 #include "Counters.h"
 #include "GS/GS.h"
+#include "GS/GSShaderCompileIndicator.h"
 #include "GS/GSCapture.h"
 #include "GS/GSVector.h"
 #include "GS/Renderers/Common/GSDevice.h"
@@ -143,6 +144,7 @@ namespace ImGuiManager
 {
 	static void FormatProcessorStat(SmallStringBase& text, double usage, double time);
 	static void DrawPerformanceOverlay(float& position_y, float scale, float margin, float spacing);
+	static void DrawShaderCompileIndicator(float scale, float margin, float spacing);
 	static void DrawSettingsOverlay(float scale, float margin, float spacing);
 	static void DrawInputsOverlay(float scale, float margin, float spacing);
 	static void DrawInputRecordingOverlay(float& position_y, float scale, float margin, float spacing);
@@ -776,6 +778,72 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 	}
 
 #undef DRAW_LINE
+}
+
+__ri void ImGuiManager::DrawShaderCompileIndicator(float scale, float margin, float spacing)
+{
+	static bool s_indicator_was_visible = false;
+	static double s_indicator_fade_in_start = 0.0;
+
+	if (!GSConfig.OsdShowGPU || !GSShaderCompileIndicator::ShouldShowOnOSD())
+	{
+		s_indicator_was_visible = false;
+		return;
+	}
+
+	const double imgui_time = ImGui::GetTime();
+	if (!s_indicator_was_visible)
+		s_indicator_fade_in_start = imgui_time;
+	s_indicator_was_visible = true;
+
+	constexpr double fade_in_seconds = 0.12;
+	const float fade_in_alpha = static_cast<float>(
+		std::min(1.0, (imgui_time - s_indicator_fade_in_start) / fade_in_seconds));
+	const float fade_out_alpha = GSShaderCompileIndicator::GetPostCompileFadeAlpha();
+	const float indicator_alpha = std::clamp(fade_in_alpha * fade_out_alpha, 0.0f, 1.0f);
+	const ImU32 text_col = IM_COL32(255, 255, 255, static_cast<int>(std::lround(255.0f * indicator_alpha)));
+	const ImU32 shadow_col = IM_COL32(0, 0, 0, static_cast<int>(std::lround(100.0f * indicator_alpha)));
+	const ImU32 spinner_track_col =
+		IM_COL32(255, 255, 255, static_cast<int>(std::lround(45.0f * indicator_alpha)));
+
+	const std::string label = TRANSLATE_STR("ImGuiOverlays", "Compiling Shaders");
+	ImFont* const font = ImGuiManager::GetOSDFont();
+	const float font_size = ImGuiManager::GetFontSizeStandard();
+	const float baseline_y =
+		GetWindowHeight() - margin - (GSConfig.OsdShowSettings ? font_size : 0.0f);
+	const float radius = std::ceil(10.0f * scale);
+	const float cx = GetWindowWidth() - margin - radius;
+	const float cy = baseline_y - spacing - radius;
+	const ImVec2 center(cx, cy);
+
+	const ImVec2 text_size = font->CalcTextSizeA(
+		font_size, std::numeric_limits<float>::max(), -1.0f, label.c_str(), label.c_str() + label.length(), nullptr);
+	const float shadow_offset = std::ceil(scale);
+	const float text_gap = std::ceil(6.0f * scale);
+	const float text_x = cx - radius - text_gap - text_size.x;
+	const float text_y = cy - font_size * 0.5f;
+
+	ImDrawList* const dl = ImGui::GetBackgroundDrawList();
+	const float a0 = static_cast<float>(ImGui::GetTime()) * 10.0f;
+	const float a1 = a0 + IM_PI * 1.12f;
+	const float thickness = std::ceil(2.5f * scale);
+
+	dl->AddText(font, font_size, ImVec2(text_x + shadow_offset, text_y + shadow_offset), shadow_col,
+		label.c_str(), label.c_str() + label.length());
+	dl->AddText(font, font_size, ImVec2(text_x, text_y), text_col, label.c_str(), label.c_str() + label.length());
+	if (GSConfig.OsdBoldText)
+	{
+		dl->AddText(font, font_size, ImVec2(text_x + 0.6f, text_y), text_col, label.c_str(),
+			label.c_str() + label.length());
+	}
+
+	dl->PathClear();
+	dl->PathArcTo(center, radius, 0.0f, 2.0f * IM_PI, 32);
+	dl->PathStroke(spinner_track_col, false, std::max(1.0f, thickness * 0.65f));
+
+	dl->PathClear();
+	dl->PathArcTo(center, radius, a0, a1, 24);
+	dl->PathStroke(text_col, false, thickness);
 }
 
 __ri void ImGuiManager::DrawSettingsOverlay(float scale, float margin, float spacing)
@@ -1698,6 +1766,7 @@ void ImGuiManager::RenderOverlays()
 	if (GSConfig.OsdPerformancePos != OsdOverlayPos::None)
 		DrawPerformanceOverlay(position_y, scale, margin, spacing);
 	DrawSettingsOverlay(scale, margin, spacing);
+	DrawShaderCompileIndicator(scale, margin, spacing);
 	DrawInputsOverlay(scale, margin, spacing);
 	if (SaveStateSelectorUI::s_open)
 		SaveStateSelectorUI::Draw();


### PR DESCRIPTION
<img width="512" height="186" alt="image" src="https://github.com/user-attachments/assets/cf0498fa-dc25-49f9-9ef6-526c91ef70ab" />

### Description of Changes
When it's compiling shaders, show that we are compiling shaders with a little spinner. It only appears if you’ve left Show GPU Usage on.

### Rationale behind Changes
So hitches from shader compiles are obvious

### Suggested Testing Steps
Flip Show GPU Usage on and off, run something that has new shaders or clear your shader cache, and see that the message only shows when that option is on.

### Did you use AI to help find, test, or implement this issue or feature?
No