### PR TITLE
Qt: Show multitap slot names in controller binding titles

### DIFF
--- a/pcsx2-qt/Settings/ControllerBindingWidget.cpp
+++ b/pcsx2-qt/Settings/ControllerBindingWidget.cpp
@@ -44,15 +44,16 @@ ControllerBindingWidget::ControllerBindingWidget(QWidget* parent, ControllerSett
 {
 	m_ui.setupUi(this);
 
-	if (sioPadIsMultitapSlot(port))
+	const auto [pad_port, pad_slot] = sioConvertPadToPortAndSlot(port);
+	const bool mtap_enabled = m_dialog->getBoolValue("Pad", (pad_port == 0) ? "MultitapPort1" : "MultitapPort2", false);
+	if (mtap_enabled)
 	{
 		static constexpr const std::array<char, 4> s_mtap_slot_names = {{'A', 'B', 'C', 'D'}};
-		const auto [pad_port, pad_slot] = sioConvertPadToPortAndSlot(port);
 		m_ui.groupBox->setTitle(tr("Controller Port %1%2").arg(pad_port + 1).arg(s_mtap_slot_names[pad_slot]));
 	}
 	else
 	{
-		m_ui.groupBox->setTitle(tr("Controller Port %1").arg(port + 1));
+		m_ui.groupBox->setTitle(tr("Controller Port %1").arg(pad_port + 1));
 	}
 
 	populateControllerTypes();
@@ -307,15 +308,16 @@ ControllerMacroWidget::ControllerMacroWidget(ControllerBindingWidget* parent)
 {
 	m_ui.setupUi(this);
 	const u32 port = parent->getPortNumber();
-	if (sioPadIsMultitapSlot(port))
+	const auto [pad_port, pad_slot] = sioConvertPadToPortAndSlot(port);
+	const bool mtap_enabled = parent->getDialog()->getBoolValue("Pad", (pad_port == 0) ? "MultitapPort1" : "MultitapPort2", false);
+	if (mtap_enabled)
 	{
 		static constexpr const std::array<char, 4> s_mtap_slot_names = {{'A', 'B', 'C', 'D'}};
-		const auto [pad_port, pad_slot] = sioConvertPadToPortAndSlot(port);
 		setWindowTitle(tr("Controller Port %1%2 Macros").arg(pad_port + 1).arg(s_mtap_slot_names[pad_slot]));
 	}
 	else
 	{
-		setWindowTitle(tr("Controller Port %1 Macros").arg(port + 1u));
+		setWindowTitle(tr("Controller Port %1 Macros").arg(pad_port + 1));
 	}
 	createWidgets(parent);
 }

--- a/pcsx2-qt/Settings/ControllerBindingWidget.cpp
+++ b/pcsx2-qt/Settings/ControllerBindingWidget.cpp
@@ -48,12 +48,10 @@ ControllerBindingWidget::ControllerBindingWidget(QWidget* parent, ControllerSett
 	{
 		static constexpr const std::array<char, 4> s_mtap_slot_names = {{'A', 'B', 'C', 'D'}};
 		const auto [pad_port, pad_slot] = sioConvertPadToPortAndSlot(port);
-		//: Controller Port is an official term from Sony. Find the official translation for your language inside the console's manual.
 		m_ui.groupBox->setTitle(tr("Controller Port %1%2").arg(pad_port + 1).arg(s_mtap_slot_names[pad_slot]));
 	}
 	else
 	{
-		//: Controller Port is an official term from Sony. Find the official translation for your language inside the console's manual.
 		m_ui.groupBox->setTitle(tr("Controller Port %1").arg(port + 1));
 	}
 
@@ -313,12 +311,10 @@ ControllerMacroWidget::ControllerMacroWidget(ControllerBindingWidget* parent)
 	{
 		static constexpr const std::array<char, 4> s_mtap_slot_names = {{'A', 'B', 'C', 'D'}};
 		const auto [pad_port, pad_slot] = sioConvertPadToPortAndSlot(port);
-		//: Controller Port is an official term from Sony. Find the official translation for your language inside the console's manual.
 		setWindowTitle(tr("Controller Port %1%2 Macros").arg(pad_port + 1).arg(s_mtap_slot_names[pad_slot]));
 	}
 	else
 	{
-		//: Controller Port is an official term from Sony. Find the official translation for your language inside the console's manual.
 		setWindowTitle(tr("Controller Port %1 Macros").arg(port + 1u));
 	}
 	createWidgets(parent);

--- a/pcsx2-qt/Settings/ControllerBindingWidget.cpp
+++ b/pcsx2-qt/Settings/ControllerBindingWidget.cpp
@@ -307,6 +307,7 @@ ControllerMacroWidget::ControllerMacroWidget(ControllerBindingWidget* parent)
 	: QWidget(parent)
 {
 	m_ui.setupUi(this);
+
 	const u32 port = parent->getPortNumber();
 	const auto [pad_port, pad_slot] = sioConvertPadToPortAndSlot(port);
 	const bool mtap_enabled = parent->getDialog()->getBoolValue("Pad", (pad_port == 0) ? "MultitapPort1" : "MultitapPort2", false);
@@ -319,6 +320,7 @@ ControllerMacroWidget::ControllerMacroWidget(ControllerBindingWidget* parent)
 	{
 		setWindowTitle(tr("Controller Port %1 Macros").arg(pad_port + 1));
 	}
+
 	createWidgets(parent);
 }
 

--- a/pcsx2-qt/Settings/ControllerBindingWidget.cpp
+++ b/pcsx2-qt/Settings/ControllerBindingWidget.cpp
@@ -7,6 +7,7 @@
 #include <QtWidgets/QMessageBox>
 #include <QtWidgets/QScrollArea>
 #include <algorithm>
+#include <array>
 #include "fmt/format.h"
 
 #include "common/Console.h"
@@ -14,6 +15,7 @@
 
 #include "pcsx2/Host.h"
 #include "pcsx2/SIO/Pad/Pad.h"
+#include "pcsx2/SIO/Sio.h"
 
 #include "Settings/ControllerBindingWidget.h"
 #include "Settings/ControllerSettingsWindow.h"
@@ -41,7 +43,19 @@ ControllerBindingWidget::ControllerBindingWidget(QWidget* parent, ControllerSett
 	, m_port_number(port)
 {
 	m_ui.setupUi(this);
-	m_ui.groupBox->setTitle(tr("Controller Port %1").arg(port + 1));
+
+	if (sioPadIsMultitapSlot(port))
+	{
+		static constexpr const std::array<char, 4> s_mtap_slot_names = {{'A', 'B', 'C', 'D'}};
+		const auto [pad_port, pad_slot] = sioConvertPadToPortAndSlot(port);
+		//: Controller Port is an official term from Sony. Find the official translation for your language inside the console's manual.
+		m_ui.groupBox->setTitle(tr("Controller Port %1%2").arg(pad_port + 1).arg(s_mtap_slot_names[pad_slot]));
+	}
+	else
+	{
+		//: Controller Port is an official term from Sony. Find the official translation for your language inside the console's manual.
+		m_ui.groupBox->setTitle(tr("Controller Port %1").arg(port + 1));
+	}
 
 	populateControllerTypes();
 	onTypeChanged();
@@ -294,7 +308,19 @@ ControllerMacroWidget::ControllerMacroWidget(ControllerBindingWidget* parent)
 	: QWidget(parent)
 {
 	m_ui.setupUi(this);
-	setWindowTitle(tr("Controller Port %1 Macros").arg(parent->getPortNumber() + 1u));
+	const u32 port = parent->getPortNumber();
+	if (sioPadIsMultitapSlot(port))
+	{
+		static constexpr const std::array<char, 4> s_mtap_slot_names = {{'A', 'B', 'C', 'D'}};
+		const auto [pad_port, pad_slot] = sioConvertPadToPortAndSlot(port);
+		//: Controller Port is an official term from Sony. Find the official translation for your language inside the console's manual.
+		setWindowTitle(tr("Controller Port %1%2 Macros").arg(pad_port + 1).arg(s_mtap_slot_names[pad_slot]));
+	}
+	else
+	{
+		//: Controller Port is an official term from Sony. Find the official translation for your language inside the console's manual.
+		setWindowTitle(tr("Controller Port %1 Macros").arg(port + 1u));
+	}
 	createWidgets(parent);
 }
 


### PR DESCRIPTION
The ControllerBindingWidget group box title and the ControllerMacroWidget window title always read "Controller Port N", ignoring multitap slots. When a multitap is enabled the side list already shows "Controller Port NA/B/C/D" (handled in ControllerSettingsWindow), but the per-slot widget titles did not follow suit, so every multitap slot looked like it referred to the base port.

Use sioPadIsMultitapSlot()/sioConvertPadToPortAndSlot() to render the same "Controller Port NA" style labels in both titles, mirroring the existing list-item logic.

Fixes #14529

### Description of Changes
Fixes the controller port titles so they include the multitap slot letter when a multitap is enabled.

The group box title in ControllerBindingWidget and the window title in ControllerMacroWidget were hardcoded to "Controller Port N", ignoring multitap slots. The side list in ControllerSettingsWindow already displayed "Controller Port NA/B/C/D", but the per-slot widget/macro titles did not, so every multitap slot's panel looked like it referred to the base port.

Both titles now use sioPadIsMultitapSlot() / sioConvertPadToPortAndSlot() (from pcsx2/SIO/Sio.h) to render the same "Controller Port NA"-style label, mirroring the existing list-item logic. The non-multitap path is unchanged.

### Rationale behind Changes
When a multitap is connected there are up to 4 slots per physical port (1A–1D, 2A–2D). The settings side list distinguishes them correctly, but once you open a slot, the panel header and the Macros window header both collapsed back to just "Controller Port 1" / "Controller Port 2". This is confusing and inconsistent — the user can't tell which slot they're actually editing. The fix reuses the exact slot-naming helpers and A/B/C/D convention already used elsewhere in the controller settings, so the UI is now consistent end-to-end with no new conventions introduced.

### Suggested Testing Steps
1. Open Settings → Controllers.
2. Under global settings, enable Multitap on Port 1 (and/or Port 2).
3. In the left list, select a multitap slot, e.g. Controller Port 1B.
4. Before: the panel's group box title reads "Controller Port 1". After: it reads "Controller Port 1B", matching the list entry.
5. Click Macros for that slot. Before: window title "Controller Port 1 Macros". After: "Controller Port 1B Macros".
6. Disable multitap and confirm a normal port still shows plain "Controller Port 1" / "Controller Port 1 Macros" (unchanged behavior).

### Did you use AI to help find, test, or implement this issue or feature?
Yes. AI (Claude) was used to locate the relevant code, implement the fix, and validate it by building locally — replicating the Linux/Qt CI (clang-17, Qt 6.11.1), which compiled cleanly. The change was reviewed for correctness and consistency with the existing ControllerSettingsWindow logic before submitting.