### PR TITLE
GS/DX11: Uav/rov optimizations.

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -2759,6 +2759,7 @@ void GSDevice11::OMSetRenderTargets(GSTexture* rt, GSTexture* ds, GSTexture* rt_
 	}
 
 	const bool changed = (m_state.rtv != rtv || m_state.dsv != dsv || m_state.rt_uav != rt_uav || m_state.ds_uav != ds_uav);
+	const bool no_uavs = m_state.rt_uav == nullptr && rt_uav == nullptr && m_state.ds_uav == nullptr && ds_uav == nullptr;
 
 	if (changed)
 		g_perfmon.Put(GSPerfMon::RenderPasses, 1.0);
@@ -2806,15 +2807,20 @@ void GSDevice11::OMSetRenderTargets(GSTexture* rt, GSTexture* ds, GSTexture* rt_
 	if (changed)
 	{
 		// OM targets and UAVs share the same namespace in DX11, so we need to pack them into contiguous slots.
-		u32 num_rtvs = rt ? 1 : 0;
-		u32 num_uavs = 0;
-		ID3D11UnorderedAccessView* uavs[2];
-		if (rt_uav)
-			uavs[num_uavs++] = rt_uav;
-		if (ds_uav)
-			uavs[num_uavs++] = ds_uav;
-		ID3D11RenderTargetView* rtvs[] = { rtv };
-		m_ctx->OMSetRenderTargetsAndUnorderedAccessViews(num_rtvs, rtvs, dsv, num_rtvs, num_uavs, uavs, nullptr);
+		const u32 num_rtvs = rt ? 1 : 0;
+		ID3D11RenderTargetView* rtvs[] = {rtv};
+		if (no_uavs)
+			m_ctx->OMSetRenderTargets(num_rtvs, rtvs, dsv);
+		else
+		{
+			u32 num_uavs = 0;
+			ID3D11UnorderedAccessView* uavs[2];
+			if (rt_uav)
+				uavs[num_uavs++] = rt_uav;
+			if (ds_uav)
+				uavs[num_uavs++] = ds_uav;
+			m_ctx->OMSetRenderTargetsAndUnorderedAccessViews(num_rtvs, rtvs, dsv, num_rtvs, num_uavs, uavs, nullptr);
+		}
 	}
 
 	if (rt || ds || rt_uav_tex || ds_uav_tex)

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -3049,6 +3049,16 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 	{
 		draw_ds = m_state.current_ds;
 	}
+	else if (!(draw_rt || draw_rt_rov) && draw_ds_rov && m_state.rt_uav && m_state.current_rt_uav && m_state.rt_uav == *static_cast<GSTexture11*>(m_state.current_rt_uav) &&
+		m_state.current_ds_uav == draw_ds_rov && config.tex != m_state.current_rt_uav)
+	{
+		draw_rt_rov = m_state.current_rt_uav;
+	}
+	else if (!(draw_ds || draw_ds_rov) && draw_rt_rov && m_state.ds_uav && m_state.current_ds_uav && m_state.ds_uav == *static_cast<GSTexture11*>(m_state.current_ds_uav) &&
+			 m_state.current_rt_uav == draw_rt_rov && config.tex != m_state.current_ds_uav)
+	{
+		draw_ds_rov = m_state.current_ds_uav;
+	}
 
 	const bool rt_feedbackloop_pass1 = config.IsFeedbackLoopRT(config.ps);
 	const bool rt_feedbackloop_pass2 = config.IsFeedbackLoopRT(config.alpha_second_pass.ps);

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -649,6 +649,20 @@ void GSDevice11::Destroy()
 	}
 	m_state.current_ds = nullptr;
 
+	if (m_state.rt_uav)
+	{
+		m_state.rt_uav->Release();
+		m_state.rt_uav = nullptr;
+	}
+	m_state.current_rt_uav = nullptr;
+
+	if (m_state.ds_uav)
+	{
+		m_state.ds_uav->Release();
+		m_state.ds_uav = nullptr;
+	}
+	m_state.current_ds_uav = nullptr;
+
 	m_shader_cache.Close();
 
 #ifdef REPORT_LEAKED_OBJECTS


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/DX11: Reuse frame buffer optimizations for uav/rov.
This significantly reduces the number of state changes.

GS/DX11: Fallback to regular OMSetRenderTargets if no uav are active.
Using OMSetRenderTargets should be faster than OMSetRenderTargetsAndUnorderedAccessViews if both the current state and pending state for uavs is null.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Optimizations.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test rov on dx11, haven't ran a dump run yet.
Edit: Dump run clear, most are single, double digit Render pass decreases, there are some outliers in triple digits and show a few fps improvement.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation as to how you used it. Please see the Large Language Model (LLM) Usage Policy for more information: https://pcsx2.net/docs/contributing/#large-language-model-llm-usage-policy -->
No.