### PR TITLE
GameDB: The Draw Buffaning

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1228,6 +1228,8 @@ PCPX-98042:
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 1 # Fixes the display of scores and text ingame.
+  gsHWFixes:
+    accurateAlphaTest: 1 # Fixes UI rendering.
 PDPX-99109:
   name: "DVD Player Version 3.04"
   name-sort: "DVDぷれーやー Version 3.04"
@@ -1386,6 +1388,7 @@ SCAJ-20010:
   region: "NTSC-Unk"
   gsHWFixes:
     textureInsideRT: 1 # Fixes inside RT shuffling.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SCAJ-20011:
   name: "Silent Line - Armored Core"
   region: "NTSC-HK"
@@ -1583,6 +1586,7 @@ SCAJ-20048:
   name-en: "R:Racing Evolution"
   region: "NTSC-J"
   gsHWFixes:
+    halfPixelOffset: 4 # Aligns bloom and shadows.
     alignSprite: 1 # Fixes vertical lines.
 SCAJ-20050:
   name: "Fatal Frame II - Crimson Butterfly"
@@ -1910,6 +1914,7 @@ SCAJ-20105:
     recommendedBlendingLevel: 3 # Fixes level brightness.
     cpuSpriteRenderBW: 2 # Fixes broken water on "Upper Sea" level.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    drawBuffering: 1 # Reduces draws and improves performance.
   dynaPatches:
     - pattern:
         - { offset: 0x0, value: 0x3C023E4C }
@@ -2474,6 +2479,8 @@ SCAJ-20181:
   region: "NTSC-Unk"
   roundModes:
     vu1RoundMode: 1 # Fixes the display of scores and text ingame.
+  gsHWFixes:
+    accurateAlphaTest: 1 # Fixes UI rendering.
 SCAJ-20182:
   name: "Tales of Destiny"
   region: "NTSC-Unk"
@@ -2578,6 +2585,8 @@ SCAJ-20198:
   region: "NTSC-Unk"
   roundModes:
     vu1RoundMode: 1 # Fixes the display of scores and text ingame.
+  gsHWFixes:
+    accurateAlphaTest: 1 # Fixes UI rendering.
 SCAJ-20199:
   name: "Tekken 5 [PlayStation2 the Best]"
   region: "NTSC-Unk"
@@ -6560,6 +6569,8 @@ SCES-54535:
   region: "PAL-M11"
   roundModes:
     vu1RoundMode: 1 # Fixes the display of scores and text ingame.
+  gsHWFixes:
+    accurateAlphaTest: 1 # Fixes UI rendering.
 SCES-54538:
   name: "Eyetoy - Play Astro Zoo"
   region: "PAL-M15"
@@ -7546,6 +7557,7 @@ SCKA-20047:
     recommendedBlendingLevel: 3 # Fixes level brightness.
     cpuSpriteRenderBW: 2 # Fixes broken water on "Upper Sea" level.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    drawBuffering: 1 # Reduces draws and improves performance.
   memcardFilters:
     - "SCKA-20047"
     - "SLKA-25201"
@@ -9644,6 +9656,8 @@ SCPS-15113:
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 1 # Fixes the display of scores and text ingame.
+  gsHWFixes:
+    accurateAlphaTest: 1 # Fixes UI rendering.
 SCPS-15114:
   name: "機甲装兵アーモダイン"
   name-sort: "きこうそうへいあーもだいん"
@@ -9690,6 +9704,7 @@ SCPS-15119:
     - OPHFlagHack # Special moves "Bankai" hang otherwise.
   gsHWFixes:
     preloadFrameData: 1 # Fixes removed bloom.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SCPS-15120:
   name: "ラチェット&クランク5 激突！ドデカ銀河のミリミリ軍団"
   name-sort: "らちぇっとあんどくらんく5 げきとつ！どでかぎんがのみりみりぐんだん"
@@ -10384,6 +10399,8 @@ SCPS-19332:
   region: "NTSC-J"
   roundModes:
     vu1RoundMode: 1 # Fixes the display of scores and text ingame.
+  gsHWFixes:
+    accurateAlphaTest: 1 # Fixes UI rendering.
 SCPS-19333:
   name: "ワイルドアームズ ザ フィフスヴァンガード [PlayStation2 the Best]"
   name-sort: "わいるどあーむず ざ ふぃふすゔぁんがーど [PlayStation2 the Best]"
@@ -13067,6 +13084,8 @@ SCUS-97610:
   compat: 5
   roundModes:
     vu1RoundMode: 1 # Fixes the display of scores and text ingame.
+  gsHWFixes:
+    accurateAlphaTest: 1 # Fixes UI rendering.
 SCUS-97611:
   name: "SingStar - Amped"
   region: "NTSC-U"
@@ -13094,6 +13113,8 @@ SCUS-97619:
   region: "NTSC-U"
   roundModes:
     vu1RoundMode: 1 # Fixes the display of scores and text ingame.
+  gsHWFixes:
+    accurateAlphaTest: 1 # Fixes UI rendering.
 SCUS-97620:
   name: "Syphon Filter - Dark Mirror [Demo]"
   region: "NTSC-U"
@@ -13465,6 +13486,7 @@ SLAJ-25075:
     nativeScaling: 2 # Fixes post effects.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    drawBuffering: 1 # Reduces draws and improves performance.
   memcardFilters:
     - "SLAJ-25075"
     - "SLPM-66232"
@@ -13541,6 +13563,7 @@ SLAJ-25091:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes car headlights and persistent trails.
     halfPixelOffset: 2 # Fixes depth line.
+    drawBuffering: 1 # Reduces draws and improves performance.
   memcardFilters:
     - "SLAJ-25091"
     # Most Wanted save grants extra money.
@@ -13673,6 +13696,8 @@ SLED-50489:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     cpuSpriteRenderBW: 4 # Fixes textures.
+    halfPixelOffset: 4 # Fixes misaligned post-processing.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLED-50587:
   name: "Top Gun - Combat Zones [Demo]"
   region: "PAL-E"
@@ -13708,6 +13733,8 @@ SLED-51012:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     cpuSpriteRenderBW: 4 # Fixes textures.
+    halfPixelOffset: 4 # Fixes misaligned post-processing.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLED-51047:
   name: "Red Faction II"
   region: "PAL-Unk"
@@ -13860,6 +13887,7 @@ SLED-51975:
     recommendedBlendingLevel: 3 # Improves reflection quality.
     halfPixelOffset: 2 # Fixes misaligned post-processing.
     PCRTCOverscan: 1 # Fixes image alignment.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLED-51987:
   name: "Kya - Dark Lineage"
   region: "PAL-Unk"
@@ -13988,6 +14016,7 @@ SLED-52736:
   gsHWFixes:
     halfPixelOffset: 5 # Fixes depth lines and reduces blur.
     nativeScaling: 1 # Aligns post effects.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLED-52851:
   name: "TOCA Race Driver 2"
   region: "PAL-Unk"
@@ -14025,8 +14054,12 @@ SLED-52890:
     nativeScaling: 1 # Fixes misaligned bloom.
     mipmap: 0 # Currently totally breaks player uniform rendering if mipmapping is enabled.
 SLED-52891:
-  name: "Rocky Legends"
-  region: "PAL-Unk"
+  name: "Rocky Legends [Demo]"
+  region: "PAL-E"
+  speedHacks:
+    instantVU1: 0 # Fixes graphical issues on character models.
+  gsHWFixes:
+    preloadFrameData: 1 # Fixes background FMV flicker.
 SLED-52899:
   name: "Killzone [Bonus Disc]"
   region: "PAL-M5"
@@ -14217,6 +14250,7 @@ SLED-53650:
     nativeScaling: 2 # Fixes post effects.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLED-53664:
   name: "FIFA 06 - Demo Pre-Release Version"
   region: "PAL-E"
@@ -14388,6 +14422,7 @@ SLED-54312:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes car headlights and persistent trails.
     halfPixelOffset: 2 # Fixes depth line.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLED-54315:
   name: "LEGO Star Wars II - The Original Trilogy [Demo]"
   region: "PAL-M5"
@@ -15246,6 +15281,8 @@ SLES-50288:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     cpuSpriteRenderBW: 4 # Fixes textures.
+    halfPixelOffset: 4 # Fixes misaligned post-processing.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLES-50296:
   name: "Gift"
   region: "PAL-F"
@@ -17274,7 +17311,7 @@ SLES-51192:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
     textureInsideRT: 1 # Fixes right side shadow lookup.
-    halfPixelOffset: 4 # Fixes misaligned lighting and other effects.
+    halfPixelOffset: 5 # Fixes misaligned lighting and other effects.
 SLES-51193:
   name: "Harry Potter et la Chambre des Secrets"
   region: "PAL-F"
@@ -17283,7 +17320,7 @@ SLES-51193:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
     textureInsideRT: 1 # Fixes right side shadow lookup.
-    halfPixelOffset: 4 # Fixes misaligned lighting and other effects.
+    halfPixelOffset: 5 # Fixes misaligned lighting and other effects.
 SLES-51194:
   name: "Harry Potter und die Kammer des Schreckens"
   region: "PAL-G"
@@ -17292,7 +17329,7 @@ SLES-51194:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
     textureInsideRT: 1 # Fixes right side shadow lookup.
-    halfPixelOffset: 4 # Fixes misaligned lighting and other effects.
+    halfPixelOffset: 5 # Fixes misaligned lighting and other effects.
 SLES-51195:
   name: "Harry Potter y la Cámara Secreta"
   region: "PAL-S"
@@ -17301,7 +17338,7 @@ SLES-51195:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
     textureInsideRT: 1 # Fixes right side shadow lookup.
-    halfPixelOffset: 4 # Fixes misaligned lighting and other effects.
+    halfPixelOffset: 5 # Fixes misaligned lighting and other effects.
 SLES-51196:
   name: "Harry Potter e La Camera dei Secreti"
   region: "PAL-I"
@@ -17310,7 +17347,7 @@ SLES-51196:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
     textureInsideRT: 1 # Fixes right side shadow lookup.
-    halfPixelOffset: 4 # Fixes misaligned lighting and other effects.
+    halfPixelOffset: 5 # Fixes misaligned lighting and other effects.
 SLES-51197:
   name: "FIFA 2003"
   region: "PAL-M7"
@@ -17366,7 +17403,7 @@ SLES-51214:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
     textureInsideRT: 1 # Fixes right side shadow lookup.
-    halfPixelOffset: 4 # Fixes misaligned lighting and other effects.
+    halfPixelOffset: 5 # Fixes misaligned lighting and other effects.
 SLES-51215:
   name: "Harry Potter og Mysteriekammeret"
   region: "PAL-NO"
@@ -17375,7 +17412,7 @@ SLES-51215:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
     textureInsideRT: 1 # Fixes right side shadow lookup.
-    halfPixelOffset: 4 # Fixes misaligned lighting and other effects.
+    halfPixelOffset: 5 # Fixes misaligned lighting and other effects.
 SLES-51216:
   name: "Harry Potter ja Salaisuuksien Kammio"
   region: "PAL-FI"
@@ -17384,7 +17421,7 @@ SLES-51216:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
     textureInsideRT: 1 # Fixes right side shadow lookup.
-    halfPixelOffset: 4 # Fixes misaligned lighting and other effects.
+    halfPixelOffset: 5 # Fixes misaligned lighting and other effects.
 SLES-51217:
   name: "Harry Potter och Hemligheternas Kammare"
   region: "PAL-SW"
@@ -17393,7 +17430,7 @@ SLES-51217:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
     textureInsideRT: 1 # Fixes right side shadow lookup.
-    halfPixelOffset: 4 # Fixes misaligned lighting and other effects.
+    halfPixelOffset: 5 # Fixes misaligned lighting and other effects.
 SLES-51218:
   name: "Harry Potter en de Geheime Kamer"
   region: "PAL-NL"
@@ -17402,7 +17439,7 @@ SLES-51218:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
     textureInsideRT: 1 # Fixes right side shadow lookup.
-    halfPixelOffset: 4 # Fixes misaligned lighting and other effects.
+    halfPixelOffset: 5 # Fixes misaligned lighting and other effects.
 SLES-51219:
   name: "Harry Potter ea Camara dos Segredos"
   region: "PAL-P"
@@ -17411,7 +17448,7 @@ SLES-51219:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
     textureInsideRT: 1 # Fixes right side shadow lookup.
-    halfPixelOffset: 4 # Fixes misaligned lighting and other effects.
+    halfPixelOffset: 5 # Fixes misaligned lighting and other effects.
 SLES-51220:
   name: "TY the Tasmanian Tiger"
   region: "PAL-M5"
@@ -17626,14 +17663,16 @@ SLES-51286:
   name: "X-Men 2 - Wolverine's Revenge"
   region: "PAL-E"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes upscaling lines.
+    halfPixelOffset: 4 # Fixes upscaling lines.
     autoFlush: 2 # Fixes sun penetration.
+    textureInsideRT: 1 # Fixes missing lighting in some rooms.
 SLES-51287:
   name: "X-Men 2 - La Vengeance de Wolverine"
   region: "PAL-F"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes upscaling lines.
+    halfPixelOffset: 4 # Fixes upscaling lines.
     autoFlush: 2 # Fixes sun penetration.
+    textureInsideRT: 1 # Fixes missing lighting in some rooms.
 SLES-51289:
   name: "Gunfighter 2 - Legend of Jesse James"
   region: "PAL-M5"
@@ -18202,8 +18241,9 @@ SLES-51548:
   name: "X-Men 2 - Wolverine's Revenge"
   region: "PAL-M3"
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes upscaling lines.
+    halfPixelOffset: 4 # Fixes upscaling lines.
     autoFlush: 2 # Fixes sun penetration.
+    textureInsideRT: 1 # Fixes missing lighting in some rooms.
 SLES-51553:
   name: "Chaos Legion"
   region: "PAL-M5"
@@ -19271,6 +19311,7 @@ SLES-51967:
     recommendedBlendingLevel: 3 # Improves reflection quality.
     halfPixelOffset: 2 # Fixes misaligned post-processing.
     PCRTCOverscan: 1 # Fixes image alignment.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLES-51968:
   name: "Nickelodeon SpongeBob SquarePants - Battle for Bikini Bottom"
   region: "PAL-E"
@@ -19510,12 +19551,14 @@ SLES-52047:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes vertical lines, font and others.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLES-52048:
   name: "The Sims - Bustin' Out"
   name-sort: "Sims, The - Bustin' Out"
   region: "PAL-M5"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes vertical lines, font and others.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLES-52055:
   name: "Harry Potter and the Philosopher's Stone"
   region: "PAL-M11"
@@ -20060,6 +20103,9 @@ SLES-52309:
   name: "R - Racing"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 4 # Aligns bloom and shadows.
+    alignSprite: 1 # Fixes vertical lines.
 SLES-52310:
   name: "Energy Airforce"
   region: "PAL-E"
@@ -21327,6 +21373,7 @@ SLES-52725:
   gsHWFixes:
     halfPixelOffset: 5 # Fixes depth lines and reduces blur.
     nativeScaling: 1 # Aligns post effects.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLES-52726:
   name: "NBA Live 2005"
   region: "PAL-F"
@@ -21433,6 +21480,8 @@ SLES-52761:
   name: "Rocky - Legends"
   region: "PAL-M3"
   compat: 5
+  speedHacks:
+    instantVU1: 0 # Fixes graphical issues on character models.
   gsHWFixes:
     preloadFrameData: 1 # Fixes background FMV flicker.
 SLES-52766:
@@ -21782,9 +21831,10 @@ SLES-52888:
   name: "Brothers in Arms - Road to Hill 30"
   region: "PAL-M5"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes ground shading.
     halfPixelOffset: 5 # Reduces ghosting on objects.
     nativeScaling: 2 # Helps smooth out ghosting.
-    recommendedBlendingLevel: 3 # Fixes ground shading.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLES-52889:
   name: "Disney's Winnie the Pooh Rumbly Tumbly Adventure"
   region: "PAL-M6"
@@ -23407,7 +23457,8 @@ SLES-53434:
   name: "Red Baron"
   region: "PAL-M3"
   gsHWFixes:
-    textureInsideRT: 1 # Fixes trees.
+    textureInsideRT: 1 # Fixes trees and half screen issue.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLES-53435:
   name: "SAS Anti-Terror Force"
   region: "PAL-M3"
@@ -23970,6 +24021,7 @@ SLES-53557:
     nativeScaling: 2 # Fixes post effects.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    drawBuffering: 1 # Reduces draws and improves performance.
   memcardFilters:
     - "SLES-53557"
     - "SLES-53558"
@@ -23985,6 +24037,7 @@ SLES-53558:
     nativeScaling: 2 # Fixes post effects.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    drawBuffering: 1 # Reduces draws and improves performance.
   memcardFilters:
     - "SLES-53557"
     - "SLES-53558"
@@ -24000,6 +24053,7 @@ SLES-53559:
     nativeScaling: 2 # Fixes post effects.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    drawBuffering: 1 # Reduces draws and improves performance.
   memcardFilters:
     - "SLES-53557"
     - "SLES-53558"
@@ -24841,6 +24895,7 @@ SLES-53819:
     recommendedBlendingLevel: 3 # Fixes level brightness.
     cpuSpriteRenderBW: 2 # Fixes broken water on "Upper Sea" level.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    drawBuffering: 1 # Reduces draws and improves performance.
   memcardFilters:
     - "SLES-53819"
     - "SLES-82036"
@@ -24956,6 +25011,7 @@ SLES-53857:
     nativeScaling: 2 # Fixes post effects.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    drawBuffering: 1 # Reduces draws and improves performance.
   memcardFilters:
     - "SLES-53557"
     - "SLES-53558"
@@ -26234,6 +26290,7 @@ SLES-54321:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes car headlights and persistent trails.
     halfPixelOffset: 2 # Fixes depth line.
+    drawBuffering: 1 # Reduces draws and improves performance.
   memcardFilters:
     - "SLES-54321"
     - "SLES-54322"
@@ -26254,6 +26311,7 @@ SLES-54322:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes car headlights and persistent trails.
     halfPixelOffset: 2 # Fixes depth line.
+    drawBuffering: 1 # Reduces draws and improves performance.
   memcardFilters:
     - "SLES-54321"
     - "SLES-54322"
@@ -26274,6 +26332,7 @@ SLES-54323:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes car headlights and persistent trails.
     halfPixelOffset: 2 # Fixes depth line.
+    drawBuffering: 1 # Reduces draws and improves performance.
   memcardFilters:
     - "SLES-54321"
     - "SLES-54322"
@@ -26294,6 +26353,7 @@ SLES-54324:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes car headlights and persistent trails.
     halfPixelOffset: 2 # Fixes depth line.
+    drawBuffering: 1 # Reduces draws and improves performance.
   memcardFilters:
     - "SLES-54321"
     - "SLES-54322"
@@ -26958,6 +27018,7 @@ SLES-54492:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes car headlights and persistent trails.
     halfPixelOffset: 2 # Fixes depth line.
+    drawBuffering: 1 # Reduces draws and improves performance.
   memcardFilters:
     - "SLES-54402"
     - "SLES-54492"
@@ -26977,6 +27038,7 @@ SLES-54493:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes car headlights and persistent trails.
     halfPixelOffset: 2 # Fixes depth line.
+    drawBuffering: 1 # Reduces draws and improves performance.
   memcardFilters:
     - "SLES-54402"
     - "SLES-54492"
@@ -31772,6 +31834,7 @@ SLKA-25136:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves reflection quality.
     halfPixelOffset: 2 # Fixes misaligned post-processing.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLKA-25137:
   name: "심즈 - 세상 밖으로"
   name-sort: "Sims, The - Bustin' Out"
@@ -31779,6 +31842,7 @@ SLKA-25137:
   region: "NTSC-K"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes vertical lines, font and others.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLKA-25138:
   name: ".hack//악성변이 Vol.2"
   name-sort: ".hack Mutation Vol. 2"
@@ -32329,6 +32393,7 @@ SLKA-25241:
   gsHWFixes:
     halfPixelOffset: 5 # Fixes depth lines and reduces blur.
     nativeScaling: 1 # Aligns post effects.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLKA-25242:
   name: "파이트 나이트 라운드 2"
   name-en: "Fight Night Round 2"
@@ -32519,9 +32584,10 @@ SLKA-25277:
   name-en: "Brothers in Arms - Road to Hill 30"
   region: "NTSC-K"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes ground shading.
     halfPixelOffset: 5 # Reduces ghosting on objects.
     nativeScaling: 2 # Helps smooth out ghosting.
-    recommendedBlendingLevel: 3 # Fixes ground shading.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLKA-25278:
   name: "MVP 베이스볼 2005"
   name-en: "MVP Baseball 2005"
@@ -32863,6 +32929,7 @@ SLKA-25334:
     nativeScaling: 2 # Fixes post effects.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    drawBuffering: 1 # Reduces draws and improves performance.
   memcardFilters:
     - "SLKA-25334"
     - "SLKA-25241" # Underground 2 save grants extra money.
@@ -33754,6 +33821,7 @@ SLPM-55003:
     nativeScaling: 2 # Fixes post effects.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    drawBuffering: 1 # Reduces draws and improves performance.
   memcardFilters:
     - "SLPM-55003"
     - "SLPM-65766" # Underground 2 save grants extra money.
@@ -34090,6 +34158,7 @@ SLPM-55061:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes car headlights and persistent trails.
     halfPixelOffset: 2 # Fixes depth line.
+    drawBuffering: 1 # Reduces draws and improves performance.
   memcardFilters:
     - "SLPM-55061"
     # Most Wanted save grants extra money.
@@ -35806,6 +35875,7 @@ SLPM-60216:
   name-en: "R:Racing Evolution [Trial]"
   region: "NTSC-J"
   gsHWFixes:
+    halfPixelOffset: 4 # Aligns bloom and shadows.
     alignSprite: 1 # Fixes vertical lines.
 SLPM-60217:
   name: "タイムクライシス3 [店頭体験版]"
@@ -35938,6 +36008,7 @@ SLPM-60250:
   gsHWFixes:
     halfPixelOffset: 5 # Fixes depth lines and reduces blur.
     nativeScaling: 1 # Aligns post effects.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLPM-60251:
   name: "Devil May Cry 3 [体験版]"
   name-sort: "でびる めい くらい 3 [たいけんばん]"
@@ -38202,7 +38273,7 @@ SLPM-62241:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
     textureInsideRT: 1 # Fixes right side shadow lookup.
-    halfPixelOffset: 4 # Fixes misaligned lighting and other effects.
+    halfPixelOffset: 5 # Fixes misaligned lighting and other effects.
 SLPM-62242:
   name: "撞球 ビリヤードマスター2"
   name-sort: "どうきゅう びりやーどますたー2"
@@ -39622,7 +39693,7 @@ SLPM-62513:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
     textureInsideRT: 1 # Fixes right side shadow lookup.
-    halfPixelOffset: 4 # Fixes misaligned lighting and other effects.
+    halfPixelOffset: 5 # Fixes misaligned lighting and other effects.
 SLPM-62514:
   name: "シムピープル ～お茶の間劇場～ [EA BEST HITS]"
   name-sort: "しむぴーぷる おちゃのまげきじょう [EA BEST HITS]"
@@ -41081,7 +41152,7 @@ SLPM-64528:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
     textureInsideRT: 1 # Fixes right side shadow lookup.
-    halfPixelOffset: 4 # Fixes misaligned lighting and other effects.
+    halfPixelOffset: 5 # Fixes misaligned lighting and other effects.
 SLPM-64532:
   name: "디지털 홈즈"
   name-en: "Digital Holmes"
@@ -42531,6 +42602,7 @@ SLPM-65234:
   region: "NTSC-J"
   gsHWFixes:
     textureInsideRT: 1 # Fixes inside RT shuffling.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLPM-65235:
   name: "ニュールーマニア ポロリ青春"
   name-sort: "にゅーるーまにあ ぽろりせいしゅん"
@@ -43918,6 +43990,7 @@ SLPM-65471:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves reflection quality.
     halfPixelOffset: 2 # Fixes misaligned post-processing.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLPM-65472:
   name: "TrainSimulator＋電車でGO！ 東京急行編"
   name-sort: "とれいんしみゅれーたー＋でんしゃでごー とうきょうきゅうこうへん"
@@ -43958,6 +44031,7 @@ SLPM-65479:
   region: "NTSC-J"
   gsHWFixes:
     halfPixelOffset: 1 # Fixes vertical lines, font and others.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLPM-65480:
   name: "michigan"
   name-sort: "みしがん"
@@ -44694,6 +44768,7 @@ SLPM-65614:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves reflection quality.
     halfPixelOffset: 2 # Fixes misaligned post-processing.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLPM-65615:
   name: "ドカポンDX -わたる世界はオニだらけ-"
   name-sort: "どかぽんDX -わたるせかいはおにだらけ-"
@@ -45621,6 +45696,7 @@ SLPM-65766:
   gsHWFixes:
     halfPixelOffset: 5 # Fixes depth lines and reduces blur.
     nativeScaling: 1 # Aligns post effects.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLPM-65767:
   name: "NBA STARTING FIVE 2005"
   name-sort: "NBA すたーてぃんぐ ふぁいぶ 2005"
@@ -47097,6 +47173,8 @@ SLPM-66019:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     cpuSpriteRenderBW: 4 # Fixes textures.
+    halfPixelOffset: 4 # Fixes misaligned post-processing.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLPM-66020:
   name: "サイオプス サイキック・オペレーション"
   name-sort: "さいおぷす さいきっく・おぺれーしょん"
@@ -47219,9 +47297,10 @@ SLPM-66042:
   name-en: "Brothers in Arms - Road to Hill 30"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes ground shading.
     halfPixelOffset: 5 # Reduces ghosting on objects.
     nativeScaling: 2 # Helps smooth out ghosting.
-    recommendedBlendingLevel: 3 # Fixes ground shading.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLPM-66043:
   name: "レーシングゲーム「注意!!!!」"
   name-sort: "れーしんぐげーむ「ちゅうい!!!!」"
@@ -47271,6 +47350,7 @@ SLPM-66051:
   gsHWFixes:
     halfPixelOffset: 5 # Fixes depth lines and reduces blur.
     nativeScaling: 1 # Aligns post effects.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLPM-66052:
   name: "巫女舞 ～永遠の想い～"
   name-sort: "みこまい えいえんのおもい"
@@ -48499,6 +48579,7 @@ SLPM-66232:
     nativeScaling: 2 # Fixes post effects.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    drawBuffering: 1 # Reduces draws and improves performance.
   memcardFilters:
     - "SLAJ-25075"
     - "SLPM-66232"
@@ -50555,6 +50636,7 @@ SLPM-66562:
     nativeScaling: 2 # Fixes post effects.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    drawBuffering: 1 # Reduces draws and improves performance.
   memcardFilters:
     - "SLAJ-25075"
     - "SLPM-66232"
@@ -50609,9 +50691,10 @@ SLPM-66568:
   name-en: "Brothers in Arms - Road to Hill 30 [Ubisoft Best]"
   region: "NTSC-J"
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes ground shading.
     halfPixelOffset: 5 # Reduces ghosting on objects.
     nativeScaling: 2 # Helps smooth out ghosting.
-    recommendedBlendingLevel: 3 # Fixes ground shading.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLPM-66569:
   name: "シークレット・オブ・エヴァンゲリオン [通常版]"
   name-sort: "しーくれっと おぶ えゔぁんげりおん [つうじょうばん]"
@@ -50919,6 +51002,7 @@ SLPM-66617:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes car headlights and persistent trails.
     halfPixelOffset: 2 # Fixes depth line.
+    drawBuffering: 1 # Reduces draws and improves performance.
   memcardFilters:
     - "SLPM-66617"
     # Most Wanted save grants extra money.
@@ -52481,6 +52565,7 @@ SLPM-66869:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes car headlights and persistent trails.
     halfPixelOffset: 2 # Fixes depth line.
+    drawBuffering: 1 # Reduces draws and improves performance.
   memcardFilters:
     - "SLPM-66869"
     # Most Wanted save grants extra money.
@@ -52985,6 +53070,7 @@ SLPM-66960:
   gsHWFixes:
     halfPixelOffset: 5 # Fixes depth lines and reduces blur.
     nativeScaling: 1 # Aligns post effects.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLPM-66961:
   name: "EA:SY！1980 BLACK"
   name-sort: "ブラック [EA:SY! 1980]"
@@ -53586,7 +53672,7 @@ SLPM-68005:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
     textureInsideRT: 1 # Fixes right side shadow lookup.
-    halfPixelOffset: 4 # Fixes misaligned lighting and other effects.
+    halfPixelOffset: 5 # Fixes misaligned lighting and other effects.
 SLPM-68007:
   name: "カラオケレボリューション用マイク同梱お試しディスク"
   name-sort: "からおけれぼりゅーしょんようまいくどうこんおためしでぃすく"
@@ -54578,6 +54664,14 @@ SLPM-74416:
   region: "NTSC-J"
   gameFixes:
     - SoftwareRendererFMVHack # Fixes brightness and striped lines in FMVs.
+SLPM-74419:
+  name: "爆走デコトラ伝説 ～男花道夢浪漫～ [PlayStation2 the Best]"
+  name-sort: "ばくそうでことらでんせつ おとこはなみちゆめろまん [PlayStation2 the Best]"
+  name-en: "Bakusou Dekotora Densetsu - Otoko Hanamichi Yume Roman [PlayStation2 the Best]"
+  region: "NTSC-J"
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes inside RT shuffling.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLPM-74420:
   name: "頭文字D Special Stage [PlayStation2 the Best]"
   name-sort: "いにしゃるD すぺしゃる すてーじ [PlayStation2 the Best]"
@@ -54717,6 +54811,8 @@ SLPS-20013:
   name-sort: "ぷらいまる いめーじ vol.1"
   name-en: "Primal Image Vol.01"
   region: "NTSC-J"
+  gsHWFixes:
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLPS-20015:
   name: "鉄拳タッグトーナメント"
   name-sort: "てっけんたっぐとーなめんと"
@@ -55808,7 +55904,7 @@ SLPS-20234:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
     textureInsideRT: 1 # Fixes right side shadow lookup.
-    halfPixelOffset: 4 # Fixes misaligned lighting and other effects.
+    halfPixelOffset: 5 # Fixes misaligned lighting and other effects.
 SLPS-20237:
   name: "Saikyou Toudai Shougi 3"
   region: "NTSC-J"
@@ -58968,6 +59064,7 @@ SLPS-25300:
   name-en: "R:Racing Evolution"
   region: "NTSC-J"
   gsHWFixes:
+    halfPixelOffset: 4 # Aligns bloom and shadows.
     alignSprite: 1 # Fixes vertical lines.
 SLPS-25301:
   name: "ミッシングパーツ side A the TANTEI stories"
@@ -59671,6 +59768,7 @@ SLPS-25408:
     recommendedBlendingLevel: 3 # Fixes level brightness.
     cpuSpriteRenderBW: 2 # Fixes broken water on "Upper Sea" level.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    drawBuffering: 1 # Reduces draws and improves performance.
   memcardFilters:
     - "SLPS-25408"
     - "SCAJ-20076"
@@ -65241,6 +65339,8 @@ SLUS-20250:
     - BlitInternalFPSHack # Fixes internal FPS detection.
   gsHWFixes:
     cpuSpriteRenderBW: 4 # Fixes textures.
+    halfPixelOffset: 4 # Fixes misaligned post-processing.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLUS-20251:
   name: "Harvest Moon - Save the Homeland"
   region: "NTSC-U"
@@ -65654,8 +65754,9 @@ SLUS-20337:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    halfPixelOffset: 2 # Fixes upscaling lines.
+    halfPixelOffset: 4 # Fixes upscaling lines.
     autoFlush: 2 # Fixes sun penetration.
+    textureInsideRT: 1 # Fixes missing lighting in some rooms.
 SLUS-20339:
   name: "Bass Fishing Duel - Sega Sports"
   region: "NTSC-U"
@@ -66927,7 +67028,7 @@ SLUS-20576:
   gsHWFixes:
     recommendedBlendingLevel: 4 # Fixes missing lighting effects.
     textureInsideRT: 1 # Fixes right side shadow lookup.
-    halfPixelOffset: 4 # Fixes misaligned lighting and other effects.
+    halfPixelOffset: 5 # Fixes misaligned lighting and other effects.
 SLUS-20577:
   name: "Drome Racers"
   region: "NTSC-U"
@@ -67710,6 +67811,7 @@ SLUS-20721:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
+    halfPixelOffset: 4 # Aligns bloom and shadows.
     alignSprite: 1 # Fixes vertical lines.
 SLUS-20722:
   name: "Maximo vs. Army of Zin"
@@ -68206,6 +68308,7 @@ SLUS-20811:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves reflection quality.
     halfPixelOffset: 2 # Fixes misaligned post-processing.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLUS-20812:
   name: "Dynasty Warriors 4 - Xtreme Legends"
   region: "NTSC-U"
@@ -68336,6 +68439,7 @@ SLUS-20842:
   compat: 5
   gsHWFixes:
     halfPixelOffset: 1 # Fixes vertical lines, font and others.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLUS-20843:
   name: "Dead to Rights II"
   region: "NTSC-U"
@@ -68632,6 +68736,8 @@ SLUS-20890:
   name: "Rocky - Legends"
   region: "NTSC-U"
   compat: 5
+  speedHacks:
+    instantVU1: 0 # Fixes graphical issues on character models.
   gsHWFixes:
     preloadFrameData: 1 # Fixes background FMV flicker.
 SLUS-20891:
@@ -69754,6 +69860,7 @@ SLUS-21065:
   gsHWFixes:
     halfPixelOffset: 5 # Fixes depth lines and reduces blur.
     nativeScaling: 1 # Aligns post effects.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLUS-21066:
   name: "The Urbz - Sims in the City"
   name-sort: "Urbz, The - Sims in the City"
@@ -70304,9 +70411,10 @@ SLUS-21163:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
+    recommendedBlendingLevel: 3 # Fixes ground shading.
     halfPixelOffset: 5 # Reduces ghosting on objects.
     nativeScaling: 2 # Helps smooth out ghosting.
-    recommendedBlendingLevel: 3 # Fixes ground shading.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLUS-21164:
   name: "Namco Museum - 50th Anniversary"
   region: "NTSC-U"
@@ -70529,6 +70637,7 @@ SLUS-21200:
     recommendedBlendingLevel: 3 # Fixes level brightness.
     cpuSpriteRenderBW: 2 # Fixes broken water on "Upper Sea" level.
     cpuSpriteRenderLevel: 2 # Needed for above.
+    drawBuffering: 1 # Reduces draws and improves performance.
   memcardFilters: # Can import data from AC:Nexus.
     - "SLUS-21200"
     - "SLUS-20986"
@@ -70925,6 +71034,7 @@ SLUS-21257:
     nativeScaling: 2 # Fixes post effects.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    drawBuffering: 1 # Reduces draws and improves performance.
   memcardFilters:
     - "SLUS-21257"
     - "SLUS-21065" # Underground 2 save grants extra money.
@@ -71012,6 +71122,7 @@ SLUS-21267:
     nativeScaling: 2 # Fixes post effects.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    drawBuffering: 1 # Reduces draws and improves performance.
   memcardFilters:
     - "SLUS-21267"
     - "SLUS-21351"
@@ -71631,6 +71742,7 @@ SLUS-21351:
     nativeScaling: 2 # Fixes post effects.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    drawBuffering: 1 # Reduces draws and improves performance.
   memcardFilters:
     - "SLUS-21267"
     - "SLUS-21351"
@@ -72601,6 +72713,7 @@ SLUS-21493:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes car headlights and persistent trails.
     halfPixelOffset: 2 # Fixes depth line.
+    drawBuffering: 1 # Reduces draws and improves performance.
   memcardFilters:
     - "SLUS-21493"
     # Most Wanted save grants extra money.
@@ -72617,6 +72730,7 @@ SLUS-21494:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes car headlights and persistent trails.
     halfPixelOffset: 2 # Fixes depth line.
+    drawBuffering: 1 # Reduces draws and improves performance.
   memcardFilters:
     - "SLUS-21494"
     # Most Wanted save grants extra money.
@@ -75391,6 +75505,7 @@ SLUS-29073:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Improves reflection quality.
     halfPixelOffset: 2 # Fixes misaligned post-processing.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLUS-29074:
   name: "DDRMAX2 Dance Dance Revolution [Demo]"
   region: "NTSC-U"
@@ -75561,6 +75676,7 @@ SLUS-29118:
   gsHWFixes:
     halfPixelOffset: 5 # Fixes depth lines and reduces blur.
     nativeScaling: 1 # Aligns post effects.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLUS-29123:
   name: "Ghost in the Shell - Stand Alone Complex [Demo]"
   region: "NTSC-U"
@@ -75739,6 +75855,7 @@ SLUS-29155:
     nativeScaling: 2 # Fixes post effects.
     cpuCLUTRender: 1 # Final colour adjustment LUT.
     gpuTargetCLUT: 1 # Fixes sun penetrating bridges (along with HPO special).
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLUS-29156:
   name: "Marvel Nemesis - Rise of the Imperfects [Demo]"
   region: "NTSC-U"
@@ -75932,6 +76049,7 @@ SLUS-29193:
   gsHWFixes:
     recommendedBlendingLevel: 3 # Fixes car headlights and persistent trails.
     halfPixelOffset: 2 # Fixes depth line.
+    drawBuffering: 1 # Reduces draws and improves performance.
 SLUS-29194:
   name: "FIFA 07 [Demo]"
   region: "NTSC-U"


### PR DESCRIPTION
### Description of Changes
Various fixes to fix the things that need fixing. Adds fixes to HP COS Rocky Legends X2 Wolverines Revenge Brothers In Arms Road To Hill 30 Primal Image Vol 1 NFS Underground NFS Underground 2 NFS Most Wanted NFS Carbon Sims Bustin Out Stuntman Armored Core Nine Breaker  Bakusou Dekotora Densetsu Otoko Hanamichi Yume Roman Red Baron Bleach Blade Battlers and R Racing.

Fixes #14441 
Fixes #13690 
Fixes #13999 

### Rationale behind Changes
Accuracy and speed improvements for many games are good.

### Suggested Testing Steps
Make sure CI passes.

### Did you use AI to help find, test, or implement this issue or feature?
No
