### PR TITLE
FullscreenUI: Fix controller navigation breaking after Big Picture Mode's window is resized

### DIFF
--- a/pcsx2/ImGui/ImGuiManager.cpp
+++ b/pcsx2/ImGui/ImGuiManager.cpp
@@ -236,6 +236,9 @@ void ImGuiManager::WindowResized()
 
 	// Scale might have changed as a result of window resize.
 	RequestScaleUpdate();
+
+	if (GImGui->NavWindow != nullptr)
+		ImGui::NavInitWindow(GImGui->NavWindow, true);
 }
 
 void ImGuiManager::RequestScaleUpdate()


### PR DESCRIPTION
### Description of Changes
Force a navigation reinitialization whenever Big Picture Mode's window is resized.

### Rationale behind Changes
While testing Big Picture Mode, I noticed that controller navigation would stop working initially after toggling fullscreen. After testing on multiple devices, I determined the issue was not related to fullscreen toggling, but rather window resizing.

If the window is resized significantly enough, the NavRectRel values become stale, causing controller navigation to break.

For example, on handheld devices, the window size usually changes only slightly when toggling fullscreen, so the issue may not occur at all.

### Suggested Testing Steps
1. On main, resize the Big Picture Mode window to a much smaller size and then toggle fullscreen.
2. Controller navigation should stop working consistently, although pressing up/down on the D-pad may fix navigation.
3. On this branch, repeat the same resizing and fullscreen toggling steps.
4. Controller navigation should continue functioning correctly after any resizing or toggling fullscreen

### Did you use AI to help find, test, or implement this issue or feature?
Technically yes. I was using AI to help debug, but it was incorrectly suggesting multithreading-related issues. The final fix was through manual debugging and testing.