### PR TITLE
SaveState: Fix compression settings

### DIFF
--- a/pcsx2-qt/Settings/AdvancedSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AdvancedSettingsWidget.ui
@@ -474,17 +474,12 @@
         </item>
         <item>
          <property name="text">
-          <string>Deflate64</string>
+          <string>Deflate</string>
          </property>
         </item>
         <item>
          <property name="text">
           <string>Zstandard</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>LZMA2</string>
          </property>
         </item>
        </widget>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -384,9 +384,8 @@ enum class GSDumpCompressionMethod : u8
 enum class SavestateCompressionMethod : u8
 {
 	Uncompressed = 0,
-	Deflate64 = 1,
-	Zstandard = 2,
-	LZMA2 = 3
+	Deflate = 1,
+	Zstandard = 2
 };
 
 enum class SavestateCompressionLevel : u8

--- a/pcsx2/ImGui/FullscreenUI_Settings.cpp
+++ b/pcsx2/ImGui/FullscreenUI_Settings.cpp
@@ -4900,9 +4900,8 @@ void FullscreenUI::DrawAdvancedSettingsPage()
 
 	static constexpr const char* s_savestate_compression_type[] = {
 		FSUI_NSTR("Uncompressed"),
-		FSUI_NSTR("Deflate64"),
+		FSUI_NSTR("Deflate"),
 		FSUI_NSTR("Zstandard"),
-		FSUI_NSTR("LZMA2"),
 	};
 
 	static constexpr const char* s_savestate_compression_ratio[] = {

--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -926,8 +926,8 @@ static bool SaveState_ReadScreenshot(zip_t* zf, u32* out_width, u32* out_height,
 // --------------------------------------------------------------------------------------
 static bool SaveState_AddToZip(zip_t* zf, ArchiveEntryList* srclist, SaveStateScreenshotData* screenshot)
 {
-	u32 compression;
-	u32 compression_level;
+	u32 compression = ZIP_CM_DEFAULT;
+	u32 compression_level = 0;
 
 	if (EmuConfig.Savestate.CompressionType == SavestateCompressionMethod::Zstandard)
 	{
@@ -942,25 +942,13 @@ static bool SaveState_AddToZip(zip_t* zf, ArchiveEntryList* srclist, SaveStateSc
 		else if (EmuConfig.Savestate.CompressionRatio == SavestateCompressionLevel::VeryHigh)
 			compression_level = 22;
 	}
-	else if (EmuConfig.Savestate.CompressionType == SavestateCompressionMethod::Deflate64)
+	else if (EmuConfig.Savestate.CompressionType == SavestateCompressionMethod::Deflate)
 	{
-		compression = ZIP_CM_DEFLATE64;
+		compression = ZIP_CM_DEFLATE;
 		if (EmuConfig.Savestate.CompressionRatio == SavestateCompressionLevel::Low)
 			compression_level = 1;
 		else if (EmuConfig.Savestate.CompressionRatio == SavestateCompressionLevel::Medium)
-			compression_level = 3;
-		else if (EmuConfig.Savestate.CompressionRatio == SavestateCompressionLevel::High)
-			compression_level = 7;
-		else if (EmuConfig.Savestate.CompressionRatio == SavestateCompressionLevel::VeryHigh)
-			compression_level = 9;
-	}
-	else if (EmuConfig.Savestate.CompressionType == SavestateCompressionMethod::LZMA2)
-	{
-		compression = ZIP_CM_LZMA2;
-		if (EmuConfig.Savestate.CompressionRatio == SavestateCompressionLevel::Low)
-			compression_level = 1;
-		else if (EmuConfig.Savestate.CompressionRatio == SavestateCompressionLevel::Medium)
-			compression_level = 3;
+			compression_level = 5;
 		else if (EmuConfig.Savestate.CompressionRatio == SavestateCompressionLevel::High)
 			compression_level = 7;
 		else if (EmuConfig.Savestate.CompressionRatio == SavestateCompressionLevel::VeryHigh)
@@ -1006,7 +994,9 @@ static bool SaveState_AddToZip(zip_t* zf, ArchiveEntryList* srclist, SaveStateSc
 			return false;
 		}
 
-		zip_set_file_compression(zf, fi, compression, compression_level);
+		// Don't compress the version indicator file so that builds that don't
+		// support a given compression method can at least still read it.
+		zip_set_file_compression(zf, fi, ZIP_CM_STORE, 0);
 	}
 
 	const uint listlen = srclist->GetLength();


### PR DESCRIPTION
### Description of Changes
- Fix deflate compression level setting for save states.
- Remove LZMA compression method for save states.
- Don't compress the version indicator for save states.
- Fix an uninitialized variable.
- Change the default deflate compression level from 3 to 5 (the previous level was never actually applied, instead it seemed to default to a very high compression level).

### Rationale behind Changes
This fixes some regressions from #11848:
- The deflate option didn't work since we were passing ZIP_CM_DEFLATE64 to zip_set_file_compression instead of ZIP_CM_DEFLATE (it's the default anyway, but it meant the compression level didn't apply). The former isn't a valid argument for that function.
- The LZMA option didn't work since we're using the 7zip SDK instead of liblzma (and we were passing the wrong argument as well).
- I don't think compressing the version indicator makes sense. Since it's so small it doesn't gain us anything, and it means that if a save state is created using a given compression method, a build that doesn't support that method won't even be able to provide a nice error message to the user.
- The compression method is loaded from the config file, and so we shouldn't read an uninitialized variable if it's wrong.

In particular, if you use deflate compression for save states (which I do, since my archive manager of choice ~~doesn't support zstd compression~~, I tested it and it does now, great!), compressing save states should be much faster now, since the compression level will be lower. On my machine it went down from 1500ms to compress a save state down to around ~~300ms~~ (450ms, I decided to bump the Medium compression level a bit). The file size will be slightly larger.

The normal default compression level for deflate is apparently 6, so I think 5 is a better default for us compared to 3.

We didn't notice these problems before since we weren't checking the return value of zip_set_file_compression. I'll hold off on fixing that for now since a lot of the save state code seems to silently ignore errors, so it would need a proper going over.

### Suggested Testing Steps
Test the remaining compression methods and levels, see if everything still makes sense.

### Did you use AI to help find, test, or implement this issue or feature?
No.