### PR TITLE
GS/DX12: Discard stencil when not in use while using depth.

### DIFF
--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -4423,7 +4423,7 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 		// Make sure the DSV is in writeable state
 		draw_ds->TransitionToState(GSTexture12::ResourceState::DepthWriteStencil);
 
-		D3D12_RECT rect = {config.drawarea.left, config.drawarea.top, config.drawarea.left + config.drawarea.width(), config.drawarea.top + config.drawarea.height()};
+		const D3D12_RECT rect = {config.drawarea.left, config.drawarea.top, config.drawarea.left + config.drawarea.width(), config.drawarea.top + config.drawarea.height()};
 		GetCommandList().list4->ClearDepthStencilView(draw_ds->GetWriteDescriptor(), D3D12_CLEAR_FLAG_STENCIL, 0.0f, 1, 1, &rect);
 	}
 
@@ -4444,11 +4444,12 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 			draw_rt ? D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE : D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
 			GetLoadOpForTexture(draw_ds),
 			draw_ds ? D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE : D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
-			stencil_DATE ? D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_PRESERVE :
-						   D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS,
-			stencil_DATE ? (need_barrier ? D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE :
-										   D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_DISCARD) :
-						   D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
+			draw_ds ? (stencil_DATE ? D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_PRESERVE :
+									  D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_DISCARD) :
+					  D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS,
+			draw_ds ? ((stencil_DATE && need_barrier) ? D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE :
+														D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_DISCARD) :
+					  D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
 			clear_color, draw_ds ? draw_ds->GetClearDepth() : 0.0f, 1);
 	}
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/DX12: Discard stencil when not in use while using depth.
Because the same texture is shared and used for both depth and stencil we want to discard when the stencil is not used instead of no access as that gives a validation error.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Fixes api error:
`D3D12 ERROR: ID3D12GraphicsCommandList::BeginRenderPass: Render pass surface that has been in a non NO_ACCESS state cannot end in an ENDING_ACCESS_TYPE_NO_ACCESS state. DSV 000002EE9BCB5B80 stencil ending access is the issue [ EXECUTION ERROR #1372: RENDER_PASS_COMMANDLIST_INVALID_END_STATE]`

Also fixes access violations when running dx12 through the VS debugger.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test Time Crisis, Hitman, GT4, see if the api error is gone using DebugView with Debug device enabled.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation as to how you used it. Please see the Large Language Model (LLM) Usage Policy for more information: https://pcsx2.net/docs/contributing/#large-language-model-llm-usage-policy -->
No.