### PR TITLE
GS/DX12: Init RWTexture as direct queue shader resource

### DIFF
--- a/pcsx2/GS/Renderers/DX12/GSTexture12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSTexture12.cpp
@@ -128,7 +128,7 @@ static D3D12_BARRIER_LAYOUT GetD3D12BarrierLayout(GSTexture12::ResourceState sta
 			return D3D12_BARRIER_LAYOUT_DEPTH_STENCIL_WRITE;
 		case GSTexture12::ResourceState::PixelShaderResource:
 		case GSTexture12::ResourceState::ComputeShaderResource:
-			return D3D12_BARRIER_LAYOUT_SHADER_RESOURCE;
+			return D3D12_BARRIER_LAYOUT_DIRECT_QUEUE_SHADER_RESOURCE;
 		case GSTexture12::ResourceState::CopySrc:
 			return D3D12_BARRIER_LAYOUT_DIRECT_QUEUE_COPY_SOURCE;
 		case GSTexture12::ResourceState::CopyDst:


### PR DESCRIPTION
### Description of Changes
Use the direct queue format when initialising a RWTexture (which is used by CAS).

### Rationale behind Changes
We previously initialised to the non-queue specific format, however, our transition logic assumes that we used the direct queue format, raising a validation warning.

### Suggested Testing Steps
Test CAS in DX12.

### Did you use AI to help find, test, or implement this issue or feature?
No.