### PR TITLE
PINE: Don't test for a valid VM when checking emulator version

### DIFF
--- a/pcsx2/PINE.cpp
+++ b/pcsx2/PINE.cpp
@@ -629,8 +629,6 @@ PINEServer::IPCBuffer PINEServer::ParseCommand(std::span<u8> buf, std::vector<u8
 			}
 			case MsgVersion:
 			{
-				if (!VMManager::HasValidVM())
-					goto error;
 				u32 size = strlen(BuildVersion::GitRev) + 7;
 				if (!SafetyChecks(buf_cnt, 0, ret_cnt, size + 4, buf_size)) [[unlikely]]
 					goto error;


### PR DESCRIPTION
### Description of Changes
Remove a check preventing PINE clients from querying the emulator verison if no game is running.

### Rationale behind Changes
Closes #14521.

This sounds like a reasonable request to me.

### Suggested Testing Steps
Test some PINE clients.

### Did you use AI to help find, test, or implement this issue or feature?
No.