### PR TITLE
GS/VK: Make sure layout changes are propagated to descriptors.

### DIFF
--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -3611,6 +3611,8 @@ void GSDeviceVK::OMSetRenderTargets(
 				{
 					// need to update descriptors to reflect the new layout
 					m_dirty_flags |= (DIRTY_FLAG_TFX_TEXTURE_0 << TFX_TEXTURE_RT);
+					if (m_tfx_textures[TFX_TEXTURE_TEXTURE] == vkRt)
+						m_dirty_flags |= DIRTY_FLAG_TFX_TEXTURE_0 << TFX_TEXTURE_TEXTURE;
 					vkRt->TransitionToLayout(GSTextureVK::Layout::FeedbackLoop);
 				}
 			}
@@ -3633,6 +3635,8 @@ void GSDeviceVK::OMSetRenderTargets(
 				if (vkDs->GetLayout() != GSTextureVK::Layout::FeedbackLoop)
 				{
 					m_dirty_flags |= (DIRTY_FLAG_TFX_TEXTURE_0 << TFX_TEXTURE_DEPTH);
+					if (m_tfx_textures[TFX_TEXTURE_TEXTURE] == vkDs)
+						m_dirty_flags |= DIRTY_FLAG_TFX_TEXTURE_0 << TFX_TEXTURE_TEXTURE;
 					vkDs->TransitionToLayout(GSTextureVK::Layout::FeedbackLoop);
 				}
 			}
@@ -3641,6 +3645,8 @@ void GSDeviceVK::OMSetRenderTargets(
 				if (vkDs->GetLayout() != GSTextureVK::Layout::FeedbackLoop)
 				{
 					m_dirty_flags |= (DIRTY_FLAG_TFX_TEXTURE_0 << TFX_TEXTURE_TEXTURE);
+					if (m_tfx_textures[TFX_TEXTURE_TEXTURE] == vkDs)
+						m_dirty_flags |= DIRTY_FLAG_TFX_TEXTURE_0 << TFX_TEXTURE_TEXTURE;
 					vkDs->TransitionToLayout(GSTextureVK::Layout::FeedbackLoop);
 				}
 			}
@@ -5266,6 +5272,7 @@ void GSDeviceVK::SetLineWidth(float width)
 void GSDeviceVK::PSSetShaderResource(int i, GSTexture* sr, bool check_state)
 {
 	GSTextureVK* vkTex = static_cast<GSTextureVK*>(sr);
+	bool update_layout = false;
 	if (vkTex)
 	{
 		if (check_state)
@@ -5274,6 +5281,7 @@ void GSDeviceVK::PSSetShaderResource(int i, GSTexture* sr, bool check_state)
 			{
 				GL_INS("Ending render pass due to resource transition");
 				EndRenderPass();
+				update_layout = true;
 			}
 
 			vkTex->CommitClear();
@@ -5286,7 +5294,7 @@ void GSDeviceVK::PSSetShaderResource(int i, GSTexture* sr, bool check_state)
 		vkTex = m_null_texture.get();
 	}
 
-	if (m_tfx_textures[i] == vkTex)
+	if (m_tfx_textures[i] == vkTex && !update_layout)
 		return;
 
 	m_tfx_textures[i] = vkTex;
@@ -6022,10 +6030,18 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 		pxAssertMsg(m_features.texture_barrier, "Texture barriers enabled");
 		PSSetShaderResource(TFX_TEXTURE_RT, draw_rt, false);
 	}
+	else
+	{
+		PSSetShaderResource(TFX_TEXTURE_RT, nullptr, false); // Unbind to avoid layout conflicts
+	}
 	if (pipe.IsDepthFeedbackLoop())
 	{
 		pxAssertMsg(m_features.texture_barrier, "Texture barriers enabled");
 		PSSetShaderResource(TFX_TEXTURE_DEPTH, draw_ds, false);
+	}
+	else
+	{
+		PSSetShaderResource(TFX_TEXTURE_DEPTH, nullptr, false); // Unbind to avoid layout conflicts
 	}
 	// Begin render pass if new target or out of the area.
 	if (!InRenderPass())


### PR DESCRIPTION
### Description of Changes
Make sure layout changes are propagated to descriptor writes. This likely only applies to transitions to/from feedback loop layout, which requires a descriptor update or the validation layer gives an error.

### Rationale behind Changes
Avoid spec violations indicated by the validation layer.

### Suggested Testing Steps
Try the attached dump in VK and make sure it doesn't have validation errors.

[hitmancontracts_l3_bjarkov.gs.xz.zip](https://github.com/user-attachments/files/27902779/hitmancontracts_l3_bjarkov.gs.xz.zip)

### Did you use AI to help find, test, or implement this issue or feature?
Yes, to ask some questions about VK descriptor/pipeline layout usage.