### PR TITLE
CMake: Don't ship Qt Network on Windows

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1338,7 +1338,7 @@ function(setup_main_executable target)
 		endforeach()
 
 		get_target_property(WINDEPLOYQT_EXE Qt6::windeployqt IMPORTED_LOCATION)
-		install(CODE "execute_process(COMMAND \"${WINDEPLOYQT_EXE}\" \"${CMAKE_SOURCE_DIR}/bin/$<TARGET_FILE_NAME:${target}>\" --plugindir \"${CMAKE_SOURCE_DIR}/bin/QtPlugins\" --pdb --no-compiler-runtime --no-system-d3d-compiler --no-system-dxc-compiler --no-translations COMMAND_ERROR_IS_FATAL ANY)")
+		install(CODE "execute_process(COMMAND \"${WINDEPLOYQT_EXE}\" \"${CMAKE_SOURCE_DIR}/bin/$<TARGET_FILE_NAME:${target}>\" --plugindir \"${CMAKE_SOURCE_DIR}/bin/QtPlugins\" --pdb --no-compiler-runtime --no-system-d3d-compiler --no-system-dxc-compiler --no-translations --no-network COMMAND_ERROR_IS_FATAL ANY)")
 		install(CODE "file(WRITE \"${CMAKE_SOURCE_DIR}/bin/qt.conf\" \"[Paths]\\nPlugins = ./QtPlugins\")")
 	endif()
 


### PR DESCRIPTION
### Description of Changes
Don't ship Qt Network on Windows.

### Rationale behind Changes
Save a couple of megabytes. As far as I know, we weren't using it.

See [windeployqt/main.cpp](https://github.com/qt/qtbase/blob/000d6c62f7880bb8d3054724e8da0b8ae244130e/src/tools/windeployqt/main.cpp#L544).

### Suggested Testing Steps
I guess you could check that networking-related features like the auto updater still work on Windows, but I'd be surprised if they didn't.

### Did you use AI to help find, test, or implement this issue or feature?
No.