### PR TITLE
Cli: Fix gamearg processing when using fast boot

### DIFF
--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -700,6 +700,7 @@ void eeloadHook()
 				{
 					// Overwrite OSDSYS with game's ELF name
 					strcpy((char*)PSM(g_osdsys_str), elfname.c_str());
+					break;
 				}
 			}
 		}


### PR DESCRIPTION
### Description of Changes
Fixes #14242

### Rationale behind Changes
 `g_osdsys_str` is found and set to the elf of the game to fast boot in `eeloadHook`, but then the loop to search for `rom0:OSDSYS` continues despite having found it - this meant that `eeloadHook2` had an invalid value for  `g_osdsys_str` to apply the gameargs.

### Suggested Testing Steps
The above issue gives a game and set of args to test: `pcsx2-qt <Syphon_Filter.iso> -gameargs "-x -lMINSK"`. 

Alternatively, running any game with any `-gameargs` and inspecting the log for the output of `Console.WriteLn("eeloadHook2: Supplying launch argument(s) '%s' to ELF '%s'.", argString, (char *)PSM(g_osdsys_str));` will show that the ELF string is empty without this fix: `eeloadHook2: Supplying launch argument(s) '-x -lMINSK' to ELF ''.`

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation as to how you used it. Please see the Large Language Model (LLM) Usage Policy for more information: https://pcsx2.net/docs/contributing/#large-language-model-llm-usage-policy -->
No.