### PR TITLE
GS/TC: Fix target combining, scale and valid areas

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2359,14 +2359,11 @@ void GSTextureCache::CombineAlignedInsideTargets(Target* target, GSTextureCache:
 							const u32 horizontal_offset = page_offset * t_psm.pgs.x;
 							const GSVector4i target_drect_unscaled = t->m_drawn_since_read + GSVector4i(horizontal_offset, vertical_offset).xyxy();
 
-							const GSVector4 source_rect = GSVector4(t->m_drawn_since_read) / (GSVector4(t->m_unscaled_size).xyxy() * t->GetScale());
+							const GSVector4 source_rect = GSVector4(t->m_drawn_since_read) / GSVector4(t->m_unscaled_size).xyxy();
 							const GSVector4 target_drect = GSVector4(target_drect_unscaled) * target->m_scale;
 
 							const bool valid_color = t->m_valid_rgb;
 							const bool valid_alpha = (t->m_valid_alpha_high || t->m_valid_alpha_low) && (GSUtil::GetChannelMask(t->m_TEX0.PSM) & 0x8);
-
-							target->m_valid_alpha_high |= t->m_valid_alpha_high;
-							target->m_valid_alpha_low |= t->m_valid_alpha_low;
 
 							GL_CACHE("Combining %x-%x in to %x-%x draw %lld", t->m_TEX0.TBP0, t->m_end_block, target->m_TEX0.TBP0, target->m_end_block, GSState::s_n);
 
@@ -2382,7 +2379,12 @@ void GSTextureCache::CombineAlignedInsideTargets(Target* target, GSTextureCache:
 								g_gs_device->StretchRect(t->m_texture, source_rect, target->m_texture, target_drect, ShaderConvert::DEPTH_COPY);
 							}
 
+							target->m_valid_rgb |= t->m_valid_rgb;
+							target->m_valid_alpha_high |= t->m_valid_alpha_high;
+							target->m_valid_alpha_low |= t->m_valid_alpha_low;
+
 							target->UpdateValidity(target_drect_unscaled);
+							target->UpdateDrawn(target_drect_unscaled);
 						}
 					}
 


### PR DESCRIPTION
### Description of Changes
Corrects upscaling behaviour of the CombineAlignedTargets function which was errantly using scale on the normalized source read rect, so the wrong data was being copied,, but also wasn't updating the draw area which caused problems later (explained below)

### Rationale behind Changes
The scale was a mistake, probably because when I originally did it I was thinking about making sure upscaling was dealt with, as you need to consider scale on the destination, but with the normalized source, you shouldn't do that. The draw area was not being copied over, and so the new data was being lost of the target was immediately resized after, which uses the draw area to make the copy.

### Suggested Testing Steps
Test Area 51, Valkyrie Profile 2,  and some other games (King Kong, Pachi Para 13, Shadow Hearts - Covenant, Time Crisis 3 all came up in the dump run but there was no visible changes)

### Did you use AI to help find, test, or implement this issue or feature?
No

Area 51:
Master:
<img width="1194" height="896" alt="image" src="https://github.com/user-attachments/assets/c369e6ca-83b4-45c6-b610-40779ad4fedc" />
PR:
<img width="1194" height="896" alt="image" src="https://github.com/user-attachments/assets/6efda3a8-11a1-48d5-b76a-30a645407171" />

Valkyrie Profile 2 (blur is in the wrong place):
Master:
<img width="1344" height="896" alt="image" src="https://github.com/user-attachments/assets/45419368-72d4-4707-b229-e7e2f51cca67" />
<img width="1344" height="896" alt="image" src="https://github.com/user-attachments/assets/a86ab6af-cba8-4dc4-a6f2-75b3df6fbe1a" />

PR:
<img width="1344" height="896" alt="image" src="https://github.com/user-attachments/assets/b17dad13-1b88-49aa-bd6e-92606fe7d8a2" />
<img width="1344" height="896" alt="image" src="https://github.com/user-attachments/assets/83ca308f-5a28-4f56-a288-4afc2803170b" />

