### PR TITLE
Qt: Fix game list view toggle with an empty game list

### DIFF
--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -654,6 +654,9 @@ void GameListWidget::refreshGridCovers()
 
 void GameListWidget::showGameList()
 {
+	Host::SetBaseBoolSettingValue("UI", "GameListGridView", false);
+	Host::CommitBaseSettingChanges();
+
 	if (m_ui.stack->currentIndex() == 0 || m_model->rowCount() == 0)
 	{
 		// We can click the toolbar multiple times, so keep it correct.
@@ -661,8 +664,6 @@ void GameListWidget::showGameList()
 		return;
 	}
 
-	Host::SetBaseBoolSettingValue("UI", "GameListGridView", false);
-	Host::CommitBaseSettingChanges();
 	m_ui.stack->setCurrentIndex(0);
 	setFocusProxy(m_ui.stack->currentWidget());
 	resizeTableViewColumnsToFit();
@@ -672,6 +673,9 @@ void GameListWidget::showGameList()
 
 void GameListWidget::showGameGrid()
 {
+	Host::SetBaseBoolSettingValue("UI", "GameListGridView", true);
+	Host::CommitBaseSettingChanges();
+
 	if (m_ui.stack->currentIndex() == 1 || m_model->rowCount() == 0)
 	{
 		// We can click the toolbar multiple times, so keep it correct.
@@ -679,8 +683,6 @@ void GameListWidget::showGameGrid()
 		return;
 	}
 
-	Host::SetBaseBoolSettingValue("UI", "GameListGridView", true);
-	Host::CommitBaseSettingChanges();
 	m_ui.stack->setCurrentIndex(1);
 	setFocusProxy(m_ui.stack->currentWidget());
 	updateToolbar();
@@ -703,7 +705,7 @@ void GameListWidget::setShowCoverTitles(bool enabled)
 
 void GameListWidget::updateToolbar()
 {
-	const bool grid_view = isShowingGameGrid();
+	const bool grid_view = Host::GetBaseBoolSettingValue("UI", "GameListGridView", false);
 	{
 		QSignalBlocker sb(m_ui.viewGameGrid);
 		m_ui.viewGameGrid->setChecked(grid_view);


### PR DESCRIPTION
### Description of Changes
When the game list is empty, the placeholder page is shown. showGameList() / showGameGrid() returned early in that state before persisting the GameListGridView setting, so toggling the view had no effect. Additionally, updateToolbar() derived the buttons' checked state from the current stack index, which is always the placeholder page when the list is empty, so the toolbar never reflected the selected mode. The fix persists the preference before the early-out and bases the toolbar state on the saved setting.

### Rationale behind Changes
As reported in [#13220](https://github.com/PCSX2/pcsx2/issues/13220), switching between list and grid view does nothing while the game list is empty, and after adding games the view can come up in grid mode while the toolbar still shows list mode — an inconsistent state. The Big Picture UI already allows switching regardless of list status. This brings the desktop UI in line: the choice is always saved and reflected, so it's honored once games appear.

### Suggested Testing Steps

1. Start PCSX2 with no game directories configured (empty game list / placeholder shown).
2. Click the Game Grid toolbar button. → The Grid button should now appear selected (before: it stayed on List).
3. Add a game directory. → Games appear in grid view, consistent with the toolbar.
4. Repeat toggling to Game List while empty, add games → list view, toolbar consistent.
5. With games present, toggle List/Grid normally → unchanged behavior.

### Did you use AI to help find, test, or implement this issue or feature?
Yes. AI (Claude) was used to locate the root cause in GameListWidget.cpp, implement the fix, and validate that it compiles by building locally (clang-17, Qt 6.11.1) replicating the Linux/Qt CI. Runtime behavior follows directly from the changed logic.