### PR TITLE
GameDB: Remove Radio Helicopter II patches

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -24921,11 +24921,6 @@ SLES-53820:
 SLES-53821:
   name: "Radio Helicopter II"
   region: "PAL-E"
-  patches:
-    9A695202:
-      content: |-
-        comment=Patch that nops a branch instruction causing a freeze.
-        patch=1,EE,001799AC,word,00000000
 SLES-53824:
   name: "Trapt"
   region: "PAL-E"
@@ -40287,11 +40282,6 @@ SLPM-62624:
   name-sort: "ぷちこぷたー2"
   name-en: "Petit Copter 2"
   region: "NTSC-J"
-  patches:
-    9A695202:
-      content: |-
-        comment=Patch that nops a branch instruction causing a freeze.
-        patch=1,EE,001799B8,word,00000000
 SLPM-62625:
   name: "鬼浜爆走愚連隊 激闘編"
   name-sort: "おにはまばくそうぐれんたい げきとうへん"


### PR DESCRIPTION
### Description of Changes
Removes no longer needed fixes for Radio Helicopter II.

### Rationale behind Changes
It was already fixed by Refraction's #13583
Closes #10380

### Suggested Testing Steps
Already tested a million times. 

However, turn off compatibility patches for the game, then test it to see 2.5.356 and every version above it working fine and 2.5.355 freezing.

### Did you use AI to help find, test, or implement this issue or feature?
No.