### PR TITLE
GS/DX: Remove IEEE strict maths flag when compiling shaders

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -261,10 +261,21 @@ float manual_lod(float uv_w)
 #endif
 
 #if PS_ANISOTROPIC_FILTERING > 1
+bool2 nan_or_inf(float2 xy)
+{
+	// FXC (<=SM5.1) may optimise away isnan and isinf.
+	// DXC (>=SM6.0) will preserve them.
+#ifdef __hlsl_dx_compiler
+	return isinf(xy) | isnan(xy);
+#else
+	return (asuint(xy) & 0x7f800000) == 0x7f800000;
+#endif
+}
+
 float4 sample_c_af(float2 uv, float uv_w)
 {
 	// HW sampler will reject bad UVs, match that here.
-	uv = any(isnan(uv) | isinf(uv)) ? float2(0, 0) : uv;
+	uv = any(nan_or_inf(uv)) ? float2(0, 0) : uv;
 
 	// Large floating point values risk NaN/Inf values.
 	// Above this value floats lose decimal precision, so seems a resonable limit for UVs.
@@ -281,7 +292,7 @@ float4 sample_c_af(float2 uv, float uv_w)
 	bool d_zero = length(dX) == 0 || length(dY) == 0;
 	bool d_par = (dX.x * dY.y - dY.x * dX.y) == 0;
 	bool d_per = dot(dX, dY) == 0;
-	bool d_inf_nan = any(isinf(dX) | isinf(dY) | isnan(dX) | isnan(dY));
+	bool d_inf_nan = any(nan_or_inf(dX) | nan_or_inf(dY));
 
 	if (!(d_zero || d_par || d_per || d_inf_nan))
 	{
@@ -305,7 +316,7 @@ float4 sample_c_af(float2 uv, float uv_w)
 			sqrt(F * (t + p) / (t * (q - t)))
 		);
 		
-		d_inf_nan = any(isinf(new_dX) | isinf(new_dY) | isnan(new_dX) | isnan(new_dY));
+		d_inf_nan = any(nan_or_inf(new_dX) | nan_or_inf(new_dY));
 		if (!d_inf_nan)
 		{
 			dX = new_dX;

--- a/pcsx2/GS/Renderers/DX11/D3D.cpp
+++ b/pcsx2/GS/Renderers/DX11/D3D.cpp
@@ -523,8 +523,8 @@ wil::com_ptr_nothrow<ID3DBlob> D3D::CompileShader(D3D::ShaderType type, D3D::Sha
 		break;
 	}
 
-	static constexpr UINT flags_non_debug = D3DCOMPILE_OPTIMIZATION_LEVEL3 | D3DCOMPILE_IEEE_STRICTNESS;
-	static constexpr UINT flags_debug = D3DCOMPILE_SKIP_OPTIMIZATION | D3DCOMPILE_DEBUG | D3DCOMPILE_DEBUG_NAME_FOR_SOURCE | D3DCOMPILE_IEEE_STRICTNESS;
+	static constexpr UINT flags_non_debug = D3DCOMPILE_OPTIMIZATION_LEVEL3;
+	static constexpr UINT flags_debug = D3DCOMPILE_SKIP_OPTIMIZATION | D3DCOMPILE_DEBUG | D3DCOMPILE_DEBUG_NAME_FOR_SOURCE;
 
 	wil::com_ptr_nothrow<ID3DBlob> blob;
 	wil::com_ptr_nothrow<ID3DBlob> error_blob;

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 95; // Last changed in PR 14439
+static constexpr u32 SHADER_CACHE_VERSION = 96; // Last changed in PR 14479


### PR DESCRIPTION
### Description of Changes
When shader based AF was added, DX shaders where set to compile with IEEE strict maths.
This PR removes that flag.

### Rationale behind Changes
Prior to https://github.com/PCSX2/pcsx2/pull/14399 and https://github.com/PCSX2/pcsx2/pull/14370, the shader could calculate a NaN ansio ratio.

Without strict maths, D3D FX compiler would reorder a condition against ansio ratio to one which behaves incorrectly with NaNs.
As earlier checks now seem to prevent a NaN ansio ratio, we can remove the strict maths flag.

I've also provided a replacement isnan/isinf function, as while the compiler currently retains the isnan/isinf intrinsics, the FX compiler can optimise them out.

### Suggested Testing Steps
Test DX11 and DX12 renders with AF enabled.

### Did you use AI to help find, test, or implement this issue or feature?
No.