### PR TITLE
GS/HW: Add toggle for Shade Boost during FMVs

### DIFF
--- a/pcsx2-qt/Settings/GraphicsPostProcessingSettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsPostProcessingSettingsTab.ui
@@ -109,6 +109,13 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="shadeBoostFMVs">
+        <property name="text">
+         <string>Shade Boost FMVs</string>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="1">
        <layout class="QGridLayout" name="gridLayout" columnstretch="0,1,0,1">
         <item row="0" column="0">

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -209,6 +209,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 	//////////////////////////////////////////////////////////////////////////
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_post.fxaa, "EmuCore/GS", "fxaa", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_post.shadeBoost, "EmuCore/GS", "ShadeBoost", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_post.shadeBoostFMVs, "EmuCore/GS", "ShadeBoostFMVs", true);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_post.shadeBoostBrightness, "EmuCore/GS", "ShadeBoost_Brightness", Pcsx2Config::GSOptions::DEFAULT_SHADEBOOST_BRIGHTNESS);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_post.shadeBoostContrast, "EmuCore/GS", "ShadeBoost_Contrast", Pcsx2Config::GSOptions::DEFAULT_SHADEBOOST_CONTRAST);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_post.shadeBoostGamma, "EmuCore/GS", "ShadeBoost_Gamma", Pcsx2Config::GSOptions::DEFAULT_SHADEBOOST_GAMMA);
@@ -685,6 +686,9 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 			tr("Enables saturation, contrast, and brightness to be adjusted. Values of brightness, saturation, and contrast are at default "
 			   "50."));
 
+		dialog()->registerWidgetHelp(m_post.shadeBoostFMVs, tr("Shade Boost for FMVs"), tr("Checked"),
+			tr("Applies saturation, contrast, and brightness adjustments to FMVs"));
+
 		dialog()->registerWidgetHelp(
 			m_post.fxaa, tr("FXAA"), tr("Unchecked"), tr("Applies the FXAA anti-aliasing algorithm to improve the visual quality of games."));
 
@@ -859,6 +863,7 @@ void GraphicsSettingsWidget::onShadeBoostChanged()
 	m_post.shadeBoostContrast->setEnabled(enabled);
 	m_post.shadeBoostGamma->setEnabled(enabled);
 	m_post.shadeBoostSaturation->setEnabled(enabled);
+	m_post.shadeBoostFMVs->setEnabled(enabled);
 }
 
 void GraphicsSettingsWidget::onTextureDumpChanged()

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -809,6 +809,7 @@ struct Pcsx2Config
 					UserHacks_DrawBuffering : 1,
 					FXAA : 1,
 					ShadeBoost : 1,
+					ShadeBoostFMVs : 1,
 					DumpGSData : 1,
 					SaveRT : 1,
 					SaveFrame : 1,

--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -431,6 +431,11 @@ extern bool EnableFMV;
 
 static bool s_last_fmv_state = false;
 
+bool IsFMVPlaying()
+{
+    return s_last_fmv_state;
+}
+
 static __fi void DoFMVSwitch()
 {
 	bool new_fmv_state = s_last_fmv_state;

--- a/pcsx2/Counters.h
+++ b/pcsx2/Counters.h
@@ -127,6 +127,8 @@ extern bool rcntCanCount(int i);
 extern void rcntSyncCounter(int i);
 extern void rcntUpdate();
 
+extern bool IsFMVPlaying();
+
 extern void rcntInit();
 extern u32	rcntRcount(int index);
 template< uint page > extern bool rcntWrite32( u32 mem, mem32_t& value );

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -14,6 +14,7 @@
 #include "PerformanceMetrics.h"
 #include "pcsx2/Config.h"
 #include "VMManager.h"
+#include "Counters.h"
 
 #include "common/FileSystem.h"
 #include "common/Image.h"
@@ -245,7 +246,7 @@ bool GSRenderer::Merge(int field)
 		g_gs_device->Interlace(fs, field ^ field2, mode, offset);
 	}
 
-	if (GSConfig.ShadeBoost)
+	if (GSConfig.ShadeBoost && (!IsFMVPlaying() || GSConfig.ShadeBoostFMVs))
 		g_gs_device->ShadeBoost();
 
 	if (GSConfig.FXAA)

--- a/pcsx2/ImGui/FullscreenUI_Settings.cpp
+++ b/pcsx2/ImGui/FullscreenUI_Settings.cpp
@@ -3251,6 +3251,8 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 
 		DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_GEM, "Shade Boost"), FSUI_CSTR("Enables brightness/contrast/gamma/saturation adjustment."), "EmuCore/GS",
 			"ShadeBoost", false);
+		DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_GEM, "Shade Boost for FMVs"), FSUI_CSTR("Applies brightness/contrast/gamma/saturation adjustment to FMVs."), "EmuCore/GS",
+			"ShadeBoostFMVs", shadeboost_active);
 		DrawIntRangeSetting(bsi, FSUI_ICONSTR(ICON_FA_SUN, "Shade Boost Brightness"), FSUI_CSTR("Adjusts brightness. 50 is normal."), "EmuCore/GS",
 			"ShadeBoost_Brightness", 50, 1, 100, "%d", shadeboost_active);
 		DrawIntRangeSetting(bsi, FSUI_ICONSTR(ICON_FA_LIGHTBULB, "Shade Boost Contrast"), FSUI_CSTR("Adjusts contrast. 50 is normal."), "EmuCore/GS",

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1002,6 +1002,7 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitBoolEx(UserHacks_DrawBuffering, "UserHacks_DrawBuffering");
 	SettingsWrapBitBoolEx(FXAA, "fxaa");
 	SettingsWrapBitBool(ShadeBoost);
+	SettingsWrapBitBool(ShadeBoostFMVs);
 	SettingsWrapBitBoolEx(DumpGSData, "DumpGSData");
 	SettingsWrapBitBoolEx(SaveRT, "SaveRT");
 	SettingsWrapBitBoolEx(SaveFrame, "SaveFrame");


### PR DESCRIPTION
### Description of Changes
Adds a toggle to enable/disable Shade Boost specifically for FMVs as per #14501 

I did this by adding a function to check whether an FMV is playing, based on the logic already in counters.cpp. I must admit I'm not convinced this file is the best place for this function, but this file is where the logic already lies.

I am absolutely unfamiliar with the UI setup of PCSX2 and most of this was done by looking at the Shade Boost UI code - very happy to make any requested changes. I'm also not sure whether I need to do anything for localisation in particular.

<img width="903" height="841" alt="image" src="https://github.com/user-attachments/assets/d44c7839-724a-4994-a3e3-6c114d9e0173" />

The PR requests all Post Processing be toggle-able, but that doesn't make much sense to me - IMO you'd want to keep things like TV Shaders consistently on or off.

### Rationale behind Changes
As per the Issue: ```The PS2's output tends to be really dark, and some games are just dark themselves, even without a CRT. The brightness and saturation boost provided by the post-processing tab is usually a good fix, but the FMVs are usually not dark, resulting in them being too bright.```

### Suggested Testing Steps
Boot into a game which uses FMVs, set your Shade Boost to something obvious, and toggle see the results.

### Did you use AI to help find, test, or implement this issue or feature?
No.