### PR TITLE
GS/CLUT: Handle special case for CSM2 32bit mode switch

### DIFF
--- a/pcsx2/GS/GSClut.cpp
+++ b/pcsx2/GS/GSClut.cpp
@@ -385,7 +385,13 @@ void GSClut::Read32(const GIFRegTEX0& TEX0, const GIFRegTEXA& TEXA)
 				case PSMT4HH:
 					clut += (TEX0.CSA & 15) << 4;
 					// TODO: merge these functions
-					ReadCLUT_T32_I4(clut, m_buff32);
+
+					// This is for a situation with Breath of Fire Dragon Quarter where it reinterprets the buffer under CSM2 after reading as CSM1.
+					if (TEX0.CSM == 1 && m_write.TEX0.CSM == 0)
+						ReadCLUT_T32_I4_Swizzled(clut, m_buff32);
+					else
+						ReadCLUT_T32_I4(clut, m_buff32);
+
 					ExpandCLUT64_T32_I8(m_buff32, (u64*)m_buff64); // sw renderer does not need m_buff64 anymore
 					break;
 			}
@@ -630,6 +636,27 @@ __forceinline void GSClut::WriteCLUT_T16_I4_CSM1(const u16* RESTRICT src, u16* R
 	{
 		clut[i] = src[clutTableT16I4[i]];
 	}
+}
+
+// These functions are only used if the CLUT is in 32bit mode and it swaps to CSM2, a very obscure setup used by Breath of Fire Dragon Quarter.
+// This doesn't handle offsetting the CLUT or anything crazy, that would be a lot more work
+void GSClut::ReadCLUT_T32_I4_Swizzled(const u16* RESTRICT clut, u32* RESTRICT dst)
+{
+	// Point to the base of the palette block
+	GSVector4i* s = (GSVector4i*)clut;
+	GSVector4i* d = (GSVector4i*)dst;
+
+	GSVector4i v0 = s[0];
+	GSVector4i v1 = s[2];
+	GSVector4i v2 = s[32];
+	GSVector4i v3 = s[34];
+
+	GSVector4i::sw16(v0, v2, v1, v3);
+
+	d[0] = v0;
+	d[1] = v1;
+	d[2] = v2;
+	d[3] = v3;
 }
 
 void GSClut::ReadCLUT_T32_I8(const u16* RESTRICT clut, u32* RESTRICT dst, int offset)

--- a/pcsx2/GS/GSClut.h
+++ b/pcsx2/GS/GSClut.h
@@ -78,6 +78,7 @@ class alignas(32) GSClut final : public GSAlignedClass<32>
 	static void WriteCLUT_T32_I4_CSM1(const u32* RESTRICT src, u16* RESTRICT clut);
 	static void WriteCLUT_T16_I8_CSM1(const u16* RESTRICT src, u16* RESTRICT clut);
 	static void WriteCLUT_T16_I4_CSM1(const u16* RESTRICT src, u16* RESTRICT clut);
+	static void ReadCLUT_T32_I4_Swizzled(const u16* RESTRICT clut, u32* RESTRICT dst);
 	static void ReadCLUT_T32_I8(const u16* RESTRICT clut, u32* RESTRICT dst, int offset);
 	static void ReadCLUT_T32_I4(const u16* RESTRICT clut, u32* RESTRICT dst);
 	//static void ReadCLUT_T32_I4(const u16* RESTRICT clut, u32* RESTRICT dst32, u64* RESTRICT dst64);


### PR DESCRIPTION
### Description of Changes
Changes the behaviour of CLUT storage mode 2 to always load the CLUT from local memory and not in to a temporary buffer.

### Rationale behind Changes
This is kind of theoretical based on the behaviour of Breath of Fire - Dragon Quarter when running a GS Dump vs PCSX2, the game will reload the CLUT in Storage Mode 1, then switch to Storage Mode 2, however the data loaded from Mode 1 is in the incorrect order, due to it being correctly swizzled and Mode 2 is sequential, meaning the main colour the text uses on the menu has black holes everywhere.

The running theory is that Mode 2 reads directly from GS memory when loading the texture cache (hence it being slower than CSM 1, along with the swizzle differences). I can't see any other way that this game would have the correct CLUT otherwise.

Ziemas is likely going to run some tests on his PS2 to try and confirm the theory, but this is the best we have for now, the dump run seems clean, to it may hold water.

### Suggested Testing Steps
Test Breath of Fire - Dragon Quarter

### Did you use AI to help find, test, or implement this issue or feature?
I did ask AI for some possible information on the web w/links that I failed to find and anything which backed up my theory, but didn't really help with any credible information.

Fixes #14543

Breath of Fire - Dragon Quarter
Master:
<img width="1436" height="1214" alt="image" src="https://github.com/user-attachments/assets/56c956c0-63ea-475f-b164-84b297f1528b" />

PR:
<img width="1436" height="1214" alt="image" src="https://github.com/user-attachments/assets/f945b022-d041-463b-bedf-dd58f7cc337b" />
