### PR TITLE
Misc: Correct Hz symbol case

### DIFF
--- a/pcsx2-qt/QtUtils.h
+++ b/pcsx2-qt/QtUtils.h
@@ -180,7 +180,7 @@ namespace QtUtils
 		}
 
 		wi.surface_refresh_rate = surface_refresh_rate.value();
-		INFO_LOG("Surface refresh rate: {} hz", wi.surface_refresh_rate);
+		INFO_LOG("Surface refresh rate: {} Hz", wi.surface_refresh_rate);
 
 		return wi;
 	}

--- a/pcsx2/Common.h
+++ b/pcsx2/Common.h
@@ -6,8 +6,8 @@
 #include "common/Pcsx2Defs.h"
 
 static const u32 BIAS = 2;				// Bus is half of the actual ps2 speed
-static const u32 PS2CLK = 294912000;	//hz	/* 294.912 mhz */
-extern u32 PSXCLK;	/* 36.864 Mhz */
+static const u32 PS2CLK = 294912000;	//Hz	/* 294.912 MHz */
+extern u32 PSXCLK;	/* 36.864 MHz */
 
 
 #include "Memory.h"

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -292,7 +292,7 @@ bool GSDevice::GetRequestedExclusiveFullscreenMode(u32* width, u32* height, floa
 
 std::string GSDevice::GetFullscreenModeString(u32 width, u32 height, float refresh_rate)
 {
-	return StringUtil::StdStringFromFormat("%u x %u @ %f hz", width, height, refresh_rate);
+	return StringUtil::StdStringFromFormat("%u x %u @ %f Hz", width, height, refresh_rate);
 }
 
 void GSDevice::GenerateExpansionIndexBuffer(void* buffer)

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -966,7 +966,7 @@ public:
 	/// Returns a string representing the specified API.
 	static const char* RenderAPIToString(RenderAPI api);
 
-	/// Parses the configured fullscreen mode into its components (width * height @ refresh hz)
+	/// Parses the configured fullscreen mode into its components (width * height @ refresh Hz)
 	static bool GetRequestedExclusiveFullscreenMode(u32* width, u32* height, float* refresh_rate);
 
 	/// Converts a fullscreen mode to a string.

--- a/pcsx2/USB/USB.cpp
+++ b/pcsx2/USB/USB.cpp
@@ -20,7 +20,7 @@
 #include <stdexcept>
 #include <string>
 
-#define PSXCLK 36864000 /* 36.864 Mhz */
+#define PSXCLK 36864000 /* 36.864 MHz */
 
 namespace USB
 {


### PR DESCRIPTION
### Description of Changes
Correct Hz symbol case in Fullscreen Mode resolution list, log and code comments.

### Rationale behind Changes
Correct SI symbol.

### Suggested Testing Steps
Changes should only be cosmetic. Tested on Windows.
Check if Fullscreen Mode resolutions are listed correctly.
Check if surface refresh rate is logged correctly.

### Did you use AI to help find, test, or implement this issue or feature?
No.