### PR TITLE
GS/TC: Add new HW Readback option to force full download

### DIFF
--- a/pcsx2-qt/Settings/GraphicsAdvancedSettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsAdvancedSettingsTab.ui
@@ -45,6 +45,11 @@
         </item>
         <item>
          <property name="text">
+          <string>Accurate Force Full (Can Reduce Readbacks)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
           <string>Disable Readbacks (Synchronize GS Thread)</string>
          </property>
         </item>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -399,6 +399,7 @@ enum class SavestateCompressionLevel : u8
 enum class GSHardwareDownloadMode : u8
 {
 	Enabled,
+	EnabledForceFull,
 	NoReadbacks,
 	Unsynchronized,
 	Disabled

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -4893,7 +4893,7 @@ void GSTextureCache::InvalidateLocalMem(const GSOffset& off, const GSVector4i& r
 	// Could be reading Z24/32 back as CT32 (Gundam Battle Assault 3)
 	if (GSLocalMemory::m_psm[psm].bpp >= 16)
 	{
-		if (GSConfig.HWDownloadMode != GSHardwareDownloadMode::Enabled)
+		if (GSConfig.HWDownloadMode > GSHardwareDownloadMode::EnabledForceFull)
 		{
 			DevCon.Error("TC: Skipping depth readback of %ux%u @ %u,%u", r.width(), r.height(), r.left, r.top);
 			return;
@@ -4926,7 +4926,7 @@ void GSTextureCache::InvalidateLocalMem(const GSOffset& off, const GSVector4i& r
 				const bool swizzle_match = GSLocalMemory::m_psm[psm].depth == GSLocalMemory::m_psm[t->m_TEX0.PSM].depth;
 				// Calculate the rect offset if the BP doesn't match.
 				GSVector4i targetr = {};
-				if (full_flush || t->readbacks_since_draw > 1)
+				if (full_flush || GSConfig.HWDownloadMode == GSHardwareDownloadMode::EnabledForceFull ||  t->readbacks_since_draw > 1)
 				{
 					targetr = t->m_drawn_since_read;
 				}
@@ -5163,7 +5163,7 @@ void GSTextureCache::InvalidateLocalMem(const GSOffset& off, const GSVector4i& r
 					}
 				}
 
-				if (GSConfig.HWDownloadMode != GSHardwareDownloadMode::Enabled)
+				if (GSConfig.HWDownloadMode > GSHardwareDownloadMode::EnabledForceFull)
 				{
 					DevCon.Error("TC: Skipping depth readback of %ux%u @ %u,%u", targetr.width(), targetr.height(), targetr.left, targetr.top);
 					continue;

--- a/pcsx2/ImGui/FullscreenUI_Settings.cpp
+++ b/pcsx2/ImGui/FullscreenUI_Settings.cpp
@@ -2862,6 +2862,7 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 	};
 	static constexpr const char* s_hw_download[] = {
 		FSUI_NSTR("Accurate (Recommended)"),
+		FSUI_NSTR("Accurate Force Full (Can Reduce Readbacks)"),
 		FSUI_NSTR("Disable Readbacks (Synchronize GS Thread)"),
 		FSUI_NSTR("Unsynchronized (Non-Deterministic)"),
 		FSUI_NSTR("Disabled (Ignore Transfers)"),

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -3252,7 +3252,7 @@ void VMManager::WarnAboutUnsafeSettings()
 			append(ICON_FA_PAINTBRUSH,
 				TRANSLATE_SV("VMManager", "Blending Accuracy is below Basic, this may break effects in some games."));
 		}
-		if (EmuConfig.GS.HWDownloadMode != GSHardwareDownloadMode::Enabled)
+		if (EmuConfig.GS.HWDownloadMode > GSHardwareDownloadMode::EnabledForceFull)
 		{
 			append(ICON_FA_DOWNLOAD,
 				TRANSLATE_SV("VMManager", "Hardware Download Mode is not set to Accurate, this may break rendering in some games."));


### PR DESCRIPTION
### Description of Changes
Adds a new option to force full target readback on hardware download

### Rationale behind Changes
Some games do multiple small readbacks which is a lot more cumbersome than just doing one big readback, so in games such as SSX (and apparently Armored Core 3) this can be advantageous to just do one big one.

### Suggested Testing Steps
Load your game/dump of choice that has readbacks (you can see these stats with the OSD), make sure you have advanced options enabled, then in your per-game settings, go to the advanced graphics tab and set the Hardware Download Mode to `Accurate Force Full`, measure any performance differences.

<img width="475" height="50" alt="image" src="https://github.com/user-attachments/assets/40752010-905a-40e7-a08a-a1b2001e10ca" />


### Did you use AI to help find, test, or implement this issue or feature?
No