### PR TITLE
Console: Improve logic for outputting color codes

### DIFF
--- a/common/Console.cpp
+++ b/common/Console.cpp
@@ -98,14 +98,25 @@ __ri void Log::WriteToConsole(LOGLEVEL level, ConsoleColors color, std::string_v
 
 	static constexpr size_t BUFFER_SIZE = 512;
 
+#ifdef _WIN32
+	constexpr bool supports_color_codes = true;
+#else
+	const int fd = (level <= LOGLEVEL_WARNING) ? STDERR_FILENO : STDOUT_FILENO;
+	const bool supports_color_codes = static_cast<bool>(isatty(fd));
+#endif
+
 	SmallStackString<BUFFER_SIZE> buffer;
 	buffer.reserve(static_cast<u32>(32 + message.length()));
-	buffer.append(s_ansi_color_codes[color]);
+	if (supports_color_codes)
+		buffer.append(s_ansi_color_codes[color]);
 
 	if (s_log_timestamps)
 		buffer.append_format(TIMESTAMP_FORMAT_STRING, Log::GetCurrentMessageTime());
 
 	buffer.append(message);
+
+	if (supports_color_codes)
+		buffer.append(s_ansi_color_codes[Color_Default]);
 	buffer.append('\n');
 
 #ifdef _WIN32
@@ -134,7 +145,6 @@ cleanup:
 	if (wmessage_buf != wbuf)
 		std::free(wmessage_buf);
 #else
-	const int fd = (level <= LOGLEVEL_WARNING) ? STDERR_FILENO : STDOUT_FILENO;
 	write(fd, buffer.data(), buffer.length());
 #endif
 }
@@ -157,7 +167,7 @@ void Log::SetConsoleOutputLevel(LOGLEVEL level)
 	if (was_enabled == now_enabled)
 		return;
 
-		// Worst that happens here is we write to a bad handle..
+	// Worst that happens here is we write to a bad handle..
 
 #if defined(_WIN32)
 	static constexpr auto enable_virtual_terminal_processing = [](HANDLE hConsole) {


### PR DESCRIPTION
### Description of Changes

On POSIX platforms, only output colour codes if the output file descriptor is a TTY.

Also, reset the terminal colour at the end of each line.

### Rationale behind Changes
This makes it so that if you redirect the output of PCSX2 to a file on POSIX systems, it doesn't include a bunch of colour code junk in the resultant file.

Resetting the colour at the end of each line means that the colour of the last line printed doesn't stick around in your terminal (which would happen if your bash prompt doesn't have any colour codes of its own).

### Suggested Testing Steps
Try redirecting the output of PCSX2 to a file, and with a bash prompt that doesn't contain any colour codes: `export PS1="test "`.

### Did you use AI to help find, test, or implement this issue or feature?
No.