### PR TITLE
Qt: Add main window fullscreen menu action

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -199,6 +199,8 @@ void MainWindow::setupAdditionalUi()
 	m_ui.actionViewStatusBar->setChecked(status_bar_visible);
 	m_ui.statusBar->setVisible(status_bar_visible);
 
+	updateMainWindowFullscreenAction();
+
 	const bool show_game_grid = Host::GetBaseBoolSettingValue("UI", "GameListGridView", false);
 	updateGameGridActions(show_game_grid);
 
@@ -347,6 +349,7 @@ void MainWindow::connectSignals()
 	connect(m_ui.actionViewToolbar, &QAction::toggled, this, &MainWindow::onViewToolbarActionToggled);
 	connect(m_ui.actionViewLockToolbar, &QAction::toggled, this, &MainWindow::onViewLockToolbarActionToggled);
 	connect(m_ui.actionViewStatusBar, &QAction::toggled, this, &MainWindow::onViewStatusBarActionToggled);
+	connect(m_ui.actionViewMainWindowFullscreen, &QAction::toggled, this, &MainWindow::onViewMainWindowFullscreenActionToggled);
 	connect(m_ui.actionViewGameList, &QAction::triggered, this, &MainWindow::onViewGameListActionTriggered);
 	connect(m_ui.actionViewGameGrid, &QAction::triggered, this, &MainWindow::onViewGameGridActionTriggered);
 	connect(m_ui.actionViewSystemDisplay, &QAction::triggered, this, &MainWindow::onViewSystemDisplayTriggered);
@@ -939,6 +942,8 @@ void MainWindow::restoreStateFromConfig()
 				showFullScreen();
 		}
 	}
+
+	updateMainWindowFullscreenAction();
 }
 
 void MainWindow::updateEmulationActions(bool starting, bool running, bool stopping)
@@ -1040,6 +1045,12 @@ void MainWindow::updateStatusBarWidgetVisibility()
 	Update(m_status_fps_widget, s_vm_valid, 0);
 	Update(m_status_vps_widget, s_vm_valid, 0);
 	Update(m_status_speed_widget, s_vm_valid, 0);
+}
+
+void MainWindow::updateMainWindowFullscreenAction()
+{
+	QSignalBlocker blocker(m_ui.actionViewMainWindowFullscreen);
+	m_ui.actionViewMainWindowFullscreen->setChecked(isFullScreen());
 }
 
 void MainWindow::updateWindowTitle()
@@ -1777,6 +1788,19 @@ void MainWindow::onViewStatusBarActionToggled(bool checked)
 	m_ui.statusBar->setVisible(checked);
 }
 
+void MainWindow::onViewMainWindowFullscreenActionToggled(bool checked)
+{
+	Host::SetBaseBoolSettingValue("UI", "MainWindowFullscreen", checked);
+	Host::CommitBaseSettingChanges();
+
+	if (checked)
+		showFullScreen();
+	else
+		setWindowState(windowState() & ~Qt::WindowFullScreen);
+
+	updateMainWindowFullscreenAction();
+}
+
 void MainWindow::onViewGameListActionTriggered()
 {
 	switchToGameListView();
@@ -2307,6 +2331,9 @@ void MainWindow::closeEvent(QCloseEvent* event)
 void MainWindow::changeEvent(QEvent* event)
 {
 	QMainWindow::changeEvent(event);
+
+	if (event->type() == QEvent::WindowStateChange)
+		updateMainWindowFullscreenAction();
 
 	if (event->type() == QEvent::StyleChange)
 	{

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -163,6 +163,7 @@ private Q_SLOTS:
 	void onViewToolbarActionToggled(bool checked);
 	void onViewLockToolbarActionToggled(bool checked);
 	void onViewStatusBarActionToggled(bool checked);
+	void onViewMainWindowFullscreenActionToggled(bool checked);
 	void onViewGameListActionTriggered();
 	void onViewGameGridActionTriggered();
 	void onViewSystemDisplayTriggered();
@@ -245,6 +246,7 @@ private:
 	void updateGameGridActions(const bool show_game_grid);
 	void updateStatusBarWidgetVisibility();
 	void updateAdvancedSettingsVisibility();
+	void updateMainWindowFullscreenAction();
 	void updateWindowTitle();
 	void updateWindowState(bool force_visible = false);
 	void setProgressBar(int current, int total);

--- a/pcsx2-qt/MainWindow.ui
+++ b/pcsx2-qt/MainWindow.ui
@@ -166,6 +166,7 @@
     <addaction name="actionViewLockToolbar"/>
     <addaction name="actionViewStatusBar"/>
     <addaction name="actionViewStatusBarVerbose"/>
+    <addaction name="actionViewMainWindowFullscreen"/>
     <addaction name="separator"/>
     <addaction name="actionViewGameList"/>
     <addaction name="actionViewGameGrid"/>
@@ -754,6 +755,17 @@
    </property>
    <property name="text">
     <string>&amp;Verbose Status</string>
+   </property>
+  </action>
+  <action name="actionViewMainWindowFullscreen">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset theme="fullscreen-line"/>
+   </property>
+   <property name="text">
+    <string>Main Window F&amp;ullscreen</string>
    </property>
   </action>
   <action name="actionViewGameList">


### PR DESCRIPTION
### Description of Changes
This adds a checkable `View > Main Window Fullscreen` action to the Qt main window.

The action updates the existing `UI/MainWindowFullscreen` setting. It also updates its checked state when Qt reports a window state change.

Closes #14405

### Rationale behind Changes
Issue #14405 asks for a menu item that toggles main window fullscreen. The change puts that control under `View` and reuses the existing fullscreen setting, so startup restore and the menu action use the same state.

### Suggested Testing Steps
I tested:

- `git diff --check`
- `cmake -S . -B build -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH="..." -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON -DDISABLE_ADVANCE_SIMD=ON -DUSE_VULKAN=OFF`
- `make -f pcsx2-qt/CMakeFiles/pcsx2-qt.dir/build.make pcsx2-qt/CMakeFiles/pcsx2-qt.dir/MainWindow.cpp.o`

The full `pcsx2-qt` target did not finish on this Mac because Xcode's Metal Toolchain is missing (`xcodebuild -downloadComponent MetalToolchain`). The build had already generated the Qt UI code and compiled `MainWindow.cpp`; the failure was at Apple Metal shader compilation.

Reviewer testing:

- Open PCSX2 Qt.
- Use `View > Main Window Fullscreen` to enter fullscreen.
- Use the same menu action to leave fullscreen.
- Check that the menu item follows fullscreen state changes.
- Restart after enabling fullscreen and check that the existing fullscreen restore behavior still works.

### Did you use AI to help find, test, or implement this issue or feature?
Yes. I used Codex/ChatGPT to pick a small starter issue, draft the first patch, write the PR text, and run local checks. I reviewed the diff before submitting it. If that is outside the project's LLM policy, I will close the PR or replace it with a manually written version.
