### PR TITLE
GS/HW: Downscale target before 8bit conversion

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -6454,7 +6454,7 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 					src->m_region.SetX(x_offset, x_offset + tw);
 					src->m_region.SetY(y_offset, y_offset + th);
 
-					if (!GSConfig.UserHacks_NativePaletteDraw)
+					if (!GSConfig.UserHacks_NativePaletteDraw && tlevels > 1 && ((tw >> 1) > dst->m_valid.z || (th >> 1) > dst->m_valid.w))
 						m_temporary_source = src;
 				}
 				else

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -6418,9 +6418,33 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 					}
 
 					const u32 destination_tbw = (dst->m_TEX0.TBP0 == TEX0.TBP0) ? (std::max<u32>(TEX0.TBW, 1u) * 64) : std::max<u32>(dst->m_TEX0.TBW, 1u) * 128;
-					g_gs_device->ConvertToIndexedTexture(sTex, dst->m_scale, x_offset, y_offset,
-						std::max<u32>(dst->m_TEX0.TBW, 1u) * 64, dst->m_TEX0.PSM, dTex,
-						destination_tbw, TEX0.PSM);
+					if (dst->GetScale() > 1.0f)
+					{
+						GSTexture* tmpTex = use_texture ?
+												g_gs_device->CreateTexture(dst->m_unscaled_size.x, dst->m_unscaled_size.y, 1, GSTexture::Format::Color, PreferReusedLabelledTexture()) :
+												g_gs_device->CreateRenderTarget(dst->m_unscaled_size.x, dst->m_unscaled_size.y, GSTexture::Format::Color, false, PreferReusedLabelledTexture());
+
+						const GSVector4 dRect = GSVector4(GSVector4i::loadh(dst->m_unscaled_size));
+
+						if (GSConfig.UserHacks_NativeScaling != GSNativeScaling::Off)
+						{
+							const u32 downsample_factor = static_cast<u32>(dst->GetScale());
+							
+							g_gs_device->FilteredDownsampleTexture(dst->m_texture, tmpTex, downsample_factor, GSVector2i(0, 0), dRect);
+						}
+						else
+							g_gs_device->StretchRect(sTex, tmpTex, dRect, ShaderConvert::COPY, false);
+
+						g_gs_device->ConvertToIndexedTexture(tmpTex, 1, x_offset, y_offset,
+							std::max<u32>(dst->m_TEX0.TBW, 1u) * 64, dst->m_TEX0.PSM, dTex,
+							destination_tbw, TEX0.PSM);
+
+						g_gs_device->Recycle(tmpTex);
+					}
+					else
+						g_gs_device->ConvertToIndexedTexture(sTex, dst->GetScale(), x_offset, y_offset,
+							std::max<u32>(dst->m_TEX0.TBW, 1u) * 64, dst->m_TEX0.PSM, dTex,
+							destination_tbw, TEX0.PSM);
 
 					// Adjust to match a PSMT8 texture (coordinates are double C32, we shouldn't be converting from anything else).
 					x_offset *= 2;


### PR DESCRIPTION
### Description of Changes
Downscales selected target for 8bit source conversion to native before conversion happens. Native Scaling has a more aggressive form of this, but will cause problems in some games using unscaled palette draws (Crash Bandicoot), hence the two versions.

### Rationale behind Changes
The 8 bit conversion routine doesn't seem to do a super great job on upscaled targets, so downscaling them filtered seems to result in a better job.

### Suggested Testing Steps
Test Valkyrie Profile 2 and Xenosaga Episode 3, plus some random games (especially if you know they do 8bit conversions)

### Did you use AI to help find, test, or implement this issue or feature?
No

Valkyrie Profile 2:
Master:
<img width="1365" height="1024" alt="image" src="https://github.com/user-attachments/assets/d75009b2-f0f4-4449-bedf-63f032efdca9" />
PR:
<img width="1365" height="1024" alt="image" src="https://github.com/user-attachments/assets/fa2a4a3b-6b7b-4083-b373-791e960cb3eb" />

Xenosaga Episode 3:
Master:
<img width="1352" height="1091" alt="image" src="https://github.com/user-attachments/assets/7aa52ab9-2260-4361-aa50-5ad7813e3b26" />
PR:
<img width="1352" height="1091" alt="image" src="https://github.com/user-attachments/assets/2b3b4c58-eaa0-4270-98d6-197c1fdf2b6d" />
