### PR TITLE
GS/GL: Revert invalidating depth stencil and add basic fallback for clip control.

### DIFF
--- a/bin/resources/shaders/opengl/tfx_vgs.glsl
+++ b/bin/resources/shaders/opengl/tfx_vgs.glsl
@@ -83,7 +83,13 @@ void vs_main()
 	// example: 133.0625 (133 + 1/16) should start from line 134, ceil(133.0625 - 0.05) still above 133
 	gl_Position.xy = vec2(i_p) - vec2(0.05f, 0.05f);
 	gl_Position.xy = gl_Position.xy * VertexScale - VertexOffset;
-	gl_Position.z = float(z) * exp_min32;
+
+	#if HAS_CLIP_CONTROL
+		gl_Position.z = float(z) * exp_min32;
+	#else
+		gl_Position.z = (float(z) * exp_min32) * 2.0f - 1.0f;
+	#endif
+
 	gl_Position.w = 1.0f;
 
 	texture_coord();
@@ -160,7 +166,13 @@ ProcessedVertex load_vertex(uint index)
 	uint z = min(i_z, MaxDepth);
 	vtx.p.xy = vec2(i_p) - vec2(0.05f, 0.05f);
 	vtx.p.xy = vtx.p.xy * VertexScale - VertexOffset;
-	vtx.p.z = float(z) * exp_min32;
+
+	#if HAS_CLIP_CONTROL
+		vtx.p.z = float(z) * exp_min32;
+	#else
+		vtx.p.z = (float(z) * exp_min32) * 2.0f - 1.0f;
+	#endif
+
 	vtx.p.w = 1.0f;
 
 	vec2 uv = vec2(i_uv) - TextureOffset;

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -3025,12 +3025,6 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 		constexpr GLint clear_color = 1;
 		glClearBufferiv(GL_STENCIL, 0, &clear_color);
 	}
-	else if (draw_ds && !(config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::Stencil ||
-			config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::StencilOne))
-	{
-		const GLenum attachments[] = {GL_STENCIL_ATTACHMENT};
-		glInvalidateFramebuffer(GL_DRAW_FRAMEBUFFER, std::size(attachments), attachments);
-	}
 
 	SendHWDraw(config, rt_feedbackloop_pass1 ? draw_rt_clone : nullptr, draw_rt, ds_feedbackloop_pass1 ? draw_ds_clone : nullptr, draw_ds,
 		config.require_one_barrier, config.require_full_barrier);

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -626,7 +626,8 @@ bool GSDeviceOGL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 	// This extension allow FS depth to range from -1 to 1. So
 	// gl_position.z could range from [0, 1]
 	// Change depth convention
-	glClipControl(GL_LOWER_LEFT, GL_ZERO_TO_ONE);
+	if (GLAD_GL_ARB_clip_control)
+		glClipControl(GL_LOWER_LEFT, GL_ZERO_TO_ONE);
 
 	// ****************************************************************
 	// HW renderer shader
@@ -778,15 +779,14 @@ bool GSDeviceOGL::CheckFeatures()
 
 	if (!GLAD_GL_VERSION_4_3 && !GLAD_GL_ARB_copy_image && !GLAD_GL_EXT_copy_image && !GLAD_GL_NV_copy_image)
 	{
-		Host::ReportFormattedErrorAsync(
-			"GS", "GL_ARB_copy_image is not supported, copies will be slower.");
+		Host::AddOSDMessage(
+			"GL_ARB_copy_image is not supported, copies will be slower.", Host::OSD_ERROR_DURATION);
 	}
 
 	if (!GLAD_GL_VERSION_4_5 && !GLAD_GL_ARB_clip_control)
 	{
-		Host::ReportFormattedErrorAsync(
-			"GS", "GL_ARB_clip_control is not supported, this is required for the OpenGL renderer.");
-		return false;
+		Host::AddOSDMessage(
+			"GL_ARB_clip_control is not supported, depth will be less accurate.", Host::OSD_ERROR_DURATION);
 	}
 
 	if (!GLAD_GL_ARB_viewport_array)
@@ -1497,6 +1497,11 @@ std::string GSDeviceOGL::GenGlslHeader(const std::string_view entry, GLenum type
 	{
 		header += "#define DEPTH_FEEDBACK_SUPPORT 2\n"; // Depth as RT
 	}
+
+	if (GLAD_GL_ARB_clip_control)
+		header += "#define HAS_CLIP_CONTROL 1\n";
+	else
+		header += "#define HAS_CLIP_CONTROL 0\n";
 
 	// Allow to puts several shader in 1 files
 	switch (type)

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 100; // Last changed in PR 14503
+static constexpr u32 SHADER_CACHE_VERSION = 101; // Last changed in PR 14547


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Revert "GS/GL: Discard stencil when not in use while using depth.
This reverts commit https://github.com/PCSX2/pcsx2/commit/e0365c1d10f2a2849fe54795b140a35c5a81ce69.
Causes crashes on intel so not worth it for barely a 1% improvement.

GS/GL: Add basic clip control fallback.
When GLAD_GL_ARB_clip_control is not supported then change the vertex shader depth ranges to make sure it matches -1 1.
I didn't do the exp24 type of depth handling that we had previously as I didn't want too much changes as the affected usecase of this is likely small and it's mostly so I can do testing in intel hardware without having to make these edits/rebase every time.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Regression crash fixes, helps older intel drivers, makes my life easier when testing on intel igpus.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Smoke test a few games that they still work on GL like dbz bt3, tomb raider fire shuffle effect.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation as to how you used it. Please see the Large Language Model (LLM) Usage Policy for more information: https://pcsx2.net/docs/contributing/#large-language-model-llm-usage-policy -->
No.