### PR TITLE
GS: Fix a number of compiler warnings.

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -385,7 +385,7 @@ void GSState::ResetDrawBuffers()
 // exclude_current is used if there is a flush for a reason other than the normal context change.
 void GSState::FlushBuffers(bool flush_base_only, bool use_flush_reason, GSFlushReason flush_reason)
 {
-	const u32 current_idx = m_current_buffer_idx;
+	const int current_idx = m_current_buffer_idx;
 	bool restore_env = false;
 
 	if (m_used_buffers_idx > 0)
@@ -5810,10 +5810,10 @@ bool GSState::CheckOverlapVerts(u32 n)
 
 			if (m_index->tail > 0)
 			{
-				int matching_verts = 0;
+				u32 matching_verts = 0;
 				for (u32 i = 0; i < n; i++)
 				{
-					const int pos = m_index->buff[(m_index->tail - n) + i];
+					const u32 pos = m_index->buff[(m_index->tail - n) + i];
 					const GSVector2i prev_vert = GSVector2i(v[pos].XYZ.X - m_context->XYOFFSET.OFX, v[pos].XYZ.Y - m_context->XYOFFSET.OFY);
 
 					for (u32 j = 0; j < n; j++)

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -1803,8 +1803,8 @@ static_assert(NUM_REMAPPED_SHADERS <= 256); // We use u8 for the remap indices.
 static constexpr std::array<u8, NUM_REMAP_INPUTS> GenRemapArray()
 {
 	std::array<u8, NUM_REMAP_INPUTS> out{};
-	u32 out_idx = 0;
-	const u32 invalid = 0xffffffff;
+	u8 out_idx = 0;
+	const u8 invalid = 0xff;
 	for (u32 i = 0; i < NUM_REMAP_INPUTS; i++)
 		out[i] = RemapIndexIsValid(i) ? out_idx++ : invalid;
 	return out;

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -516,6 +516,8 @@ static inline ShaderConvertSelector GetConvertShader(GSTexture::Format src, GSTe
 							break;
 					}
 					break;
+				default:
+					pxAssert(false);
 			}
 			break;
 		default:

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -278,6 +278,7 @@ private:
 	std::string m_tfx_source;
 
 protected:
+	using GSDevice::DoStretchRect; // Suppress overloaded virtual function warning
 	virtual void DoStretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect,
 		ShaderConvertSelector shader, Filter filter) override;
 public:

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.h
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.h
@@ -439,6 +439,7 @@ private:
 	void DestroyResources();
 
 protected:
+	using GSDevice::DoStretchRect; // Suppress overloaded virtual function warning
 	virtual void DoStretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect,
 		ShaderConvertSelector shader, Filter filter) override;
 	virtual void DoStretchRect(GSTexture* sTex, const GSVector4& sRect, const GSVector4& dRect,

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5805,8 +5805,6 @@ void GSRendererHW::DetermineAlphaScaling(GSTextureCache::Target* rt, GSTextureCa
 
 void GSRendererHW::EmulateAA1()
 {
-	const GSDevice::FeatureSupport& features = g_gs_device->Features();
-
 	pxAssert(!features.aa1 || features.feedback_loops());
 
 	if (IsCoverageAlphaSupported())

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -3577,8 +3577,6 @@ bool GSTextureCache::PreloadTarget(GIFRegTEX0 TEX0, const GSVector2i& size, cons
 				const int page_diff = std::abs(static_cast<int>(old_dst->m_TEX0.TBP0 - dst->m_TEX0.TBP0)) >> 5;
 				const u32 new_buffer_width = std::max(1U, dst->m_TEX0.TBW);
 				const u32 old_buffer_width = std::max(1U, old_dst->m_TEX0.TBW);
-				const u32 new_pages_wide = new_buffer_width * 64 / psm_s.pgs.x;
-				const u32 old_pages_wide = old_buffer_width * 64 / psm_s.pgs.x; // Same PSM for old at this point.
 
 				// Handle cases where the buffer widths don't match.
 				if (new_buffer_width != old_buffer_width)
@@ -3593,6 +3591,7 @@ bool GSTextureCache::PreloadTarget(GIFRegTEX0 TEX0, const GSVector2i& size, cons
 					if (dst->m_TEX0.TBP0 > old_dst->m_TEX0.TBP0 && dst_end_block >= old_dst->UnwrappedEndBlock())
 					{
 						const int block_diff = dst->m_TEX0.TBP0 - old_dst->m_TEX0.TBP0;
+						const u32 old_pages_wide = old_buffer_width * 64 / psm_s.pgs.x;
 						if ((block_diff % (32 * old_pages_wide)) == 0) // Check for left alignment.
 						{
 							const int new_height = block_diff / (32 * old_pages_wide) * psm_s.pgs.y;

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -289,6 +289,7 @@ private:
 	void SetIndexBuffer(std::unique_ptr<GLStreamBuffer>& buffer, const void* index, size_t count);
 
 protected:
+	using GSDevice::DoStretchRect; // Suppress overloaded virtual function warning
 	virtual void DoStretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect,
 		ShaderConvertSelector shader, Filter filter) override;
 public:

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -491,6 +491,7 @@ private:
 	void DestroyResources();
 
 protected:
+	using GSDevice::DoStretchRect; // Suppress overloaded virtual function warning
 	virtual void DoStretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect,
 		ShaderConvertSelector shader, Filter filter) override;
 	virtual void DoStretchRect(GSTexture* sTex, const GSVector4& sRect, const GSVector4& dRect,


### PR DESCRIPTION
### Description of Changes
Fix a number of compiler warnings:
- Missing default case in switch statement.
- Signed/unsigned implict conversion.
- Unused variables.
- Hidden virtual overloaded function.

### Rationale behind Changes
Silence compiler warnings.

### Suggested Testing Steps
Check the build log to make sure the warnings are no longer there.

### Did you use AI to help find, test, or implement this issue or feature?
Yes, to ask questions about C++ compiler warnings.