### PR TITLE
Debugger: Fix parameter symbol creation dialog

### DIFF
--- a/pcsx2-qt/Debugger/SymbolTree/NewSymbolDialogs.cpp
+++ b/pcsx2-qt/Debugger/SymbolTree/NewSymbolDialogs.cpp
@@ -567,7 +567,6 @@ bool NewParameterVariableDialog::parseUserInput()
 			return;
 		}
 
-		std::variant<ccc::RegisterStorage, ccc::StackStorage> storage;
 		switch (storageType())
 		{
 			case GLOBAL_STORAGE:
@@ -577,13 +576,13 @@ bool NewParameterVariableDialog::parseUserInput()
 			}
 			case REGISTER_STORAGE:
 			{
-				ccc::RegisterStorage& register_storage = storage.emplace<ccc::RegisterStorage>();
+				ccc::RegisterStorage& register_storage = m_storage.emplace<ccc::RegisterStorage>();
 				register_storage.dbx_register_number = m_ui.registerComboBox->currentIndex();
 				break;
 			}
 			case STACK_STORAGE:
 			{
-				ccc::StackStorage& stack_storage = storage.emplace<ccc::StackStorage>();
+				ccc::StackStorage& stack_storage = m_storage.emplace<ccc::StackStorage>();
 				stack_storage.stack_pointer_offset = m_ui.stackPointerOffsetSpinBox->value();
 
 				// Convert to caller sp relative.


### PR DESCRIPTION
### Description of Changes
This fixes the parameter symbol creation dialog, so that it sets the storage member of the newly created symbol properly. Previously, it would be left as its default value.

### Rationale behind Changes
Previously the parameter variant of the symbol creation dialog was broken (the parameters view is mainly intended for symbols loaded from an ELF file, so I guess this didn't get much testing).

### Suggested Testing Steps
Try to create a parameter manually.

### Did you use AI to help find, test, or implement this issue or feature?
No.