### PR TITLE
Simplify EE/IOP cycle sync

### DIFF
--- a/pcsx2/HwRead.cpp
+++ b/pcsx2/HwRead.cpp
@@ -69,7 +69,7 @@ mem32_t _hwRead32(u32 mem)
 			if (mem == INTC_STAT)
 			{
 				// Disable INTC hack when in PS1 mode as it seems to break games.
-				if (intcstathack && !(psxHu32(HW_ICFG) & (1 << 3))) IntCHackCheck();
+				if (intcstathack && !psxPs1Mode()) IntCHackCheck();
 				return psHu32(INTC_STAT);
 			}
 

--- a/pcsx2/IopHw.h
+++ b/pcsx2/IopHw.h
@@ -325,3 +325,8 @@ extern void psxHw4Write8(u32 add, u8  value);
 
 extern void psxDmaInterrupt(int n);
 extern void psxDmaInterrupt2(int n);
+
+static inline int psxPs1Mode() {
+	return !!(psxHu32(HW_ICFG) & (1 << 3));
+}
+

--- a/pcsx2/R3000A.cpp
+++ b/pcsx2/R3000A.cpp
@@ -134,8 +134,7 @@ __fi void PSX_INT( IopEventId n, s32 ecycle )
 	psxRegs.eCycle[n] = ecycle;
 
 	psxSetNextBranchDelta(ecycle);
-	const float mutiplier = static_cast<float>(PS2CLK) / static_cast<float>(PSXCLK);
-	const s32 iopDelta = (psxRegs.iopNextEventCycle - psxRegs.cycle) * mutiplier;
+	const s32 iopDelta = IOPToEECycles(psxRegs.iopNextEventCycle - psxRegs.cycle);
 
 	if (psxRegs.inIop == false)
 	{

--- a/pcsx2/R3000A.cpp
+++ b/pcsx2/R3000A.cpp
@@ -139,7 +139,7 @@ __fi void PSX_INT( IopEventId n, s32 ecycle )
 	const float mutiplier = static_cast<float>(PS2CLK) / static_cast<float>(PSXCLK);
 	const s32 iopDelta = (psxRegs.iopNextEventCycle - psxRegs.cycle) * mutiplier;
 
-	if (psxRegs.iopCycleEE < iopDelta)
+	if (psxRegs.inIop == false)
 	{
 		// The EE called this int, so inform it to branch as needed:
 		

--- a/pcsx2/R3000A.cpp
+++ b/pcsx2/R3000A.cpp
@@ -42,9 +42,7 @@ void psxReset()
 	psxRegs.CP0.n.Status = 0x00400000; // BEV = 1
 	psxRegs.CP0.n.PRid   = 0x0000001f; // PRevID = Revision ID, same as the IOP R3000A
 
-	psxRegs.iopBreak = 0;
-	psxRegs.iopCycleEE = -1;
-	psxRegs.iopCycleEECarry = 0;
+	psxRegs.iopDeadline = 0;
 	psxRegs.iopNextEventCycle = psxRegs.cycle + 4;
 
 	psxHwReset();
@@ -142,8 +140,11 @@ __fi void PSX_INT( IopEventId n, s32 ecycle )
 	if (psxRegs.inIop == false)
 	{
 		// The EE called this int, so inform it to branch as needed:
-		
-		cpuSetNextEventDelta(iopDelta - psxRegs.iopCycleEE);
+
+		// TODO: check that this works, not sure what the intention was with
+		// subtracting iopCycleEE
+		//cpuSetNextEventDelta(iopDelta - psxRegs.iopCycleEE);
+		cpuSetNextEventDelta(iopDelta);
 	}
 }
 

--- a/pcsx2/R3000A.h
+++ b/pcsx2/R3000A.h
@@ -107,7 +107,7 @@ struct psxRegisters {
 	u64 sCycle[32];		// start cycle for signaled ints
 	s32 eCycle[32];		// cycle delta for signaled ints (sCycle + eCycle == branch cycle)
 
-	bool inIop; // True if the IOP is currently running
+	char inIop; // True if the IOP is currently running
 				// Used to know if PSX_INT was called from the EE...
 
 };

--- a/pcsx2/R3000A.h
+++ b/pcsx2/R3000A.h
@@ -114,8 +114,10 @@ struct psxRegisters {
 
 	u64 sCycle[32];		// start cycle for signaled ints
 	s32 eCycle[32];		// cycle delta for signaled ints (sCycle + eCycle == branch cycle)
-	//u32 _msflag[32];
-	//u32 _smflag[32];
+
+	bool inIop; // True if the IOP is currently running
+				// Used to know if PSX_INT was called from the EE...
+
 };
 
 alignas(16) extern psxRegisters psxRegs;

--- a/pcsx2/R3000A.h
+++ b/pcsx2/R3000A.h
@@ -101,16 +101,8 @@ struct psxRegisters {
 	// Controls when branch tests are performed.
 	u64 iopNextEventCycle;
 
-	// This value is used when the IOP execution is broken to return control to the EE.
-	// (which happens when the IOP throws EE-bound interrupts).  It holds the value of
-	// iopCycleEE (which is set to zero to facilitate the code break), so that the unrun
-	// cycles can be accounted for later.
-	s32 iopBreak;
-
-	// Tracks current number of cycles IOP can run in EE cycles. When it dips below zero,
-	// control is returned to the EE.
-	s32 iopCycleEE;
-	u32 iopCycleEECarry;
+	// The cycle target at which the IOP should yield control back to the EE
+	u64 iopDeadline;
 
 	u64 sCycle[32];		// start cycle for signaled ints
 	s32 eCycle[32];		// cycle delta for signaled ints (sCycle + eCycle == branch cycle)
@@ -183,7 +175,7 @@ extern bool iopIsDelaySlot;
 struct R3000Acpu {
 	void (*Reserve)();
 	void (*Reset)();
-	s32 (*ExecuteBlock)( s32 eeCycles );		// executes the given number of EE cycles.
+	s32 (*ExecuteBlock)(u64 deadline);
 	void (*Clear)(u32 Addr, u32 Size);
 	void (*Shutdown)();
 };

--- a/pcsx2/R3000AInterpreter.cpp
+++ b/pcsx2/R3000AInterpreter.cpp
@@ -278,7 +278,7 @@ static s32 intExecuteBlock( u64 deadline )
 
 	while (psxRegs.cycle < psxRegs.iopDeadline)
 	{
-		if ((psxHu32(HW_ICFG) & 8) && ((psxRegs.pc & 0x1fffffffU) == 0xa0 || (psxRegs.pc & 0x1fffffffU) == 0xb0 || (psxRegs.pc & 0x1fffffffU) == 0xc0))
+		if (psxPs1Mode() && ((psxRegs.pc & 0x1fffffffU) == 0xa0 || (psxRegs.pc & 0x1fffffffU) == 0xb0 || (psxRegs.pc & 0x1fffffffU) == 0xc0))
 			psxBiosCall();
 
 		branch2 = 0;

--- a/pcsx2/R3000AInterpreter.cpp
+++ b/pcsx2/R3000AInterpreter.cpp
@@ -271,45 +271,24 @@ static void intReset() {
 	intAlloc();
 }
 
-static s32 intExecuteBlock( s32 eeCycles )
+static s32 intExecuteBlock( u64 deadline )
 {
-	psxRegs.iopBreak = 0;
-	psxRegs.iopCycleEE = eeCycles;
-	u64 lastIOPCycle = 0;
+	psxRegs.iopDeadline = deadline;
 	psxRegs.inIop = true;
 
-	while (psxRegs.iopCycleEE > 0)
+	while (psxRegs.cycle < psxRegs.iopDeadline)
 	{
-		lastIOPCycle = psxRegs.cycle;
 		if ((psxHu32(HW_ICFG) & 8) && ((psxRegs.pc & 0x1fffffffU) == 0xa0 || (psxRegs.pc & 0x1fffffffU) == 0xb0 || (psxRegs.pc & 0x1fffffffU) == 0xc0))
 			psxBiosCall();
 
 		branch2 = 0;
 		while (!branch2)
 			execI();
-
-		
-		if ((psxHu32(HW_ICFG) & (1 << 3)))
-		{
-			// F = gcd(PS2CLK, PSXCLK) = 230400
-			const u32 cnum = 1280; // PS2CLK / F
-			const u32 cdenom = 147; // PSXCLK / F
-
-			//One of the Iop to EE delta clocks to be set in PS1 mode.
-			const u32 t = ((cnum * (psxRegs.cycle - lastIOPCycle)) + psxRegs.iopCycleEECarry);
-			psxRegs.iopCycleEE -= t / cdenom;
-			psxRegs.iopCycleEECarry = t % cdenom;
-		}
-		else
-		{ 
-			//default ps2 mode value
-			psxRegs.iopCycleEE -= (psxRegs.cycle - lastIOPCycle) * 8;
-		}
 	}
 
 	psxRegs.inIop = false;
 
-	return psxRegs.iopBreak + psxRegs.iopCycleEE;
+	return 0;
 }
 
 static void intClear(u32 Addr, u32 Size) {

--- a/pcsx2/R3000AInterpreter.cpp
+++ b/pcsx2/R3000AInterpreter.cpp
@@ -276,6 +276,7 @@ static s32 intExecuteBlock( s32 eeCycles )
 	psxRegs.iopBreak = 0;
 	psxRegs.iopCycleEE = eeCycles;
 	u64 lastIOPCycle = 0;
+	psxRegs.inIop = true;
 
 	while (psxRegs.iopCycleEE > 0)
 	{
@@ -305,6 +306,8 @@ static s32 intExecuteBlock( s32 eeCycles )
 			psxRegs.iopCycleEE -= (psxRegs.cycle - lastIOPCycle) * 8;
 		}
 	}
+
+	psxRegs.inIop = false;
 
 	return psxRegs.iopBreak + psxRegs.iopCycleEE;
 }

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -31,9 +31,6 @@
 
 using namespace R5900;	// for R5900 disasm tools
 
-s32 EEsCycle;		// used to sync the IOP to the EE
-u64 EEoCycle;
-
 alignas(16) cpuRegistersPack _cpuRegistersPack;
 alignas(16) tlbs tlb[48];
 cachedTlbs_t cachedTlbs;
@@ -71,8 +68,6 @@ void cpuReset()
 	fpuRegs.fprc[31]		= 0x01000001; // fpu Status/Control
 
 	cpuRegs.nextEventCycle = cpuRegs.cycle + 4;
-	EEsCycle = 0;
-	EEoCycle = cpuRegs.cycle;
 
 	psxReset();
 	pgifInit();
@@ -382,18 +377,16 @@ __fi void _cpuEventTest_Shared()
 	//   cpuEventTest, the IOP generally starts to run way ahead of the EE.
 
 	// It's also important to sync up the IOP before updating the timers, since gates will depend on starting/stopping in the right place!
-	EEsCycle += cpuRegs.cycle - EEoCycle;
-	EEoCycle = cpuRegs.cycle;
 
-	if (EEsCycle > 0)
+	const float multiplier = static_cast<float>(PS2CLK) / static_cast<float>(PSXCLK);
+	s64 iop_delta = cpuRegs.cycle - (psxRegs.cycle * multiplier);
+
+	if (iop_delta > 0)
 		iopEventAction = true;
 
 	if (iopEventAction)
 	{
-		//if( EEsCycle < -450 )
-		//	Console.WriteLn( " IOP ahead by: %d cycles", -EEsCycle );
-
-		EEsCycle = psxCpu->ExecuteBlock(EEsCycle);
+		psxCpu->ExecuteBlock(cpuRegs.cycle / multiplier);
 
 		iopEventAction = false;
 	}
@@ -434,21 +427,19 @@ __fi void _cpuEventTest_Shared()
 	CpuVU1->ExecuteBlock();
 
 	// ---- Schedule Next Event Test --------------
-	const float mutiplier = static_cast<float>(PS2CLK) / static_cast<float>(PSXCLK);
-	const int nextIopEventDeta = ((psxRegs.iopNextEventCycle - psxRegs.cycle) * mutiplier);
+	const s64 nextIopEventDeta = ((psxRegs.iopNextEventCycle - psxRegs.cycle) * multiplier);
 	// 8 or more cycles behind and there's an event scheduled
-	if (EEsCycle >= nextIopEventDeta)
+	if (iop_delta >= nextIopEventDeta)
 	{
 		// EE's running way ahead of the IOP still, so we should branch quickly to give the
 		// IOP extra timeslices in short order.
 
 		cpuSetNextEventDelta(48);
-		//Console.Warning( "EE ahead of the IOP -- Rapid Event!  %d", EEsCycle );
 	}
 	else
 	{
 		// Otherwise IOP is caught up/not doing anything so we can wait for the next event.
-		cpuSetNextEventDelta(((psxRegs.iopNextEventCycle - psxRegs.cycle) * mutiplier) - EEsCycle);
+		cpuSetNextEventDelta(((psxRegs.iopNextEventCycle - psxRegs.cycle) * multiplier));
 	}
 
 	// Apply vsync and other counter nextCycles
@@ -468,10 +459,9 @@ __ri void cpuTestINTCInts()
 		return;
 
 	cpuSetNextEventDelta(4);
-	if (eeEventTestIsActive && (psxRegs.iopCycleEE > 0))
+	if (eeEventTestIsActive && psxRegs.inIop)
 	{
-		psxRegs.iopBreak += psxRegs.iopCycleEE; // record the number of cycles the IOP didn't run.
-		psxRegs.iopCycleEE = 0;
+		psxRegs.iopDeadline = 0;
 	}
 }
 
@@ -487,10 +477,9 @@ __fi void cpuTestDMACInts()
 		return;
 
 	cpuSetNextEventDelta(4);
-	if (eeEventTestIsActive && (psxRegs.iopCycleEE > 0))
+	if (eeEventTestIsActive && psxRegs.inIop)
 	{
-		psxRegs.iopBreak += psxRegs.iopCycleEE; // record the number of cycles the IOP didn't run.
-		psxRegs.iopCycleEE = 0;
+		psxRegs.iopDeadline = 0;
 	}
 }
 
@@ -543,13 +532,12 @@ __fi void CPU_INT( EE_EventType n, s32 ecycle)
 
 	// Interrupt is happening soon: make sure both EE and IOP are aware.
 
-	if (ecycle <= 28 && psxRegs.iopCycleEE > 0)
+	if (ecycle <= 28 && psxRegs.inIop)
 	{
 		// If running in the IOP, force it to break immediately into the EE.
 		// the EE's branch test is due to run.
 
-		psxRegs.iopBreak += psxRegs.iopCycleEE; // record the number of cycles the IOP didn't run.
-		psxRegs.iopCycleEE = 0;
+		psxRegs.iopDeadline = 0;
 	}
 
 	cpuSetNextEventDelta(cpuRegs.eCycle[n]);

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -4,6 +4,7 @@
 #include "Common.h"
 
 #include "common/StringUtil.h"
+#include "IopHw.h"
 #include "ps2/BiosTools.h"
 #include "R5900.h"
 #include "R3000A.h"
@@ -28,6 +29,8 @@
 #include "R5900OpcodeTables.h"
 
 #include "fmt/format.h"
+
+#include <numeric>
 
 using namespace R5900;	// for R5900 disasm tools
 
@@ -351,6 +354,42 @@ static bool cpuIntsEnabled(int Interrupt)
 		!cpuRegs.CP0.n.Status.b.EXL && (cpuRegs.CP0.n.Status.b.ERL == 0);
 }
 
+u64 EEToIOPCycles(u64 cycles)
+{
+	if (psxPs1Mode() == 0) [[likely]]
+	{
+		return cycles >> 3;
+	}
+	else
+	{
+		// EE  clock = 294912000
+		// PS1 clock = 33868800
+		static constexpr int gcd = std::gcd(294912000, 33868800);
+		static constexpr int den = 294912000 / gcd;
+		static constexpr int num = 33868800 / gcd;
+
+		return cycles * num / den;
+	}
+}
+
+u64 IOPToEECycles(u64 cycles)
+{
+	if (psxPs1Mode() == 0) [[likely]]
+	{
+		return cycles << 3;
+	}
+	else
+	{
+		// EE  clock = 294912000
+		// PS1 clock = 33868800
+		static constexpr int gcd = std::gcd(294912000, 33868800);
+		static constexpr int num = 294912000 / gcd;
+		static constexpr int den = 33868800 / gcd;
+
+		return cycles * num / den;
+	}
+}
+
 // Shared portion of the branch test, called from both the Interpreter
 // and the recompiler.  (moved here to help alleviate redundant code)
 __fi void _cpuEventTest_Shared()
@@ -378,15 +417,14 @@ __fi void _cpuEventTest_Shared()
 
 	// It's also important to sync up the IOP before updating the timers, since gates will depend on starting/stopping in the right place!
 
-	const float multiplier = static_cast<float>(PS2CLK) / static_cast<float>(PSXCLK);
-	s64 iop_delta = cpuRegs.cycle - (psxRegs.cycle * multiplier);
+	s64 iop_delta = cpuRegs.cycle - IOPToEECycles(psxRegs.cycle);
 
 	if (iop_delta > 0)
 		iopEventAction = true;
 
 	if (iopEventAction)
 	{
-		psxCpu->ExecuteBlock(cpuRegs.cycle / multiplier);
+		psxCpu->ExecuteBlock(EEToIOPCycles(cpuRegs.cycle));
 
 		iopEventAction = false;
 	}
@@ -427,9 +465,9 @@ __fi void _cpuEventTest_Shared()
 	CpuVU1->ExecuteBlock();
 
 	// ---- Schedule Next Event Test --------------
-	const s64 nextIopEventDeta = ((psxRegs.iopNextEventCycle - psxRegs.cycle) * multiplier);
+	const s64 nextIopEventDelta = IOPToEECycles(psxRegs.iopNextEventCycle - psxRegs.cycle);
 	// 8 or more cycles behind and there's an event scheduled
-	if (iop_delta >= nextIopEventDeta)
+	if (iop_delta >= nextIopEventDelta)
 	{
 		// EE's running way ahead of the IOP still, so we should branch quickly to give the
 		// IOP extra timeslices in short order.
@@ -439,7 +477,7 @@ __fi void _cpuEventTest_Shared()
 	else
 	{
 		// Otherwise IOP is caught up/not doing anything so we can wait for the next event.
-		cpuSetNextEventDelta(((psxRegs.iopNextEventCycle - psxRegs.cycle) * multiplier));
+		cpuSetNextEventDelta(nextIopEventDelta);
 	}
 
 	// Apply vsync and other counter nextCycles

--- a/pcsx2/R5900.h
+++ b/pcsx2/R5900.h
@@ -14,9 +14,6 @@ namespace R5900 {
 extern const char* const bios[256];
 }
 
-extern s32 EEsCycle;
-extern u64 EEoCycle;
-
 union GPR_reg {   // Declare union type GPR register
 	u128 UQ;
 	s128 SQ;

--- a/pcsx2/R5900.h
+++ b/pcsx2/R5900.h
@@ -402,6 +402,8 @@ extern void cpuClearInt(uint n);
 extern void GoemonPreloadTlb();
 extern void GoemonUnloadTlb(u32 key);
 
+extern u64 EEToIOPCycles(u64 cycles);
+extern u64 IOPToEECycles(u64 cycles);
 extern void cpuSetNextEvent( u64 startCycle, s32 delta );
 extern void cpuSetNextEventDelta( s32 delta );
 extern int  cpuTestCycle( u64 startCycle, s32 delta );

--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -197,8 +197,6 @@ bool SaveStateBase::FreezeInternals(Error* error)
 	if (!FreezeTag("Cycles"))
 		return false;
 
-	Freeze(EEsCycle);
-	Freeze(EEoCycle);
 	Freeze(nextDeltaCounter);
 	Freeze(nextStartCounter);
 	Freeze(psxNextStartCounter);

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -26,7 +26,7 @@ enum class FreezeAction
 // [SAVEVERSION+]
 // This informs the auto updater that the users savestates will be invalidated.
 
-static const u32 g_SaveVersion = (0x9A5A << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A5B << 16) | 0x0000;
 
 
 // the freezing data between submodules and core

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -26,7 +26,7 @@ enum class FreezeAction
 // [SAVEVERSION+]
 // This informs the auto updater that the users savestates will be invalidated.
 
-static const u32 g_SaveVersion = (0x9A59 << 16) | 0x0000;
+static const u32 g_SaveVersion = (0x9A5A << 16) | 0x0000;
 
 
 // the freezing data between submodules and core

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -1010,6 +1010,7 @@ static __noinline s32 recExecuteBlock(s32 eeCycles)
 {
 	psxRegs.iopBreak = 0;
 	psxRegs.iopCycleEE = eeCycles;
+	psxRegs.inIop = true;
 
 #ifdef PCSX2_DEVBUILD
 	//if (SysTrace.SIF.IsActive())
@@ -1035,6 +1036,7 @@ static __noinline s32 recExecuteBlock(s32 eeCycles)
 	((void (*)())iopEnterRecompiledCode)();
 
 	return psxRegs.iopBreak + psxRegs.iopCycleEE;
+	psxRegs.inIop = false;
 }
 
 // Returns the offset to the next instruction after any cleared memory

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -1006,10 +1006,9 @@ static void iopClearRecLUT(BASEBLOCK* base, int count)
 		base[i].SetFnptr((uptr)iopJITCompile);
 }
 
-static __noinline s32 recExecuteBlock(s32 eeCycles)
+static __noinline s32 recExecuteBlock(u64 deadline)
 {
-	psxRegs.iopBreak = 0;
-	psxRegs.iopCycleEE = eeCycles;
+	psxRegs.iopDeadline = deadline;
 	psxRegs.inIop = true;
 
 #ifdef PCSX2_DEVBUILD
@@ -1035,8 +1034,8 @@ static __noinline s32 recExecuteBlock(s32 eeCycles)
 
 	((void (*)())iopEnterRecompiledCode)();
 
-	return psxRegs.iopBreak + psxRegs.iopCycleEE;
 	psxRegs.inIop = false;
+	return 0;
 }
 
 // Returns the offset to the next instruction after any cleared memory
@@ -1144,51 +1143,26 @@ static __fi u32 psxScaleBlockCycles()
 	return s_psxBlockCycles;
 }
 
-static void iPsxAddEECycles(u32 blockCycles)
-{
-	if (!(psxHu32(HW_ICFG) & (1 << 3))) [[likely]]
-	{
-		if (blockCycles != 0xFFFFFFFF)
-			xSUB(ptr32[&psxRegs.iopCycleEE], blockCycles * 8);
-		else
-			xSUB(ptr32[&psxRegs.iopCycleEE], eax);
-		return;
-	}
-
-	// F = gcd(PS2CLK, PSXCLK) = 230400
-	const u32 cnum = 1280; // PS2CLK / F
-	const u32 cdenom = 147; // PSXCLK / F
-
-	if (blockCycles != 0xFFFFFFFF)
-		xMOV(eax, blockCycles * cnum);
-	xADD(eax, ptr32[&psxRegs.iopCycleEECarry]);
-	xMOV(ecx, cdenom);
-	xXOR(edx, edx);
-	xUDIV(ecx);
-	xMOV(ptr32[&psxRegs.iopCycleEECarry], edx);
-	xSUB(ptr32[&psxRegs.iopCycleEE], eax);
-}
-
 static void iPsxBranchTest(u32 newpc, u32 cpuBranch)
 {
 	u32 blockCycles = psxScaleBlockCycles();
 
 	if (EmuConfig.Speedhacks.WaitLoop && s_nBlockFF && newpc == s_branchTo)
 	{
-		xMOV(rax, ptr64[&psxRegs.cycle]);
-		xMOV(rcx, rax);
-		xMOV(rdx, ptr32[&psxRegs.iopCycleEE]);
-		xADD(rdx, 7);
-		xSHR(rdx, 3);
-		xADD(rax, rdx);
-		xCMP(rax, ptr64[&psxRegs.iopNextEventCycle]);
-		xCMOVNS(rax, ptr64[&psxRegs.iopNextEventCycle]);
+		// pick the closest cycle target
+		// cycle = min(psxRegs.iopNextEventCycle, psxRegs.iopDeadline)
+		xMOV(rax, ptr64[&psxRegs.iopNextEventCycle]);
+		xCMP(rax, ptr64[&psxRegs.iopDeadline]);
+		xCMOVNS(rax, ptr64[&psxRegs.iopDeadline]);
+
+		// Go directly to target
 		xMOV(ptr64[&psxRegs.cycle], rax);
-		xSUB(rax, rcx);
-		xSHL(rax, 3);
-		iPsxAddEECycles(0xFFFFFFFF);
+
+		// If we've hit the deadline, exit
+		xCMP(ptr64[&psxRegs.iopDeadline], rax);
 		xJLE(iopExitRecompiledCode);
 
+		// Otherwise, check events and continue
 		xFastCall((void*)iopEventTest);
 
 		if (newpc != 0xffffffff)
@@ -1199,12 +1173,15 @@ static void iPsxBranchTest(u32 newpc, u32 cpuBranch)
 	}
 	else
 	{
+		// Add block cycles to our cycle counter
 		xMOV(r12, ptr64[&psxRegs.cycle]);
 		xADD(r12, blockCycles);
-		xMOV(ptr64[&psxRegs.cycle], r12); // update cycles
+		xMOV(ptr64[&psxRegs.cycle], r12);
 
-		// jump if iopCycleEE <= 0  (iop's timeslice timed out, so time to return control to the EE)
-		iPsxAddEECycles(blockCycles);
+		// If we've reached or deadline we should exit
+		// TODO: should we really exit instantly? what if we have events on the same cycle
+		// We don't check events when entering the IOP JIT so it's a bit weird to skip on exit too
+		xCMP(ptr64[&psxRegs.iopDeadline], r12);
 		xJLE(iopExitRecompiledCode);
 
 		// check if an event is pending
@@ -1255,7 +1232,6 @@ void rpsxSYSCALL()
 	j8Ptr[0] = JE8(0);
 
 	xADD(ptr64[&psxRegs.cycle], psxScaleBlockCycles());
-	iPsxAddEECycles(psxScaleBlockCycles());
 	JMP32((uptr)iopDispatcherReg - ((uptr)x86Ptr + 5));
 
 	// jump target for skipping blockCycle updates
@@ -1277,7 +1253,6 @@ void rpsxBREAK()
 	xCMP(ptr32[&psxRegs.pc], psxpc - 4);
 	j8Ptr[0] = JE8(0);
 	xADD(ptr64[&psxRegs.cycle], psxScaleBlockCycles());
-	iPsxAddEECycles(psxScaleBlockCycles());
 	JMP32((uptr)iopDispatcherReg - ((uptr)x86Ptr + 5));
 	x86SetJ8(j8Ptr[0]);
 
@@ -1780,7 +1755,6 @@ StartRecomp:
 		else
 		{
 			xADD(ptr64[&psxRegs.cycle], psxScaleBlockCycles());
-			iPsxAddEECycles(psxScaleBlockCycles());
 		}
 
 		if (link_next_block || !psxbranch)

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -209,11 +209,14 @@ static const void* _DynGen_EnterRecompiledCode()
 #else
 		xScopedStackFrame frame(false, true);
 #endif
+		xMOV(ptr64[&psxRegs.iopDeadline], arg1reg);
+		xMOV(ptr8[&psxRegs.inIop], 1);
 
 		xJMP((void*)iopDispatcherReg);
 
 		// Save an exit point
 		iopExitRecompiledCode = xGetPtr();
+		xMOV(ptr8[&psxRegs.inIop], 0);
 	}
 
 	xRET();
@@ -241,10 +244,10 @@ static void _DynGen_Dispatchers()
 	// Place the EventTest and DispatcherReg stuff at the top, because they get called the
 	// most and stand to benefit from strong alignment and direct referencing.
 	iopDispatcherReg = _DynGen_DispatcherReg();
-
 	iopJITCompile = _DynGen_JITCompile();
 	iopEnterRecompiledCode = _DynGen_EnterRecompiledCode();
-	iopUnmappedRecLUTPage =  _DynGen_UnmappedRecLUTPage();
+	psxCpu->ExecuteBlock = (int (*)(u64))iopEnterRecompiledCode;
+	iopUnmappedRecLUTPage = _DynGen_UnmappedRecLUTPage();
 
 	recBlocks.SetJITCompile(iopJITCompile);
 
@@ -1006,38 +1009,6 @@ static void iopClearRecLUT(BASEBLOCK* base, int count)
 		base[i].SetFnptr((uptr)iopJITCompile);
 }
 
-static __noinline s32 recExecuteBlock(u64 deadline)
-{
-	psxRegs.iopDeadline = deadline;
-	psxRegs.inIop = true;
-
-#ifdef PCSX2_DEVBUILD
-	//if (SysTrace.SIF.IsActive())
-	//	SysTrace.IOP.R3000A.Write("Switching to IOP CPU for %d cycles", eeCycles);
-#endif
-
-	// [TODO] recExecuteBlock could be replaced by a direct call to the iopEnterRecompiledCode()
-	//   (by assigning its address to the psxRec structure).  But for that to happen, we need
-	//   to move iopBreak/iopCycleEE update code to emitted assembly code. >_<  --air
-
-	// Likely Disasm, as borrowed from MSVC:
-
-	// Entry:
-	// 	mov         eax,dword ptr [esp+4]
-	// 	mov         dword ptr [iopBreak (0E88DCCh)],0
-	// 	mov         dword ptr [iopCycleEE (832A84h)],eax
-
-	// Exit:
-	// 	mov         ecx,dword ptr [iopBreak (0E88DCCh)]
-	// 	mov         edx,dword ptr [iopCycleEE (832A84h)]
-	// 	lea         eax,[edx+ecx]
-
-	((void (*)())iopEnterRecompiledCode)();
-
-	psxRegs.inIop = false;
-	return 0;
-}
-
 // Returns the offset to the next instruction after any cleared memory
 static __fi u32 psxRecClearMem(u32 pc)
 {
@@ -1785,7 +1756,7 @@ StartRecomp:
 R3000Acpu psxRec = {
 	recReserve,
 	recResetIOP,
-	recExecuteBlock,
+	NULL,
 	recClearIOP,
 	recShutdown,
 };

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -153,17 +153,11 @@ static ZyanStatus ZydisFormatterPrintAddressAbsolute(const ZydisFormatter* forma
 
 static void iopRecRecompile(u32 startpc);
 
-static const void* iopDispatcherEvent = nullptr;
 static const void* iopDispatcherReg = nullptr;
 static const void* iopJITCompile = nullptr;
 static const void* iopEnterRecompiledCode = nullptr;
 static const void* iopExitRecompiledCode = nullptr;
 static const void* iopUnmappedRecLUTPage = nullptr;
-
-static void recEventTest()
-{
-	_cpuEventTest_Shared();
-}
 
 // The address for all cleared blocks.  It recompiles the current pc and then
 // dispatches to the recompiled block address.
@@ -246,8 +240,6 @@ static void _DynGen_Dispatchers()
 
 	// Place the EventTest and DispatcherReg stuff at the top, because they get called the
 	// most and stand to benefit from strong alignment and direct referencing.
-	iopDispatcherEvent = xGetPtr();
-	xFastCall((void*)recEventTest);
 	iopDispatcherReg = _DynGen_DispatcherReg();
 
 	iopJITCompile = _DynGen_JITCompile();

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -1580,7 +1580,7 @@ static void iopRecRecompile(const u32 startpc)
 
 	_initX86regs();
 
-	if ((psxHu32(HW_ICFG) & 8) && (HWADDR(startpc) == 0xa0 || HWADDR(startpc) == 0xb0 || HWADDR(startpc) == 0xc0))
+	if (psxPs1Mode() && (HWADDR(startpc) == 0xa0 || HWADDR(startpc) == 0xb0 || HWADDR(startpc) == 0xc0))
 	{
 		xFastCall((void*)psxBiosCall);
 		xTEST(al, al);

--- a/pcsx2/x86/ix86-32/iR5900.cpp
+++ b/pcsx2/x86/ix86-32/iR5900.cpp
@@ -686,11 +686,7 @@ static void recSafeExitExecution()
 	else
 	{
 		// IOP might be running, so break out if so.
-		if (psxRegs.iopCycleEE > 0)
-		{
-			psxRegs.iopBreak += psxRegs.iopCycleEE; // record the number of cycles the IOP didn't run.
-			psxRegs.iopCycleEE = 0;
-		}
+		psxRegs.iopDeadline = 0;
 	}
 }
 


### PR DESCRIPTION
### Description of Changes
Simplifies the way the EE and IOP sync up. The IOP is given a deadline in absolute cycle value that is appropriate for the current PS2/PS1 mode. When the current cycle reaches the deadline it exits.

Also introduces a flag that indicates if the IOP JIT is currently executing, some stuff used to infer this from the now-removed IOP cycle countdown.

Hopefully you guys can help me carefully look over the logic, some of the stuff I've replaced I honestly don't fully understand. Particularly the stuff that was using the now-deleted `EEsCycle/EEoCycle` variables.

### Rationale behind Changes
Now that we have 64bit cycle counters we can greatly simplify stuff like this.

### Suggested Testing Steps
This needs lots of testing to make sure stuff didn't break, the nature of it is that literally anything could.

### Did you use AI to help find, test, or implement this issue or feature?
No