### PR TITLE
Deps: Workaround MSVC ICE with PlutoVG

### DIFF
--- a/.github/workflows/scripts/windows/build-dependencies.bat
+++ b/.github/workflows/scripts/windows/build-dependencies.bat
@@ -469,6 +469,7 @@ echo "Building PlutoVG..."
 rmdir /S /Q "plutovg-%PLUTOVG%"
 %SEVENZIP% x "plutovg-%PLUTOVG%.zip" || goto error
 cd "plutovg-%PLUTOVG%" || goto error
+%PATCH% -p1 < "%SCRIPTDIR%\plutovg-workaround-msvc-ice.patch" || goto error
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="%INSTALLDIR%" -DCMAKE_INSTALL_PREFIX="%INSTALLDIR%" -DBUILD_SHARED_LIBS=ON -DPLUTOVG_BUILD_EXAMPLES=OFF -B build -G Ninja || goto error
 cmake --build build --parallel || goto error
 ninja -C build install || goto error

--- a/.github/workflows/scripts/windows/plutovg-workaround-msvc-ice.patch
+++ b/.github/workflows/scripts/windows/plutovg-workaround-msvc-ice.patch
@@ -1,0 +1,52 @@
+diff --git a/source/plutovg-font.c b/source/plutovg-font.c
+index 0ad89b1..110de7f 100644
+--- a/source/plutovg-font.c
++++ b/source/plutovg-font.c
+@@ -836,7 +836,8 @@ int plutovg_font_face_cache_load_file(plutovg_font_face_cache_t* cache, const ch
+         size_t family_index = 0;
+         if(unicode_family_name) {
+             const stbtt_uint8* family_name = unicode_family_name;
+-            while(family_length) {
++            //while(family_length) {
++            for (int i = family_length; i > 0; i -= 2) {
+                 stbtt_uint16 ch = family_name[0] * 256 + family_name[1];
+                 if(ch < 0x80) {
+                     entry->family[family_index++] = ch;
+@@ -853,7 +854,8 @@ int plutovg_font_face_cache_load_file(plutovg_font_face_cache_t* cache, const ch
+                     entry->family[family_index++] = (0x80 + ((c) & 0x3f));
+ 
+                     family_name += 2;
+-                    family_length -= 2;
++                    //family_length -= 2;
++                    i -= 2;
+                 } else {
+                     entry->family[family_index++] = (0xe0 + (ch >> 12));
+                     entry->family[family_index++] = (0x80 + ((ch >> 6) & 0x3f));
+@@ -861,7 +863,7 @@ int plutovg_font_face_cache_load_file(plutovg_font_face_cache_t* cache, const ch
+                 }
+ 
+                 family_name += 2;
+-                family_length -= 2;
++                //family_length -= 2;
+             }
+ 
+             entry->family[family_index] = '\0';
+@@ -902,7 +904,8 @@ int plutovg_font_face_cache_load_file(plutovg_font_face_cache_t* cache, const ch
+             };
+ 
+             const stbtt_uint8* family_name = roman_family_name;
+-            while(family_length) {
++            //while(family_length) {
++            for (int i2 = family_length; i2 > 0; i2--) {
+                 stbtt_uint16 ch = MAC_ROMAN_TABLE[family_name[0]];
+                 if(ch < 0x80) {
+                     entry->family[family_index++] = ch;
+@@ -916,7 +919,7 @@ int plutovg_font_face_cache_load_file(plutovg_font_face_cache_t* cache, const ch
+                 }
+ 
+                 family_name += 1;
+-                family_length -= 1;
++                //family_length -= 1;
+             }
+ 
+             entry->family[family_index] = '\0';


### PR DESCRIPTION
### Description of Changes
Patches PlutoVG to avoid an MSVC compiler error with later versions of VS 2026

### Rationale behind Changes
A VS update introduced a compiler error when building PlutoVG, replacing a couple while loops with for loops seems to workaround the issue.

### Suggested Testing Steps
Test SVG rendering in BPM

### Did you use AI to help find, test, or implement this issue or feature?
No