### PR TITLE
GS/HW: Fix offset draw vertex trace/draw rect.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -10454,6 +10454,16 @@ void GSRendererHW::OffsetDraw(s32 fbp_offset, s32 zbp_offset, s32 xoffset, s32 y
 		m_vertex->buff[i].XYZ.X += fp_xoffset;
 		m_vertex->buff[i].XYZ.Y += fp_yoffset;
 	}
+
+	m_vt.m_min.p.x += static_cast<float>(xoffset);
+	m_vt.m_min.p.y += static_cast<float>(yoffset);
+	m_vt.m_max.p.x += static_cast<float>(xoffset);
+	m_vt.m_max.p.y += static_cast<float>(yoffset);
+
+	m_r.x += xoffset;
+	m_r.y += yoffset;
+	m_r.z += xoffset;
+	m_r.w += yoffset;
 }
 
 GSHWDrawConfig& GSRendererHW::BeginHLEHardwareDraw(


### PR DESCRIPTION
### Description of Changes
Fix vertex trace/draw rect when offsetting vertices in GSRendererHW::OffsetDraw().

### Rationale behind Changes
Fixes https://github.com/PCSX2/pcsx2/issues/14296 broken graphics in the attached dump in DX11.


[Catwoman_SLUS-20992_20260523162159_small.gs.xz.zip](https://github.com/user-attachments/files/28182861/Catwoman_SLUS-20992_20260523162159_small.gs.xz.zip)

### Suggested Testing Steps
Test the attached dump in DX11 in master and PR.

### Did you use AI to help find, test, or implement this issue or feature?
No.