### PR TITLE
Common/Emitter: Inline _xMovRtoR into xImpl_Mov operator

### DIFF
--- a/common/emitter/internal.h
+++ b/common/emitter/internal.h
@@ -30,8 +30,6 @@ namespace x86Emitter
 	extern void EmitRex(SIMDInstructionInfo info, const xRegisterBase& reg1, const xRegisterBase& reg2);
 	extern void EmitRex(SIMDInstructionInfo info, const xRegisterBase& reg1, const xIndirectVoid& sib);
 
-	extern void _xMovRtoR(const xRegisterInt& to, const xRegisterInt& from);
-
 	template <typename T>
 	inline void xWrite(T val)
 	{

--- a/common/emitter/movs.cpp
+++ b/common/emitter/movs.cpp
@@ -22,7 +22,7 @@
 namespace x86Emitter
 {
 
-	void _xMovRtoR(const xRegisterInt& to, const xRegisterInt& from)
+	void xImpl_Mov::operator()(const xRegisterInt& to, const xRegisterInt& from) const
 	{
 		pxAssert(to.GetOperandSize() == from.GetOperandSize());
 
@@ -30,12 +30,6 @@ namespace x86Emitter
 			return; // ignore redundant MOVs.
 
 		xOpWrite(from.GetPrefix16(), from.Is8BitOp() ? 0x88 : 0x89, from, to);
-	}
-
-	void xImpl_Mov::operator()(const xRegisterInt& to, const xRegisterInt& from) const
-	{
-		// FIXME WTF?
-		_xMovRtoR(to, from);
 	}
 
 	void xImpl_Mov::operator()(const xIndirectVoid& dest, const xRegisterInt& from) const

--- a/common/emitter/x86emitter.cpp
+++ b/common/emitter/x86emitter.cpp
@@ -1045,7 +1045,7 @@ const xRegister32
 			}
 			else if (displacement_size == 0)
 			{
-				_xMovRtoR(to, src.Index.MatchSizeTo(to));
+				xMOV(to, src.Index.MatchSizeTo(to));
 				return;
 			}
 			else if (!preserve_flags)
@@ -1053,7 +1053,7 @@ const xRegister32
 				// encode as MOV and ADD combo.  Make sure to use the immediate on the
 				// ADD since it can encode as an 8-bit sign-extended value.
 
-				_xMovRtoR(to, src.Index.MatchSizeTo(to));
+				xMOV(to, src.Index.MatchSizeTo(to));
 				xADD(to, src.Displacement);
 				return;
 			}
@@ -1071,7 +1071,7 @@ const xRegister32
 					// (this does not apply to older model P4s with the broken barrel shifter,
 					//  but we currently aren't optimizing for that target anyway).
 
-					_xMovRtoR(to, src.Index);
+					xMOV(to, src.Index);
 					xSHL(to, src.Scale);
 					return;
 				}
@@ -1085,14 +1085,14 @@ const xRegister32
 						if (src.Index == rsp)
 						{
 							// ESP is not encodable as an index (ix86 ignores it), thus:
-							_xMovRtoR(to, src.Base.MatchSizeTo(to)); // will do the trick!
+							xMOV(to, src.Base.MatchSizeTo(to)); // will do the trick!
 							if (src.Displacement)
 								xADD(to, src.Displacement);
 							return;
 						}
 						else if (src.Displacement == 0)
 						{
-							_xMovRtoR(to, src.Base.MatchSizeTo(to));
+							xMOV(to, src.Base.MatchSizeTo(to));
 							xADD(to, src.Index.MatchSizeTo(to));
 							return;
 						}
@@ -1102,7 +1102,7 @@ const xRegister32
 						// special case handling of ESP as Index, which is replaceable with
 						// a single MOV even when preserve_flags is set! :D
 
-						_xMovRtoR(to, src.Base.MatchSizeTo(to));
+						xMOV(to, src.Base.MatchSizeTo(to));
 						return;
 					}
 				}


### PR DESCRIPTION
### Description of Changes
Removed `_xMovRtoR` and inlined it into `xImpl_Mov::operator()`.

(first time touching the emitter code so it's a little bit out of my comfort zone, but gave it a shot anyway)

### Rationale behind Changes
`_xMovRtoR` was just wrapping the actual impl, so it didn't seem like it was adding much value. And also it finally resolves that "FIXME WTF?" comment from 10 years ago.

### Suggested Testing Steps
I personally tried all the games I have and had no issues but just test booting on a few games to make sure the JIT is fine.

### Did you use AI to help find, test, or implement this issue or feature?
No