### PR TITLE
CI: Add a debug build to the Linux build matrix

### DIFF
--- a/.github/workflows/linux_build_matrix.yml
+++ b/.github/workflows/linux_build_matrix.yml
@@ -20,6 +20,18 @@ jobs:
       cmakeflags: ""
       buildAppImage: true
     secrets: inherit
+  build_linux_debug:
+    name: "Debug"
+    if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
+    uses: ./.github/workflows/linux_build_qt.yml
+    with:
+      jobName: "Debug Build"
+      artifactPrefixName: "PCSX2-linux-Qt-x64-debug"
+      compiler: clang
+      cmakeflags: ""
+      buildAppImage: true
+      cmakeBuildType: Debug
+    secrets: inherit
   build_linux_flatpak:
     name: "Flatpak"
     if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'

--- a/.github/workflows/linux_build_qt.yml
+++ b/.github/workflows/linux_build_qt.yml
@@ -39,6 +39,10 @@ on:
         required: false
         type: boolean
         default: false
+      cmakeBuildType:
+        required: false
+        type: string
+        default: Release
 
 jobs:
   build_linux:
@@ -129,7 +133,7 @@ jobs:
           ADDITIONAL_CMAKE_ARGS: ${{ inputs.cmakeflags }}
         run: |
           cmake -B build -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_BUILD_TYPE="${{ inputs.cmakeBuildType }}" \
             -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
             -DCMAKE_PREFIX_PATH="$HOME/deps" \
             -DCMAKE_C_COMPILER=clang-17 \


### PR DESCRIPTION
### Description of Changes
Add a debug build to the Linux build matrix for the CI.

### Rationale behind Changes
It's very easy to forget to update an assertion when refactoring code. Since pxAssert invocations are compiled out in release builds, the CI previously wouldn't catch this.

This would've prevented the following instances of broken changes being merged to master:
- https://github.com/PCSX2/pcsx2/commit/fbaba52bc219fd7e97897e014ebed13e138b5022
- https://github.com/PCSX2/pcsx2/pull/12994

### Suggested Testing Steps
Have a look at the generated artifact, and the CI logs.

### Did you use AI to help find, test, or implement this issue or feature?
No.