### PR TITLE
CMake: Fix typo in BuildParameters.cmake

### DIFF
--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -300,8 +300,8 @@ else()
 	if(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
 		message(WARNING
 			"The CMAKE_INTERPROCEDURAL_OPTIMIZATION option is enabled but the "
-			"CMAKE_POSITION_INDEPENDENT_CODE option is disabled. This has been "
-			"found to result in broken builds on certain platforms.")
+			"POSITION_INDEPENDENT_CODE option is disabled. This has been found "
+			"to result in broken builds on certain platforms.")
 	endif()
 
 	set(CMAKE_POSITION_INDEPENDENT_CODE OFF)


### PR DESCRIPTION
### Description of Changes
Fix a typo.

### Rationale behind Changes
Prevent confusion.

### Suggested Testing Steps
Stare at the modified lines really hard.

### Did you use AI to help find, test, or implement this issue or feature?
No.