### PR TITLE
GS/DX12: Enable Tight alignment

### DIFF
--- a/.github/workflows/scripts/windows/build-dependencies.bat
+++ b/.github/workflows/scripts/windows/build-dependencies.bat
@@ -97,6 +97,7 @@ set SHADERC_SPIRVHEADERS=58006c901d1d5c37dece6b6610e9af87fa951375
 set SHADERC_SPIRVTOOLS=6337eb62cadd7d124ac6789bf39c0f71148f0a73
 
 set AGILITYSDK=1.619.2
+set DXHEADERS=1.619.1
 
 call :downloadfile "qtbase-everywhere-src-%QT%.zip" "https://download.qt.io/official_releases/qt/%QTMINOR%/%QT%/submodules/qtbase-everywhere-src-%QT%.zip" 3529cc37297a5a7aae4486843b9fd41c30df1d79a770f85e240b537dcc327ca5 || goto error
 call :downloadfile "qtimageformats-everywhere-src-%QT%.zip" "https://download.qt.io/official_releases/qt/%QTMINOR%/%QT%/submodules/qtimageformats-everywhere-src-%QT%.zip" 37fba768f2780580dfae535ad6654cb9dc0bf2272e71b9b9781988de9ed0dac0 || goto error
@@ -129,6 +130,7 @@ call :downloadfile "KDDockWidgets-%KDDOCKWIDGETS%.zip" "https://github.com/KDAB/
 call :downloadfile "plutovg-%PLUTOVG%.zip" "https://github.com/sammycage/plutovg/archive/v%PLUTOVG%.zip" 4fe4e48f28aa80171b2166d45c0976ab0f21eecedb52cd4c3ef73b5afb48fac9 || goto error
 call :downloadfile "plutosvg-%PLUTOSVG%.zip" "https://github.com/sammycage/plutosvg/archive/v%PLUTOSVG%.zip" 82dee2c57ad712bdd6d6d81d3e76249d89caa4b5a4214353660fd5adff12201a || goto error
 call :downloadfile "agility-sdk-%AGILITYSDK%.nupkg" "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.D3D12/%AGILITYSDK%" eb92d90bb23b2ec23410c41d791e41dbdbec942ab946924d1fdcb31eac6f0735 || goto error
+call :downloadfile "DirectX-Headers-%DXHEADERS%.zip" "https://github.com/microsoft/DirectX-Headers/archive/v%DXHEADERS%.zip" 9eb8b102a90a42e4ea72a825f7d249d55ec90d164f030966c9b7784b93374927 || goto error
 call :downloadfile "rapidyaml-%RAPIDYAML%-src.zip" "https://github.com/biojppm/rapidyaml/releases/download/v%RAPIDYAML%/rapidyaml-%RAPIDYAML%-src.zip" 96276f55b9fa7837ac8f3f72fd52965879cbb5d5d2e6af548c69a177fb078304 || goto error
 
 call :downloadfile "shaderc-%SHADERC%.zip" "https://github.com/google/shaderc/archive/refs/tags/v%SHADERC%.zip" f9401cc5cb36c276cd1e072b6595dbd728148e8dba389e50f7339e2d388dbc08 || goto error
@@ -505,6 +507,16 @@ copy "build\native\bin\x64\D3D12Core.dll" "%INSTALLDIR%\bin\D3D12\D3D12Core.dll"
 if %DEBUG%==1 (
   copy "build\native\bin\x64\d3d12SDKLayers.dll" "%INSTALLDIR%\bin\D3D12\d3d12SDKLayers.dll" || goto error
 )
+cd .. || goto error
+
+rem DirectX Headers include a CMakeList file, which is absent in the Nuget package
+echo Unpacking DirectX Headers
+rmdir /S /Q "DirectX-Headers-%DXHEADERS%"
+%SEVENZIP% x "DirectX-Headers-%DXHEADERS%.zip" || goto error
+cd "DirectX-Headers-%DXHEADERS%" || goto error
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="%INSTALLDIR%" -DCMAKE_INSTALL_PREFIX="%INSTALLDIR%" -DDXHEADERS_BUILD_TEST=OFF -DDXHEADERS_BUILD_GOOGLE_TEST=OFF -B build -G Ninja || goto error
+cmake --build build --parallel || goto error
+ninja -C build install || goto error
 cd .. || goto error
 
 echo Building shaderc...

--- a/3rdparty/d3d12memalloc/CMakeLists.txt
+++ b/3rdparty/d3d12memalloc/CMakeLists.txt
@@ -3,5 +3,7 @@ add_library(D3D12MemAlloc
 	src/D3D12MemAlloc.cpp
 )
 
+target_link_libraries(D3D12MemAlloc PRIVATE Microsoft::DirectX-Headers)
+
 target_include_directories(D3D12MemAlloc PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
 disable_compiler_warnings_for_target(D3D12MemAlloc)

--- a/3rdparty/d3d12memalloc/d3d12memalloc.vcxproj
+++ b/3rdparty/d3d12memalloc/d3d12memalloc.vcxproj
@@ -20,6 +20,7 @@
   <ImportGroup Label="PropertySheets">
     <Import Project="..\DefaultProjectRootDir.props" />
     <Import Project="..\3rdparty.props" />
+    <Import Project="..\..\common\vsprops\DepsDir.props" />
     <Import Condition="$(Configuration.Contains(Debug))" Project="..\..\common\vsprops\CodeGen_Debug.props" />
     <Import Condition="$(Configuration.Contains(Devel))" Project="..\..\common\vsprops\CodeGen_Devel.props" />
     <Import Condition="$(Configuration.Contains(Release))" Project="..\..\common\vsprops\CodeGen_Release.props" />
@@ -37,9 +38,9 @@
   </ItemGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>D3D12MA_USING_DIRECTX_HEADERS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>TurnOffAllWarnings</WarningLevel>
-      <AdditionalIncludeDirectories>$(ProjectDir)include;$(ProjectDir)src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(DepsIncludeDir);$(ProjectDir)include;$(ProjectDir)src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/3rdparty/d3d12memalloc/include/D3D12MemAlloc.h
+++ b/3rdparty/d3d12memalloc/include/D3D12MemAlloc.h
@@ -24,7 +24,7 @@
 
 /** \mainpage D3D12 Memory Allocator
 
-<b>Version 3.1.0</b> (2026-02-23)
+<b>Version 3.2.0</b> (2026-06-05)
 
 Copyright (c) 2019-2026 Advanced Micro Devices, Inc. All rights reserved. \n
 License: MIT
@@ -889,10 +889,17 @@ enum POOL_FLAGS
     */
     POOL_FLAG_MSAA_TEXTURES_ALWAYS_COMMITTED = 0x2,
     /** Every allocation made in this pool will be created as a committed resource - will have its own memory block.
-    
+     
     There is also an equivalent flag for the entire allocator: D3D12MA::ALLOCATOR_FLAG_ALWAYS_COMMITTED.
     */
     POOL_FLAG_ALWAYS_COMMITTED = 0x4,
+    /** Disables tight resource alignment for all resources created from this pool.
+    
+    When tight alignment is supported and enabled for the allocator, resources created from custom pools
+    normally use it automatically. Specify this flag to restore pre-tight-alignment behavior for this pool:
+    tight alignment won't be requested and small buffers may again be preferred as committed resources.
+    */
+    POOL_FLAG_DONT_USE_TIGHT_ALIGNMENT = 0x8,
 
     // Bit mask to extract only `ALGORITHM` bits from entire set of flags.
     POOL_FLAG_ALGORITHM_MASK = POOL_FLAG_ALGORITHM_LINEAR
@@ -1114,7 +1121,8 @@ enum ALLOCATOR_FLAGS
     It can also be disabled for a single allocation by using #ALLOCATION_FLAG_STRATEGY_MIN_TIME.
 
     If the tight resource alignment feature is used by the library (which happens automatically whenever supported,
-    unless you use flag #ALLOCATOR_FLAG_DONT_USE_TIGHT_ALIGNMENT), then small buffers are not preferred as committed.
+    unless you use flag #ALLOCATOR_FLAG_DONT_USE_TIGHT_ALIGNMENT or
+    #POOL_FLAG_DONT_USE_TIGHT_ALIGNMENT on a custom pool), then small buffers are not preferred as committed.
     Long story short, you don't need to specify any of these flags.
     The library chooses the most optimal method automatically.
     */
@@ -2892,6 +2900,7 @@ as it is no longer needed.
 
 You can check if the tight alignment it is available in the current system by calling D3D12MA::Allocator::IsTightAlignmentSupported().
 You can tell the library to not use it by specifying D3D12MA::ALLOCATOR_FLAG_DONT_USE_TIGHT_ALIGNMENT.
+Custom pools can opt out independently by specifying D3D12MA::POOL_FLAG_DONT_USE_TIGHT_ALIGNMENT.
 Typically, you don't need to do any of those.
 
 The library automatically aligns all buffers to at least 256 B, even when the system supports smaller alignment.

--- a/3rdparty/d3d12memalloc/src/D3D12MemAlloc.cpp
+++ b/3rdparty/d3d12memalloc/src/D3D12MemAlloc.cpp
@@ -163,6 +163,14 @@ especially to test compatibility with D3D12_RESOURCE_HEAP_TIER_1 on modern GPUs.
     #endif
 #endif
 
+#ifndef D3D12MA_OPTIONS4_SUPPORTED
+    #ifdef __ID3D12Device5_INTERFACE_DEFINED__
+        #define D3D12MA_OPTIONS4_SUPPORTED 1
+    #else
+        #define D3D12MA_OPTIONS4_SUPPORTED 0
+    #endif
+#endif
+
 #ifndef D3D12MA_DEBUG_LOG
    #define D3D12MA_DEBUG_LOG(format, ...)
    /*
@@ -703,6 +711,13 @@ static UINT GetBitsPerPixel(DXGI_FORMAT format)
     case DXGI_FORMAT_R24_UNORM_X8_TYPELESS:
     case DXGI_FORMAT_X24_TYPELESS_G8_UINT:
         return 32;
+    case DXGI_FORMAT_B8G8R8A8_UNORM:
+    case DXGI_FORMAT_B8G8R8X8_UNORM:
+    case DXGI_FORMAT_B8G8R8A8_TYPELESS:
+    case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+    case DXGI_FORMAT_B8G8R8X8_TYPELESS:
+    case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+        return 32;
     case DXGI_FORMAT_R8G8_TYPELESS:
     case DXGI_FORMAT_R8G8_UNORM:
     case DXGI_FORMAT_R8G8_UINT:
@@ -716,6 +731,9 @@ static UINT GetBitsPerPixel(DXGI_FORMAT format)
     case DXGI_FORMAT_R16_UINT:
     case DXGI_FORMAT_R16_SNORM:
     case DXGI_FORMAT_R16_SINT:
+        return 16;
+    case DXGI_FORMAT_B5G6R5_UNORM:
+    case DXGI_FORMAT_B5G5R5A1_UNORM:
         return 16;
     case DXGI_FORMAT_R8_TYPELESS:
     case DXGI_FORMAT_R8_UNORM:
@@ -767,46 +785,175 @@ static ResourceClass ResourceDescToResourceClass(const D3D12_RESOURCE_DESC_T& re
         (resDesc.Flags & (D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET | D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL)) != 0;
     return isRenderTargetOrDepthStencil ? ResourceClass::RT_DS_Texture : ResourceClass::Non_RT_DS_Texture;
 }
+
+static bool ResourceDimensionIsTexture(D3D12_RESOURCE_DIMENSION dimension)
+{
+    return dimension == D3D12_RESOURCE_DIMENSION_TEXTURE1D ||
+        dimension == D3D12_RESOURCE_DIMENSION_TEXTURE2D ||
+        dimension == D3D12_RESOURCE_DIMENSION_TEXTURE3D;
+}
+
+static bool ResourceFlagsContainRenderTargetOrDepthStencil(D3D12_RESOURCE_FLAGS flags)
+{
+    return (flags & (D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET | D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL)) != 0;
+}
     
-// This algorithm is overly conservative.
+struct SmallAlignmentTileShape
+{
+    UINT Width;
+    UINT Height;
+    UINT Depth;
+};
+
+static bool GetSmallAlignmentTileShape(
+    D3D12_RESOURCE_DIMENSION dimension,
+    bool isMsaa,
+    UINT bitsPerUnit,
+    SmallAlignmentTileShape& outTileShape)
+{
+    if (isMsaa)
+    {
+        if (dimension != D3D12_RESOURCE_DIMENSION_TEXTURE2D)
+            return false;
+
+        switch (bitsPerUnit)
+        {
+        case    8: outTileShape = { 256, 256, 1 }; return true;
+        case   16: outTileShape = { 256, 128, 1 }; return true;
+        case   32: outTileShape = { 128, 128, 1 }; return true;
+        case   64: outTileShape = { 128,  64, 1 }; return true;
+        case  128: outTileShape = {  64,  64, 1 }; return true;
+        case  256: outTileShape = {  64,  32, 1 }; return true;
+        case  512: outTileShape = {  32,  32, 1 }; return true;
+        case 1024: outTileShape = {  32,  16, 1 }; return true;
+        case 2048: outTileShape = {  16,  16, 1 }; return true;
+        default: return false;
+        }
+    }
+
+    switch (dimension)
+    {
+    case D3D12_RESOURCE_DIMENSION_TEXTURE1D:
+        switch (bitsPerUnit)
+        {
+        case   8: outTileShape = { 4096, 1, 1 }; return true;
+        case  16: outTileShape = { 2048, 1, 1 }; return true;
+        case  32: outTileShape = { 1024, 1, 1 }; return true;
+        case  64: outTileShape = {  512, 1, 1 }; return true;
+        case 128: outTileShape = {  256, 1, 1 }; return true;
+        default: return false;
+        }
+
+    case D3D12_RESOURCE_DIMENSION_TEXTURE2D:
+        switch (bitsPerUnit)
+        {
+        case   8: outTileShape = { 64, 64, 1 }; return true;
+        case  16: outTileShape = { 64, 32, 1 }; return true;
+        case  32: outTileShape = { 32, 32, 1 }; return true;
+        case  64: outTileShape = { 32, 16, 1 }; return true;
+        case 128: outTileShape = { 16, 16, 1 }; return true;
+        default: return false;
+        }
+
+    case D3D12_RESOURCE_DIMENSION_TEXTURE3D:
+        // 4 KB counterparts of the documented 64 KB volume-tile shapes.
+        switch (bitsPerUnit)
+        {
+        case   8: outTileShape = { 16, 16, 16 }; return true;
+        case  16: outTileShape = { 16, 16,  8 }; return true;
+        case  32: outTileShape = { 16,  8,  8 }; return true;
+        case  64: outTileShape = {  8,  8,  8 }; return true;
+        case 128: outTileShape = {  8,  8,  4 }; return true;
+        default: return false;
+        }
+
+    default:
+        return false;
+    }
+}
+
+// This algorithm is overly conservative and applies only to the legacy small-alignment heuristic path.
 template<typename D3D12_RESOURCE_DESC_T>
 static bool CanUseSmallAlignment(const D3D12_RESOURCE_DESC_T& resourceDesc)
 {
-    if (resourceDesc.Dimension != D3D12_RESOURCE_DIMENSION_TEXTURE2D)
+    if (resourceDesc.SampleDesc.Count == 0 ||
+        resourceDesc.Layout != D3D12_TEXTURE_LAYOUT_UNKNOWN ||
+        resourceDesc.Width > UINT_MAX)
+    {
         return false;
-    if ((resourceDesc.Flags & (D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET | D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL)) != 0)
+    }
+
+    const bool isMsaa = resourceDesc.SampleDesc.Count > 1;
+    const bool isRtDs = ResourceFlagsContainRenderTargetOrDepthStencil(resourceDesc.Flags);
+    if (isMsaa && !isRtDs)
+    {
         return false;
-    if (resourceDesc.SampleDesc.Count > 1)
+    }
+    if (!isMsaa &&
+        isRtDs)
+    {
         return false;
-    if (resourceDesc.DepthOrArraySize != 1)
-        return false;
+    }
 
     UINT sizeX = (UINT)resourceDesc.Width;
-    UINT sizeY = resourceDesc.Height;
-    UINT bitsPerPixel = GetBitsPerPixel(resourceDesc.Format);
-    if (bitsPerPixel == 0)
+    UINT sizeY = 1;
+    UINT sizeZ = 1;
+    UINT bitsPerUnit = GetBitsPerPixel(resourceDesc.Format);
+    if (bitsPerUnit == 0)
         return false;
 
-    if (IsFormatCompressed(resourceDesc.Format))
+    switch (resourceDesc.Dimension)
     {
-        sizeX = DivideRoundingUp(sizeX, 4u);
-        sizeY = DivideRoundingUp(sizeY, 4u);
-        bitsPerPixel *= 16;
+    case D3D12_RESOURCE_DIMENSION_TEXTURE1D:
+        if (isMsaa)
+            return false;
+        // For 1D arrays, small-alignment eligibility depends on the mip0 slice size, not array size.
+        if (IsFormatCompressed(resourceDesc.Format))
+            return false;
+        break;
+
+    case D3D12_RESOURCE_DIMENSION_TEXTURE2D:
+        // For 2D arrays, small-alignment eligibility depends on mip0 width/height, not array size.
+        sizeY = resourceDesc.Height;
+        if (isMsaa && IsFormatCompressed(resourceDesc.Format))
+            return false;
+        if (IsFormatCompressed(resourceDesc.Format))
+        {
+            sizeX = DivideRoundingUp(sizeX, 4u);
+            sizeY = DivideRoundingUp(sizeY, 4u);
+            bitsPerUnit *= 16;
+        }
+        break;
+
+    case D3D12_RESOURCE_DIMENSION_TEXTURE3D:
+        if (isMsaa)
+            return false;
+        sizeY = resourceDesc.Height;
+        sizeZ = resourceDesc.DepthOrArraySize;
+        if (IsFormatCompressed(resourceDesc.Format))
+        {
+            sizeX = DivideRoundingUp(sizeX, 4u);
+            sizeY = DivideRoundingUp(sizeY, 4u);
+            bitsPerUnit *= 16;
+        }
+        break;
+
+    default:
+        return false;
     }
 
-    UINT tileSizeX = 0, tileSizeY = 0;
-    switch (bitsPerPixel)
-    {
-    case   8: tileSizeX = 64; tileSizeY = 64; break;
-    case  16: tileSizeX = 64; tileSizeY = 32; break;
-    case  32: tileSizeX = 32; tileSizeY = 32; break;
-    case  64: tileSizeX = 32; tileSizeY = 16; break;
-    case 128: tileSizeX = 16; tileSizeY = 16; break;
-    default: return false;
-    }
+    bitsPerUnit *= resourceDesc.SampleDesc.Count;
 
-    const UINT tileCount = DivideRoundingUp(sizeX, tileSizeX) * DivideRoundingUp(sizeY, tileSizeY);
-    return tileCount <= 16;
+    SmallAlignmentTileShape tileShape = {};
+    if (!GetSmallAlignmentTileShape(resourceDesc.Dimension, isMsaa, bitsPerUnit, tileShape))
+        return false;
+
+    const UINT64 tileCount =
+        UINT64(DivideRoundingUp(sizeX, tileShape.Width)) *
+        UINT64(DivideRoundingUp(sizeY, tileShape.Height)) *
+        UINT64(DivideRoundingUp(sizeZ, tileShape.Depth));
+    // Non-MSAA compares 64 KB against 4 KB tiles => 16 pages. MSAA compares 4 MB against 64 KB tiles => 64 pages.
+    return tileCount <= (isMsaa ? 64 : 16);
 }
     
 static bool ValidateAllocateMemoryParameters(
@@ -5988,6 +6135,7 @@ public:
     BOOL IsCacheCoherentUMA() const { return m_D3D12Architecture.CacheCoherentUMA; }
     bool SupportsResourceHeapTier2() const { return m_D3D12Options.ResourceHeapTier >= D3D12_RESOURCE_HEAP_TIER_2; }
     bool IsGPUUploadHeapSupported() const { return m_GPUUploadHeapSupported != FALSE; }
+    bool IsMsaa64KBAlignedTextureSupported() const { return m_MSAA64KBAlignedTextureSupported != FALSE; }
     bool IsTightAlignmentSupported() const { return m_TightAlignmentSupported != FALSE; }
     bool IsTightAlignmentEnabled() const { return IsTightAlignmentSupported() && m_UseTightAlignment; }
     bool UseMutex() const { return m_UseMutex; }
@@ -6076,7 +6224,7 @@ private:
     const bool m_UseMutex;
     const bool m_AlwaysCommitted;
     const bool m_MsaaAlwaysCommitted;
-    bool m_PreferSmallBuffersCommitted;
+    const bool m_PreferSmallBuffersCommitted;
     const bool m_UseTightAlignment;
     bool m_DefaultPoolsNotZeroed = false;
     ID3D12Device* m_Device; // AddRef
@@ -6105,6 +6253,7 @@ private:
     DXGI_ADAPTER_DESC m_AdapterDesc;
     D3D12_FEATURE_DATA_D3D12_OPTIONS m_D3D12Options;
     BOOL m_GPUUploadHeapSupported = FALSE;
+    BOOL m_MSAA64KBAlignedTextureSupported = FALSE;
     BOOL m_TightAlignmentSupported = FALSE;
     D3D12_FEATURE_DATA_ARCHITECTURE m_D3D12Architecture;
     AllocationObjectAllocator m_AllocationObjectAllocator;
@@ -6121,7 +6270,7 @@ private:
     */
     template<typename D3D12_RESOURCE_DESC_T>
     bool PrefersCommittedAllocation(const D3D12_RESOURCE_DESC_T& resourceDesc,
-        ALLOCATION_FLAGS strategy);
+        ALLOCATION_FLAGS strategy, bool useTightAlignment) const;
 
     // Allocates and registers new committed resource with implicit heap, as dedicated allocation.
     // Creates and returns Allocation object and optionally D3D12 resource.
@@ -6141,6 +6290,7 @@ private:
     template<typename D3D12_RESOURCE_DESC_T>
     HRESULT CalcAllocationParams(const ALLOCATION_DESC& allocDesc, UINT64 allocSize,
         const D3D12_RESOURCE_DESC_T* resDesc, // Optional
+        bool useTightAlignment,
         BlockVector*& outBlockVector, CommittedAllocationParameters& outCommittedAllocationParams, bool& outPreferCommitted);
 
     // Returns UINT32_MAX if index cannot be calculcated.
@@ -6174,7 +6324,10 @@ private:
     template<typename D3D12_RESOURCE_DESC_T>
     HRESULT GetResourceAllocationInfo(D3D12_RESOURCE_DESC_T& inOutResourceDesc,
         UINT32 NumCastableFormats, const DXGI_FORMAT* pCastableFormats,
-        D3D12_RESOURCE_ALLOCATION_INFO& outAllocInfo) const;
+        D3D12_RESOURCE_ALLOCATION_INFO& outAllocInfo,
+        bool useTightAlignment) const;
+
+    bool IsTightAlignmentEnabled(const ALLOCATION_DESC& allocDesc) const;
 
     bool NewAllocationWithinBudget(D3D12_HEAP_TYPE heapType, UINT64 size);
 
@@ -6277,6 +6430,17 @@ HRESULT AllocatorPimpl::Init(const ALLOCATOR_DESC& desc)
     }
 #endif // #if D3D12MA_OPTIONS16_SUPPORTED
 
+#if D3D12MA_OPTIONS4_SUPPORTED
+    {
+        D3D12_FEATURE_DATA_D3D12_OPTIONS4 options4 = {};
+        hr = m_Device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS4, &options4, sizeof(options4));
+        if (SUCCEEDED(hr))
+        {
+            m_MSAA64KBAlignedTextureSupported = options4.MSAA64KBAlignedTextureSupported;
+        }
+    }
+#endif // #if D3D12MA_OPTIONS4_SUPPORTED
+
 #if D3D12MA_TIGHT_ALIGNMENT_SUPPORTED
     {
         D3D12_FEATURE_DATA_TIGHT_ALIGNMENT tightAlignment = {};
@@ -6285,13 +6449,6 @@ HRESULT AllocatorPimpl::Init(const ALLOCATOR_DESC& desc)
         {
             m_TightAlignmentSupported = tightAlignment.SupportTier >= D3D12_TIGHT_ALIGNMENT_TIER_1;
             
-            // If tight alignment is supported (checked by the code above) and wasn't disabled by the developer
-            // (with ALLOCATOR_FLAG_DONT_USE_TIGHT_ALIGNMENT), disable the preference for creating small buffers as committed,
-            // as if ALLOCATOR_FLAG_DONT_PREFER_SMALL_BUFFERS_COMMITTED was specified.
-            if (IsTightAlignmentEnabled())
-            {
-                m_PreferSmallBuffersCommitted = false;
-            }
         }
     }
 #endif // #if D3D12MA_TIGHT_ALIGNMENT_SUPPORTED
@@ -6490,6 +6647,7 @@ HRESULT AllocatorPimpl::CreateResource(
     }
 
     HRESULT hr = E_NOINTERFACE;
+    const bool useTightAlignment = IsTightAlignmentEnabled(*pAllocDesc);
     CREATE_RESOURCE_PARAMS finalCreateParams = createParams;
     D3D12_RESOURCE_DESC finalResourceDesc;
 #ifdef __ID3D12Device8_INTERFACE_DEFINED__
@@ -6500,7 +6658,7 @@ HRESULT AllocatorPimpl::CreateResource(
     {
         finalResourceDesc = *createParams.GetResourceDesc();
         finalCreateParams.AccessResourceDesc() = &finalResourceDesc;
-        hr = GetResourceAllocationInfo(finalResourceDesc, 0, NULL, resAllocInfo);
+        hr = GetResourceAllocationInfo(finalResourceDesc, 0, NULL, resAllocInfo, useTightAlignment);
     }
 #ifdef __ID3D12Device8_INTERFACE_DEFINED__
     else if (createParams.Variant == CREATE_RESOURCE_PARAMS::VARIANT_WITH_STATE_AND_DESC1)
@@ -6509,7 +6667,7 @@ HRESULT AllocatorPimpl::CreateResource(
         {
             finalResourceDesc1 = *createParams.GetResourceDesc1();
             finalCreateParams.AccessResourceDesc1() = &finalResourceDesc1;
-            hr = GetResourceAllocationInfo(finalResourceDesc1, 0, NULL, resAllocInfo);
+            hr = GetResourceAllocationInfo(finalResourceDesc1, 0, NULL, resAllocInfo, useTightAlignment);
         }
     }
 #endif
@@ -6521,7 +6679,7 @@ HRESULT AllocatorPimpl::CreateResource(
             finalResourceDesc1 = *createParams.GetResourceDesc1();
             finalCreateParams.AccessResourceDesc1() = &finalResourceDesc1;
             hr = GetResourceAllocationInfo(finalResourceDesc1,
-                createParams.GetNumCastableFormats(), createParams.GetCastableFormats(), resAllocInfo);
+                createParams.GetNumCastableFormats(), createParams.GetCastableFormats(), resAllocInfo, useTightAlignment);
         }
     }
 #endif
@@ -6547,14 +6705,14 @@ HRESULT AllocatorPimpl::CreateResource(
     if (createParams.Variant >= CREATE_RESOURCE_PARAMS::VARIANT_WITH_STATE_AND_DESC1)
     {
         hr = CalcAllocationParams<D3D12_RESOURCE_DESC1>(*pAllocDesc, resAllocInfo.SizeInBytes,
-            createParams.GetResourceDesc1(),
+            createParams.GetResourceDesc1(), useTightAlignment,
             blockVector, committedAllocationParams, preferCommitted);
     }
     else
 #endif
     {
         hr = CalcAllocationParams<D3D12_RESOURCE_DESC>(*pAllocDesc, resAllocInfo.SizeInBytes,
-            createParams.GetResourceDesc(),
+            createParams.GetResourceDesc(), useTightAlignment,
             blockVector, committedAllocationParams, preferCommitted);
     }
     if (FAILED(hr))
@@ -6601,6 +6759,7 @@ HRESULT AllocatorPimpl::AllocateMemory(
     bool preferCommitted = false;
     HRESULT hr = CalcAllocationParams<D3D12_RESOURCE_DESC>(*pAllocDesc, pAllocInfo->SizeInBytes,
         NULL, // pResDesc
+        false, // useTightAlignment - irrelevant for AllocateMemory
         blockVector, committedAllocationParams, preferCommitted);
     if (FAILED(hr))
         return hr;
@@ -6649,7 +6808,7 @@ HRESULT AllocatorPimpl::CreateAliasingResource(
     {
         finalResourceDesc = *createParams.GetResourceDesc();
         finalCreateParams.AccessResourceDesc() = &finalResourceDesc;
-        hr = GetResourceAllocationInfo(finalResourceDesc, 0, NULL, resAllocInfo);
+        hr = GetResourceAllocationInfo(finalResourceDesc, 0, NULL, resAllocInfo, IsTightAlignmentEnabled());
     }
 #ifdef __ID3D12Device8_INTERFACE_DEFINED__
     else if (createParams.Variant == CREATE_RESOURCE_PARAMS::VARIANT_WITH_STATE_AND_DESC1)
@@ -6658,7 +6817,7 @@ HRESULT AllocatorPimpl::CreateAliasingResource(
         {
             finalResourceDesc1 = *createParams.GetResourceDesc1();
             finalCreateParams.AccessResourceDesc1() = &finalResourceDesc1;
-            hr = GetResourceAllocationInfo(finalResourceDesc1, 0, NULL, resAllocInfo);
+            hr = GetResourceAllocationInfo(finalResourceDesc1, 0, NULL, resAllocInfo, IsTightAlignmentEnabled());
         }
     }
 #endif
@@ -6670,7 +6829,7 @@ HRESULT AllocatorPimpl::CreateAliasingResource(
             finalResourceDesc1 = *createParams.GetResourceDesc1();
             finalCreateParams.AccessResourceDesc1() = &finalResourceDesc1;
             hr = GetResourceAllocationInfo(finalResourceDesc1,
-                createParams.GetNumCastableFormats(), createParams.GetCastableFormats(), resAllocInfo);
+                createParams.GetNumCastableFormats(), createParams.GetCastableFormats(), resAllocInfo, IsTightAlignmentEnabled());
         }
     }
 #endif
@@ -7305,13 +7464,14 @@ void AllocatorPimpl::FreeStatsString(WCHAR* pStatsString)
 
 template<typename D3D12_RESOURCE_DESC_T>
 bool AllocatorPimpl::PrefersCommittedAllocation(const D3D12_RESOURCE_DESC_T& resourceDesc,
-    ALLOCATION_FLAGS strategy)
+    ALLOCATION_FLAGS strategy, bool useTightAlignment) const
 {
     // Prefer creating small buffers <= 32 KB as committed, because drivers pack them better,
     // while placed buffers require 64 KB alignment.
     if(resourceDesc.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER &&
         resourceDesc.Width <= D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT / 2 &&
         strategy != ALLOCATION_FLAG_STRATEGY_MIN_TIME &&  // Creating as committed would be slower.
+        !useTightAlignment &&
         m_PreferSmallBuffersCommitted)
     {
         return true;
@@ -7526,7 +7686,7 @@ HRESULT AllocatorPimpl::AllocateHeap(
 
 template<typename D3D12_RESOURCE_DESC_T>
 HRESULT AllocatorPimpl::CalcAllocationParams(const ALLOCATION_DESC& allocDesc, UINT64 allocSize,
-    const D3D12_RESOURCE_DESC_T* resDesc,
+    const D3D12_RESOURCE_DESC_T* resDesc, bool useTightAlignment,
     BlockVector*& outBlockVector, CommittedAllocationParameters& outCommittedAllocationParams, bool& outPreferCommitted)
 {
     outBlockVector = NULL;
@@ -7599,7 +7759,7 @@ HRESULT AllocatorPimpl::CalcAllocationParams(const ALLOCATION_DESC& allocDesc, U
     {
         if (resDesc->SampleDesc.Count > 1 && msaaAlwaysCommitted)
             outBlockVector = NULL;
-        if (!outPreferCommitted && PrefersCommittedAllocation(*resDesc, allocDesc.Flags & ALLOCATION_FLAG_STRATEGY_MASK))
+        if (!outPreferCommitted && PrefersCommittedAllocation(*resDesc, allocDesc.Flags & ALLOCATION_FLAG_STRATEGY_MASK, useTightAlignment))
             outPreferCommitted = true;
     }
 
@@ -7810,12 +7970,13 @@ template<typename D3D12_RESOURCE_DESC_T>
 HRESULT AllocatorPimpl::GetResourceAllocationInfo(
     D3D12_RESOURCE_DESC_T& inOutResourceDesc,
     UINT32 NumCastableFormats, const DXGI_FORMAT* pCastableFormats,
-    D3D12_RESOURCE_ALLOCATION_INFO& outAllocInfo) const
+    D3D12_RESOURCE_ALLOCATION_INFO& outAllocInfo,
+    bool useTightAlignment) const
 {
 #ifdef __ID3D12Device1_INTERFACE_DEFINED__
 
 #if D3D12MA_TIGHT_ALIGNMENT_SUPPORTED
-    if (IsTightAlignmentEnabled())
+    if (useTightAlignment)
     {
         // Don't allow USE_TIGHT_ALIGNMENT together with ALLOW_CROSS_ADAPTER as there is a D3D Debug Layer error:
         // D3D12 ERROR: ID3D12Device::GetResourceAllocationInfo: D3D12_RESOURCE_DESC::Flag D3D12_RESOURCE_FLAG_USE_TIGHT_ALIGNMENT will be ignored since D3D12_RESOURCE_FLAG_ALLOW_CROSS_ADAPTER is set. [ STATE_CREATION ERROR #599: CREATERESOURCE_INVALIDMISCFLAGS]
@@ -7839,7 +8000,7 @@ HRESULT AllocatorPimpl::GetResourceAllocationInfo(
     */
     if (inOutResourceDesc.Alignment == 0 &&
         inOutResourceDesc.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER &&
-        !IsTightAlignmentEnabled())
+        !useTightAlignment)
     {
         outAllocInfo = {
             AlignUp<UINT64>(inOutResourceDesc.Width, D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT), // SizeInBytes
@@ -7852,16 +8013,33 @@ HRESULT AllocatorPimpl::GetResourceAllocationInfo(
     HRESULT hr = S_OK;
 
 #if D3D12MA_USE_SMALL_RESOURCE_PLACEMENT_ALIGNMENT
-    if (inOutResourceDesc.Alignment == 0 &&
-        (inOutResourceDesc.Flags & D3D12_RESOURCE_FLAG_USE_TIGHT_ALIGNMENT_COPY) == 0 &&
-        (inOutResourceDesc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE1D ||
-            inOutResourceDesc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE2D ||
-            inOutResourceDesc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE3D) &&
-        (inOutResourceDesc.Flags & (D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET | D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL)) == 0
+    bool trySmallAlignment = false;
+
+    if (inOutResourceDesc.Alignment == 0
+        && (inOutResourceDesc.Flags & D3D12_RESOURCE_FLAG_USE_TIGHT_ALIGNMENT_COPY) == 0
+        && inOutResourceDesc.Layout == D3D12_TEXTURE_LAYOUT_UNKNOWN
+        && ResourceDimensionIsTexture(inOutResourceDesc.Dimension))
+    {
+        // MSAA texture.
+        if(inOutResourceDesc.SampleDesc.Count > 1)
+        {
+            trySmallAlignment = IsMsaa64KBAlignedTextureSupported()
+                && ResourceFlagsContainRenderTargetOrDepthStencil(inOutResourceDesc.Flags)
+                && inOutResourceDesc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+        }
+        // Non-MSAA texture.
+        else
+        {
+            trySmallAlignment = !ResourceFlagsContainRenderTargetOrDepthStencil(inOutResourceDesc.Flags);
+        }
+    }
+
 #if D3D12MA_USE_SMALL_RESOURCE_PLACEMENT_ALIGNMENT == 1
-        && CanUseSmallAlignment(inOutResourceDesc)
+    if(trySmallAlignment)
+        trySmallAlignment = CanUseSmallAlignment(inOutResourceDesc);
 #endif
-        )
+    
+    if (trySmallAlignment)
     {
         /*
         The algorithm here is based on Microsoft sample: "Small Resources Sample"
@@ -7884,6 +8062,20 @@ HRESULT AllocatorPimpl::GetResourceAllocationInfo(
 
     return GetResourceAllocationInfoMiddle(
         inOutResourceDesc, NumCastableFormats, pCastableFormats, outAllocInfo);
+}
+
+bool AllocatorPimpl::IsTightAlignmentEnabled(const ALLOCATION_DESC& allocDesc) const
+{
+    if (!IsTightAlignmentEnabled())
+        return false;
+
+    if (allocDesc.CustomPool != NULL &&
+        (allocDesc.CustomPool->m_Pimpl->GetDesc().Flags & POOL_FLAG_DONT_USE_TIGHT_ALIGNMENT) != 0)
+    {
+        return false;
+    }
+
+    return true;
 }
 
 bool AllocatorPimpl::NewAllocationWithinBudget(D3D12_HEAP_TYPE heapType, UINT64 size)

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -22,6 +22,9 @@ find_package(Freetype 2.10 REQUIRED) # 2.10 is the first with COLRv0 support, wh
 find_package(plutovg 1.1.0 REQUIRED)
 find_package(plutosvg 0.0.7 REQUIRED)
 find_package(ryml REQUIRED)
+if (WIN32)
+	find_package(DirectX-Headers 1.618.1 REQUIRED)
+endif()
 
 if(USE_VULKAN)
 	find_package(Shaderc REQUIRED)

--- a/common/vsprops/DepsDir.props
+++ b/common/vsprops/DepsDir.props
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DepsRootDir Condition="'$(Platform)'=='x64'">$(SolutionDir)deps\</DepsRootDir>
+    <DepsRootDir Condition="'$(Platform)'=='ARM64'">$(SolutionDir)deps-arm64\</DepsRootDir>
+    <DepsBinDir>$(DepsRootDir)bin\</DepsBinDir>
+    <DepsLibDir>$(DepsRootDir)lib\</DepsLibDir>
+    <DepsIncludeDir>$(DepsRootDir)include\</DepsIncludeDir>
+  </PropertyGroup>
+</Project>

--- a/common/vsprops/common.props
+++ b/common/vsprops/common.props
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets">
+    <Import Project="DepsDir.props" />
+  </ImportGroup>
   <PropertyGroup Label="UserMacros">
     <SSEString />
     <SSEString Condition="$(Configuration.Contains(AVX2))">-avx2</SSEString>
@@ -15,11 +18,6 @@
   <PropertyGroup>
     <OutDir>$(SolutionDir)build\lib-$(PlatformName)-$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)build\obj-$(ProjectName)-$(PlatformName)-$(Configuration)\</IntDir>
-    <DepsRootDir Condition="'$(Platform)'=='x64'">$(SolutionDir)deps\</DepsRootDir>
-    <DepsRootDir Condition="'$(Platform)'=='ARM64'">$(SolutionDir)deps-arm64\</DepsRootDir>
-    <DepsBinDir>$(DepsRootDir)bin\</DepsBinDir>
-    <DepsLibDir>$(DepsRootDir)lib\</DepsLibDir>
-    <DepsIncludeDir>$(DepsRootDir)include\</DepsIncludeDir>
   </PropertyGroup>
   <PropertyGroup>
     <LinkIncremental>false</LinkIncremental>

--- a/pcsx2/GS/Renderers/DX11/D3D.cpp
+++ b/pcsx2/GS/Renderers/DX11/D3D.cpp
@@ -20,7 +20,7 @@
 
 #include <array>
 #include <d3d11.h>
-#include <d3d12.h>
+#include <directx/d3d12.h>
 #include <d3dcompiler.h>
 #include <fstream>
 

--- a/pcsx2/GS/Renderers/DX12/D3D12Builders.h
+++ b/pcsx2/GS/Renderers/DX12/D3D12Builders.h
@@ -8,7 +8,7 @@
 #include "common/RedtapeWilCom.h"
 
 #include <array>
-#include <d3d12.h>
+#include <directx/d3d12.h>
 #include <string_view>
 
 class D3D12ShaderCache;

--- a/pcsx2/GS/Renderers/DX12/D3D12DescriptorHeapManager.h
+++ b/pcsx2/GS/Renderers/DX12/D3D12DescriptorHeapManager.h
@@ -10,7 +10,7 @@
 
 #include <bitset>
 #include <cstring>
-#include <d3d12.h>
+#include <directx/d3d12.h>
 #include <unordered_map>
 #include <vector>
 

--- a/pcsx2/GS/Renderers/DX12/D3D12ShaderCache.h
+++ b/pcsx2/GS/Renderers/DX12/D3D12ShaderCache.h
@@ -10,7 +10,7 @@
 #include "common/RedtapeWilCom.h"
 
 #include <cstdio>
-#include <d3d12.h>
+#include <directx/d3d12.h>
 #include <string_view>
 #include <unordered_map>
 #include <vector>

--- a/pcsx2/GS/Renderers/DX12/D3D12StreamBuffer.h
+++ b/pcsx2/GS/Renderers/DX12/D3D12StreamBuffer.h
@@ -8,7 +8,7 @@
 #include "common/RedtapeWilCom.h"
 #include "common/Assertions.h"
 
-#include <d3d12.h>
+#include <directx/d3d12.h>
 #include <deque>
 #include <utility>
 

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -1442,6 +1442,7 @@ bool GSDevice12::CheckFeatures(const u32& vendor_id)
 	m_device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS, &options, sizeof(D3D12_FEATURE_DATA_D3D12_OPTIONS));
 	m_features.rov = options.ROVsSupported;
 
+	Console.WriteLnFmt("D3D12: Tight Alignment: {}", m_allocator->IsTightAlignmentSupported() ? "Supported" : "Not Supported");
 	return true;
 }
 

--- a/pcsx2/pcsx2.vcxproj
+++ b/pcsx2/pcsx2.vcxproj
@@ -62,7 +62,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>PrecompiledHeader.h</PrecompiledHeaderFile>
       <ForcedIncludeFiles>PrecompiledHeader.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
-      <PreprocessorDefinitions>C4_NO_DEBUG_BREAK;ST_NO_EXCEPTION_HANDLING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>C4_NO_DEBUG_BREAK;ST_NO_EXCEPTION_HANDLING;D3D12MA_USING_DIRECTX_HEADERS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Platform)'!='ARM64'">ENABLE_RAINTEGRATION;ENABLE_OPENGL;ENABLE_VULKAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Platform)'=='x64'">XBYAK_NO_EXCEPTION;ZYCORE_STATIC_BUILD;ZYDIS_STATIC_BUILD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Platform)'=='ARM64'">VIXL_INCLUDE_TARGET_AARCH64;%(PreprocessorDefinitions)</PreprocessorDefinitions>


### PR DESCRIPTION
### Description of Changes
Updates D3D12MemoryAllocator to v3.2.0
Build using newer [DirectX-Headers](https://github.com/microsoft/DirectX-Headers) to allow D3D12MemoryAllocator to use tight alignment.

### Rationale behind Changes
DX12's tight alignment allows memory allocations for textures and buffers to potentially be packed closer to together in memory, which may result in more efficient VRAM usage.

I've used the headers provided from the DirectX-Headers from the github repo instead of the headers contained within the Agility nuget package, as the former lacks the CMake include files.

### Suggested Testing Steps
Test the DX12 renderer for performance or memory usage changes.

### Did you use AI to help find, test, or implement this issue or feature?
No