### PR TITLE
Memcard: Add automated rolling local backup system

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -35,6 +35,7 @@ target_sources(common PRIVATE
 	WAVWriter.cpp
 	WindowInfo.cpp
 	YAML.cpp
+	ZipFile.cpp
 )
 
 target_sources(common PRIVATE
@@ -83,6 +84,7 @@ target_sources(common PRIVATE
 	WindowInfo.h
 	WrappedMemCopy.h
 	YAML.h
+	ZipFile.h
 )
 
 if(ARCH_X86)
@@ -212,6 +214,7 @@ target_link_libraries(common PUBLIC
 	fmt::fmt
 	fast_float
 	ryml::ryml
+	libzip::zip
 )
 
 fixup_file_properties(common)

--- a/common/ZipFile.cpp
+++ b/common/ZipFile.cpp
@@ -1,0 +1,653 @@
+// SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "ZipFile.h"
+
+#include "common/Assertions.h"
+#include "common/Console.h"
+#include "common/FileSystem.h"
+#include "common/Path.h"
+
+ZipArchive::ZipArchive()
+{
+}
+
+ZipArchive::~ZipArchive()
+{
+	if (m_zip)
+		DiscardChangesAndClose();
+}
+
+ZipArchive::ZipArchive(ZipArchive&& rhs)
+	: m_zip(rhs.m_zip)
+{
+	rhs.m_zip = nullptr;
+}
+
+ZipArchive& ZipArchive::operator=(ZipArchive&& rhs)
+{
+	if (m_zip)
+		DiscardChangesAndClose();
+
+	m_zip = rhs.m_zip;
+	rhs.m_zip = nullptr;
+
+	return *this;
+}
+
+bool ZipArchive::Open(const char* path, int flags, int* error_code, Error* error)
+{
+	pxAssert(!m_zip);
+
+	int err;
+	m_zip = zip_open(path, flags, &err);
+	if (!m_zip)
+	{
+		if (error_code)
+			*error_code = err;
+
+		zip_error_t open_error;
+		zip_error_init_with_code(&open_error, err);
+		Error::SetString(error, zip_error_strerror(&open_error));
+		zip_error_fini(&open_error);
+
+		return false;
+	}
+
+	return true;
+}
+
+bool ZipArchive::SaveChangesAndClose(Error* error)
+{
+	if (zip_close(m_zip) != 0)
+	{
+		Error::SetString(error, zip_strerror(m_zip));
+		return false;
+	}
+
+	m_zip = nullptr;
+	return true;
+}
+
+void ZipArchive::DiscardChangesAndClose()
+{
+	pxAssert(m_zip);
+
+	zip_discard(m_zip);
+	m_zip = nullptr;
+}
+
+bool ZipArchive::IsValid()
+{
+	return m_zip != nullptr;
+}
+
+std::optional<ZipEntryIndex> ZipArchive::LocateFile(const char* name, zip_flags_t flags, Error* error)
+{
+	pxAssert(m_zip);
+
+	s64 index = zip_name_locate(m_zip, name, flags);
+	if (index < 0)
+	{
+		Error::SetString(error, zip_strerror(m_zip));
+		return std::nullopt;
+	}
+
+	return static_cast<ZipEntryIndex>(index);
+}
+
+std::optional<zip_stat_t> ZipArchive::StatFile(ZipEntryIndex index, zip_flags_t flags, Error* error)
+{
+	pxAssert(m_zip);
+
+	zip_stat_t stat = {};
+	if (zip_stat_index(m_zip, index, flags, &stat) != 0)
+	{
+		Error::SetString(error, zip_strerror(m_zip));
+		return std::nullopt;
+	}
+
+	return stat;
+}
+
+std::optional<std::string> ZipArchive::ReadTextFile(ZipEntryIndex index, zip_flags_t flags, Error* error)
+{
+	pxAssert(m_zip);
+
+	ZipEntry file;
+	if (!file.Open(*this, index, flags, error))
+		return std::nullopt;
+
+	return file.ReadText(error);
+}
+
+std::optional<std::vector<u8>> ZipArchive::ReadBinaryFile(ZipEntryIndex index, zip_flags_t flags, Error* error)
+{
+	pxAssert(m_zip);
+
+	ZipEntry file;
+	if (!file.Open(*this, index, flags, error))
+		return std::nullopt;
+
+	return file.ReadBinary(error);
+}
+
+bool ZipArchive::ExtractFile(ZipEntryIndex index, const char* output_path, Error* error)
+{
+	pxAssert(m_zip);
+
+	auto output_file = FileSystem::OpenManagedCFile(output_path, "wb");
+	if (!output_file.get())
+	{
+		Error::SetString(error, "Failed to open output file");
+		return false;
+	}
+
+	ZipEntry entry;
+	if (!entry.Open(*this, index, 0, error))
+		return false;
+
+	std::optional<u64> size = entry.Size(error);
+	if (!size.has_value())
+		return false;
+
+	std::vector<u8> buffer(_64kb);
+	for (u64 i = 0; i < *size; i += buffer.size())
+	{
+		u64 block_size = std::min(*size - i, buffer.size());
+
+		if (!entry.Read(buffer.data(), block_size, error))
+			return false;
+
+		if (std::fwrite(buffer.data(), block_size, 1, output_file.get()) != 1)
+		{
+			Error::SetString(error, "Failed to extract file");
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool ZipArchive::ExtractDirectory(std::string zip_directory, std::string output_directory, Error* error)
+{
+	pxAssert(m_zip);
+
+	if (!FileSystem::DirectoryExists(output_directory.c_str()))
+	{
+		Error::SetString(error, "Output directory does not exist");
+		return false;
+	}
+
+	// We're going to be comparing this with canonicalized paths later.
+	output_directory = Path::Canonicalize(output_directory.c_str());
+
+	if (!zip_directory.empty() && !zip_directory.ends_with('/'))
+		zip_directory += '/';
+
+	s64 entry_count = zip_get_num_entries(m_zip, 0);
+	if (entry_count < 0)
+	{
+		Error::SetStringFmt(error, "zip_get_num_entries returned %d", static_cast<int>(entry_count));
+		return false;
+	}
+
+	// Iterate over every file in the zip, and extract it if it's inside the
+	// source directory.
+	for (ZipEntryIndex index = 0; index < static_cast<ZipEntryIndex>(entry_count); index++)
+	{
+		std::optional<zip_stat_t> stat = StatFile(index, ZIP_STAT_NAME, error);
+		if (!stat.has_value())
+			return false;
+
+		if (!(stat->valid & ZIP_STAT_NAME))
+		{
+			Error::SetString(error, "Cannot stat name");
+			return false;
+		}
+
+		if (std::strncmp(stat->name, zip_directory.c_str(), zip_directory.size()) != 0)
+			continue;
+
+		// Convert to native separators.
+		std::string relative_zip_path = stat->name + zip_directory.size();
+		for (char& c : relative_zip_path)
+			if (c == '/')
+				c = FS_OSPATH_SEPARATOR_CHARACTER;
+
+		std::string output_path = Path::Canonicalize(output_directory + relative_zip_path);
+
+		// Prevent directory traversal.
+		if (!output_path.starts_with(output_directory))
+			continue;
+
+		std::string parent_path(Path::GetDirectory(output_path));
+		if (!FileSystem::CreateDirectoryPath(parent_path.c_str(), true, error))
+			return false;
+
+		if (!ExtractFile(index, output_path.c_str(), error))
+			return false;
+	}
+
+	return true;
+}
+
+bool ZipArchive::AddFile(
+	const char* input_path, const char* zip_path, const ZipCompressionOptions& compression, Error* error)
+{
+	pxAssert(m_zip);
+
+	ZipSource source;
+	if (!source.CreateFileSource(input_path, 0, ZIP_LENGTH_TO_END, error))
+		return false;
+
+	std::optional<ZipEntryIndex> index = AddFileFromSource(zip_path, source, ZIP_FL_ENC_UTF_8, error);
+	if (!index.has_value())
+		return false;
+
+	return SetFileCompression(*index, compression, error);
+}
+
+bool ZipArchive::AddDirectory(
+	const char* input_path,
+	const std::string& zip_directory,
+	const ZipCompressionOptions& compression,
+	bool follow_symbolic_links,
+	Error* error)
+{
+	pxAssert(m_zip);
+
+	if (!FileSystem::DirectoryExists(input_path))
+	{
+		Error::SetString(error, "Output directory does not exist");
+		return false;
+	}
+
+	std::vector<FILESYSTEM_FIND_DATA> files;
+	if (!FileSystem::FindFiles(
+			input_path, "*",
+			FILESYSTEM_FIND_HIDDEN_FILES | FILESYSTEM_FIND_FILES | FILESYSTEM_FIND_FOLDERS, &files))
+	{
+		Error::SetString(error, "Failed to enumerate files in directory");
+		return false;
+	}
+
+	for (const FILESYSTEM_FIND_DATA& file : files)
+	{
+		if (!follow_symbolic_links && FileSystem::IsSymbolicLink(file.FileName.c_str()))
+			continue;
+
+		std::string zip_path;
+		if (!zip_directory.empty() && !zip_directory.ends_with("/"))
+			zip_path = fmt::format("{}/{}", zip_directory, Path::GetFileName(file.FileName));
+		else
+			zip_path = fmt::format("{}{}", zip_directory, Path::GetFileName(file.FileName));
+
+		if (file.Attributes & FILESYSTEM_FILE_ATTRIBUTE_DIRECTORY)
+		{
+			if (!AddDirectory(file.FileName.c_str(), zip_path, compression, follow_symbolic_links, error))
+				return false;
+		}
+		else
+		{
+			if (!AddFile(file.FileName.c_str(), zip_path.c_str(), compression, error))
+				return false;
+		}
+	}
+
+	return true;
+}
+
+std::optional<ZipEntryIndex> ZipArchive::AddFileFromBuffer(
+	const char* name, void* data, u64 length, zip_flags_t flags, int freep, Error* error)
+{
+	pxAssert(m_zip);
+
+	ZipSource source;
+
+	if (!source.CreateBufferSource(data, length, freep, error))
+		return false;
+
+	return AddFileFromSource(name, source, flags, error);
+}
+
+std::optional<ZipEntryIndex> ZipArchive::AddFileFromSource(
+	const char* name, ZipSource& source, zip_flags_t flags, Error* error)
+{
+	pxAssert(m_zip);
+
+	s64 index = zip_file_add(m_zip, name, source.m_source, flags);
+	if (index < 0)
+	{
+		Error::SetString(error, zip_strerror(m_zip));
+		return std::nullopt;
+	}
+
+	// Ownership of the source has been transferred.
+	source.m_source = nullptr;
+
+	return static_cast<ZipEntryIndex>(index);
+}
+
+bool ZipArchive::SetFileCompression(ZipEntryIndex index, const ZipCompressionOptions& compression, Error* error)
+{
+	pxAssert(m_zip);
+
+	if (zip_set_file_compression(m_zip, index, compression.method, compression.level) != 0)
+	{
+		Error::SetString(error, zip_strerror(m_zip));
+		return false;
+	}
+
+	return true;
+}
+
+// *****************************************************************************
+
+ZipEntry::ZipEntry()
+{
+}
+
+ZipEntry::~ZipEntry()
+{
+	if (m_file)
+	{
+		Error close_error;
+		if (!Close(&close_error))
+			Console.ErrorFmt("Failed to close zip entry: {}", close_error.GetDescription());
+	}
+}
+
+ZipEntry::ZipEntry(ZipEntry&& rhs)
+	: m_archive(rhs.m_archive)
+	, m_index(rhs.m_index)
+	, m_file(rhs.m_file)
+{
+	rhs.m_archive = nullptr;
+	rhs.m_index = 0;
+	rhs.m_file = nullptr;
+}
+
+ZipEntry& ZipEntry::operator=(ZipEntry&& rhs)
+{
+	if (m_file)
+	{
+		Error close_error;
+		if (!Close(&close_error))
+			Console.ErrorFmt("Failed to close zip entry: {}", close_error.GetDescription());
+	}
+
+	m_archive = rhs.m_archive;
+	m_index = rhs.m_index;
+	m_file = rhs.m_file;
+
+	rhs.m_archive = nullptr;
+	rhs.m_index = 0;
+	rhs.m_file = nullptr;
+
+	return *this;
+}
+
+bool ZipEntry::Open(ZipArchive& archive, ZipEntryIndex index, zip_flags_t flags, Error* error)
+{
+	pxAssert(!m_file);
+	pxAssert(archive.m_zip);
+
+	m_file = zip_fopen_index(archive.m_zip, index, flags);
+	if (!m_file)
+	{
+		Error::SetString(error, zip_strerror(archive.m_zip));
+		return false;
+	}
+
+	m_archive = &archive;
+	m_index = index;
+
+	return true;
+}
+
+bool ZipEntry::Close(Error* error)
+{
+	pxAssert(m_file);
+
+	zip_file_t* file = m_file;
+
+	m_archive = nullptr;
+	m_index = 0;
+	m_file = nullptr;
+
+	int error_code = zip_fclose(file);
+	if (error_code != 0)
+	{
+		zip_error_t close_error;
+		zip_error_init_with_code(&close_error, error_code);
+		Error::SetString(error, zip_error_strerror(&close_error));
+		zip_error_fini(&close_error);
+
+		return false;
+	}
+
+	return true;
+}
+
+bool ZipEntry::IsValid()
+{
+	return m_file != nullptr;
+}
+
+bool ZipEntry::Read(void* buffer, u64 nbytes, Error* error)
+{
+	pxAssert(m_file);
+
+	s64 bytes = zip_fread(m_file, buffer, nbytes);
+	if (bytes < 0)
+	{
+		Error::SetString(error, zip_file_strerror(m_file));
+		return false;
+	}
+
+	if (static_cast<u64>(bytes) != nbytes)
+	{
+		Error::SetString(error, "Tried to read past end of file");
+		return false;
+	}
+
+	return true;
+}
+
+bool ZipEntry::Seek(s64 offset, int whence, Error* error)
+{
+	pxAssert(m_file);
+
+	if (zip_fseek(m_file, offset, whence) != 0)
+	{
+		Error::SetString(error, zip_file_strerror(m_file));
+		return false;
+	}
+
+	return true;
+}
+
+std::optional<u64> ZipEntry::Tell(Error* error)
+{
+	pxAssert(m_file);
+
+	s64 offset = zip_ftell(m_file);
+	if (offset < 0)
+	{
+		Error::SetString(error, zip_file_strerror(m_file));
+		return std::nullopt;
+	}
+
+	return static_cast<u64>(offset);
+}
+
+std::optional<u64> ZipEntry::Size(Error* error)
+{
+	pxAssert(m_file);
+
+	std::optional<zip_stat_t> stat = m_archive->StatFile(m_index, ZIP_STAT_SIZE, error);
+	if (!stat.has_value())
+		return std::nullopt;
+
+	if (!(stat->valid & ZIP_STAT_SIZE))
+	{
+		Error::SetString(error, "Cannot stat size");
+		return std::nullopt;
+	}
+
+	return stat->size;
+}
+
+std::optional<std::string> ZipEntry::ReadText(Error* error)
+{
+	pxAssert(m_file);
+
+	std::optional<u64> size = Size(error);
+	if (!size.has_value())
+		return std::nullopt;
+
+	std::string string(*size, '\0');
+	if (!Read(string.data(), string.size(), error))
+		return std::nullopt;
+
+	return string;
+}
+
+std::optional<std::vector<u8>> ZipEntry::ReadBinary(Error* error)
+{
+	pxAssert(m_file);
+
+	std::optional<u64> size = Size(error);
+	if (!size.has_value())
+		return std::nullopt;
+
+	std::vector<u8> binary(*size, '\0');
+	if (!Read(binary.data(), binary.size(), error))
+		return std::nullopt;
+
+	return binary;
+}
+
+// *****************************************************************************
+
+ZipSource::ZipSource()
+{
+}
+
+ZipSource::~ZipSource()
+{
+	if (m_source)
+		Free();
+}
+
+ZipSource::ZipSource(ZipSource&& rhs)
+	: m_source(rhs.m_source)
+{
+	rhs.m_source = nullptr;
+}
+
+ZipSource& ZipSource::operator=(ZipSource&& rhs)
+{
+	if (m_source)
+		Free();
+
+	m_source = rhs.m_source;
+	rhs.m_source = nullptr;
+
+	return *this;
+}
+
+bool ZipSource::CreateBufferSource(void* data, u64 length, int freep, Error* error)
+{
+	pxAssert(!m_source);
+
+	zip_error_t create_error;
+	zip_error_init(&create_error);
+
+	m_source = zip_source_buffer_create(data, length, freep, &create_error);
+	if (!m_source)
+	{
+		Error::SetString(error, zip_error_strerror(&create_error));
+		zip_error_fini(&create_error);
+		if (freep)
+			std::free(data);
+		return false;
+	}
+
+	zip_error_fini(&create_error);
+
+	return true;
+}
+
+bool ZipSource::CreateFileSource(const char* path, u64 start_offset, s64 length, Error* error)
+{
+	pxAssert(!m_source);
+
+	zip_error_t create_error;
+	zip_error_init(&create_error);
+
+	m_source = zip_source_file_create(path, start_offset, length, &create_error);
+	if (!m_source)
+	{
+		Error::SetString(error, zip_error_strerror(&create_error));
+		zip_error_fini(&create_error);
+		return false;
+	}
+
+	zip_error_fini(&create_error);
+
+	return true;
+}
+
+void ZipSource::Free()
+{
+	pxAssert(m_source);
+
+	zip_source_free(m_source);
+	m_source = nullptr;
+}
+
+bool ZipSource::IsValid()
+{
+	return m_source != nullptr;
+}
+
+bool ZipSource::BeginWrite(Error* error)
+{
+	pxAssert(m_source);
+
+	if (zip_source_begin_write(m_source) != 0)
+	{
+		Error::SetString(error, zip_error_strerror(zip_source_error(m_source)));
+		return false;
+	}
+
+	return true;
+}
+
+bool ZipSource::Write(const void* data, u64 length, Error* error)
+{
+	pxAssert(m_source);
+
+	if (zip_source_write(m_source, data, length) != 0)
+	{
+		Error::SetString(error, zip_error_strerror(zip_source_error(m_source)));
+		return false;
+	}
+
+	return true;
+}
+
+bool ZipSource::CommitWrite(Error* error)
+{
+	pxAssert(m_source);
+
+	if (zip_source_commit_write(m_source) != 0)
+	{
+		Error::SetString(error, zip_error_strerror(zip_source_error(m_source)));
+		return false;
+	}
+
+	return true;
+}

--- a/common/ZipFile.h
+++ b/common/ZipFile.h
@@ -1,0 +1,239 @@
+// SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#pragma once
+
+#include "Error.h"
+
+#include <zip.h>
+
+#include <optional>
+#include <vector>
+
+class ZipEntry;
+class ZipSource;
+
+/// An index of a file in the central directory of a ZIP archive.
+using ZipEntryIndex = u64;
+
+struct ZipCompressionOptions
+{
+	s32 method = ZIP_CM_DEFLATE;
+	u32 level = 0;
+};
+
+/// A ZIP archive. RAII wrapper around a zip_t object from libzip.
+class ZipArchive
+{
+	friend ZipEntry;
+
+public:
+	ZipArchive();
+	~ZipArchive();
+
+	/// Don't allow copying.
+	ZipArchive(const ZipArchive& rhs) = delete;
+	ZipArchive& operator=(const ZipArchive& rhs) = delete;
+
+	/// Allow moving.
+	ZipArchive(ZipArchive&& rhs);
+	ZipArchive& operator=(ZipArchive&& rhs);
+
+	/// Open the archive using zip_open.
+	///
+	/// Valid flags:
+	///   ZIP_CHECKCONS, ZIP_CREATE, ZIP_EXCL, ZIP_TRUNCATE, ZIP_RDONLY
+	[[nodiscard]] bool Open(const char* path, int flags, int* error_code, Error* error);
+
+	/// Save changes made to the archive and close it using zip_close.
+	[[nodiscard]] bool SaveChangesAndClose(Error* error);
+
+	/// Discard changes made to the archive and close it using zip_discard.
+	void DiscardChangesAndClose();
+
+	/// Check if the archive is open.
+	[[nodiscard]] bool IsValid();
+
+	/// Find a file inside the archive given its name using zip_name_locate.
+	///
+	/// Valid flags:
+	///   ZIP_FL_NOCASE, ZIP_FL_NODIR, ZIP_FL_ENC_GUESS,
+	///   ZIP_FL_ENC_RAW, ZIP_FL_ENC_STRICT, ZIP_FL_ENC_CP437, ZIP_FL_ENC_UTF_8
+	std::optional<ZipEntryIndex> LocateFile(const char* name, zip_flags_t flags, Error* error);
+
+	/// Retrieve file metadata using zip_stat_index. Ownership of the name
+	/// string is NOT transferred to the caller.
+	///
+	/// Valid flags:
+	///   ZIP_STAT_NAME, ZIP_STAT_INDEX, ZIP_STAT_SIZE,
+	///   ZIP_STAT_COMP_SIZE, ZIP_STAT_MTIME, ZIP_STAT_CRC,
+	///   ZIP_STAT_COMP_METHOD, ZIP_STAT_ENCRYPTION_METHOD, ZIP_STAT_FLAGS
+	std::optional<zip_stat_t> StatFile(ZipEntryIndex index, zip_flags_t flags, Error* error);
+
+	/// Read the entire contents of a file into a std::string.
+	///
+	/// Valid flags:
+	///   ZIP_FL_COMPRESSED, ZIP_FL_UNCHANGED
+	std::optional<std::string> ReadTextFile(ZipEntryIndex index, zip_flags_t flags, Error* error);
+
+	/// Read the entire contents of a file into a std::vector<u8>.
+	///
+	/// Valid flags:
+	///   ZIP_FL_COMPRESSED, ZIP_FL_UNCHANGED
+	std::optional<std::vector<u8>> ReadBinaryFile(ZipEntryIndex index, zip_flags_t flags, Error* error);
+
+	/// Extract the file from the archive.
+	[[nodiscard]] bool ExtractFile(ZipEntryIndex index, const char* output_path, Error* error);
+
+	/// Extract the contents of a directory from the archive.
+	[[nodiscard]] bool ExtractDirectory(std::string zip_directory, std::string output_directory, Error* error);
+
+	/// Add a file from the filesystem to the zip.
+	[[nodiscard]] bool AddFile(
+		const char* input_path, const char* zip_path, const ZipCompressionOptions& compression, Error* error);
+
+	/// Recursively add a directroy from the filesystem to the zip.
+	[[nodiscard]] bool AddDirectory(
+		const char* input_path,
+		const std::string& zip_directory,
+		const ZipCompressionOptions& compression,
+		bool follow_symbolic_links,
+		Error* error);
+
+	/// Add a file to the zip using zip_source_buffer_create and zip_file_add.
+	/// If freep is non-zero, ownership of the buffer will be transferred, and
+	/// will be freed if there's an error.
+	///
+	/// Valid flags:
+	///   ZIP_FL_OVERWRITE, ZIP_FL_ENC_GUESS, ZIP_FL_ENC_UTF_8, ZIP_FL_ENC_CP437
+	std::optional<ZipEntryIndex> AddFileFromBuffer(
+		const char* name, void* data, u64 length, zip_flags_t flags, int freep, Error* error);
+
+	/// Add a file to the zip using zip_file_add.
+	/// On success, ownership of the underlying source will be transferred to
+	/// the file and the source object will be made empty.
+	///
+	/// Valid flags:
+	///   ZIP_FL_OVERWRITE, ZIP_FL_ENC_GUESS, ZIP_FL_ENC_UTF_8, ZIP_FL_ENC_CP437
+	std::optional<ZipEntryIndex> AddFileFromSource(
+		const char* name, ZipSource& source, zip_flags_t flags, Error* error);
+
+	/// Set the compression method for a file using zip_set_file_compression.
+	bool SetFileCompression(ZipEntryIndex index, const ZipCompressionOptions& compression, Error* error);
+
+private:
+	zip_t* m_zip = nullptr;
+};
+
+/// An individual file inside a ZIP archive.
+/// RAII wrapper around a zip_file_t object from libzip.
+class ZipEntry
+{
+public:
+	ZipEntry();
+	~ZipEntry();
+
+	/// Don't allow copying.
+	ZipEntry(const ZipEntry& rhs) = delete;
+	ZipEntry& operator=(const ZipEntry& rhs) = delete;
+
+	/// Allow moving.
+	ZipEntry(ZipEntry&& rhs);
+	ZipEntry& operator=(ZipEntry&& rhs);
+
+	/// Open the file from the given archive using zip_fopen_index.
+	///
+	/// Valid flags:
+	///   ZIP_FL_COMPRESSED, ZIP_FL_UNCHANGED
+	[[nodiscard]] bool Open(ZipArchive& archive, ZipEntryIndex index, zip_flags_t flags, Error* error);
+
+	/// Close the file using zip_fclose.
+	[[nodiscard]] bool Close(Error* error);
+
+	/// Check if the file is open.
+	[[nodiscard]] bool IsValid();
+
+	/// Read nbytes bytes into buffer using zip_fread.
+	[[nodiscard]] bool Read(void* buffer, u64 nbytes, Error* error);
+
+	/// Set the position indicator using zip_fseek.
+	[[nodiscard]] bool Seek(s64 offset, int whence, Error* error);
+
+	/// Retrieve the position indicator using zip_ftell.
+	std::optional<u64> Tell(Error* error);
+
+	/// Retrieve the uncompressed size of the file.
+	std::optional<u64> Size(Error* error);
+
+	/// Read the entire file into a std::string.
+	std::optional<std::string> ReadText(Error* error);
+
+	/// Read the entire file into a std::vector.
+	std::optional<std::vector<u8>> ReadBinary(Error* error);
+
+	/// Read sizeof(Value) bytes into a variable of type Value and return it.
+	template <typename Value>
+	std::optional<Value> ReadValue(Error* error)
+	{
+		Value value;
+
+		if (!Read(&value, sizeof(Value), error))
+			return std::nullopt;
+
+		return value;
+	}
+
+private:
+	ZipArchive* m_archive = nullptr;
+	u64 m_index = 0;
+	zip_file_t* m_file = nullptr;
+};
+
+/// Data source for the contents of a file in a ZIP archive.
+/// RAII wrapper around a zip_source_t object from libzip.
+/// Users of this class shouldn't have to worry about zip_source_t being
+/// reference counted.
+class ZipSource
+{
+	friend ZipArchive;
+
+public:
+	ZipSource();
+	~ZipSource();
+
+	/// Don't allow copying.
+	ZipSource(const ZipSource& rhs) = delete;
+	ZipSource& operator=(const ZipSource& rhs) = delete;
+
+	/// Allow moving.
+	ZipSource(ZipSource&& rhs);
+	ZipSource& operator=(ZipSource&& rhs);
+
+	/// Create an in-memory source using zip_source_buffer_create. If freep is
+	/// non-zero, ownership of the buffer will be transferred, and the buffer
+	/// be freed if there's an error.
+	[[nodiscard]] bool CreateBufferSource(void* data, u64 length, int freep, Error* error);
+
+	/// Create a file source using zip_source_file_create. To use the entire
+	/// file, pass ZIP_LENGTH_TO_END in as the length.
+	[[nodiscard]] bool CreateFileSource(const char* path, u64 start_offset, s64 length, Error* error);
+
+	/// Free the source using zip_source_free.
+	void Free();
+
+	/// Check if the underlying source exists.
+	[[nodiscard]] bool IsValid();
+
+	/// Start writing data to the source using zip_source_begin_write.
+	[[nodiscard]] bool BeginWrite(Error* error);
+
+	/// Write data to the source using zip_source_write.
+	/// The source takes a copy of the data.
+	[[nodiscard]] bool Write(const void* data, u64 length, Error* error);
+
+	/// Stop writing data to the source using zip_source_commit_write.
+	[[nodiscard]] bool CommitWrite(Error* error);
+
+private:
+	zip_source_t* m_source = nullptr;
+};

--- a/common/common.vcxproj
+++ b/common/common.vcxproj
@@ -36,6 +36,7 @@
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SolutionDir)3rdparty\fast_float\include</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SolutionDir)3rdparty\fmt\include</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SolutionDir)3rdparty\jpgd</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SolutionDir)3rdparty\libzip\msvc;$(SolutionDir)3rdparty\libzip\lib</AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <ForcedIncludeFiles>PrecompiledHeader.h</ForcedIncludeFiles>
       <PrecompiledHeaderFile>PrecompiledHeader.h</PrecompiledHeaderFile>
@@ -74,6 +75,7 @@
     <ClCompile Include="WAVWriter.cpp" />
     <ClCompile Include="WindowInfo.cpp" />
     <ClCompile Include="YAML.cpp" />
+    <ClCompile Include="ZipFile.cpp" />
     <ClCompile Include="Perf.cpp" />
     <ClCompile Include="PrecompiledHeader.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
@@ -162,6 +164,7 @@
     <ClInclude Include="WAVWriter.h" />
     <ClInclude Include="WindowInfo.h" />
     <ClInclude Include="YAML.h" />
+    <ClInclude Include="ZipFile.h" />
     <ClInclude Include="Threading.h" />
     <ClInclude Include="emitter\implement\avx.h" />
     <ClInclude Include="emitter\implement\bmi.h" />

--- a/common/common.vcxproj.filters
+++ b/common/common.vcxproj.filters
@@ -133,6 +133,9 @@
     <ClCompile Include="YAML.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ZipFile.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AlignedMalloc.h">
@@ -345,6 +348,9 @@
     <ClInclude Include="SingleRegisterTypes.h" />
     <ClInclude Include="FPControl.h" />
     <ClInclude Include="YAML.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ZipFile.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/pcsx2-qt/CMakeLists.txt
+++ b/pcsx2-qt/CMakeLists.txt
@@ -146,6 +146,11 @@ target_sources(pcsx2-qt PRIVATE
 	Settings/MemoryCardCreateDialog.cpp
 	Settings/MemoryCardCreateDialog.h
 	Settings/MemoryCardCreateDialog.ui
+	Settings/MemoryCardBackupModel.cpp
+	Settings/MemoryCardBackupModel.h
+	Settings/MemoryCardBackupWidget.cpp
+	Settings/MemoryCardBackupWidget.h
+	Settings/MemoryCardBackupWidget.ui
 	Settings/MemoryCardSettingsWidget.cpp
 	Settings/MemoryCardSettingsWidget.h
 	Settings/MemoryCardSettingsWidget.ui

--- a/pcsx2-qt/Settings/MemoryCardBackupModel.cpp
+++ b/pcsx2-qt/Settings/MemoryCardBackupModel.cpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "MemoryCardBackupModel.h"
+
+#include "Config.h"
+
+MemoryCardBackupModel::MemoryCardBackupModel(QObject* parent)
+	: QAbstractTableModel(parent)
+{
+	refresh();
+}
+
+int MemoryCardBackupModel::rowCount(const QModelIndex& parent) const
+{
+	return static_cast<int>(m_backups.size());
+}
+
+int MemoryCardBackupModel::columnCount(const QModelIndex& parent) const
+{
+	return COLUMN_COUNT;
+}
+
+QVariant MemoryCardBackupModel::data(const QModelIndex& index, int role) const
+{
+	size_t row = static_cast<size_t>(index.row());
+	if (row >= m_backups.size())
+		return QVariant();
+
+	if (role != Qt::DisplayRole)
+		return QVariant();
+
+	const MemoryCardBackup::BackupMetadata& backup = m_backups[row];
+
+	switch (index.column())
+	{
+		case CARD_NAME:
+			return QString::fromStdString(backup.name);
+		case CREATION_TIME:
+			return QString::number(backup.creation_time);
+		case COMPRESSED_SIZE:
+			return QString::number(backup.backup_size);
+	}
+
+	return QVariant();
+}
+
+QVariant MemoryCardBackupModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+	switch (section)
+	{
+		case CARD_NAME:
+			return tr("Card Name");
+		case CREATION_TIME:
+			return tr("Creation Time");
+		case COMPRESSED_SIZE:
+			return tr("Compressed Size");
+	}
+
+	return QVariant();
+}
+
+void MemoryCardBackupModel::refresh()
+{
+	beginResetModel();
+	m_backups = MemoryCardBackup::EnumerateBackups(EmuFolders::MemoryCardBackups);
+	endResetModel();
+}
+
+#include "moc_MemoryCardBackupModel.cpp"

--- a/pcsx2-qt/Settings/MemoryCardBackupModel.h
+++ b/pcsx2-qt/Settings/MemoryCardBackupModel.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#pragma once
+
+#include "SIO/Memcard/MemoryCardBackup.h"
+
+#include <QtCore/QAbstractTableModel>
+
+class MemoryCardBackupModel : public QAbstractTableModel
+{
+	Q_OBJECT
+
+public:
+	MemoryCardBackupModel(QObject* parent = nullptr);
+
+	int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+	int columnCount(const QModelIndex& parent = QModelIndex()) const override;
+	QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+	QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
+
+	void refresh();
+
+private:
+	enum Columnn
+	{
+		CARD_NAME,
+		CREATION_TIME,
+		COMPRESSED_SIZE,
+		COLUMN_COUNT
+	};
+
+	std::vector<MemoryCardBackup::BackupMetadata> m_backups;
+};

--- a/pcsx2-qt/Settings/MemoryCardBackupWidget.cpp
+++ b/pcsx2-qt/Settings/MemoryCardBackupWidget.cpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "MemoryCardBackupWidget.h"
+
+#include "MemoryCardBackupModel.h"
+
+MemoryCardBackupWidget::MemoryCardBackupWidget(QWidget* parent)
+	: QWidget(parent)
+{
+	m_ui.setupUi(this);
+
+	m_model = new MemoryCardBackupModel(m_ui.backupsTable);
+	m_ui.backupsTable->setModel(m_model);
+}
+#include "moc_MemoryCardBackupWidget.cpp"

--- a/pcsx2-qt/Settings/MemoryCardBackupWidget.h
+++ b/pcsx2-qt/Settings/MemoryCardBackupWidget.h
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#pragma once
+
+#include <QtWidgets/QWidget>
+
+#include "ui_MemoryCardBackupWidget.h"
+
+class MemoryCardBackupModel;
+
+class MemoryCardBackupWidget : public QWidget
+{
+	Q_OBJECT
+
+public:
+	MemoryCardBackupWidget(QWidget* parent = nullptr);
+
+private:
+	Ui::MemoryCardBackupWidget m_ui;
+
+	MemoryCardBackupModel* m_model;
+};

--- a/pcsx2-qt/Settings/MemoryCardBackupWidget.ui
+++ b/pcsx2-qt/Settings/MemoryCardBackupWidget.ui
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MemoryCardBackupWidget</class>
+ <widget class="QWidget" name="MemoryCardBackupWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>700</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,1">
+   <item>
+    <widget class="QLabel" name="descriptionLabel">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;PCSX2 features an automated rolling local backup system for memory cards. Older backups will be deleted to make space for new backups, according to the configured minimum and maximum numbers of backups to keep, and the drive space usage limit.&lt;/p&gt;&lt;p&gt;This system protects your save games in the case that a game crashes or is forcibly shutdown while saving, but NOT in the case that the drive used to store the memory card files is damaged, so this does NOT replace a traditional backup system.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="optionsGroup">
+     <property name="title">
+      <string>Options</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="enableRollingBackups">
+        <property name="text">
+         <string>Enable Automatic Backups</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QCheckBox" name="checkBox_2">
+        <property name="text">
+         <string>Enable Advanced Compression (Zstandard)</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="driveSpaceGroup">
+     <property name="title">
+      <string>Storage</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="3" column="0">
+       <widget class="QLabel" name="driveSpaceLimitLabel">
+        <property name="text">
+         <string>Drive Space Usage Limit:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <layout class="QHBoxLayout" name="driveSpaceLayout">
+        <item>
+         <widget class="QSlider" name="driveSpaceSlider">
+          <property name="orientation">
+           <enum>Qt::Orientation::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="driveSpaceSpinBox">
+          <property name="suffix">
+           <string>MiB</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="backupsToKeepLabel">
+        <property name="text">
+         <string>Number Of Backups To Keep:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLineEdit" name="folderLineEdit"/>
+        </item>
+        <item>
+         <widget class="QPushButton" name="folderBrowseButton">
+          <property name="text">
+           <string>Browse...</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="folderOpenButton">
+          <property name="text">
+           <string>Open...</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="folderResetButton">
+          <property name="text">
+           <string>Reset</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="folderLabel">
+        <property name="text">
+         <string>Backup Folder:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <layout class="QHBoxLayout" name="backupsToKeepLayout" stretch="0,1,0,1">
+        <item>
+         <widget class="QLabel" name="minimumToKeepLabel">
+          <property name="text">
+           <string>Minimum:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="minimumToKeepSpinBox"/>
+        </item>
+        <item>
+         <widget class="QLabel" name="maximumToKeepLabel">
+          <property name="text">
+           <string>Maximum:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="maximumToKeepSpinBox"/>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="backupsGroup">
+     <property name="title">
+      <string>Backups</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <layout class="QHBoxLayout" name="filterLayout" stretch="0,1">
+        <item>
+         <widget class="QLabel" name="filterLabel">
+          <property name="text">
+           <string>Filter:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="filterComboBox"/>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QTableView" name="backupsTable"/>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="backupsButtonLayout">
+        <item>
+         <widget class="QPushButton" name="refreshButton">
+          <property name="text">
+           <string>Refresh</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Orientation::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="restoreButton">
+          <property name="text">
+           <string>Restore</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
@@ -10,6 +10,7 @@
 
 #include "common/StringUtil.h"
 
+#include "MemoryCardBackupWidget.h"
 #include "MemoryCardConvertDialog.h"
 #include "MemoryCardCreateDialog.h"
 #include "MemoryCardSettingsWidget.h"
@@ -32,7 +33,13 @@ MemoryCardSettingsWidget::MemoryCardSettingsWidget(SettingsWindow* settings_dial
 {
 	SettingsInterface* sif = dialog()->getSettingsInterface();
 
-	setupTab(m_ui);
+	setupTab(m_ui, tr("General"));
+
+	if (!settings_dialog->isPerGameSettings())
+	{
+		m_backup_widget = new MemoryCardBackupWidget(this);
+		addTab(tr("Backups"), m_backup_widget, false);
+	}
 
 	// this is a bit lame, but resizeEvent() isn't good enough to autosize our columns,
 	// since the group box hasn't been resized at that point.

--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.h
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.h
@@ -16,6 +16,7 @@
 #include <string>
 
 struct AvailableMcdInfo;
+class MemoryCardBackupWidget;
 
 class MemoryCardListWidget final : public QTreeWidget
 {
@@ -104,6 +105,7 @@ private:
 	void convertCard();
 
 	Ui::MemoryCardSettingsWidget m_ui;
+	MemoryCardBackupWidget* m_backup_widget = nullptr;
 
 	std::array<SlotGroup, MAX_SLOTS> m_slots;
 };

--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.ui
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.ui
@@ -10,7 +10,7 @@
     <height>600</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1">
    <property name="leftMargin">
     <number>0</number>
    </property>

--- a/pcsx2-qt/pcsx2-qt.vcxproj
+++ b/pcsx2-qt/pcsx2-qt.vcxproj
@@ -160,6 +160,8 @@
     <ClCompile Include="Settings\ControllerSettingsWindow.cpp" />
     <ClCompile Include="Settings\AudioSettingsWidget.cpp" />
     <ClCompile Include="Settings\MemoryCardConvertDialog.cpp" />
+    <ClCompile Include="Settings\MemoryCardBackupModel.cpp" />
+    <ClCompile Include="Settings\MemoryCardBackupWidget.cpp" />
     <ClCompile Include="Settings\MemoryCardSettingsWidget.cpp" />
     <ClCompile Include="Settings\DEV9DnsHostDialog.cpp" />
     <ClCompile Include="Settings\DEV9SettingsWidget.cpp" />
@@ -205,6 +207,8 @@
     <QtMoc Include="Settings\ControllerSettingsWindow.h" />
     <QtMoc Include="Settings\AudioSettingsWidget.h" />
     <QtMoc Include="Settings\MemoryCardConvertDialog.h" />
+    <QtMoc Include="Settings\MemoryCardBackupModel.h" />
+    <QtMoc Include="Settings\MemoryCardBackupWidget.h" />
     <QtMoc Include="Settings\MemoryCardSettingsWidget.h" />
     <QtMoc Include="Settings\DEV9DnsHostDialog.h" />
     <QtMoc Include="Settings\DEV9SettingsWidget.h" />
@@ -362,6 +366,7 @@
     <QtUi Include="Settings\InterfaceSettingsWidget.ui" />
     <QtUi Include="Settings\MemoryCardConvertDialog.ui" />
     <QtUi Include="Settings\MemoryCardCreateDialog.ui" />
+    <QtUi Include="Settings\MemoryCardBackupWidget.ui" />
     <QtUi Include="Settings\MemoryCardSettingsWidget.ui" />
     <QtUi Include="Settings\OSDSettingsWidget.ui" />
     <QtUi Include="Settings\OsdFontPickerDialog.ui" />

--- a/pcsx2-qt/pcsx2-qt.vcxproj.filters
+++ b/pcsx2-qt/pcsx2-qt.vcxproj.filters
@@ -113,6 +113,12 @@
     <ClCompile Include="Settings\MemoryCardConvertDialog.cpp">
       <Filter>Settings</Filter>
     </ClCompile>
+    <ClCompile Include="Settings\MemoryCardBackupModel.cpp">
+      <Filter>Settings</Filter>
+    </ClCompile>
+    <ClCompile Include="Settings\MemoryCardBackupWidget.cpp">
+      <Filter>Settings</Filter>
+    </ClCompile>
     <ClCompile Include="Settings\MemoryCardSettingsWidget.cpp">
       <Filter>Settings</Filter>
     </ClCompile>
@@ -371,6 +377,12 @@
       <Filter>Settings</Filter>
     </QtMoc>
     <QtMoc Include="Settings\MemoryCardConvertDialog.h">
+      <Filter>Settings</Filter>
+    </QtMoc>
+    <QtMoc Include="Settings\MemoryCardBackupModel.h">
+      <Filter>Settings</Filter>
+    </QtMoc>
+    <QtMoc Include="Settings\MemoryCardBackupWidget.h">
       <Filter>Settings</Filter>
     </QtMoc>
     <QtMoc Include="Settings\MemoryCardSettingsWidget.h">
@@ -720,6 +732,9 @@
       <Filter>Settings</Filter>
     </QtUi>
     <QtUi Include="Settings\MemoryCardCreateDialog.ui">
+      <Filter>Settings</Filter>
+    </QtUi>
+    <QtUi Include="Settings\MemoryCardBackupWidget.ui">
       <Filter>Settings</Filter>
     </QtUi>
     <QtUi Include="Settings\MemoryCardSettingsWidget.ui">

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1151,7 +1151,6 @@ target_link_libraries(PCSX2_FLAGS INTERFACE
 	imgui
 	fmt::fmt
 	libchdr
-	libzip::zip
 	cpuinfo
 	cubeb
 	rcheevos

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -112,6 +112,7 @@ set(pcsx2Sources
 	SIO/Sio2.cpp
 	SIO/Sio0.cpp
 	SIO/Multitap/MultitapProtocol.cpp
+	SIO/Memcard/MemoryCardBackup.cpp
 	SIO/Memcard/MemoryCardFile.cpp
 	SIO/Memcard/MemoryCardFolder.cpp
 	SIO/Memcard/MemoryCardProtocol.cpp
@@ -188,6 +189,7 @@ set(pcsx2Headers
 	SIO/Sio0.h
 	SIO/SioTypes.h
 	SIO/Multitap/MultitapProtocol.h
+	SIO/Memcard/MemoryCardBackup.h
 	SIO/Memcard/MemoryCardFile.h
 	SIO/Memcard/MemoryCardFolder.h
 	SIO/Memcard/MemoryCardProtocol.h

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -470,9 +470,9 @@ enum class GSNativeScaling : u8
 
 enum class GSDepthFeedbackMode : u8
 {
-	None      = 0,
-	Auto      = 1,
-	Depth     = 2,
+	None = 0,
+	Auto = 1,
+	Depth = 2,
 	DepthAsRT = 3,
 };
 
@@ -1155,7 +1155,6 @@ struct Pcsx2Config
 	// ------------------------------------------------------------------------
 	struct DebugAnalysisOptions
 	{
-
 		static const char* RunConditionNames[];
 		static const char* FunctionScanModeNames[];
 
@@ -1278,8 +1277,35 @@ struct Pcsx2Config
 	struct McdOptions
 	{
 		std::string Filename; // user-configured location of this memory card
-		bool Enabled; // memory card enabled (if false, memcard will not show up in-game)
-		MemoryCardType Type; // the memory card implementation that should be used
+		bool Enabled = false; // memory card enabled (if false, memcard will not show up in-game)
+		MemoryCardType Type = MemoryCardType::Empty; // the memory card implementation that should be used
+
+		friend auto operator<=>(const McdOptions& lhs, const McdOptions& rhs) = default;
+	};
+
+	struct MemoryCardBackupOptions
+	{
+		bool EnableAutomaticBackups = true;
+		bool EnableZstdCompression = true;
+		u32 MinimumBackupsToKeep = 3;
+		u32 MaximumBackupsToKeep = 100;
+		u32 DriveSpaceUsageLimitMiB = 200;
+
+		void LoadSave(SettingsWrapper& wrap);
+
+		friend auto operator<=>(const MemoryCardBackupOptions& lhs, const MemoryCardBackupOptions& rhs) = default;
+	};
+
+	// ------------------------------------------------------------------------
+	struct MemoryCardOptions
+	{
+		static constexpr u32 NUM_SLOTS = 8;
+
+		std::array<McdOptions, NUM_SLOTS> Slots;
+		MemoryCardBackupOptions Backup;
+
+		MemoryCardOptions();
+		void LoadSave(SettingsWrapper& wrap);
 	};
 
 	// ------------------------------------------------------------------------
@@ -1381,6 +1407,7 @@ struct Pcsx2Config
 	DEV9Options DEV9;
 	USBOptions USB;
 	PadOptions Pad;
+	MemoryCardOptions MemoryCard;
 
 	TraceLogFilters Trace;
 
@@ -1388,9 +1415,6 @@ struct Pcsx2Config
 
 	AchievementsOptions Achievements;
 
-	// Memorycard options - first 2 are default slots, last 6 are multitap 1 and 2
-	// slots (3 each)
-	McdOptions Mcd[8];
 	std::string GzipIsoIndexTemplate; // for quick-access index with gzipped ISO
 
 	int PINESlot;
@@ -1415,7 +1439,6 @@ struct Pcsx2Config
 	Pcsx2Config();
 	void LoadSave(SettingsWrapper& wrap);
 	void LoadSaveCore(SettingsWrapper& wrap);
-	void LoadSaveMemcards(SettingsWrapper& wrap);
 
 	/// Reloads options affected by patches.
 	void ReloadPatchAffectingOptions();
@@ -1450,6 +1473,7 @@ namespace EmuFolders
 	extern std::string Snapshots;
 	extern std::string Savestates;
 	extern std::string MemoryCards;
+	extern std::string MemoryCardBackups;
 	extern std::string Logs;
 	extern std::string Cheats;
 	extern std::string Patches;

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -158,6 +158,7 @@ namespace EmuFolders
 	std::string Snapshots;
 	std::string Savestates;
 	std::string MemoryCards;
+	std::string MemoryCardBackups;
 	std::string Logs;
 	std::string Cheats;
 	std::string Patches;
@@ -1875,6 +1876,52 @@ bool Pcsx2Config::PadOptions::Port::operator!=(const PadOptions::Port& right) co
 	return !this->operator==(right);
 }
 
+void Pcsx2Config::MemoryCardBackupOptions::LoadSave(SettingsWrapper& wrap)
+{
+	SettingsWrapSection("MemoryCards/Backup");
+
+	SettingsWrapBitBool(EnableAutomaticBackups);
+	SettingsWrapBitBool(EnableZstdCompression);
+	SettingsWrapBitfield(MinimumBackupsToKeep);
+	SettingsWrapBitfield(MaximumBackupsToKeep);
+	SettingsWrapBitfield(DriveSpaceUsageLimitMiB);
+}
+
+Pcsx2Config::MemoryCardOptions::MemoryCardOptions()
+{
+	for (uint slot = 0; slot < NUM_SLOTS; slot++)
+	{
+		Slots[slot].Enabled = !FileMcd_IsMultitapSlot(slot); // enables main 2 slots
+		Slots[slot].Filename = FileMcd_GetDefaultName(slot);
+		// Folder memory card is autodetected later.
+		Slots[slot].Type = MemoryCardType::File;
+	}
+}
+
+void Pcsx2Config::MemoryCardOptions::LoadSave(SettingsWrapper& wrap)
+{
+	for (uint slot = 0; slot < 2; ++slot)
+	{
+		wrap.Entry("MemoryCards", StringUtil::StdStringFromFormat("Slot%u_Enable", slot + 1).c_str(),
+			Slots[slot].Enabled, Slots[slot].Enabled);
+		wrap.Entry("MemoryCards", StringUtil::StdStringFromFormat("Slot%u_Filename", slot + 1).c_str(),
+			Slots[slot].Filename, Slots[slot].Filename);
+	}
+
+	for (uint slot = 2; slot < NUM_SLOTS; ++slot)
+	{
+		int mtport = FileMcd_GetMtapPort(slot) + 1;
+		int mtslot = FileMcd_GetMtapSlot(slot) + 1;
+
+		wrap.Entry("MemoryCards", StringUtil::StdStringFromFormat("Multitap%u_Slot%u_Enable", mtport, mtslot).c_str(),
+			Slots[slot].Enabled, Slots[slot].Enabled);
+		wrap.Entry("MemoryCards", StringUtil::StdStringFromFormat("Multitap%u_Slot%u_Filename", mtport, mtslot).c_str(),
+			Slots[slot].Filename, Slots[slot].Filename);
+	}
+
+	Backup.LoadSave(wrap);
+}
+
 Pcsx2Config::AchievementsOptions::AchievementsOptions()
 {
 	bitset = 0;
@@ -1953,15 +2000,6 @@ Pcsx2Config::Pcsx2Config()
 	ManuallySetRealTimeClock = false;
 	UseSystemLocaleFormat = false;
 
-	// To be moved to FileMemoryCard pluign (someday)
-	for (uint slot = 0; slot < 8; ++slot)
-	{
-		Mcd[slot].Enabled = !FileMcd_IsMultitapSlot(slot); // enables main 2 slots
-		Mcd[slot].Filename = FileMcd_GetDefaultName(slot);
-		// Folder memory card is autodetected later.
-		Mcd[slot].Type = MemoryCardType::File;
-	}
-
 	GzipIsoIndexTemplate = "$(f).pindex.tmp";
 	PINESlot = 28011;
 	RtcYear = 0;
@@ -2032,7 +2070,6 @@ void Pcsx2Config::LoadSaveCore(SettingsWrapper& wrap)
 
 	BaseFilenames.LoadSave(wrap);
 	EmulationSpeed.LoadSave(wrap);
-	LoadSaveMemcards(wrap);
 
 	if (wrap.IsLoading())
 	{
@@ -2050,28 +2087,7 @@ void Pcsx2Config::LoadSave(SettingsWrapper& wrap)
 	LoadSaveCore(wrap);
 	USB.LoadSave(wrap);
 	Pad.LoadSave(wrap);
-}
-
-void Pcsx2Config::LoadSaveMemcards(SettingsWrapper& wrap)
-{
-	for (uint slot = 0; slot < 2; ++slot)
-	{
-		wrap.Entry("MemoryCards", StringUtil::StdStringFromFormat("Slot%u_Enable", slot + 1).c_str(),
-			Mcd[slot].Enabled, Mcd[slot].Enabled);
-		wrap.Entry("MemoryCards", StringUtil::StdStringFromFormat("Slot%u_Filename", slot + 1).c_str(),
-			Mcd[slot].Filename, Mcd[slot].Filename);
-	}
-
-	for (uint slot = 2; slot < 8; ++slot)
-	{
-		int mtport = FileMcd_GetMtapPort(slot) + 1;
-		int mtslot = FileMcd_GetMtapSlot(slot) + 1;
-
-		wrap.Entry("MemoryCards", StringUtil::StdStringFromFormat("Multitap%u_Slot%u_Enable", mtport, mtslot).c_str(),
-			Mcd[slot].Enabled, Mcd[slot].Enabled);
-		wrap.Entry("MemoryCards", StringUtil::StdStringFromFormat("Multitap%u_Slot%u_Filename", mtport, mtslot).c_str(),
-			Mcd[slot].Filename, Mcd[slot].Filename);
-	}
+	MemoryCard.LoadSave(wrap);
 }
 
 std::string Pcsx2Config::FullpathToBios() const
@@ -2084,7 +2100,7 @@ std::string Pcsx2Config::FullpathToBios() const
 
 std::string Pcsx2Config::FullpathToMcd(uint slot) const
 {
-	return Path::Combine(EmuFolders::MemoryCards, Mcd[slot].Filename);
+	return Path::Combine(EmuFolders::MemoryCards, MemoryCard.Slots[slot].Filename);
 }
 
 void Pcsx2Config::CopyRuntimeConfig(Pcsx2Config& cfg)
@@ -2096,10 +2112,8 @@ void Pcsx2Config::CopyRuntimeConfig(Pcsx2Config& cfg)
 	CurrentCustomAspectRatio = cfg.CurrentCustomAspectRatio;
 	IsPortableMode = cfg.IsPortableMode;
 
-	for (u32 i = 0; i < sizeof(Mcd) / sizeof(Mcd[0]); i++)
-	{
-		Mcd[i].Type = cfg.Mcd[i].Type;
-	}
+	for (u32 i = 0; i < MemoryCardOptions::NUM_SLOTS; i++)
+		MemoryCard.Slots[i].Type = cfg.MemoryCard.Slots[i].Type;
 }
 
 void Pcsx2Config::CopyConfiguration(SettingsInterface* dest_si, SettingsInterface& src_si)
@@ -2284,6 +2298,7 @@ void EmuFolders::SetDefaults(SettingsInterface& si)
 	si.SetStringValue("Folders", "Snapshots", "snaps");
 	si.SetStringValue("Folders", "Savestates", "sstates");
 	si.SetStringValue("Folders", "MemoryCards", "memcards");
+	si.SetStringValue("Folders", "MemoryCardBackups", "memcardbackups");
 	si.SetStringValue("Folders", "Logs", "logs");
 	si.SetStringValue("Folders", "Cheats", "cheats");
 	si.SetStringValue("Folders", "Patches", "patches");
@@ -2310,6 +2325,7 @@ void EmuFolders::LoadConfig(SettingsInterface& si)
 	Snapshots = LoadPathFromSettings(si, DataRoot, "Snapshots", "snaps");
 	Savestates = LoadPathFromSettings(si, DataRoot, "Savestates", "sstates");
 	MemoryCards = LoadPathFromSettings(si, DataRoot, "MemoryCards", "memcards");
+	MemoryCardBackups = LoadPathFromSettings(si, DataRoot, "MemoryCardBackups", "memcardbackups");
 	Logs = LoadPathFromSettings(si, DataRoot, "Logs", "logs");
 	Cheats = LoadPathFromSettings(si, DataRoot, "Cheats", "cheats");
 	Patches = LoadPathFromSettings(si, DataRoot, "Patches", "patches");
@@ -2326,7 +2342,8 @@ void EmuFolders::LoadConfig(SettingsInterface& si)
 	Console.WriteLn("BIOS Directory: %s", Bios.c_str());
 	Console.WriteLn("Snapshots Directory: %s", Snapshots.c_str());
 	Console.WriteLn("Savestates Directory: %s", Savestates.c_str());
-	Console.WriteLn("MemoryCards Directory: %s", MemoryCards.c_str());
+	Console.WriteLn("Memory Cards Directory: %s", MemoryCards.c_str());
+	Console.WriteLn("Memory Card Backups Directory: %s", MemoryCardBackups.c_str());
 	Console.WriteLn("Logs Directory: %s", Logs.c_str());
 	Console.WriteLn("Cheats Directory: %s", Cheats.c_str());
 	Console.WriteLn("Patches Directory: %s", Patches.c_str());
@@ -2349,6 +2366,7 @@ bool EmuFolders::EnsureFoldersExist()
 	result = FileSystem::CreateDirectoryPath(Snapshots.c_str(), false) && result;
 	result = FileSystem::CreateDirectoryPath(Savestates.c_str(), false) && result;
 	result = FileSystem::CreateDirectoryPath(MemoryCards.c_str(), false) && result;
+	result = FileSystem::CreateDirectoryPath(MemoryCardBackups.c_str(), false) && result;
 	result = FileSystem::CreateDirectoryPath(Logs.c_str(), false) && result;
 	result = FileSystem::CreateDirectoryPath(Cheats.c_str(), false) && result;
 	result = FileSystem::CreateDirectoryPath(Patches.c_str(), false) && result;

--- a/pcsx2/SIO/Memcard/MemoryCardBackup.cpp
+++ b/pcsx2/SIO/Memcard/MemoryCardBackup.cpp
@@ -1,0 +1,496 @@
+// SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "MemoryCardBackup.h"
+
+#include "Config.h"
+#include "Host.h"
+#include "SIO/Memcard/MemoryCardFile.h"
+
+#include "common/Console.h"
+#include "common/Error.h"
+#include "common/FileSystem.h"
+#include "common/Path.h"
+#include "common/ZipFile.h"
+
+#include "rapidjson/document.h"
+#include "rapidjson/writer.h"
+
+#include <chrono>
+#include <thread>
+
+static bool OpenBackupForReading(
+	std::string path, ZipArchive& archive, MemoryCardBackup::BackupMetadata& metadata, Error* error);
+static bool MakeMemoryCardBackup(
+	const std::string& memory_card_path,
+	const std::string& backup_path,
+	std::chrono::time_point<std::chrono::system_clock> creation_time,
+	bool zstd_compression,
+	Error* error);
+static bool WriteBackupMetadata(
+	ZipArchive& archive, const MemoryCardBackup::BackupMetadata& metadata, Error* error);
+static size_t PurgeOldBackups(
+	const std::string& backup_directory,
+	size_t min_backups_to_keep,
+	size_t max_backups_to_keep,
+	size_t drive_space_usage_limit_mib);
+static std::string GetBackupPath(
+	const std::string& memory_card_path,
+	const std::string& backup_directory,
+	std::chrono::time_point<std::chrono::system_clock> creation_time);
+
+static constexpr const char* MEMORY_CARD_BACKUP_FORMAT_NAME = "PCSX2 Memory Card Backup";
+static constexpr int MEMORY_CARD_BACKUP_FORMAT_VERSION = 1;
+
+static constexpr const char* MEMORY_CARD_BACKUP_JSON_FILE_NAME = "backup.json";
+static constexpr const char* MEMORY_CARD_BACKUP_CARD_FILE_NAME = "card.ps2";
+
+static std::jthread s_backup_thread;
+
+void MemoryCardBackup::MakeBackup(
+	const std::string& memory_card_path, bool purge_old_backups)
+{
+	const std::chrono::time_point creation_time = std::chrono::system_clock::now();
+
+	const bool zstd_compression = EmuConfig.MemoryCard.Backup.EnableZstdCompression;
+	const u32 min_backups_to_keep = EmuConfig.MemoryCard.Backup.MinimumBackupsToKeep;
+	const u32 max_backups_to_keep = EmuConfig.MemoryCard.Backup.MaximumBackupsToKeep;
+	const u32 drive_space_usage_limit_mib = EmuConfig.MemoryCard.Backup.DriveSpaceUsageLimitMiB;
+
+	// We don't want to overwrite another backup made on the same day, since
+	// then if the memory card does get corrupted, we'd be more likely to write
+	// over the most recent backup with the corrupted version.
+	const std::string backup_directory = EmuFolders::MemoryCardBackups;
+	const std::string backup_path = GetBackupPath(backup_directory, memory_card_path, creation_time);
+	if (FileSystem::FileExists(backup_path.c_str()))
+		return;
+
+	s_backup_thread = std::jthread(
+		[memory_card_path, backup_directory, backup_path, creation_time, zstd_compression,
+			purge_old_backups, min_backups_to_keep, max_backups_to_keep, drive_space_usage_limit_mib](
+			std::stop_token token) {
+			const std::string_view file_name = Path::GetFileName(memory_card_path);
+
+			Error error;
+			if (!MakeMemoryCardBackup(memory_card_path, backup_path, creation_time, zstd_compression, &error))
+			{
+				Console.ErrorFmt("[MemoryCard] Cannot create backup of '{}': {}",
+					file_name, error.GetDescription());
+				return;
+			}
+
+			size_t backups_deleted = 0;
+			if (purge_old_backups)
+				backups_deleted = PurgeOldBackups(
+					backup_directory, min_backups_to_keep, max_backups_to_keep, drive_space_usage_limit_mib);
+
+			Console.WriteLnFmt("[MemoryCard] Wrote backup of '{}' to '{}', deleted {} old backup{}.",
+				file_name, backup_path, backups_deleted, (backups_deleted != 1) ? "s" : "");
+		});
+}
+
+void MemoryCardBackup::CancelBackup()
+{
+	if (s_backup_thread.joinable())
+	{
+		s_backup_thread.request_stop();
+		s_backup_thread.join();
+	}
+}
+
+bool MemoryCardBackup::RestoreBackup(
+	const std::string& backup_path, const std::string& output_path, Error* error)
+{
+	ZipArchive archive;
+	BackupMetadata metadata;
+	if (!OpenBackupForReading(backup_path, archive, metadata, error))
+		return false;
+
+	switch (metadata.type)
+	{
+		case BackupType::FILE_CARD:
+		{
+			std::optional<ZipEntryIndex> index = archive.LocateFile(
+				MEMORY_CARD_BACKUP_CARD_FILE_NAME, ZIP_FL_ENC_UTF_8, error);
+			if (!index.has_value())
+				return false;
+
+			if (!archive.ExtractFile(*index, output_path.c_str(), error))
+				return false;
+
+			break;
+		}
+		case BackupType::FOLDER_CARD:
+		{
+			if (!FileSystem::CreateDirectoryPath(output_path.c_str(), false, error))
+				return false;
+
+			if (!archive.ExtractDirectory(MEMORY_CARD_BACKUP_CARD_FILE_NAME, output_path.c_str(), error))
+				return false;
+
+			break;
+		}
+	}
+
+	return true;
+}
+
+std::vector<MemoryCardBackup::BackupMetadata> MemoryCardBackup::EnumerateBackups(
+	const std::string& backups_directory)
+{
+	std::vector<FILESYSTEM_FIND_DATA> files;
+	if (!FileSystem::FindFiles(
+			backups_directory.c_str(), "*.zip", FILESYSTEM_FIND_HIDDEN_FILES | FILESYSTEM_FIND_FILES, &files))
+		return {};
+
+	std::vector<MemoryCardBackup::BackupMetadata> backups;
+
+	for (const FILESYSTEM_FIND_DATA& file : files)
+	{
+		ZipArchive archive;
+		BackupMetadata metadata;
+		if (!OpenBackupForReading(file.FileName, archive, metadata, nullptr))
+		{
+			// Ignore any errors, so that if the user puts random .zip files in
+			// the backups folder it doesn't spam log messages.
+			continue;
+		}
+
+		backups.push_back(std::move(metadata));
+	}
+
+	// Sort by creation time in descending order.
+	std::sort(backups.begin(), backups.end(),
+		[](const BackupMetadata& lhs, const BackupMetadata& rhs) {
+			return lhs.creation_time > rhs.creation_time;
+		});
+
+	return backups;
+}
+
+static bool OpenBackupForReading(
+	std::string path, ZipArchive& archive, MemoryCardBackup::BackupMetadata& metadata, Error* error)
+{
+	const fmt::runtime_format_string<> missing_or_invalid_error_message =
+		TRANSLATE_FS("MemoryCardBackup", "The '{}' file has missing or invalid '{}' property.");
+
+	metadata.backup_path = path;
+
+	FILESYSTEM_STAT_DATA stat;
+	if (!FileSystem::StatFile(path.c_str(), &stat))
+	{
+		Error::SetString(error, TRANSLATE("MemoryCardBackup", "Failed to stat archive file."));
+		return false;
+	}
+
+	metadata.backup_size = static_cast<u64>(stat.Size);
+
+	if (!archive.Open(path.c_str(), ZIP_RDONLY, nullptr, error))
+		return false;
+
+	std::optional<ZipEntryIndex> index = archive.LocateFile(MEMORY_CARD_BACKUP_JSON_FILE_NAME, 0, nullptr);
+	if (!index.has_value())
+	{
+		Error::SetString(error, TRANSLATE("MemoryCardBackup", "Archive does not contain a 'backup.json' file."));
+		return false;
+	}
+
+	std::optional<std::string> json_string = archive.ReadTextFile(*index, 0, error);
+	if (!json_string.has_value())
+		return false;
+
+	rapidjson::Document json;
+	if (json.Parse(json_string->c_str()).HasParseError() || !json.IsObject())
+	{
+		Error::SetString(error, TRANSLATE("MemoryCardBackup", "Failed to parse 'backup.json' file."));
+		return false;
+	}
+
+	auto format = json.FindMember("format");
+	if (format == json.MemberEnd() ||
+		!format->value.IsString() ||
+		std::strcmp(format->value.GetString(), MEMORY_CARD_BACKUP_FORMAT_NAME) != 0)
+	{
+		Error::SetStringFmt(error, missing_or_invalid_error_message, MEMORY_CARD_BACKUP_JSON_FILE_NAME, "format");
+		return false;
+	}
+
+	auto version = json.FindMember("version");
+	if (version == json.MemberEnd() ||
+		!version->value.IsInt())
+	{
+		Error::SetStringFmt(error, missing_or_invalid_error_message, MEMORY_CARD_BACKUP_JSON_FILE_NAME, "version");
+		return false;
+	}
+
+	metadata.format_version = version->value.GetInt();
+	if (metadata.format_version > MEMORY_CARD_BACKUP_FORMAT_VERSION)
+	{
+		Error::SetString(error,
+			TRANSLATE(
+				"MemoryCardBackup",
+				"The 'backup.json' file was created by a newer version of PCSX2 and is not recognized."));
+		return false;
+	}
+
+	auto name = json.FindMember("name");
+	if (name == json.MemberEnd() ||
+		!name->value.IsString())
+	{
+		Error::SetStringFmt(error, missing_or_invalid_error_message, MEMORY_CARD_BACKUP_JSON_FILE_NAME, "name");
+		return false;
+	}
+
+	metadata.name = name->value.GetString();
+
+	auto type = json.FindMember("type");
+	if (type == json.MemberEnd() ||
+		!type->value.IsString() ||
+		(std::strcmp(type->value.GetString(), "file") != 0 &&
+			std::strcmp(type->value.GetString(), "folder") != 0))
+	{
+		Error::SetStringFmt(error, missing_or_invalid_error_message, MEMORY_CARD_BACKUP_JSON_FILE_NAME, "type");
+		return false;
+	}
+
+	if (std::strcmp(type->value.GetString(), "file") == 0)
+		metadata.type = MemoryCardBackup::BackupType::FILE_CARD;
+	else
+		metadata.type = MemoryCardBackup::BackupType::FOLDER_CARD;
+
+	auto creation_time = json.FindMember("creation_time");
+	if (creation_time == json.MemberEnd() ||
+		!creation_time->value.IsUint64())
+	{
+		Error::SetStringFmt(
+			error, missing_or_invalid_error_message, MEMORY_CARD_BACKUP_JSON_FILE_NAME, "creation_time");
+		return false;
+	}
+
+	metadata.creation_time = creation_time->value.GetUint64();
+
+	auto temporary = json.FindMember("temporary");
+	if (temporary == json.MemberEnd() ||
+		!temporary->value.IsBool())
+	{
+		Error::SetStringFmt(
+			error, missing_or_invalid_error_message, MEMORY_CARD_BACKUP_JSON_FILE_NAME, "temporary");
+		return false;
+	}
+
+	metadata.temporary = temporary->value.GetBool();
+
+	return true;
+}
+
+static bool MakeMemoryCardBackup(
+	const std::string& memory_card_path,
+	const std::string& backup_path,
+	std::chrono::time_point<std::chrono::system_clock> creation_time,
+	bool zstd_compression,
+	Error* error)
+{
+	FILESYSTEM_STAT_DATA stat_data;
+	if (!FileSystem::StatFile(memory_card_path.c_str(), &stat_data))
+	{
+		Error::SetString(error, "Failed to stat file.");
+		return false;
+	}
+
+	ZipArchive archive;
+
+	Error open_error;
+	int error_code;
+	if (!archive.Open(backup_path.c_str(), ZIP_CREATE | ZIP_EXCL, &error_code, &open_error))
+	{
+		Error::SetString(error, open_error.GetDescription() + " (while opening the archive)");
+		return false;
+	}
+
+	MemoryCardBackup::BackupMetadata metadata;
+	metadata.format_version = MEMORY_CARD_BACKUP_FORMAT_VERSION;
+	metadata.name = Path::GetFileName(memory_card_path);
+
+	std::chrono::duration creation_time_duration = creation_time.time_since_epoch();
+	metadata.creation_time = std::chrono::duration_cast<std::chrono::seconds>(creation_time_duration).count();
+
+	metadata.temporary = true;
+
+	ZipCompressionOptions compression;
+	if (zstd_compression)
+	{
+		compression.method = ZIP_CM_ZSTD;
+		compression.level = 3;
+	}
+	else
+	{
+		compression.method = ZIP_CM_DEFLATE;
+		compression.level = 6;
+	}
+
+	if (!(stat_data.Attributes & FILESYSTEM_FILE_ATTRIBUTE_DIRECTORY))
+	{
+		metadata.type = MemoryCardBackup::BackupType::FILE_CARD;
+
+		Error metadata_error;
+		if (!WriteBackupMetadata(archive, metadata, &metadata_error))
+		{
+			Error::SetStringFmt(error,
+				"{} (while writing '{}')", metadata_error.GetDescription(), MEMORY_CARD_BACKUP_JSON_FILE_NAME);
+			return false;
+		}
+
+		Error add_error;
+		if (!archive.AddFile(memory_card_path.c_str(), MEMORY_CARD_BACKUP_CARD_FILE_NAME, compression, &add_error))
+		{
+			Error::SetString(error, add_error.GetDescription() + " (while adding the memory card file to the archive)");
+			return false;
+		}
+	}
+	else
+	{
+		if (!FileMcd_IsFolder(memory_card_path))
+		{
+			Error::SetString(error, "Folder does not contain a superblock.");
+			return false;
+		}
+
+		metadata.type = MemoryCardBackup::BackupType::FOLDER_CARD;
+
+		Error metadata_error;
+		if (!WriteBackupMetadata(archive, metadata, &metadata_error))
+		{
+			Error::SetStringFmt(error,
+				"{} (while writing '{}')", metadata_error.GetDescription(), MEMORY_CARD_BACKUP_JSON_FILE_NAME);
+			return false;
+		}
+
+		Error add_error;
+		if (!archive.AddDirectory(
+				memory_card_path.c_str(), MEMORY_CARD_BACKUP_CARD_FILE_NAME, compression, false, &add_error))
+		{
+			Error::SetString(error, add_error.GetDescription() + " (while adding memory card files to the archive)");
+			return false;
+		}
+	}
+
+	Error save_error;
+	if (!archive.SaveChangesAndClose(&save_error))
+	{
+		Error::SetString(error, save_error.GetDescription() + " (while saving changes to the archive)");
+		return false;
+	}
+
+	return true;
+}
+
+static bool WriteBackupMetadata(
+	ZipArchive& archive, const MemoryCardBackup::BackupMetadata& metadata, Error* error)
+{
+	rapidjson::Document json(rapidjson::kObjectType);
+
+	rapidjson::Value format;
+	format.SetString(MEMORY_CARD_BACKUP_FORMAT_NAME, std::strlen(MEMORY_CARD_BACKUP_FORMAT_NAME));
+	json.AddMember("format", format, json.GetAllocator());
+
+	json.AddMember("version", MEMORY_CARD_BACKUP_FORMAT_VERSION, json.GetAllocator());
+
+	rapidjson::Value name;
+	name.SetString(metadata.name.c_str(), metadata.name.size());
+	json.AddMember("name", name, json.GetAllocator());
+
+	rapidjson::Value type;
+	switch (metadata.type)
+	{
+		case MemoryCardBackup::BackupType::FILE_CARD:
+			type.SetString("file", std::strlen("file"));
+			break;
+		case MemoryCardBackup::BackupType::FOLDER_CARD:
+			type.SetString("folder", std::strlen("folder"));
+			break;
+	}
+	json.AddMember("type", type, json.GetAllocator());
+
+	rapidjson::Value creation_time;
+	creation_time.SetUint64(metadata.creation_time);
+	json.AddMember("creation_time", creation_time, json.GetAllocator());
+
+	json.AddMember("temporary", metadata.temporary, json.GetAllocator());
+
+	rapidjson::StringBuffer buffer;
+	rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+	json.Accept(writer);
+
+	// We need to make a copy here, since the pointer will be stored and read
+	// later when the zip file is actually written to disk.
+	void* string = std::malloc(buffer.GetSize());
+	std::memcpy(string, buffer.GetString(), buffer.GetSize());
+
+	if (!archive.AddFileFromBuffer(
+			MEMORY_CARD_BACKUP_JSON_FILE_NAME, string, buffer.GetSize(), ZIP_FL_ENC_UTF_8, 1, error))
+	{
+		return false;
+	}
+
+	return true;
+}
+
+static size_t PurgeOldBackups(
+	const std::string& backup_directory,
+	const size_t min_backups_to_keep,
+	const size_t max_backups_to_keep,
+	const size_t drive_space_usage_limit_mib)
+{
+	std::vector<MemoryCardBackup::BackupMetadata> backups = MemoryCardBackup::EnumerateBackups(backup_directory);
+
+	size_t drive_space_usage_bytes = 0;
+	for (const MemoryCardBackup::BackupMetadata& backup : backups)
+		drive_space_usage_bytes += backup.backup_size;
+
+	size_t backups_deleted = 0;
+
+	const size_t drive_space_usage_limit_bytes = drive_space_usage_limit_mib * _1mb;
+	for (size_t i = backups.size(); i > 0; i--)
+	{
+		const size_t backups_remaining = backups.size() - backups_deleted;
+		if (backups_remaining <= max_backups_to_keep)
+		{
+			if (backups_remaining <= min_backups_to_keep)
+				break;
+
+			if (drive_space_usage_bytes <= drive_space_usage_limit_bytes)
+				break;
+		}
+
+		const MemoryCardBackup::BackupMetadata& backup = backups[i - 1];
+
+		Error error;
+		if (!FileSystem::DeleteFilePath(backup.backup_path.c_str(), &error))
+		{
+			Console.ErrorFmt("[MemoryCard] Cannot delete old backup file '{}': {}",
+				backup.backup_path, error.GetDescription());
+			break;
+		}
+
+		drive_space_usage_bytes -= backup.backup_size;
+		backups_deleted++;
+	}
+
+	return backups_deleted;
+}
+
+static std::string GetBackupPath(
+	const std::string& memory_card_path,
+	const std::string& backup_directory,
+	std::chrono::time_point<std::chrono::system_clock> creation_time)
+{
+	std::chrono::year_month_day year_month_day(std::chrono::floor<std::chrono::days>(creation_time));
+	s32 year = static_cast<s32>(year_month_day.year());
+	u32 month = static_cast<u32>(year_month_day.month());
+	u32 day = static_cast<u32>(year_month_day.day());
+
+	std::string_view memory_card_name = Path::GetFileName(memory_card_path);
+
+	std::string file_name = fmt::format("temporary_{:04}-{:02}-{:02}_{}.zip", year, month, day, memory_card_name);
+	return Path::Combine(backup_directory, file_name);
+}

--- a/pcsx2/SIO/Memcard/MemoryCardBackup.h
+++ b/pcsx2/SIO/Memcard/MemoryCardBackup.h
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "common/Pcsx2Defs.h"
+
+#include <string>
+#include <vector>
+
+class Error;
+
+namespace MemoryCardBackup
+{
+	enum class BackupType
+	{
+		FILE_CARD,
+		FOLDER_CARD,
+	};
+
+	struct BackupMetadata
+	{
+		std::string backup_path;
+		u64 backup_size = 0;
+		int format_version = -1;
+		std::string name;
+		BackupType type = BackupType::FILE_CARD;
+		u64 creation_time = 0;
+		bool temporary = false;
+	};
+
+	/// Start a worker thread to backup the memory card, cancelling the
+	/// currently in-progress backup operation if there is one. If the backup
+	/// completes successfully, and purge_old_backups is true, delete the oldest
+	/// rolling backups until the disk space is within the desired limit again.
+	void MakeBackup(const std::string& memory_card_path, bool purge_old_backups);
+
+	/// Cancel the currently in-progress backup operation if there is one.
+	void CancelBackup();
+
+	/// Extract a memory card from a backup file.
+	bool RestoreBackup(const std::string& backup_path, const std::string& output_path, Error* error);
+
+	/// Return a list of all the backups in the specified directory, sorted by
+	/// creation time in descending order.
+	std::vector<BackupMetadata> EnumerateBackups(const std::string& backups_directory);
+} // namespace MemoryCardBackup

--- a/pcsx2/SIO/Memcard/MemoryCardFile.cpp
+++ b/pcsx2/SIO/Memcard/MemoryCardFile.cpp
@@ -3,6 +3,7 @@
 
 #include "SIO/Memcard/MemoryCardFile.h"
 
+#include "SIO/Memcard/MemoryCardBackup.h"
 #include "SIO/Memcard/MemoryCardFolder.h"
 #include "SIO/Sio.h"
 #include <SIO/SioTypes.h>
@@ -265,7 +266,7 @@ void FileMemoryCard::Open()
 	{
 		m_filenames[slot] = {};
 
-		if (EmuConfig.Mcd[slot].Type != MemoryCardType::File)
+		if (EmuConfig.MemoryCard.Slots[slot].Type != MemoryCardType::File)
 			continue;
 
 		if (FileMcd_IsMultitapSlot(slot))
@@ -278,11 +279,14 @@ void FileMemoryCard::Open()
 
 		const std::string fname = EmuConfig.FullpathToMcd(slot);
 
-		if (!EmuConfig.Mcd[slot].Enabled || fname.empty())
+		if (!EmuConfig.MemoryCard.Slots[slot].Enabled || fname.empty())
 		{
 			Console.WriteLnFmt("McdSlot {} [File]: [disabled/empty filename]", slot);
 			continue;
 		}
+
+		if (EmuConfig.MemoryCard.Backup.EnableAutomaticBackups)
+			MemoryCardBackup::MakeBackup(fname, true);
 
 		if (FileSystem::GetPathFileSize(fname.c_str()) <= 0)
 		{
@@ -586,11 +590,11 @@ void FileMcd_SetType()
 	// detect inserted memory card types
 	for (uint slot = 0; slot < 8; ++slot)
 	{
-		if (EmuConfig.Mcd[slot].Filename.empty())
+		if (EmuConfig.MemoryCard.Slots[slot].Filename.empty())
 		{
-			EmuConfig.Mcd[slot].Type = MemoryCardType::Empty;
+			EmuConfig.MemoryCard.Slots[slot].Type = MemoryCardType::Empty;
 		}
-		else if (EmuConfig.Mcd[slot].Enabled)
+		else if (EmuConfig.MemoryCard.Slots[slot].Enabled)
 		{
 			MemoryCardType type = MemoryCardType::File; // default to file if we can't find anything at the path so it gets auto-generated
 
@@ -598,7 +602,7 @@ void FileMcd_SetType()
 			if (FileSystem::DirectoryExists(path.c_str()))
 				type = MemoryCardType::Folder;
 
-			EmuConfig.Mcd[slot].Type = type;
+			EmuConfig.MemoryCard.Slots[slot].Type = type;
 		}
 	}
 }
@@ -672,8 +676,8 @@ void FileMcd_Swap()
 	const std::string card2Filename = Host::GetStringSettingValue("MemoryCards", "Slot2_Filename");
 
 	// Copy each McdOptions to local memory
-	Pcsx2Config::McdOptions firstSlot = EmuConfig.Mcd[0];
-	Pcsx2Config::McdOptions secondSlot = EmuConfig.Mcd[1];
+	Pcsx2Config::McdOptions firstSlot = EmuConfig.MemoryCard.Slots[0];
+	Pcsx2Config::McdOptions secondSlot = EmuConfig.MemoryCard.Slots[1];
 
 	if (!firstSlot.Enabled || !secondSlot.Enabled || card1Filename.empty() || card2Filename.empty())
 	{
@@ -686,21 +690,21 @@ void FileMcd_Swap()
 	Host::SetBaseStringSettingValue("MemoryCards", "Slot2_Filename", card1Filename.c_str());
 	Host::CommitBaseSettingChanges();
 	VMManager::ApplySettings();
-	EmuConfig.Mcd[0] = secondSlot;
-	EmuConfig.Mcd[1] = firstSlot;
+	EmuConfig.MemoryCard.Slots[0] = secondSlot;
+	EmuConfig.MemoryCard.Slots[1] = firstSlot;
 
 	// Reopen them
 	FileMcd_EmuClose();
 	FileMcd_SetType();
 	FileMcd_EmuOpen();
 	AutoEject::SetAll();
-	Host::AddIconOSDMessage("MemoryCardSwap", ICON_PF_MEMORY_CARD, fmt::format(TRANSLATE_FS("MemoryCardSwap", "Memory Cards have been swapped.\nSlot 1: {}\nSlot 2: {}"), EmuConfig.Mcd[0].Filename, EmuConfig.Mcd[1].Filename), Host::OSD_INFO_DURATION);
+	Host::AddIconOSDMessage("MemoryCardSwap", ICON_PF_MEMORY_CARD, fmt::format(TRANSLATE_FS("MemoryCardSwap", "Memory Cards have been swapped.\nSlot 1: {}\nSlot 2: {}"), EmuConfig.MemoryCard.Slots[0].Filename, EmuConfig.MemoryCard.Slots[1].Filename), Host::OSD_INFO_DURATION);
 }
 
 s32 FileMcd_IsPresent(uint port, uint slot)
 {
 	const uint combinedSlot = FileMcd_ConvertToSlot(port, slot);
-	switch (EmuConfig.Mcd[combinedSlot].Type)
+	switch (EmuConfig.MemoryCard.Slots[combinedSlot].Type)
 	{
 		case MemoryCardType::File:
 			return Mcd::impl.IsPresent(combinedSlot);
@@ -714,7 +718,7 @@ s32 FileMcd_IsPresent(uint port, uint slot)
 void FileMcd_GetSizeInfo(uint port, uint slot, McdSizeInfo* outways)
 {
 	const uint combinedSlot = FileMcd_ConvertToSlot(port, slot);
-	switch (EmuConfig.Mcd[combinedSlot].Type)
+	switch (EmuConfig.MemoryCard.Slots[combinedSlot].Type)
 	{
 		case MemoryCardType::File:
 			Mcd::impl.GetSizeInfo(combinedSlot, *outways);
@@ -730,7 +734,7 @@ void FileMcd_GetSizeInfo(uint port, uint slot, McdSizeInfo* outways)
 bool FileMcd_IsPSX(uint port, uint slot)
 {
 	const uint combinedSlot = FileMcd_ConvertToSlot(port, slot);
-	switch (EmuConfig.Mcd[combinedSlot].Type)
+	switch (EmuConfig.MemoryCard.Slots[combinedSlot].Type)
 	{
 		case MemoryCardType::File:
 			return Mcd::impl.IsPSX(combinedSlot);
@@ -744,7 +748,7 @@ bool FileMcd_IsPSX(uint port, uint slot)
 s32 FileMcd_Read(uint port, uint slot, u8* dest, u32 adr, int size)
 {
 	const uint combinedSlot = FileMcd_ConvertToSlot(port, slot);
-	switch (EmuConfig.Mcd[combinedSlot].Type)
+	switch (EmuConfig.MemoryCard.Slots[combinedSlot].Type)
 	{
 		case MemoryCardType::File:
 			return Mcd::impl.Read(combinedSlot, dest, adr, size);
@@ -758,7 +762,7 @@ s32 FileMcd_Read(uint port, uint slot, u8* dest, u32 adr, int size)
 s32 FileMcd_Save(uint port, uint slot, const u8* src, u32 adr, int size)
 {
 	const uint combinedSlot = FileMcd_ConvertToSlot(port, slot);
-	switch (EmuConfig.Mcd[combinedSlot].Type)
+	switch (EmuConfig.MemoryCard.Slots[combinedSlot].Type)
 	{
 		case MemoryCardType::File:
 			return Mcd::impl.Save(combinedSlot, src, adr, size);
@@ -772,7 +776,7 @@ s32 FileMcd_Save(uint port, uint slot, const u8* src, u32 adr, int size)
 s32 FileMcd_EraseBlock(uint port, uint slot, u32 adr)
 {
 	const uint combinedSlot = FileMcd_ConvertToSlot(port, slot);
-	switch (EmuConfig.Mcd[combinedSlot].Type)
+	switch (EmuConfig.MemoryCard.Slots[combinedSlot].Type)
 	{
 		case MemoryCardType::File:
 			return Mcd::impl.EraseBlock(combinedSlot, adr);
@@ -786,7 +790,7 @@ s32 FileMcd_EraseBlock(uint port, uint slot, u32 adr)
 u64 FileMcd_GetCRC(uint port, uint slot)
 {
 	const uint combinedSlot = FileMcd_ConvertToSlot(port, slot);
-	switch (EmuConfig.Mcd[combinedSlot].Type)
+	switch (EmuConfig.MemoryCard.Slots[combinedSlot].Type)
 	{
 		case MemoryCardType::File:
 			return Mcd::impl.GetCRC(combinedSlot);
@@ -800,7 +804,7 @@ u64 FileMcd_GetCRC(uint port, uint slot)
 void FileMcd_NextFrame(uint port, uint slot)
 {
 	const uint combinedSlot = FileMcd_ConvertToSlot(port, slot);
-	switch (EmuConfig.Mcd[combinedSlot].Type)
+	switch (EmuConfig.MemoryCard.Slots[combinedSlot].Type)
 	{
 		//case MemoryCardType::MemoryCard_File:
 		//	Mcd::impl.NextFrame( combinedSlot );
@@ -817,7 +821,7 @@ int FileMcd_ReIndex(uint port, uint slot, const std::string& filter)
 {
 	const int combinedSlot = FileMcd_ConvertToSlot(port, slot);
 
-	switch (EmuConfig.Mcd[combinedSlot].Type)
+	switch (EmuConfig.MemoryCard.Slots[combinedSlot].Type)
 	{
 		//case MemoryCardType::File:
 		//	return Mcd::impl.ReIndex( combinedSlot, filter );
@@ -855,7 +859,7 @@ static MemoryCardFileType GetMemoryCardFileTypeFromSize(s64 size)
 		return MemoryCardFileType::Unknown;
 }
 
-static bool FileMcd_IsFolder(const std::string& path)
+bool FileMcd_IsFolder(const std::string& path)
 {
 	const std::string superblock_path(Path::Combine(path, s_folder_mem_card_id_file));
 	return FileSystem::FileExists(superblock_path.c_str());
@@ -903,9 +907,9 @@ std::vector<AvailableMcdInfo> FileMcd_GetAvailableCards(bool include_in_use_card
 		if (!include_in_use_cards)
 		{
 			bool in_use = false;
-			for (size_t i = 0; i < std::size(EmuConfig.Mcd); i++)
+			for (size_t i = 0; i < std::size(EmuConfig.MemoryCard.Slots); i++)
 			{
-				if (EmuConfig.Mcd[i].Filename == basename)
+				if (EmuConfig.MemoryCard.Slots[i].Filename == basename)
 				{
 					in_use = true;
 					break;

--- a/pcsx2/SIO/Memcard/MemoryCardFile.h
+++ b/pcsx2/SIO/Memcard/MemoryCardFile.h
@@ -8,6 +8,7 @@
 #include <cstdio>
 #include <ctime>
 #include <optional>
+#include <set>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -55,6 +56,7 @@ int FileMcd_ReIndex(uint port, uint slot, const std::string& filter);
 
 std::vector<AvailableMcdInfo> FileMcd_GetAvailableCards(bool include_in_use_cards);
 std::optional<AvailableMcdInfo> FileMcd_GetCardInfo(const std::string_view name);
+bool FileMcd_IsFolder(const std::string& path);
 bool FileMcd_IsMemoryCardFormatted(const std::string& path);
 bool FileMcd_IsMemoryCardFormatted(std::FILE* fp);
 bool FileMcd_CreateNewCard(const std::string_view name, MemoryCardType type, MemoryCardFileType file_type);

--- a/pcsx2/SIO/Memcard/MemoryCardFolder.cpp
+++ b/pcsx2/SIO/Memcard/MemoryCardFolder.cpp
@@ -138,7 +138,7 @@ bool FolderMemoryCard::IsFormatted() const
 
 void FolderMemoryCard::Open(const bool enableFiltering, std::string filter)
 {
-	Open(EmuConfig.FullpathToMcd(m_slot), EmuConfig.Mcd[m_slot], 0, enableFiltering, std::move(filter), false);
+	Open(EmuConfig.FullpathToMcd(m_slot), EmuConfig.MemoryCard.Slots[m_slot], 0, enableFiltering, std::move(filter), false);
 }
 
 void FolderMemoryCard::Open(std::string fullPath, const Pcsx2Config::McdOptions& mcdOptions, const u32 sizeInClusters, const bool enableFiltering, std::string filter, bool simulateFileWrites)

--- a/pcsx2/SIO/Sio.cpp
+++ b/pcsx2/SIO/Sio.cpp
@@ -73,7 +73,7 @@ void AutoEject::CountDownTicks()
 			if (mcds[port][slot].autoEjectTicks > 0)
 			{
 				if (--mcds[port][slot].autoEjectTicks == 0)
-					reinserted |= EmuConfig.Mcd[sioConvertPortAndSlotToPad(port, slot)].Enabled;
+					reinserted |= EmuConfig.MemoryCard.Slots[sioConvertPortAndSlotToPad(port, slot)].Enabled;
 			}
 		}
 	}

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -3043,10 +3043,10 @@ void VMManager::CheckForMemoryCardConfigChanges(const Pcsx2Config& old_config)
 {
 	bool changed = false;
 
-	for (size_t i = 0; i < std::size(EmuConfig.Mcd); i++)
+	for (size_t i = 0; i < Pcsx2Config::MemoryCardOptions::NUM_SLOTS; i++)
 	{
-		if (EmuConfig.Mcd[i].Enabled != old_config.Mcd[i].Enabled ||
-			EmuConfig.Mcd[i].Filename != old_config.Mcd[i].Filename)
+		if (EmuConfig.MemoryCard.Slots[i].Enabled != old_config.MemoryCard.Slots[i].Enabled ||
+			EmuConfig.MemoryCard.Slots[i].Filename != old_config.MemoryCard.Slots[i].Filename)
 		{
 			changed = true;
 			break;
@@ -3064,8 +3064,8 @@ void VMManager::CheckForMemoryCardConfigChanges(const Pcsx2Config& old_config)
 		for (u32 slot = 0; slot < 4; slot++)
 		{
 			const uint index = FileMcd_ConvertToSlot(port, slot);
-			if (EmuConfig.Mcd[index].Enabled != old_config.Mcd[index].Enabled ||
-				EmuConfig.Mcd[index].Filename != old_config.Mcd[index].Filename)
+			if (EmuConfig.MemoryCard.Slots[index].Enabled != EmuConfig.MemoryCard.Slots[index].Enabled ||
+				EmuConfig.MemoryCard.Slots[index].Filename != EmuConfig.MemoryCard.Slots[index].Filename)
 			{
 				Console.WriteLn("Ejecting memory card %u (port %u slot %u) due to source change", index, port, slot);
 				AutoEject::Set(port, slot);

--- a/pcsx2/pcsx2.vcxproj
+++ b/pcsx2/pcsx2.vcxproj
@@ -290,6 +290,7 @@
     <ClCompile Include="Recording\InputRecordingFile.cpp" />
     <ClCompile Include="Recording\PadData.cpp" />
     <ClCompile Include="Recording\Utilities\InputRecordingLogger.cpp" />
+    <ClCompile Include="SIO\Memcard\MemoryCardBackup.cpp" />
     <ClCompile Include="SIO\Memcard\MemoryCardFile.cpp" />
     <ClCompile Include="SIO\Memcard\MemoryCardFolder.cpp" />
     <ClCompile Include="SIO\Memcard\MemoryCardProtocol.cpp" />
@@ -738,6 +739,7 @@
     <ClInclude Include="Recording\PadData.h" />
     <ClInclude Include="Recording\Utilities\InputRecordingLogger.h" />
     <ClInclude Include="ShaderCacheVersion.h" />
+    <ClInclude Include="SIO\Memcard\MemoryCardBackup.h" />
     <ClInclude Include="SIO\Memcard\MemoryCardFile.h" />
     <ClInclude Include="SIO\Memcard\MemoryCardFolder.h" />
     <ClInclude Include="SIO\Memcard\MemoryCardProtocol.h" />

--- a/pcsx2/pcsx2.vcxproj.filters
+++ b/pcsx2/pcsx2.vcxproj.filters
@@ -1367,6 +1367,9 @@
     <ClCompile Include="SIO\Multitap\MultitapProtocol.cpp">
       <Filter>System\Ps2\Iop\SIO\Multitap</Filter>
     </ClCompile>
+    <ClCompile Include="SIO\Memcard\MemoryCardBackup.cpp">
+      <Filter>System\Ps2\Iop\SIO\Memcard</Filter>
+    </ClCompile>
     <ClCompile Include="SIO\Memcard\MemoryCardFile.cpp">
       <Filter>System\Ps2\Iop\SIO\Memcard</Filter>
     </ClCompile>
@@ -2324,6 +2327,9 @@
     </ClInclude>
     <ClInclude Include="SIO\Multitap\MultitapProtocol.h">
       <Filter>System\Ps2\Iop\SIO\Multitap</Filter>
+    </ClInclude>
+    <ClInclude Include="SIO\Memcard\MemoryCardBackup.h">
+      <Filter>System\Ps2\Iop\SIO\Memcard</Filter>
     </ClInclude>
     <ClInclude Include="SIO\Memcard\MemoryCardFile.h">
       <Filter>System\Ps2\Iop\SIO\Memcard</Filter>


### PR DESCRIPTION
### Description of Changes

Not yet ready for testing.

This adds an automated rolling local backup system for memory cards, as well as some new classes for handling ZIP files.

Memory cards will be automatically copied at most once a day, and older backups will automatically be deleted according to a configurable disk space usage limit.

TODO:
- [X] Add libzip wrapper classes.
- [X] Implement logic for making and restoring backups.
- [x] Implement logic for deleting old backups.
- [ ] Hook up the Qt UI.
- [ ] Add ImGui UI for it.
- [ ] Implement support for cancelling saving of the ZIP file, so the backup thread can stop immediately.
- [ ] Synchronise backups with the memory card system, so that we cancel a backup if we want to write to the card.

### Rationale behind Changes
A while back there was a conversation about changing the design of the memory card busy dialog to make it harder to accidentally corrupt your memory card. Ultimately, nothing was done to it, but this got me thinking about what we could do to improve the situation.

By the time the memory card busy dialog appears, depending on circumstances it may already be too late. The game may have crashed while saving for example, so forcibly shutting it down may be the only option. Hence, modifying the design of this dialog alone would not be a bullet proof solution.

This brought me to the idea of automated backups.

I've tried to make the limitations of this system very clear in the UI, to prevent confusion:
```
This system protects your save games in the case that a game crashes or is forcibly shutdown
while saving, but NOT in the case that the drive used to store the memory card files is 
damaged, so this does NOT replace a traditional backup system.
```

The zip classes I'm adding were originally written for #13763 (but extended to support extracting folders from the zip, and adding them to the zip recursively). This way the classes can be integrated with our Error class. I didn't want to build on top of the existing ZipHelpers functions because they have broken error handling.

### Suggested Testing Steps
Not yet ready for testing.

### Did you use AI to help find, test, or implement this issue or feature?
No.