### PR TITLE
GS/DX11/GL: Adapt full barrier multidraw FB copy for sampling RT/DS hazards.

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2616,6 +2616,7 @@ void GSState::FlushPrim()
 		m_quad_check_valid_shuffle = false;
 		m_drawlist.clear();
 		m_drawlist_bbox.clear();
+		m_drawlist_bbox_tex.clear();
 
 		if (GSConfig.ShouldDump(s_n, g_perfmon.GetFrame()))
 		{
@@ -4722,6 +4723,71 @@ GSState::PRIM_OVERLAP GSState::GetPrimitiveOverlapDrawlist(bool save_drawlist, b
 		default:
 			pxFail("Invalid primclass."); // Impossible.
 			return PRIM_OVERLAP_UNKNOW;
+	}
+}
+
+template <u32 primclass, bool fst>
+void GSState::GetPrimitiveOverlapDrawlistTextureBBoxImpl(float bbox_scale)
+{
+	pxAssert(m_drawlist_bbox_tex.empty()); // Should only call this once per draw.
+
+	constexpr int n = GSUtil::GetClassVertexCount(primclass);
+	const GSVertex* RESTRICT v = m_vertex->buff;
+	const u16* RESTRICT index = m_index->buff;
+	const u32 count = m_index->tail;
+
+	for (u32 i = 0; i < count; i += n)
+	{
+		const float q = primclass == GS_SPRITE_CLASS ? v[index[i + 1]].RGBAQ.Q : v[index[i]].RGBAQ.Q;
+		GSVector4 bbox = GetTexCoordsImpl<fst>(v[index[i]], q);
+
+		for (u32 j = 1; j < n; j++)
+		{
+			const GSVector4 tex = GetTexCoordsImpl<fst>(v[index[i + j]]);
+			bbox = bbox.min(tex).xyzw(bbox.max(tex));
+		}
+
+		bbox = bbox * bbox_scale; // Account for upscaling.
+		bbox = bbox.floor().xyzw(bbox.ceil()); // Round.
+		bbox += GSVector4(-1.0f, -1.0f, 1.0f, 1.0f); // +1 on all sides for bilinear.
+
+		m_drawlist_bbox_tex.push_back(GSVector4i(bbox));
+	}
+}
+
+void GSState::GetPrimitiveOverlapDrawlistTextureBBox(float bbox_scale)
+{
+	pxAssert(PRIM->TME);
+
+	switch (m_vt.m_primclass)
+	{
+		case GS_POINT_CLASS:
+			if (PRIM->FST)
+				GetPrimitiveOverlapDrawlistTextureBBoxImpl<GS_POINT_CLASS, true>(bbox_scale);
+			else
+				GetPrimitiveOverlapDrawlistTextureBBoxImpl<GS_POINT_CLASS, false>(bbox_scale);
+			break;
+		case GS_LINE_CLASS:
+			if (PRIM->FST)
+				GetPrimitiveOverlapDrawlistTextureBBoxImpl<GS_LINE_CLASS, true>(bbox_scale);
+			else
+				GetPrimitiveOverlapDrawlistTextureBBoxImpl<GS_LINE_CLASS, false>(bbox_scale);
+			break;
+		case GS_TRIANGLE_CLASS:
+			if (PRIM->FST)
+				GetPrimitiveOverlapDrawlistTextureBBoxImpl<GS_TRIANGLE_CLASS, true>(bbox_scale);
+			else
+				GetPrimitiveOverlapDrawlistTextureBBoxImpl<GS_TRIANGLE_CLASS, false>(bbox_scale);
+			break;
+		case GS_SPRITE_CLASS:
+			if (PRIM->FST)
+				GetPrimitiveOverlapDrawlistTextureBBoxImpl<GS_SPRITE_CLASS, true>(bbox_scale);
+			else
+				GetPrimitiveOverlapDrawlistTextureBBoxImpl<GS_SPRITE_CLASS, false>(bbox_scale);
+			break;
+		default:
+			pxAssert(false);
+			return;
 	}
 }
 

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -392,6 +392,7 @@ public:
 	PRIM_OVERLAP m_prim_overlap = PRIM_OVERLAP_UNKNOW;
 	std::vector<size_t> m_drawlist;
 	std::vector<GSVector4i> m_drawlist_bbox;
+	std::vector<GSVector4i> m_drawlist_bbox_tex;
 
 	struct GSPCRTCRegs
 	{
@@ -535,6 +536,9 @@ public:
 	PRIM_OVERLAP GetPrimitiveOverlapDrawlistImpl(bool save_drawlist = false, bool save_bbox = false, float bbox_scale = 1.0f);
 	PRIM_OVERLAP GetPrimitiveOverlapDrawlist(bool save_drawlist = false, bool save_bbox = false, float bbox_scale = 1.0f);
 	PRIM_OVERLAP PrimitiveOverlap(bool save_drawlist = false);
+	template <u32 primclass, bool fst>
+	void GetPrimitiveOverlapDrawlistTextureBBoxImpl(float bbox_scale = 1.0f);
+	void GetPrimitiveOverlapDrawlistTextureBBox(float bbox_scale = 1.0f);
 	bool SpriteDrawWithoutGaps();
 	void CalculatePrimitiveCoversWithoutGaps();
 	GIFRegTEX0 GetTex0Layer(u32 lod);

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -3027,6 +3027,58 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 	}
 }
 
+void GSDevice11::FeedbackCopyAndBind(const GSHWDrawConfig& config,
+	GSTexture* rt, GSTexture* rt_clone, GSTexture* ds, GSTexture* ds_clone, const GSVector4i& copyarea)
+{
+	if (rt_clone)
+	{
+		CopyRect(rt, rt_clone, copyarea, copyarea.left, copyarea.top);
+		PSSetShaderResource(2, rt_clone);
+		if (config.tex_hazard == GSHWDrawConfig::TEX_HAZARD_RT)
+			PSSetShaderResource(0, rt_clone);
+	}
+	if (ds_clone)
+	{
+		CopyRect(ds, ds_clone, copyarea, copyarea.left, copyarea.top);
+		PSSetShaderResource(4, ds_clone);
+		if (config.tex_hazard == GSHWDrawConfig::TEX_HAZARD_DEPTH)
+			PSSetShaderResource(0, ds_clone);
+	}
+}
+
+// Choose the best copy area based on the hazards and whether we need RT and/or DS copies.
+void GSDevice11::FeedbackCopyAndBind(const GSHWDrawConfig& config,
+	GSTexture* rt, GSTexture* rt_clone, GSTexture* ds, GSTexture* ds_clone,
+	const GSVector4i& copyarea, const GSVector4i& samplearea)
+{
+	const GSVector4i rtsize = (rt ? rt : ds)->GetRect();
+
+	// DX11 can't do partial depth copies so only do attempt individual copies for RT hazards.
+	if (config.tex_hazard == GSHWDrawConfig::TEX_HAZARD_RT)
+	{
+		const GSVector4i union_rect = config.drawarea.runion(config.samplearea);
+		const u32 size_union = union_rect.width() * union_rect.height();
+		const u32 size_indiv = config.drawarea.width() * config.drawarea.height() +
+			config.samplearea.width() * config.samplearea.height();
+
+		// Do an individual copy if the union is larger than the sum of individual areas.
+		if (size_union > size_indiv)
+		{
+			FeedbackCopyAndBind(config, rt, rt_clone, ds, ds_clone, ProcessCopyArea(rtsize, config.drawarea));
+			FeedbackCopyAndBind(config, rt, rt_clone, ds, ds_clone, ProcessCopyArea(rtsize, config.samplearea));
+		}
+		else
+		{
+			FeedbackCopyAndBind(config, rt, rt_clone, ds, ds_clone, ProcessCopyArea(rtsize, union_rect));
+		}
+	}
+	else
+	{
+		// No RT hazards so just need the draw area (or full area for DS).
+		FeedbackCopyAndBind(config, rt, rt_clone, ds, ds_clone, ProcessCopyArea(rtsize, config.drawarea));
+	}
+};
+
 void GSDevice11::SendHWDraw(const GSHWDrawConfig& config,
 	GSTexture* draw_rt_clone, GSTexture* draw_rt, GSTexture* draw_ds_clone, GSTexture* draw_ds,
 	const bool one_barrier, const bool full_barrier)
@@ -3035,27 +3087,6 @@ void GSDevice11::SendHWDraw(const GSHWDrawConfig& config,
 	if ((one_barrier || full_barrier) && !(config.IsFeedbackLoopRT(config.ps) || config.IsFeedbackLoopDepth(config.ps))) [[unlikely]]
 		Console.Warning("D3D11: Possible unnecessary copy detected.");
 #endif
-
-	auto CopyAndBind = [&](GSVector4i drawarea) {
-		if (draw_rt_clone)
-		{
-			CopyRect(draw_rt, draw_rt_clone, drawarea, drawarea.left, drawarea.top);
-			if ((one_barrier || full_barrier))
-				PSSetShaderResource(2, draw_rt_clone);
-			if (config.tex_hazard == GSHWDrawConfig::TEX_HAZARD_RT)
-				PSSetShaderResource(0, draw_rt_clone);
-		}
-		if (draw_ds_clone)
-		{
-			CopyRect(draw_ds, draw_ds_clone, drawarea, drawarea.left, drawarea.top);
-			if ((one_barrier || full_barrier))
-				PSSetShaderResource(4, draw_ds_clone);
-			if (config.tex_hazard == GSHWDrawConfig::TEX_HAZARD_DEPTH)
-				PSSetShaderResource(0, draw_ds_clone);
-		}
-	};
-
-	const GSVector4i rtsize(0, 0, (draw_rt ? draw_rt : draw_ds)->GetWidth(), (draw_rt ? draw_rt : draw_ds)->GetHeight());
 
 	if (full_barrier)
 	{
@@ -3067,10 +3098,13 @@ void GSDevice11::SendHWDraw(const GSHWDrawConfig& config,
 
 		for (u32 n = 0, p = 0; n < draw_list_size; n++)
 		{
-			const u32 count = (*config.drawlist)[n] * indices_per_prim;
+			const u32 count = config.drawlist->at(n) * indices_per_prim;
 
-			const GSVector4i original_bbox = (*config.drawlist_bbox)[n].rintersect(config.drawarea);
-			CopyAndBind(ProcessCopyArea(rtsize, original_bbox));
+			const GSVector4i bbox = config.drawlist_bbox->at(n).rintersect(config.drawarea);
+			const GSVector4i bbox_tex = config.drawlist_bbox_tex ?
+				config.drawlist_bbox_tex->at(n).rintersect(config.samplearea) : GSVector4i::zero();
+
+			FeedbackCopyAndBind(config, draw_rt, draw_rt_clone, draw_ds, draw_ds_clone, bbox, bbox_tex);
 
 			Draw(config, p, count);
 
@@ -3082,29 +3116,7 @@ void GSDevice11::SendHWDraw(const GSHWDrawConfig& config,
 
 	if (one_barrier)
 	{
-		// DX11 can't do partial depth copies.
-		if (config.tex_hazard == GSHWDrawConfig::TEX_HAZARD_RT)
-		{
-			const GSVector4i union_rect = config.drawarea.runion(config.samplearea);
-			const u32 size_union = union_rect.width() * union_rect.height();
-			const u32 size_indiv = config.drawarea.width() * config.drawarea.height() +
-			                       config.samplearea.width() * config.samplearea.height();
-
-			// Do an individual copy if the union is larger than the sum of individual areas.
-			if (size_union > size_indiv)
-			{
-				CopyAndBind(ProcessCopyArea(rtsize, config.drawarea));
-				CopyAndBind(ProcessCopyArea(rtsize, config.samplearea));
-			}
-			else
-			{
-				CopyAndBind(ProcessCopyArea(rtsize, union_rect));
-			}
-		}
-		else
-		{
-			CopyAndBind(ProcessCopyArea(rtsize, config.drawarea));
-		}
+		FeedbackCopyAndBind(config, draw_rt, draw_rt_clone, draw_ds, draw_ds_clone, config.drawarea, config.samplearea);
 	}
 
 	Draw(config);

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -372,6 +372,12 @@ public:
 	void SetupOM(OMDepthStencilSelector dssel, OMBlendSelector bsel, u8 afix);
 
 	void RenderHW(GSHWDrawConfig& config) override;
+
+	void FeedbackCopyAndBind(const GSHWDrawConfig& config,
+		GSTexture* rt, GSTexture* rt_clone, GSTexture* ds, GSTexture* ds_clone, const GSVector4i& copyarea);
+	void FeedbackCopyAndBind(const GSHWDrawConfig& config,
+		GSTexture* rt, GSTexture* rt_clone, GSTexture* ds, GSTexture* ds_clone,
+		const GSVector4i& copyarea, const GSVector4i& samplearea);
 	void SendHWDraw(const GSHWDrawConfig& config,
 		GSTexture* draw_rt_clone, GSTexture* draw_rt, GSTexture* draw_ds_clone, GSTexture* draw_ds,
 		const bool one_barrier, const bool full_barrier);

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -4585,7 +4585,7 @@ void GSDevice12::SendHWDraw(const PipelineSelector& pipe, const GSHWDrawConfig& 
 
 			for (u32 n = 0, p = 0; n < draw_list_size; n++)
 			{
-				const u32 count = (*config.drawlist)[n] * indices_per_prim;
+				const u32 count = config.drawlist->at(n) * indices_per_prim;
 
 				if (feedback_rt)
 					FeedbackBarrier(draw_rt);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -6161,7 +6161,7 @@ void GSRendererHW::DetermineVSConfig(GSTextureCache::Target* rt, float rtscale, 
 	m_conf.vs.iip = !IsFlatShaded();
 }
 
-void GSRendererHW::DetermineBarriers(GSTextureCache::Target* rt)
+void GSRendererHW::DetermineBarriers(GSTextureCache::Target* rt, GSTextureCache::Source* tex)
 {
 	const GSDevice::FeatureSupport& features = g_gs_device->Features();
 
@@ -6204,6 +6204,16 @@ void GSRendererHW::DetermineBarriers(GSTextureCache::Target* rt)
 		ComputeDrawlistGetSize(rt->m_scale);
 		m_conf.drawlist = &m_drawlist;
 		m_conf.drawlist_bbox = &m_drawlist_bbox;
+
+		if (m_conf.tex_hazard != GSHWDrawConfig::TEX_HAZARD_NONE)
+		{
+			GetPrimitiveOverlapDrawlistTextureBBox(tex->GetScale());
+			m_conf.drawlist_bbox_tex = &m_drawlist_bbox_tex;
+		}
+		else
+		{
+			m_conf.drawlist_bbox_tex = nullptr;
+		}
 	}
 }
 
@@ -9027,7 +9037,7 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 	}
 
 	// Barriers must be determined before indices are modified via HandleProvokingVertexFirst/SetupIA.
-	DetermineBarriers(rt);
+	DetermineBarriers(rt, tex);
 
 	// Perform second pass setup here once barriers are determined.
 	EmulateAlphaTestSecondPass();

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -251,7 +251,7 @@ private:
 
 	void DetermineVSConfig(GSTextureCache::Target* rt, float rtscale, const GSVector2i& rtsize,
 		const GSVector2i& unscaled_size, float& vs_scale_x, float& vs_scale_y);
-	void DetermineBarriers(GSTextureCache::Target* rt);
+	void DetermineBarriers(GSTextureCache::Target* rt, GSTextureCache::Source* tex);
 
 	void SetTCOffset();
 	bool NextDrawColClip() const;

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -2518,7 +2518,7 @@ void GSDeviceMTL::SendHWDraw(GSHWDrawConfig& config, id<MTLRenderCommandEncoder>
 
 		for (u32 n = 0, p = 0; n < draw_list_size; n++)
 		{
-			const size_t count = (*config.drawlist)[n] * indices_per_prim;
+			const size_t count = config.drawlist->at(n) * indices_per_prim;
 			textureBarrier(enc);
 			EncodeDraw(enc, topology, count, buffer, off, p);
 			p += count;

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -3033,6 +3033,57 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 	}
 }
 
+void GSDeviceOGL::FeedbackCopyAndBind(const GSHWDrawConfig& config,
+	GSTexture* rt, GSTexture* rt_clone, GSTexture* ds, GSTexture* ds_clone, const GSVector4i& copyarea)
+{
+	if (rt_clone)
+	{
+		CopyRect(rt, rt_clone, copyarea, copyarea.left, copyarea.top);
+		PSSetShaderResource(2, rt_clone);
+		if (config.tex_hazard == GSHWDrawConfig::TEX_HAZARD_RT)
+			PSSetShaderResource(0, rt_clone);
+	}
+	if (ds_clone)
+	{
+		CopyRect(ds, ds_clone, copyarea, copyarea.left, copyarea.top);
+		PSSetShaderResource(4, ds_clone);
+		if (config.tex_hazard == GSHWDrawConfig::TEX_HAZARD_DEPTH)
+			PSSetShaderResource(0, ds_clone);
+	}
+}
+
+// Choose the best copy area based on the hazards and whether we need RT and/or DS copies.
+void GSDeviceOGL::FeedbackCopyAndBind(const GSHWDrawConfig& config,
+	GSTexture* rt, GSTexture* rt_clone, GSTexture* ds, GSTexture* ds_clone,
+	const GSVector4i& copyarea, const GSVector4i& samplearea)
+{
+	const GSVector4i rtsize = (rt ? rt : ds)->GetRect();
+
+	if (config.tex_hazard != GSHWDrawConfig::TEX_HAZARD_NONE)
+	{
+		const GSVector4i union_rect = config.drawarea.runion(config.samplearea);
+		const u32 size_union = union_rect.width() * union_rect.height();
+		const u32 size_indiv = config.drawarea.width() * config.drawarea.height() +
+			config.samplearea.width() * config.samplearea.height();
+
+		// Do an individual copy if the union is larger than the sum of individual areas.
+		if (size_union > size_indiv)
+		{
+			FeedbackCopyAndBind(config, rt, rt_clone, ds, ds_clone, ProcessCopyArea(rtsize, config.drawarea));
+			FeedbackCopyAndBind(config, rt, rt_clone, ds, ds_clone, ProcessCopyArea(rtsize, config.samplearea));
+		}
+		else
+		{
+			FeedbackCopyAndBind(config, rt, rt_clone, ds, ds_clone, ProcessCopyArea(rtsize, union_rect));
+		}
+	}
+	else
+	{
+		// No RT/DS hazards so just need the draw area.
+		FeedbackCopyAndBind(config, rt, rt_clone, ds, ds_clone, ProcessCopyArea(rtsize, config.drawarea));
+	}
+}
+
 void GSDeviceOGL::SendHWDraw(const GSHWDrawConfig& config,
 	GSTexture* draw_rt_clone, GSTexture* draw_rt, GSTexture* draw_ds_clone, GSTexture* draw_ds,
 	const bool one_barrier, const bool full_barrier)
@@ -3041,27 +3092,6 @@ void GSDeviceOGL::SendHWDraw(const GSHWDrawConfig& config,
 	if ((one_barrier || full_barrier) && !(config.IsFeedbackLoopRT(config.ps) || config.IsFeedbackLoopDepth(config.ps))) [[unlikely]]
 		Console.Warning("OpenGL: Possible unnecessary barrier detected.");
 #endif
-
-	auto CopyAndBind = [&](GSVector4i drawarea) {
-		if (draw_rt_clone)
-		{
-			CopyRect(draw_rt, draw_rt_clone, drawarea, drawarea.left, drawarea.top);
-			if ((one_barrier || full_barrier))
-				PSSetShaderResource(2, draw_rt_clone);
-			if (config.tex_hazard == GSHWDrawConfig::TEX_HAZARD_RT)
-				PSSetShaderResource(0, draw_rt_clone);
-		}
-		if (draw_ds_clone)
-		{
-			CopyRect(draw_ds, draw_ds_clone, drawarea, drawarea.left, drawarea.top);
-			if ((one_barrier || full_barrier))
-				PSSetShaderResource(4, draw_ds_clone);
-			if (config.tex_hazard == GSHWDrawConfig::TEX_HAZARD_DEPTH)
-				PSSetShaderResource(0, draw_ds_clone);
-		}
-	};
-
-	const GSVector4i rtsize(0, 0, (draw_rt ? draw_rt : draw_ds)->GetWidth(), (draw_rt ? draw_rt : draw_ds)->GetHeight());
 
 	if (full_barrier)
 	{
@@ -3077,7 +3107,7 @@ void GSDeviceOGL::SendHWDraw(const GSHWDrawConfig& config,
 
 		for (u32 n = 0, p = 0; n < draw_list_size; n++)
 		{
-			const u32 count = (*config.drawlist)[n] * indices_per_prim;
+			const u32 count = config.drawlist->at(n) * indices_per_prim;
 
 			if (m_features.texture_barrier)
 			{
@@ -3085,8 +3115,10 @@ void GSDeviceOGL::SendHWDraw(const GSHWDrawConfig& config,
 			}
 			else
 			{
-				const GSVector4i original_bbox = (*config.drawlist_bbox)[n].rintersect(config.drawarea);
-				CopyAndBind(ProcessCopyArea(rtsize, original_bbox));
+				const GSVector4i bbox = config.drawlist_bbox->at(n).rintersect(config.drawarea);
+				const GSVector4i bbox_tex = config.drawlist_bbox_tex ?
+					config.drawlist_bbox_tex->at(n).rintersect(config.samplearea) : GSVector4i::zero();
+				FeedbackCopyAndBind(config, draw_rt, draw_rt_clone, draw_ds, draw_ds_clone, bbox, bbox_tex);
 			}
 
 			Draw(config, p, count);
@@ -3106,28 +3138,7 @@ void GSDeviceOGL::SendHWDraw(const GSHWDrawConfig& config,
 		else
 		{
 			// Optimization: For alpha second pass we can reuse the copy snapshot from the first pass.
-			if (config.tex_hazard)
-			{
-				const GSVector4i union_rect = config.drawarea.runion(config.samplearea);
-				const u32 size_union = union_rect.width() * union_rect.height();
-				const u32 size_indiv = config.drawarea.width() * config.drawarea.height() +
-				                       config.samplearea.width() * config.samplearea.height();
-
-				// Do an individual copy if the union is larger than the sum of individual areas.
-				if (size_union > size_indiv)
-				{
-					CopyAndBind(ProcessCopyArea(rtsize, config.drawarea));
-					CopyAndBind(ProcessCopyArea(rtsize, config.samplearea));
-				}
-				else
-				{
-					CopyAndBind(ProcessCopyArea(rtsize, union_rect));
-				}
-			}
-			else
-			{
-				CopyAndBind(ProcessCopyArea(rtsize, config.drawarea));
-			}
+			FeedbackCopyAndBind(config, draw_rt, draw_rt_clone, draw_ds, draw_ds_clone, config.drawarea, config.samplearea);
 		}
 	}
 

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -352,6 +352,11 @@ public:
 	void DoMultiStretchRects(const MultiStretchRect* rects, u32 num_rects, const GSVector2& ds);
 
 	void RenderHW(GSHWDrawConfig& config) override;
+	void FeedbackCopyAndBind(const GSHWDrawConfig& config,
+		GSTexture* rt, GSTexture* rt_clone, GSTexture* ds, GSTexture* ds_clone, const GSVector4i& copyarea);
+	void FeedbackCopyAndBind(const GSHWDrawConfig& config,
+		GSTexture* rt, GSTexture* rt_clone, GSTexture* ds, GSTexture* ds_clone,
+		const GSVector4i& copyarea, const GSVector4i& samplearea);
 	void SendHWDraw(const GSHWDrawConfig& config,
 		GSTexture* draw_rt_clone, GSTexture* draw_rt, GSTexture* draw_ds_clone, GSTexture* draw_ds,
 		const bool one_barrier, const bool full_barrier);

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -6370,7 +6370,7 @@ void GSDeviceVK::SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt, 
 		{
 			IssueBarriers();
 
-			const u32 count = (*config.drawlist)[n] * indices_per_prim;
+			const u32 count = config.drawlist->at(n) * indices_per_prim;
 			Draw(config, p, count);
 			p += count;
 		}


### PR DESCRIPTION
### Description of Changes
Adapt full barrier multidraw FB copy for sampling RT/DS hazards. Currently RT/DS sampling hazards are only considered in the one barrier case.

Added a one-line code cleanup to all backends.

### Rationale behind Changes
Fixes some broken effects on DX11 with max blend.

### Suggested Testing Steps
Use DX11 with max blend. Affected games: MGS3, Destroy All Humans, V-Rally 3.

Currently tested on DX11 with a dump run at native and a smoke test at 2x.

Destroy_All_Humans_SLES-53196_20230823011850.gs.xz

Master DX11
<img width="640" height="448" alt="S075816_f00003_fr-1_00000_C_16S_Destroy_All_Humans_SLES-53196_20230823011850 gs xz_master" src="https://github.com/user-attachments/assets/0cab4d23-cbb2-42aa-9d09-7d863f752d41" />

PR Dx11
<img width="640" height="448" alt="S075816_f00003_fr-1_00000_C_16S_Destroy_All_Humans_SLES-53196_20230823011850 gs xz_sample-2" src="https://github.com/user-attachments/assets/045d9ad1-3386-4d10-89d8-e193b3f4a921" />

Metal Gear Solid 3 - Snake Eater_SLES-82024_20240622231204.gs.xz

Master DX11
<img width="512" height="448" alt="S063576_f00002_fr-1_01000_C_32_Metal_Gear_Solid_3_- upscale gs xz_master" src="https://github.com/user-attachments/assets/5ab46b35-852c-478f-822f-d4e7235648bf" />

PR DX11
<img width="512" height="448" alt="S063576_f00002_fr-1_01000_C_32_Metal_Gear_Solid_3_- upscale gs xz_sample-2" src="https://github.com/user-attachments/assets/e9e1e102-9c25-4212-98ef-a470b4e71d56" />

V-Rally_3_SLES-50725_20221103161354.gs.xz

Master DX11
<img width="512" height="512" alt="S006113_f00001_fr-1_01000_C_32_V-Rally_3_SLES-50725_20221103161354 gs xz_master" src="https://github.com/user-attachments/assets/bffc89e9-cfa2-43da-84b3-be01851fed1b" />

PR DX11
<img width="512" height="512" alt="S006113_f00001_fr-1_01000_C_32_V-Rally_3_SLES-50725_20221103161354 gs xz_sample-2" src="https://github.com/user-attachments/assets/0f878ec4-ec56-44f9-a909-5a02fab95ac2" />

### Did you use AI to help find, test, or implement this issue or feature?
No.