### PR TITLE
Debugger Breakpoint Instrumentation

### DIFF
--- a/pcsx2-qt/Debugger/Breakpoints/BreakpointDialog.cpp
+++ b/pcsx2-qt/Debugger/Breakpoints/BreakpointDialog.cpp
@@ -44,6 +44,7 @@ BreakpointDialog::BreakpointDialog(QWidget* parent, DebugInterface* cpu, Breakpo
 		m_ui.chkEnable->setChecked(bp->enabled);
 		m_ui.txtAddress->setText(QtUtils::FilledQStringFromValue(bp->addr, 16));
 		m_ui.txtDescription->setText(QString::fromStdString(bp->description));
+		m_ui.spnMaxHitCount->setValue(static_cast<int>(bp->maxHits));
 
 		if (bp->hasCond)
 			m_ui.txtCondition->setText(QString::fromStdString(bp->cond.expressionString));
@@ -63,6 +64,7 @@ BreakpointDialog::BreakpointDialog(QWidget* parent, DebugInterface* cpu, Breakpo
 
 		m_ui.chkEnable->setChecked(mc->result & MEMCHECK_BREAK);
 		m_ui.chkLog->setChecked(mc->result & MEMCHECK_LOG);
+		m_ui.spnMaxHitCount->setValue(static_cast<int>(mc->maxHits));
 
 		if (mc->hasCond)
 			m_ui.txtCondition->setText(QString::fromStdString(mc->cond.expressionString));
@@ -105,9 +107,13 @@ void BreakpointDialog::accept()
 			return;
 		}
 
+		// Reset totalHits if the address of the BP changes.
+		if (static_cast<u32>(address) != bp->addr)
+			bp->totalHits = 0;
+
 		bp->addr = address;
 		bp->description = m_ui.txtDescription->text().toStdString();
-
+		bp->maxHits = static_cast<u32>(m_ui.spnMaxHitCount->value());
 		bp->enabled = m_ui.chkEnable->isChecked();
 
 		if (!m_ui.txtCondition->text().isEmpty())
@@ -146,8 +152,13 @@ void BreakpointDialog::accept()
 			return;
 		}
 
+		// Reset totalHits if the address range of the MC changes.
+		if (static_cast<u32>(startAddress) != mc->start || static_cast<u32>(startAddress + size) != mc->end)
+			mc->totalHits = 0;
+
 		mc->start = startAddress;
 		mc->end = startAddress + size;
+		mc->maxHits = static_cast<u32>(m_ui.spnMaxHitCount->value());
 		mc->description = m_ui.txtDescription->text().toStdString();
 
 		if (!m_ui.txtCondition->text().isEmpty())

--- a/pcsx2-qt/Debugger/Breakpoints/BreakpointDialog.cpp
+++ b/pcsx2-qt/Debugger/Breakpoints/BreakpointDialog.cpp
@@ -46,6 +46,10 @@ BreakpointDialog::BreakpointDialog(QWidget* parent, DebugInterface* cpu, Breakpo
 		m_ui.txtDescription->setText(QString::fromStdString(bp->description));
 		m_ui.spnMaxHitCount->setValue(static_cast<int>(bp->maxHits));
 
+		m_ui.grpInstrumentation->setChecked(bp->instrumentationEnabled);
+		m_ui.txtLogFormat->setText(QString::fromStdString(bp->logFormat));
+		m_ui.chkContinueOnHit->setChecked(bp->continueOnHit);
+
 		if (bp->hasCond)
 			m_ui.txtCondition->setText(QString::fromStdString(bp->cond.expressionString));
 	}
@@ -65,6 +69,10 @@ BreakpointDialog::BreakpointDialog(QWidget* parent, DebugInterface* cpu, Breakpo
 		m_ui.chkEnable->setChecked(mc->result & MEMCHECK_BREAK);
 		m_ui.chkLog->setChecked(mc->result & MEMCHECK_LOG);
 		m_ui.spnMaxHitCount->setValue(static_cast<int>(mc->maxHits));
+
+		m_ui.grpInstrumentation->setChecked(mc->instrumentationEnabled);
+		m_ui.txtLogFormat->setText(QString::fromStdString(mc->logFormat));
+		m_ui.chkContinueOnHit->setChecked(mc->continueOnHit);
 
 		if (mc->hasCond)
 			m_ui.txtCondition->setText(QString::fromStdString(mc->cond.expressionString));
@@ -116,6 +124,17 @@ void BreakpointDialog::accept()
 		bp->maxHits = static_cast<u32>(m_ui.spnMaxHitCount->value());
 		bp->enabled = m_ui.chkEnable->isChecked();
 
+		const bool instrumentationEnabled = m_ui.grpInstrumentation->isChecked();
+		const std::string logFormat = m_ui.txtLogFormat->text().toStdString();
+		if (instrumentationEnabled && !logFormat.empty() && !ValidateInstrumentationLogFormat(*m_cpu, logFormat, error))
+		{
+			AsyncDialogs::warning(g_debugger_window, tr("Invalid Log Format"), QString::fromStdString(error));
+			return;
+		}
+		bp->instrumentationEnabled = instrumentationEnabled;
+		bp->logFormat = logFormat;
+		bp->continueOnHit = m_ui.chkContinueOnHit->isChecked();
+
 		if (!m_ui.txtCondition->text().isEmpty())
 		{
 			bp->hasCond = true;
@@ -160,6 +179,17 @@ void BreakpointDialog::accept()
 		mc->end = startAddress + size;
 		mc->maxHits = static_cast<u32>(m_ui.spnMaxHitCount->value());
 		mc->description = m_ui.txtDescription->text().toStdString();
+
+		const bool instrumentationEnabled = m_ui.grpInstrumentation->isChecked();
+		const std::string logFormat = m_ui.txtLogFormat->text().toStdString();
+		if (instrumentationEnabled && !logFormat.empty() && !ValidateInstrumentationLogFormat(*m_cpu, logFormat, error))
+		{
+			AsyncDialogs::warning(g_debugger_window, tr("Invalid Log Format"), QString::fromStdString(error));
+			return;
+		}
+		mc->instrumentationEnabled = instrumentationEnabled;
+		mc->logFormat = logFormat;
+		mc->continueOnHit = m_ui.chkContinueOnHit->isChecked();
 
 		if (!m_ui.txtCondition->text().isEmpty())
 		{

--- a/pcsx2-qt/Debugger/Breakpoints/BreakpointDialog.cpp
+++ b/pcsx2-qt/Debugger/Breakpoints/BreakpointDialog.cpp
@@ -46,7 +46,7 @@ BreakpointDialog::BreakpointDialog(QWidget* parent, DebugInterface* cpu, Breakpo
 		m_ui.txtDescription->setText(QString::fromStdString(bp->description));
 		m_ui.spnMaxHitCount->setValue(static_cast<int>(bp->maxHits));
 
-		m_ui.grpInstrumentation->setChecked(bp->instrumentationEnabled);
+		m_ui.grpLogWhenHit->setChecked(bp->instrumentationEnabled);
 		m_ui.txtLogFormat->setText(QString::fromStdString(bp->logFormat));
 		m_ui.chkContinueOnHit->setChecked(bp->continueOnHit);
 
@@ -67,10 +67,9 @@ BreakpointDialog::BreakpointDialog(QWidget* parent, DebugInterface* cpu, Breakpo
 		m_ui.chkChange->setChecked(mc->memCond & MEMCHECK_WRITE_ONCHANGE);
 
 		m_ui.chkEnable->setChecked(mc->result & MEMCHECK_BREAK);
-		m_ui.chkLog->setChecked(mc->result & MEMCHECK_LOG);
 		m_ui.spnMaxHitCount->setValue(static_cast<int>(mc->maxHits));
 
-		m_ui.grpInstrumentation->setChecked(mc->instrumentationEnabled);
+		m_ui.grpLogWhenHit->setChecked(mc->instrumentationEnabled);
 		m_ui.txtLogFormat->setText(QString::fromStdString(mc->logFormat));
 		m_ui.chkContinueOnHit->setChecked(mc->continueOnHit);
 
@@ -89,7 +88,6 @@ void BreakpointDialog::onRdoButtonToggled()
 
 	m_ui.grpMemory->setEnabled(!isExecute);
 
-	m_ui.chkLog->setEnabled(!isExecute);
 }
 
 void BreakpointDialog::accept()
@@ -124,7 +122,7 @@ void BreakpointDialog::accept()
 		bp->maxHits = static_cast<u32>(m_ui.spnMaxHitCount->value());
 		bp->enabled = m_ui.chkEnable->isChecked();
 
-		const bool instrumentationEnabled = m_ui.grpInstrumentation->isChecked();
+		const bool instrumentationEnabled = m_ui.grpLogWhenHit->isChecked();
 		const std::string logFormat = m_ui.txtLogFormat->text().toStdString();
 		if (instrumentationEnabled && !logFormat.empty() && !ValidateInstrumentationLogFormat(*m_cpu, logFormat, error))
 		{
@@ -180,7 +178,7 @@ void BreakpointDialog::accept()
 		mc->maxHits = static_cast<u32>(m_ui.spnMaxHitCount->value());
 		mc->description = m_ui.txtDescription->text().toStdString();
 
-		const bool instrumentationEnabled = m_ui.grpInstrumentation->isChecked();
+		const bool instrumentationEnabled = m_ui.grpLogWhenHit->isChecked();
 		const std::string logFormat = m_ui.txtLogFormat->text().toStdString();
 		if (instrumentationEnabled && !logFormat.empty() && !ValidateInstrumentationLogFormat(*m_cpu, logFormat, error))
 		{
@@ -225,8 +223,6 @@ void BreakpointDialog::accept()
 		int result = 0;
 		if (m_ui.chkEnable->isChecked())
 			result |= MEMCHECK_BREAK;
-		if (m_ui.chkLog->isChecked())
-			result |= MEMCHECK_LOG;
 
 		mc->result = static_cast<MemCheckResult>(result);
 	}

--- a/pcsx2-qt/Debugger/Breakpoints/BreakpointDialog.ui
+++ b/pcsx2-qt/Debugger/Breakpoints/BreakpointDialog.ui
@@ -285,7 +285,7 @@
   </widget>
   <widget class="QGroupBox" name="grpInstrumentation">
    <property name="enabled">
-    <bool>false</bool>
+    <bool>true</bool>
    </property>
    <property name="geometry">
     <rect>
@@ -318,12 +318,12 @@
     <item row="0" column="1">
      <widget class="QLineEdit" name="txtLogFormat">
       <property name="toolTip">
-       <string>Logged to the console when the breakpoint is hit. Wrap an expression in braces to substitute its value, e.g. &quot;ra={ra} val={[4,sp]}&quot;. Use &quot;{{&quot; and &quot;}}&quot; for literal braces.</string>
+       <string>Logged to the console when the breakpoint is hit. Wrap an expression in braces to substitute its value, e.g. "ra={ra} val={[sp,4]}". Use "{{" and "}}" for literal braces.</string>
       </property>
      </widget>
     </item>
     <item row="1" column="0" colspan="2">
-     <widget class="QCheckBox" name="chkLogContinue">
+     <widget class="QCheckBox" name="chkContinueOnHit">
       <property name="toolTip">
        <string>Log the message and resume execution instead of pausing.</string>
       </property>
@@ -434,7 +434,7 @@
   <tabstop>txtSize</tabstop>
   <tabstop>txtCondition</tabstop>
   <tabstop>txtLogFormat</tabstop>
-  <tabstop>chkLogContinue</tabstop>
+  <tabstop>chkContinueOnHit</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/pcsx2-qt/Debugger/Breakpoints/BreakpointDialog.ui
+++ b/pcsx2-qt/Debugger/Breakpoints/BreakpointDialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>375</width>
-    <height>300</height>
+    <height>400</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -22,19 +22,19 @@
   <property name="minimumSize">
    <size>
     <width>375</width>
-    <height>300</height>
+    <height>400</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
     <width>375</width>
-    <height>300</height>
+    <height>400</height>
    </size>
   </property>
   <property name="baseSize">
    <size>
     <width>375</width>
-    <height>300</height>
+    <height>400</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -44,7 +44,7 @@
    <property name="geometry">
     <rect>
      <x>20</x>
-     <y>260</y>
+     <y>360</y>
      <width>341</width>
      <height>32</height>
     </rect>
@@ -283,6 +283,57 @@
     </item>
    </layout>
   </widget>
+  <widget class="QGroupBox" name="grpInstrumentation">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="geometry">
+    <rect>
+     <x>110</x>
+     <y>255</y>
+     <width>251</width>
+     <height>95</height>
+    </rect>
+   </property>
+   <property name="title">
+    <string>Instrumentation</string>
+   </property>
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>false</bool>
+   </property>
+   <layout class="QFormLayout" name="formLayout_5">
+    <item row="0" column="0">
+     <widget class="QLabel" name="label_5">
+      <property name="text">
+       <string>Log Format</string>
+      </property>
+      <property name="buddy">
+       <cstring>txtLogFormat</cstring>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="1">
+     <widget class="QLineEdit" name="txtLogFormat">
+      <property name="toolTip">
+       <string>Logged to the console when the breakpoint is hit. Wrap an expression in braces to substitute its value, e.g. &quot;ra={ra} val={[4,sp]}&quot;. Use &quot;{{&quot; and &quot;}}&quot; for literal braces.</string>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="0" colspan="2">
+     <widget class="QCheckBox" name="chkLogContinue">
+      <property name="toolTip">
+       <string>Log the message and resume execution instead of pausing.</string>
+      </property>
+      <property name="text">
+       <string>Continue on hit</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
   <widget class="QGroupBox" name="groupBox_5">
    <property name="geometry">
     <rect>
@@ -321,6 +372,53 @@
     </item>
    </layout>
   </widget>
+  <widget class="QGroupBox" name="grpHitCount">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>170</y>
+     <width>91</width>
+     <height>91</height>
+    </rect>
+   </property>
+   <property name="title">
+    <string>Hit Count</string>
+   </property>
+   <layout class="QVBoxLayout" name="verticalLayout_3">
+    <item>
+     <widget class="QLabel" name="label_6">
+      <property name="text">
+       <string>Max Hits</string>
+      </property>
+      <property name="buddy">
+       <cstring>spnMaxHitCount</cstring>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QSpinBox" name="spnMaxHitCount">
+      <property name="toolTip">
+       <string>Automatically disable this breakpoint after it has been hit this many times. Set to 0 for the breakpoint to never disable.</string>
+      </property>
+      <property name="specialValueText">
+       <string>None</string>
+      </property>
+      <property name="wrapping">
+       <bool>true</bool>
+      </property>
+      <property name="minimum">
+       <number>0</number>
+      </property>
+      <property name="maximum">
+       <number>9999999</number>
+      </property>
+      <property name="value">
+       <number>0</number>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
  </widget>
  <tabstops>
   <tabstop>rdoMemory</tabstop>
@@ -329,11 +427,14 @@
   <tabstop>txtDescription</tabstop>
   <tabstop>chkLog</tabstop>
   <tabstop>chkEnable</tabstop>
+  <tabstop>spnMaxHitCount</tabstop>
   <tabstop>chkRead</tabstop>
   <tabstop>chkWrite</tabstop>
   <tabstop>chkChange</tabstop>
   <tabstop>txtSize</tabstop>
   <tabstop>txtCondition</tabstop>
+  <tabstop>txtLogFormat</tabstop>
+  <tabstop>chkLogContinue</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/pcsx2-qt/Debugger/Breakpoints/BreakpointDialog.ui
+++ b/pcsx2-qt/Debugger/Breakpoints/BreakpointDialog.ui
@@ -283,7 +283,7 @@
     </item>
    </layout>
   </widget>
-  <widget class="QGroupBox" name="grpInstrumentation">
+  <widget class="QGroupBox" name="grpLogWhenHit">
    <property name="enabled">
     <bool>true</bool>
    </property>
@@ -296,7 +296,7 @@
     </rect>
    </property>
    <property name="title">
-    <string>Instrumentation</string>
+    <string>Log When Hit</string>
    </property>
    <property name="checkable">
     <bool>true</bool>
@@ -347,19 +347,6 @@
     <string/>
    </property>
    <layout class="QVBoxLayout" name="verticalLayout">
-    <item>
-     <widget class="QCheckBox" name="chkLog">
-      <property name="enabled">
-       <bool>true</bool>
-      </property>
-      <property name="text">
-       <string>Log</string>
-      </property>
-      <property name="checked">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
     <item>
      <widget class="QCheckBox" name="chkEnable">
       <property name="text">
@@ -425,7 +412,6 @@
   <tabstop>rdoExecute</tabstop>
   <tabstop>txtAddress</tabstop>
   <tabstop>txtDescription</tabstop>
-  <tabstop>chkLog</tabstop>
   <tabstop>chkEnable</tabstop>
   <tabstop>spnMaxHitCount</tabstop>
   <tabstop>chkRead</tabstop>
@@ -433,6 +419,7 @@
   <tabstop>chkChange</tabstop>
   <tabstop>txtSize</tabstop>
   <tabstop>txtCondition</tabstop>
+  <tabstop>grpLogWhenHit</tabstop>
   <tabstop>txtLogFormat</tabstop>
   <tabstop>chkContinueOnHit</tabstop>
  </tabstops>

--- a/pcsx2-qt/Debugger/Breakpoints/BreakpointDialog.ui
+++ b/pcsx2-qt/Debugger/Breakpoints/BreakpointDialog.ui
@@ -320,6 +320,9 @@
       <property name="toolTip">
        <string>Logged to the console when the breakpoint is hit. Wrap an expression in braces to substitute its value, e.g. "ra={ra} val={[sp,4]}". Use "{{" and "}}" for literal braces.</string>
       </property>
+      <property name="placeholderText">
+       <string>Hit breakpoint @ {pc}</string>
+      </property>
      </widget>
     </item>
     <item row="1" column="0" colspan="2">

--- a/pcsx2-qt/Debugger/Breakpoints/BreakpointModel.cpp
+++ b/pcsx2-qt/Debugger/Breakpoints/BreakpointModel.cpp
@@ -89,7 +89,7 @@ QVariant BreakpointModel::data(const QModelIndex& index, int role) const
 				case BreakpointColumns::CONDITION:
 					return bp->hasCond ? QString::fromStdString(bp->cond.expressionString) : "";
 				case BreakpointColumns::HITS:
-					return tr("--");
+					return QString::number(bp->totalHits);
 			}
 		}
 		else if (const auto* mc = std::get_if<MemCheck>(&bp_mc))
@@ -118,7 +118,7 @@ QVariant BreakpointModel::data(const QModelIndex& index, int role) const
 				case BreakpointColumns::CONDITION:
 					return mc->hasCond ? QString::fromStdString(mc->cond.expressionString) : "";
 				case BreakpointColumns::HITS:
-					return QString::number(mc->numHits);
+					return QString::number(mc->totalHits);
 			}
 		}
 	}
@@ -167,7 +167,7 @@ QVariant BreakpointModel::data(const QModelIndex& index, int role) const
 				case BreakpointColumns::CONDITION:
 					return bp->hasCond ? QString::fromStdString(bp->cond.expressionString) : "";
 				case BreakpointColumns::HITS:
-					return 0;
+					return bp->totalHits;
 			}
 		}
 		else if (const auto* mc = std::get_if<MemCheck>(&bp_mc))
@@ -189,7 +189,7 @@ QVariant BreakpointModel::data(const QModelIndex& index, int role) const
 				case BreakpointColumns::CONDITION:
 					return mc->hasCond ? QString::fromStdString(mc->cond.expressionString) : "";
 				case BreakpointColumns::HITS:
-					return mc->numHits;
+					return mc->totalHits;
 			}
 		}
 	}
@@ -215,7 +215,7 @@ QVariant BreakpointModel::data(const QModelIndex& index, int role) const
 				case BreakpointColumns::CONDITION:
 					return bp->hasCond ? QString::fromStdString(bp->cond.expressionString) : "";
 				case BreakpointColumns::HITS:
-					return 0;
+					return bp->totalHits;
 			}
 		}
 		else if (const auto* mc = std::get_if<MemCheck>(&bp_mc))
@@ -235,7 +235,7 @@ QVariant BreakpointModel::data(const QModelIndex& index, int role) const
 				case BreakpointColumns::CONDITION:
 					return mc->hasCond ? QString::fromStdString(mc->cond.expressionString) : "";
 				case BreakpointColumns::HITS:
-					return mc->numHits;
+					return mc->totalHits;
 				case BreakpointColumns::ENABLED:
 					return (mc->result & MEMCHECK_BREAK);
 			}
@@ -515,6 +515,8 @@ bool BreakpointModel::insertBreakpointRows(int row, int count, std::vector<Break
 			Host::RunOnCPUThread([cpu = m_cpu.getCpuType(), bp = *bp] {
 				CBreakPoints::AddBreakPoint(cpu, bp.addr, false, bp.enabled);
 				CBreakPoints::ChangeBreakPointDescription(cpu, bp.addr, bp.description);
+				CBreakPoints::ChangeBreakPointMaxHits(cpu, bp.addr, bp.maxHits);
+				CBreakPoints::ChangeBreakPointTotalHits(cpu, bp.addr, bp.totalHits);
 				if (bp.hasCond)
 				{
 					CBreakPoints::ChangeBreakPointAddCond(cpu, bp.addr, bp.cond);
@@ -526,6 +528,8 @@ bool BreakpointModel::insertBreakpointRows(int row, int count, std::vector<Break
 			Host::RunOnCPUThread([cpu = m_cpu.getCpuType(), mc = *mc] {
 				CBreakPoints::AddMemCheck(cpu, mc.start, mc.end, mc.memCond, mc.result);
 				CBreakPoints::ChangeMemCheckDescription(cpu, mc.start, mc.end, mc.description);
+				CBreakPoints::ChangeMemCheckMaxHits(cpu, mc.start, mc.end, mc.maxHits);
+				CBreakPoints::ChangeMemCheckTotalHits(cpu, mc.start, mc.end, mc.totalHits);
 				if (mc.hasCond)
 				{
 					CBreakPoints::ChangeMemCheckAddCond(cpu, mc.start, mc.end, mc.cond);

--- a/pcsx2-qt/Debugger/Breakpoints/BreakpointModel.cpp
+++ b/pcsx2-qt/Debugger/Breakpoints/BreakpointModel.cpp
@@ -517,6 +517,7 @@ bool BreakpointModel::insertBreakpointRows(int row, int count, std::vector<Break
 				CBreakPoints::ChangeBreakPointDescription(cpu, bp.addr, bp.description);
 				CBreakPoints::ChangeBreakPointMaxHits(cpu, bp.addr, bp.maxHits);
 				CBreakPoints::ChangeBreakPointTotalHits(cpu, bp.addr, bp.totalHits);
+				CBreakPoints::ChangeBreakPointInstrumentation(cpu, bp.addr, bp.instrumentationEnabled, bp.logFormat, bp.continueOnHit);
 				if (bp.hasCond)
 				{
 					CBreakPoints::ChangeBreakPointAddCond(cpu, bp.addr, bp.cond);
@@ -530,6 +531,7 @@ bool BreakpointModel::insertBreakpointRows(int row, int count, std::vector<Break
 				CBreakPoints::ChangeMemCheckDescription(cpu, mc.start, mc.end, mc.description);
 				CBreakPoints::ChangeMemCheckMaxHits(cpu, mc.start, mc.end, mc.maxHits);
 				CBreakPoints::ChangeMemCheckTotalHits(cpu, mc.start, mc.end, mc.totalHits);
+				CBreakPoints::ChangeMemCheckInstrumentation(cpu, mc.start, mc.end, mc.instrumentationEnabled, mc.logFormat, mc.continueOnHit);
 				if (mc.hasCond)
 				{
 					CBreakPoints::ChangeMemCheckAddCond(cpu, mc.start, mc.end, mc.cond);

--- a/pcsx2-qt/Debugger/Breakpoints/BreakpointView.cpp
+++ b/pcsx2-qt/Debugger/Breakpoints/BreakpointView.cpp
@@ -5,6 +5,7 @@
 
 #include "QtUtils.h"
 #include "Debugger/DebuggerSettingsManager.h"
+#include "Debugger/DebuggerWindow.h"
 #include "BreakpointDialog.h"
 #include "BreakpointModel.h"
 
@@ -23,6 +24,8 @@ BreakpointView::BreakpointView(const DebuggerViewParameters& parameters)
 	m_ui.breakpointList->setModel(m_model);
 	m_ui.breakpointList->horizontalHeader()->setSectionsMovable(true);
 	this->resizeColumns();
+
+	connect(g_debugger_window, &DebuggerWindow::onVMActuallyPaused, m_model, &BreakpointModel::refreshData);
 }
 
 void BreakpointView::onDoubleClicked(const QModelIndex& index)

--- a/pcsx2-qt/Debugger/Breakpoints/BreakpointView.cpp
+++ b/pcsx2-qt/Debugger/Breakpoints/BreakpointView.cpp
@@ -25,7 +25,11 @@ BreakpointView::BreakpointView(const DebuggerViewParameters& parameters)
 	m_ui.breakpointList->horizontalHeader()->setSectionsMovable(true);
 	this->resizeColumns();
 
-	connect(g_debugger_window, &DebuggerWindow::onVMActuallyPaused, m_model, &BreakpointModel::refreshData);
+	connect(g_debugger_window, &DebuggerWindow::onVMActuallyPaused, this, [this]() {
+		const bool isEditing = m_ui.breakpointList->viewport()->findChild<QWidget*>(QString(), Qt::FindDirectChildrenOnly) != nullptr;
+		if (!isEditing)
+			m_model->refreshData();
+	});
 
 	connect(m_model, &QAbstractTableModel::modelAboutToBeReset, this, [this]() {
 		const QItemSelectionModel* sel = m_ui.breakpointList->selectionModel();
@@ -55,8 +59,7 @@ BreakpointView::BreakpointView(const DebuggerViewParameters& parameters)
 	receiveEvent<DebuggerEvents::Refresh>([this](const DebuggerEvents::Refresh& event) -> bool {
 		// If focus is on a child of the breakpoint list and not the list itself,
 		// we assume an inline editor is active and we should not refresh.
-		bool isEditing = m_ui.breakpointList->isAncestorOf(QApplication::focusWidget()) 
-			&& QApplication::focusWidget() != m_ui.breakpointList;
+		const bool isEditing = m_ui.breakpointList->viewport()->findChild<QWidget*>(QString(), Qt::FindDirectChildrenOnly) != nullptr;
 
 		if (!QtHost::IsVMPaused() && !isEditing)
 			m_model->refreshData();

--- a/pcsx2-qt/Debugger/Breakpoints/BreakpointView.cpp
+++ b/pcsx2-qt/Debugger/Breakpoints/BreakpointView.cpp
@@ -26,6 +26,36 @@ BreakpointView::BreakpointView(const DebuggerViewParameters& parameters)
 	this->resizeColumns();
 
 	connect(g_debugger_window, &DebuggerWindow::onVMActuallyPaused, m_model, &BreakpointModel::refreshData);
+
+	connect(m_model, &QAbstractTableModel::modelAboutToBeReset, this, [this]() {
+		const QItemSelectionModel* sel = m_ui.breakpointList->selectionModel();
+		if (sel->hasSelection())
+		{
+			m_selectedRowOnRefresh = sel->selectedIndexes().first().row();
+			m_selectedColOnRefresh = sel->selectedIndexes().first().column();
+		}
+		else
+		{
+			m_selectedRowOnRefresh = -1;
+			m_selectedColOnRefresh = -1;
+		}
+	});
+	connect(m_model, &QAbstractTableModel::modelReset, this, [this]() {
+		if (m_selectedRowOnRefresh >= 0 && m_selectedRowOnRefresh < m_model->rowCount())
+		{
+			const QModelIndex idx = m_model->index(m_selectedRowOnRefresh, m_selectedColOnRefresh);
+			m_ui.breakpointList->selectionModel()->setCurrentIndex(idx, QItemSelectionModel::ClearAndSelect);
+		}
+	});
+
+	// Continue-on-hit breakpoints update their hit counts without ever pausing the VM,
+	// so onVMActuallyPaused never fires. Refresh periodically off the debugger's
+	// refresh timer so the UI can update regularly.
+	receiveEvent<DebuggerEvents::Refresh>([this](const DebuggerEvents::Refresh& event) -> bool {
+		if (!QtHost::IsVMPaused())
+			m_model->refreshData();
+		return true;
+	});
 }
 
 void BreakpointView::onDoubleClicked(const QModelIndex& index)

--- a/pcsx2-qt/Debugger/Breakpoints/BreakpointView.cpp
+++ b/pcsx2-qt/Debugger/Breakpoints/BreakpointView.cpp
@@ -50,10 +50,17 @@ BreakpointView::BreakpointView(const DebuggerViewParameters& parameters)
 
 	// Continue-on-hit breakpoints update their hit counts without ever pausing the VM,
 	// so onVMActuallyPaused never fires. Refresh periodically off the debugger's
-	// refresh timer so the UI can update regularly.
+	// refresh timer so the UI can update regularly. We don't refresh if the VM is paused
+	// or if a child of the breakpoint list is being edited.
 	receiveEvent<DebuggerEvents::Refresh>([this](const DebuggerEvents::Refresh& event) -> bool {
-		if (!QtHost::IsVMPaused())
+		// If focus is on a child of the breakpoint list and not the list itself,
+		// we assume an inline editor is active and we should not refresh.
+		bool isEditing = m_ui.breakpointList->isAncestorOf(QApplication::focusWidget()) 
+			&& QApplication::focusWidget() != m_ui.breakpointList;
+
+		if (!QtHost::IsVMPaused() && !isEditing)
 			m_model->refreshData();
+
 		return true;
 	});
 }

--- a/pcsx2-qt/Debugger/Breakpoints/BreakpointView.h
+++ b/pcsx2-qt/Debugger/Breakpoints/BreakpointView.h
@@ -40,4 +40,6 @@ private:
 	Ui::BreakpointView m_ui;
 
 	BreakpointModel* m_model;
+	int m_selectedRowOnRefresh = -1;
+	int m_selectedColOnRefresh = -1;
 };

--- a/pcsx2/DebugTools/Breakpoints.cpp
+++ b/pcsx2/DebugTools/Breakpoints.cpp
@@ -6,7 +6,10 @@
 #include "MIPSAnalyst.h"
 #include <cstdio>
 #include "R5900.h"
+#include "R5900OpcodeTables.h"
 #include "R3000A.h"
+#include "Memory.h"
+#include "IopMem.h"
 #include "common/Console.h"
 
 std::vector<BreakPoint> CBreakPoints::breakPoints_;
@@ -157,6 +160,26 @@ static void LogInstrumentation(BreakPointCpu cpu, const std::string& logFormat)
 													: static_cast<DebugInterface&>(r5900Debug);
 	const ConsoleColors color = (cpu == BREAKPOINT_IOP) ? Color_Yellow : Color_Cyan;
 	Console.WriteLn(color, "%s", EvaluateInstrumentationLogFormat(debug, logFormat).c_str());
+}
+
+std::string GetMemCheckDefaultLogFormat(BreakPointCpu cpu)
+{
+	const u32 pc = (cpu == BREAKPOINT_IOP) ? psxRegs.pc : cpuRegs.pc;
+
+	// We need to handle the branch delay slot!!! When the memory access happens in a branch
+	// delay slot, PC points at the branch but the actual load/store is one instruction later.
+	// To handle that, we can check the return of isMemCheckNeeded and handle pc appropriately.
+	const int needed = (cpu == BREAKPOINT_IOP) ? psxIsMemcheckNeeded(pc) : isMemcheckNeeded(pc);
+	const bool inDelaySlot = (needed == 2);
+	const u32 accessPc = inDelaySlot ? pc + 4 : pc;
+	const u32 op = (cpu == BREAKPOINT_IOP) ? iopMemRead32(accessPc) : memRead32(accessPc);
+
+	// The R5900 opcode table is used for both CPUs... confusing, I know!
+	const char* const pcExpr = inDelaySlot ? "{pc + 4}" : "{pc}";
+	const std::string defaultLogFormat = (R5900::GetInstruction(op).flags & IS_STORE)
+		? std::string("Hit write breakpoint @ ") + pcExpr
+		: std::string("Hit read breakpoint @ ") + pcExpr;
+	return defaultLogFormat;
 }
 
 MemCheck::MemCheck()
@@ -471,7 +494,9 @@ bool CBreakPoints::HandleBreakpointHit(BreakPointCpu cpu, u32 addr)
 	breakpoint.totalHits++;
 
 	const bool instrumentationEnabled = breakpoint.instrumentationEnabled;
-	const std::string logFormat = breakpoint.logFormat;
+	const std::string logFormat = breakpoint.logFormat.empty()
+		? "Hit execute breakpoint @ {pc}"
+		: breakpoint.logFormat;
 	const bool continueOnHit = breakpoint.continueOnHit;
 
 	if (instrumentationEnabled)
@@ -499,7 +524,9 @@ bool CBreakPoints::HandleMemCheckHit(BreakPointCpu cpu, u32 start, u32 end)
 	memCheck.totalHits++;
 
 	const bool instrumentationEnabled = memCheck.instrumentationEnabled;
-	const std::string logFormat = memCheck.logFormat;
+	const std::string logFormat = memCheck.logFormat.empty()
+		? GetMemCheckDefaultLogFormat(cpu)
+		: memCheck.logFormat;
 	const bool continueOnHit = memCheck.continueOnHit;
 
 	if (instrumentationEnabled)

--- a/pcsx2/DebugTools/Breakpoints.cpp
+++ b/pcsx2/DebugTools/Breakpoints.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 #include "R5900.h"
 #include "R3000A.h"
+#include "common/Console.h"
 
 std::vector<BreakPoint> CBreakPoints::breakPoints_;
 u32 CBreakPoints::breakSkipFirstAtEE_ = 0;
@@ -35,6 +36,129 @@ u32 standardizeBreakpointAddress(u32 addr)
 	return addr;
 }
 
+// Parses a format string. Calls onLiteral for strings of literal characters and calls
+// onExpression for escaped expressions. An escaped expression is an expression that appears
+// between curly braces (e.g. {v0}). Can interpret literal curly braces by double escaping,
+// e.g. "{{v0}}" would call onLiteral on "{v0}" rather than onExpression. Ideally this is
+// meant to be used how we use it in EvaluateInstrumentationLogFormat, building a literal
+// string out of the literal segments and evaluating the expressions for the expression statements.
+// Returns false if the brackets are unbalanced (e.g. "{{}" contains an unbalanced set of brackets).
+template <typename LiteralFn, typename ExpressionFn>
+static bool ParseInstrumentationLogFormat(const std::string& format, std::string& error, LiteralFn onLiteral, ExpressionFn onExpression)
+{
+	std::string literal;
+	for (size_t i = 0; i < format.size(); i++)
+	{
+		const char c = format[i];
+		if (c == '{')
+		{
+			if (i + 1 < format.size() && format[i + 1] == '{')
+			{
+				literal += '{';
+				i++;
+				continue;
+			}
+
+			const size_t close = format.find('}', i + 1);
+			if (close == std::string::npos)
+			{
+				error = "Unmatched '{' in log format.";
+				return false;
+			}
+
+			if (!literal.empty())
+			{
+				onLiteral(literal);
+				literal.clear();
+			}
+
+			onExpression(format.substr(i + 1, close - (i + 1)));
+			i = close;
+		}
+		else if (c == '}')
+		{
+			if (i + 1 < format.size() && format[i + 1] == '}')
+			{
+				literal += '}';
+				i++;
+				continue;
+			}
+
+			error = "Unmatched '}' in log format.";
+			return false;
+		}
+		else
+		{
+			literal += c;
+		}
+	}
+
+	if (!literal.empty())
+		onLiteral(literal);
+
+	return true;
+}
+
+// Example of evaluated strings:
+// format: "hit at PC={pc} ra={ra} a0={a0} a1={a1} v0={v0} sp={sp} mem=[{sp}]={{[{sp}]}} lit={{braces}}"
+// out: "hit at PC=0x438AB4 ra=0x438AAC a0=0x0 a1=0x0 v0=0x0 sp=0x1FFFA70 mem=[0x1FFFA70]={[0x1FFFA70]} lit={braces}"
+std::string EvaluateInstrumentationLogFormat(DebugInterface& debug, const std::string& format)
+{
+	std::string out;
+	std::string error;
+	ParseInstrumentationLogFormat(
+		format,
+		error,
+		[&out](const std::string& literal) { out += literal; },
+		[&out, &debug](const std::string& expression) {
+			PostfixExpression expr;
+			std::string err;
+			u64 value;
+			if (debug.initExpression(expression.c_str(), expr, err) && debug.parseExpression(expr, value, err))
+			{
+				char buffer[32];
+				std::snprintf(buffer, sizeof(buffer), "0x%llX", static_cast<unsigned long long>(value));
+				out += buffer;
+			}
+			else
+			{
+				out += "<err>";
+			}
+		});
+	return out;
+}
+
+bool ValidateInstrumentationLogFormat(DebugInterface& debug, const std::string& format, std::string& error)
+{
+	bool areExpressionsValid = true;
+	const bool areBracketsBalanced = ParseInstrumentationLogFormat(
+		format,
+		error,
+		[](const std::string&) {},
+		[&areExpressionsValid, &error, &debug](const std::string& expression) {
+			if (!areExpressionsValid)
+				return;
+			PostfixExpression expr;
+			u64 value;
+			if (!debug.initExpression(expression.c_str(), expr, error) ||
+				!debug.parseExpression(expr, value, error))
+				areExpressionsValid = false;
+		});
+	return areBracketsBalanced && areExpressionsValid;
+}
+
+// Logs an instrumentation message to the console for the breakpoint/memcheck that was just hit.
+static void LogInstrumentation(BreakPointCpu cpu, const std::string& logFormat)
+{
+	if (logFormat.empty())
+		return;
+
+	DebugInterface& debug = (cpu == BREAKPOINT_IOP) ? static_cast<DebugInterface&>(r3000Debug)
+													: static_cast<DebugInterface&>(r5900Debug);
+	const ConsoleColors color = (cpu == BREAKPOINT_IOP) ? Color_Yellow : Color_Cyan;
+	Console.WriteLn(color, "%s", EvaluateInstrumentationLogFormat(debug, logFormat).c_str());
+}
+
 MemCheck::MemCheck()
 	: start(0)
 	, end(0)
@@ -45,6 +169,8 @@ MemCheck::MemCheck()
 	, maxHits(0)
 	, hitsSinceEnabled(0)
 	, totalHits(0)
+	, instrumentationEnabled(false)
+	, continueOnHit(false)
 	, lastPC(0)
 	, lastAddr(0)
 	, lastSize(0)
@@ -318,8 +444,24 @@ void CBreakPoints::ChangeBreakPointTotalHits(BreakPointCpu cpu, u32 addr, u32 to
 	}
 }
 
+void CBreakPoints::ChangeBreakPointInstrumentation(BreakPointCpu cpu, u32 addr, bool enabled, const std::string& logFormat, bool continueOnHit)
+{
+	const size_t bp = FindBreakpoint(cpu, addr, true, false);
+	if (bp != INVALID_BREAKPOINT)
+	{
+		breakPoints_[bp].instrumentationEnabled = enabled;
+		breakPoints_[bp].logFormat = logFormat;
+		breakPoints_[bp].continueOnHit = continueOnHit;
+		Update();
+	}
+}
+
 bool CBreakPoints::HandleBreakpointHit(BreakPointCpu cpu, u32 addr)
 {
+
+	if (IsTempBreakPoint(cpu, addr))
+		return true;
+
 	const size_t breakpointIndex = FindBreakpoint(cpu, addr, true, false);
 	if (breakpointIndex == INVALID_BREAKPOINT)
 		return false;
@@ -328,10 +470,20 @@ bool CBreakPoints::HandleBreakpointHit(BreakPointCpu cpu, u32 addr)
 	breakpoint.hitsSinceEnabled++;
 	breakpoint.totalHits++;
 
+	const bool instrumentationEnabled = breakpoint.instrumentationEnabled;
+	const std::string logFormat = breakpoint.logFormat;
+	const bool continueOnHit = breakpoint.continueOnHit;
+
+	if (instrumentationEnabled)
+		LogInstrumentation(cpu, logFormat);
+
 	if(breakpoint.maxHits > 0 && breakpoint.hitsSinceEnabled >= breakpoint.maxHits)
 	{
 		ChangeBreakPoint(cpu, addr, false);
 	}
+
+	if (instrumentationEnabled && continueOnHit)
+		return false;
 
 	return true;
 }
@@ -346,10 +498,20 @@ bool CBreakPoints::HandleMemCheckHit(BreakPointCpu cpu, u32 start, u32 end)
 	memCheck.hitsSinceEnabled++;
 	memCheck.totalHits++;
 
+	const bool instrumentationEnabled = memCheck.instrumentationEnabled;
+	const std::string logFormat = memCheck.logFormat;
+	const bool continueOnHit = memCheck.continueOnHit;
+
+	if (instrumentationEnabled)
+		LogInstrumentation(cpu, logFormat);
+
 	if(memCheck.maxHits > 0 && memCheck.hitsSinceEnabled >= memCheck.maxHits)
 	{
 		ChangeMemCheck(cpu, start, end, memCheck.memCond, MemCheckResult(memCheck.result & ~MEMCHECK_BREAK));
 	}
+
+	if (instrumentationEnabled && continueOnHit)
+		return false;
 
 	return true;
 }
@@ -452,6 +614,18 @@ void CBreakPoints::ChangeMemCheckTotalHits(BreakPointCpu cpu, u32 start, u32 end
 	if (mc != INVALID_MEMCHECK)
 	{
 		memChecks_[mc].totalHits = totalHits;
+		Update(cpu);
+	}
+}
+
+void CBreakPoints::ChangeMemCheckInstrumentation(BreakPointCpu cpu, u32 start, u32 end, bool enabled, const std::string& logFormat, bool continueOnHit)
+{
+	const size_t mc = FindMemCheck(cpu, start, end);
+	if (mc != INVALID_MEMCHECK)
+	{
+		memChecks_[mc].instrumentationEnabled = enabled;
+		memChecks_[mc].logFormat = logFormat;
+		memChecks_[mc].continueOnHit = continueOnHit;
 		Update(cpu);
 	}
 }

--- a/pcsx2/DebugTools/Breakpoints.cpp
+++ b/pcsx2/DebugTools/Breakpoints.cpp
@@ -42,7 +42,9 @@ MemCheck::MemCheck()
 	, memCond(MEMCHECK_READWRITE)
 	, result(MEMCHECK_BOTH)
 	, cpu(BREAKPOINT_EE)
-	, numHits(0)
+	, maxHits(0)
+	, hitsSinceEnabled(0)
+	, totalHits(0)
 	, lastPC(0)
 	, lastAddr(0)
 	, lastSize(0)
@@ -58,7 +60,7 @@ void MemCheck::Action(u32 addr, bool write, int size, u32 pc)
 	int mask = write ? MEMCHECK_WRITE : MEMCHECK_READ;
 	if (memCond & mask)
 	{
-		++numHits;
+		++totalHits;
 
 		Log(addr, write, size, pc);
 		if (result & MEMCHECK_BREAK)
@@ -223,6 +225,7 @@ void CBreakPoints::ChangeBreakPoint(BreakPointCpu cpu, u32 addr, bool status)
 	if (bp != INVALID_BREAKPOINT)
 	{
 		breakPoints_[bp].enabled = status;
+		breakPoints_[bp].hitsSinceEnabled = 0;
 		Update(cpu, addr);
 	}
 }
@@ -295,6 +298,62 @@ void CBreakPoints::ChangeBreakPointDescription(BreakPointCpu cpu, u32 addr, cons
 	}
 }
 
+void CBreakPoints::ChangeBreakPointMaxHits(BreakPointCpu cpu, u32 addr, u32 maxHits)
+{
+	const size_t bp = FindBreakpoint(cpu, addr, true, false);
+	if (bp != INVALID_BREAKPOINT)
+	{
+		breakPoints_[bp].maxHits = maxHits;
+		Update();
+	}
+}
+
+void CBreakPoints::ChangeBreakPointTotalHits(BreakPointCpu cpu, u32 addr, u32 totalHits)
+{
+	const size_t bp = FindBreakpoint(cpu, addr, true, false);
+	if (bp != INVALID_BREAKPOINT)
+	{
+		breakPoints_[bp].totalHits = totalHits;
+		Update();
+	}
+}
+
+bool CBreakPoints::HandleBreakpointHit(BreakPointCpu cpu, u32 addr)
+{
+	const size_t breakpointIndex = FindBreakpoint(cpu, addr, true, false);
+	if (breakpointIndex == INVALID_BREAKPOINT)
+		return false;
+
+	BreakPoint& breakpoint = breakPoints_[breakpointIndex];
+	breakpoint.hitsSinceEnabled++;
+	breakpoint.totalHits++;
+
+	if(breakpoint.maxHits > 0 && breakpoint.hitsSinceEnabled >= breakpoint.maxHits)
+	{
+		ChangeBreakPoint(cpu, addr, false);
+	}
+
+	return true;
+}
+
+bool CBreakPoints::HandleMemCheckHit(BreakPointCpu cpu, u32 start, u32 end)
+{
+	const size_t memCheckIndex = FindMemCheck(cpu, start, end);
+	if (memCheckIndex == INVALID_MEMCHECK)
+		return false;
+
+	MemCheck& memCheck = memChecks_[memCheckIndex];
+	memCheck.hitsSinceEnabled++;
+	memCheck.totalHits++;
+
+	if(memCheck.maxHits > 0 && memCheck.hitsSinceEnabled >= memCheck.maxHits)
+	{
+		ChangeMemCheck(cpu, start, end, memCheck.memCond, MemCheckResult(memCheck.result & ~MEMCHECK_BREAK));
+	}
+
+	return true;
+}
+
 void CBreakPoints::AddMemCheck(BreakPointCpu cpu, u32 start, u32 end, MemCheckCondition cond, MemCheckResult result)
 {
 	// This will ruin any pending memchecks.
@@ -341,6 +400,7 @@ void CBreakPoints::ChangeMemCheck(BreakPointCpu cpu, u32 start, u32 end, MemChec
 	{
 		memChecks_[mc].memCond = cond;
 		memChecks_[mc].result = result;
+		memChecks_[mc].hitsSinceEnabled = 0;
 		Update(cpu);
 	}
 }
@@ -372,6 +432,26 @@ void CBreakPoints::ChangeMemCheckDescription(BreakPointCpu cpu, u32 start, u32 e
 	if (mc != INVALID_MEMCHECK)
 	{
 		memChecks_[mc].description = description;
+		Update(cpu);
+	}
+}
+
+void CBreakPoints::ChangeMemCheckMaxHits(BreakPointCpu cpu, u32 start, u32 end, u32 maxHits)
+{
+	const size_t mc = FindMemCheck(cpu, start, end);
+	if (mc != INVALID_MEMCHECK)
+	{
+		memChecks_[mc].maxHits = maxHits;
+		Update(cpu);
+	}
+}
+
+void CBreakPoints::ChangeMemCheckTotalHits(BreakPointCpu cpu, u32 start, u32 end, u32 totalHits)
+{
+	const size_t mc = FindMemCheck(cpu, start, end);
+	if (mc != INVALID_MEMCHECK)
+	{
+		memChecks_[mc].totalHits = totalHits;
 		Update(cpu);
 	}
 }

--- a/pcsx2/DebugTools/Breakpoints.h
+++ b/pcsx2/DebugTools/Breakpoints.h
@@ -70,7 +70,6 @@ enum MemCheckCondition
 enum MemCheckResult
 {
 	MEMCHECK_IGNORE = 0x00,
-	MEMCHECK_LOG = 0x01,
 	MEMCHECK_BREAK = 0x02,
 
 	MEMCHECK_BOTH = 0x03,

--- a/pcsx2/DebugTools/Breakpoints.h
+++ b/pcsx2/DebugTools/Breakpoints.h
@@ -41,6 +41,10 @@ struct BreakPoint
 	u32 hitsSinceEnabled = 0;
 	u32 totalHits = 0;
 
+	bool instrumentationEnabled = false;
+	std::string logFormat;
+	bool continueOnHit = false;
+
 	std::string description;
 
 	bool operator==(const BreakPoint& other) const
@@ -90,6 +94,10 @@ struct MemCheck
 	u32 hitsSinceEnabled;
 	u32 totalHits;
 
+	bool instrumentationEnabled;
+	std::string logFormat;
+	bool continueOnHit;
+
 	u32 lastPC;
 	u32 lastAddr;
 	int lastSize;
@@ -132,6 +140,7 @@ public:
 	static void ChangeBreakPointDescription(BreakPointCpu cpu, u32 addr, const std::string& description);
 	static void ChangeBreakPointMaxHits(BreakPointCpu cpu, u32 addr, u32 maxHits);
 	static void ChangeBreakPointTotalHits(BreakPointCpu cpu, u32 addr, u32 totalHits);
+	static void ChangeBreakPointInstrumentation(BreakPointCpu cpu, u32 addr, bool enabled, const std::string& logFormat, bool continueOnHit);
 
 	static bool HandleBreakpointHit(BreakPointCpu cpu, u32 addr);
 
@@ -143,6 +152,7 @@ public:
 	static void ChangeMemCheckDescription(BreakPointCpu cpu, u32 start, u32 end, const std::string& description);
 	static void ChangeMemCheckMaxHits(BreakPointCpu cpu, u32 start, u32 end, u32 maxHits);
 	static void ChangeMemCheckTotalHits(BreakPointCpu cpu, u32 start, u32 end, u32 totalHits);
+	static void ChangeMemCheckInstrumentation(BreakPointCpu cpu, u32 start, u32 end, bool enabled, const std::string& logFormat, bool continueOnHit);
 	static void ClearAllMemChecks();
 
 	static bool HandleMemCheckHit(BreakPointCpu cpu, u32 start, u32 end);
@@ -200,3 +210,6 @@ private:
 
 // called from the dynarec
 u32 standardizeBreakpointAddress(u32 addr);
+
+std::string EvaluateInstrumentationLogFormat(DebugInterface& debug, const std::string& format);
+bool ValidateInstrumentationLogFormat(DebugInterface& debug, const std::string& format, std::string& error);

--- a/pcsx2/DebugTools/Breakpoints.h
+++ b/pcsx2/DebugTools/Breakpoints.h
@@ -37,6 +37,10 @@ struct BreakPoint
 	BreakPointCond cond;
 	BreakPointCpu cpu;
 
+	u32 maxHits = 0;
+	u32 hitsSinceEnabled = 0;
+	u32 totalHits = 0;
+
 	std::string description;
 
 	bool operator==(const BreakPoint& other) const
@@ -82,7 +86,9 @@ struct MemCheck
 
 	std::string description;
 
-	u32 numHits;
+	u32 maxHits;
+	u32 hitsSinceEnabled;
+	u32 totalHits;
 
 	u32 lastPC;
 	u32 lastAddr;
@@ -124,6 +130,10 @@ public:
 	static void ChangeBreakPointRemoveCond(BreakPointCpu cpu, u32 addr);
 	static BreakPointCond* GetBreakPointCondition(BreakPointCpu cpu, u32 addr);
 	static void ChangeBreakPointDescription(BreakPointCpu cpu, u32 addr, const std::string& description);
+	static void ChangeBreakPointMaxHits(BreakPointCpu cpu, u32 addr, u32 maxHits);
+	static void ChangeBreakPointTotalHits(BreakPointCpu cpu, u32 addr, u32 totalHits);
+
+	static bool HandleBreakpointHit(BreakPointCpu cpu, u32 addr);
 
 	static void AddMemCheck(BreakPointCpu cpu, u32 start, u32 end, MemCheckCondition cond, MemCheckResult result);
 	static void RemoveMemCheck(BreakPointCpu cpu, u32 start, u32 end);
@@ -131,7 +141,12 @@ public:
 	static void ChangeMemCheckRemoveCond(BreakPointCpu cpu, u32 start, u32 end);
 	static void ChangeMemCheckAddCond(BreakPointCpu cpu, u32 start, u32 end, const BreakPointCond& cond);
 	static void ChangeMemCheckDescription(BreakPointCpu cpu, u32 start, u32 end, const std::string& description);
+	static void ChangeMemCheckMaxHits(BreakPointCpu cpu, u32 start, u32 end, u32 maxHits);
+	static void ChangeMemCheckTotalHits(BreakPointCpu cpu, u32 start, u32 end, u32 totalHits);
 	static void ClearAllMemChecks();
+
+	static bool HandleMemCheckHit(BreakPointCpu cpu, u32 start, u32 end);
+
 
 	static void SetSkipFirst(BreakPointCpu cpu, u32 pc);
 	static u32 CheckSkipFirst(BreakPointCpu cpu, u32 pc);

--- a/pcsx2/Interpreter.cpp
+++ b/pcsx2/Interpreter.cpp
@@ -77,6 +77,9 @@ void intBreakpoint(bool memcheck)
 		auto cond = CBreakPoints::GetBreakPointCondition(BREAKPOINT_EE, pc);
 		if (cond && !cond->Evaluate())
 			return;
+
+		if(!CBreakPoints::HandleBreakpointHit(BREAKPOINT_EE, pc))
+			return;
 	}
 
 	CBreakPoints::SetBreakpointTriggered(true, BREAKPOINT_EE);

--- a/pcsx2/R3000AInterpreter.cpp
+++ b/pcsx2/R3000AInterpreter.cpp
@@ -130,6 +130,9 @@ void psxBreakpoint(bool memcheck)
 		auto cond = CBreakPoints::GetBreakPointCondition(BREAKPOINT_IOP, pc);
 		if (cond && !cond->Evaluate())
 			return;
+
+		if (!CBreakPoints::HandleBreakpointHit(BREAKPOINT_IOP, pc))
+			return;
 	}
 
 	CBreakPoints::SetBreakpointTriggered(true, BREAKPOINT_IOP);

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -1383,13 +1383,8 @@ static bool psxDynarecMemcheck(size_t i)
 			return false;
 	}
 
-	if (mc.result & MEMCHECK_LOG)
-	{
-		if (opcode.flags & IS_STORE)
-			DevCon.WriteLn("Hit R3000 store breakpoint @0x%x", pc);
-		else
-			DevCon.WriteLn("Hit R3000 load breakpoint @0x%x", pc);
-	}
+	if (!CBreakPoints::HandleMemCheckHit(BREAKPOINT_IOP, mc.start, mc.end))
+		return false;
 
 	CBreakPoints::SetBreakpointTriggered(true, BREAKPOINT_IOP);
 	VMManager::SetPaused(true);

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -1341,7 +1341,8 @@ static bool psxDynarecCheckBreakpoint()
 		auto cond = CBreakPoints::GetBreakPointCondition(BREAKPOINT_IOP, pc);
 		if (cond == NULL || cond->Evaluate())
 		{
-			hit = true;
+			if(CBreakPoints::HandleBreakpointHit(BREAKPOINT_IOP, pc))
+				hit = true;
 		}
 	}
 	//check breakpoint in delay slot
@@ -1349,7 +1350,8 @@ static bool psxDynarecCheckBreakpoint()
 	{
 		auto cond = CBreakPoints::GetBreakPointCondition(BREAKPOINT_IOP, pc + 4);
 		if (cond == NULL || cond->Evaluate())
-			hit = true;
+			if(CBreakPoints::HandleBreakpointHit(BREAKPOINT_IOP, pc + 4))
+				hit = true;
 	}
 
 	if (!hit)

--- a/pcsx2/x86/ix86-32/iR5900.cpp
+++ b/pcsx2/x86/ix86-32/iR5900.cpp
@@ -1580,14 +1580,6 @@ void dynarecMemcheck(size_t i)
 			return;
 	}
 
-	if (mc.result & MEMCHECK_LOG)
-	{
-		if (opcode.flags & IS_STORE)
-			DevCon.WriteLn("Hit store breakpoint @0x%x", cpuRegs.pc);
-		else
-			DevCon.WriteLn("Hit load breakpoint @0x%x", cpuRegs.pc);
-	}
-
 	if (!CBreakPoints::HandleMemCheckHit(BREAKPOINT_EE, mc.start, mc.end))
 		return;
 

--- a/pcsx2/x86/ix86-32/iR5900.cpp
+++ b/pcsx2/x86/ix86-32/iR5900.cpp
@@ -1541,7 +1541,8 @@ void dynarecCheckBreakpoint()
 		auto cond = CBreakPoints::GetBreakPointCondition(BREAKPOINT_EE, pc);
 		if (cond == NULL || cond->Evaluate())
 		{
-			hit = true;
+			if(CBreakPoints::HandleBreakpointHit(BREAKPOINT_EE, pc))
+				hit = true;
 		}
 	}
 	//check breakpoint in delay slot
@@ -1549,7 +1550,8 @@ void dynarecCheckBreakpoint()
 	{
 		auto cond = CBreakPoints::GetBreakPointCondition(BREAKPOINT_EE, pc + 4);
 		if (cond == NULL || cond->Evaluate())
-			hit = true;
+			if(CBreakPoints::HandleBreakpointHit(BREAKPOINT_EE, pc + 4))
+				hit = true;
 	}
 
 	if (!hit)
@@ -1585,6 +1587,9 @@ void dynarecMemcheck(size_t i)
 		else
 			DevCon.WriteLn("Hit load breakpoint @0x%x", cpuRegs.pc);
 	}
+
+	if (!CBreakPoints::HandleMemCheckHit(BREAKPOINT_EE, mc.start, mc.end))
+		return;
 
 	CBreakPoints::SetBreakpointTriggered(true, BREAKPOINT_EE);
 	VMManager::SetPaused(true);


### PR DESCRIPTION
### Description of Changes
Implemented an instrumentation feature for the debugger that allows the user to instrument breakpoints. The three primary features are:
1. Instrumentation allows the user to log custom messages when breakpoints are hit and print the values of registers or memory addresses.
2. Instrumented breakpoints can "Continue on Hit" allowing the logs to print without actually stopping at the breakpoint.
3. Added a "max hit count" feature for breakpoints that lets the user define the number of times the breakpoint can be hit before automatically disabling.

Also added the following minor changes:
1. Breakpoints now display the hit count in the breakpoint list ui.
2. The breakpoint list ui now refreshes about every second and every time a hit pauses the VM.
3. Added some data persistence through breakpoint edits, such as keeping the total hits a breakpoint has had. This resets if the breakpoint address changes.
4. Breakpoint list entry selections now persist through UI refreshes.
5. An error box will pop up if a bad instrumentation log format is being provided.

### Rationale behind Changes
Not sure how descriptive this needs to be, but...

- The idea behind instrumentation was to easily log values of registers or memory over many iterations quickly without needing to actually pause the game. This also comes with the obvious upside of not needing to hit the Go/Pause button over and over while manually looking at the registers :). I tried to use as much of the existing functionality as possible, combining some of my logic for parsing literals while passing expressions into already existing functions to parse those expressions and then printing the returned values. Below is an example of an instrumentation log string and an example output:
```
// format: "hit at PC={pc} ra={ra} v0={v0} sp={sp} lit={{braces}}"
// out: "hit at PC=0x438AB4 ra=0x438AAC v0=0x0 sp=0x1FFFA70 lit={braces}"
```

- The max hit count feature is just a nice quality of life feature that also happens to be useful for instrumentation. In high traffic instrumentation locations, you can get a deterministic number of logs rather than have it spewing tens of thousands of logs.

- The UI changes were simply to make the UI more intuitive. As the refreshes happen at more regular intervals, the hit column is updated regularly which means the hit column is actually usable in a meaningful way. The refreshes also help update breakpoint state, such as in the case when a breakpoint is disabled after hitting the max hit count. Without the refresh, a breakpoint would still show as being enabled even if it really was disabled. More regular refreshes, however, will cause selected entries in the list to become unselected. Due to this, I had to add some functionality to the BreakpointView to make sure the selected row and column persisted, otherwise the right-click context menu wouldn't work properly.

- Data persistence between breakpoint edits makes the hit column more meaningful since it doesn't just get obliterated if you accidentally edit the breakpoint. I figured that resetting the count if the address changed made the most sense, since that implies the breakpoint is actually different than it was before. Also had to add persistence for the instrumentation functionality, otherwise that too would get destroyed everytime I went to edit a breakpoint.

### Suggested Testing Steps

- Create an execute breakpoint, set Max Hits to 3, run. Verify it auto-disables after exactly 3 hits and the HITS column shows 3.

- Edit the breakpoint without changing its address. Verify HITS column is preserved. Change the address or size. Verify it resets to 0.

- Enable instrumentation with a format string like "hit at pc={pc} ra={ra} sp={sp} mem={[sp]}". Verify the log line appears in the console on each hit with correct evaluated values.

- Test {{ and }} in the format string. Verify they produce literal braces in the output.

- Enter an invalid expression like {%%%}. Verify the dialog shows an error and does not close.

- Enable "Continue on hit". Verify the breakpoint logs but does not pause, and the HITS column increments live while the game runs.

- Perform the above for both memory breakpoints (memchecks) and execution breakpoints.

- Select a row in the breakpoint list and ensure it doesn't deselect when the UI refreshes.

There might be some other test cases I missed, but I think that covers the majority of cases here.

### Did you use AI to help find, test, or implement this issue or feature?
Yes! I used Claude Sonnet and Opus 4.8 primarily for pointing out the classes and functions I would be interested in for the feature. I used Claude to help with the implementation of the log format parsing.