### PR TITLE
GS/TC: Don't pre-downscale if native palette draw is enabled

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -6426,7 +6426,7 @@ GSTextureCache::Source* GSTextureCache::CreateSource(const GIFRegTEX0& TEX0, con
 					}
 
 					const u32 destination_tbw = (dst->m_TEX0.TBP0 == TEX0.TBP0) ? (std::max<u32>(TEX0.TBW, 1u) * 64) : std::max<u32>(dst->m_TEX0.TBW, 1u) * 128;
-					if (dst->GetScale() > 1.0f)
+					if (!GSConfig.UserHacks_NativePaletteDraw && dst->GetScale() > 1.0f)
 					{
 						GSTexture* tmpTex = use_texture ?
 							g_gs_device->CreateTexture(dst->m_unscaled_size, 1, GSTexture::Format::Color, PreferReusedLabelledTexture()) :


### PR DESCRIPTION
### Description of Changes
Stops it downscaling before 8bit palette conversion if native palette draw is in use.

### Rationale behind Changes
Regression from #14492 but only with Crash Bandicoot on AMD. But I don't really want to diagnose it, so I'll just exclude that what game does from doing it.

### Suggested Testing Steps
Test Crash Bandicoot Wrath of Cortex, should have no lines in the misty cold level.

### Did you use AI to help find, test, or implement this issue or feature?
No