### PR TITLE
Qt: Add button to main menu's view tab to allow GUI to enter fullscreen.

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -349,6 +349,7 @@ void MainWindow::connectSignals()
 	connect(m_ui.actionViewStatusBar, &QAction::toggled, this, &MainWindow::onViewStatusBarActionToggled);
 	connect(m_ui.actionViewGameList, &QAction::triggered, this, &MainWindow::onViewGameListActionTriggered);
 	connect(m_ui.actionViewGameGrid, &QAction::triggered, this, &MainWindow::onViewGameGridActionTriggered);
+	connect(m_ui.actionViewFullscreenGUI, &QAction::triggered, this, &MainWindow::onViewFullscreenGUIActionTriggered);
 	connect(m_ui.actionViewSystemDisplay, &QAction::triggered, this, &MainWindow::onViewSystemDisplayTriggered);
 	connect(m_ui.actionViewGameProperties, &QAction::triggered, this, &MainWindow::onViewGamePropertiesActionTriggered);
 	connect(m_ui.actionGitHubRepository, &QAction::triggered, this, &MainWindow::onGitHubRepositoryActionTriggered);
@@ -934,7 +935,10 @@ void MainWindow::restoreStateFromConfig()
 		{
 			const bool fullscreen = Host::GetBaseBoolSettingValue("UI", "MainWindowFullscreen");
 			if (fullscreen)
+			{
+				m_ui.actionViewFullscreenGUI->setChecked(true);
 				showFullScreen();
+			}
 		}
 	}
 }
@@ -1766,6 +1770,11 @@ void MainWindow::onViewLockToolbarActionToggled(bool checked)
 	Host::SetBaseBoolSettingValue("UI", "LockToolbar", checked);
 	Host::CommitBaseSettingChanges();
 	m_ui.toolBar->setMovable(!checked);
+}
+
+void MainWindow::onViewFullscreenGUIActionTriggered(bool checked) {
+	Host::SetBaseBoolSettingValue("UI", "MainWindowFullscreen", checked);
+	checked ? showFullScreen() : showNormal();
 }
 
 void MainWindow::onViewStatusBarActionToggled(bool checked)

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -163,6 +163,7 @@ private Q_SLOTS:
 	void onViewToolbarActionToggled(bool checked);
 	void onViewLockToolbarActionToggled(bool checked);
 	void onViewStatusBarActionToggled(bool checked);
+	void onViewFullscreenGUIActionTriggered(bool checked);
 	void onViewGameListActionTriggered();
 	void onViewGameGridActionTriggered();
 	void onViewSystemDisplayTriggered();

--- a/pcsx2-qt/MainWindow.ui
+++ b/pcsx2-qt/MainWindow.ui
@@ -166,6 +166,7 @@
     <addaction name="actionViewLockToolbar"/>
     <addaction name="actionViewStatusBar"/>
     <addaction name="actionViewStatusBarVerbose"/>
+    <addaction name="actionViewFullscreenGUI"/>
     <addaction name="separator"/>
     <addaction name="actionViewGameList"/>
     <addaction name="actionViewGameGrid"/>
@@ -1073,6 +1074,17 @@
    </property>
    <property name="text">
     <string>Edit &amp;Patches...</string>
+   </property>
+  </action>
+  <action name="actionViewFullscreenGUI">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Fullscreen (GUI)</string>
+   </property>
+   <property name="toolTip">
+    <string>Make the PCSX2 GUI Fullscreen</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
### Description of Changes
Fulfills the request for a feature in #14405 which asks to add the option to enter fullscreen from the main menu bar, rather than having to add `MainWindowFullscreen = true` to the PSCX2.ini file.
In the view tab of the main menu bar, I've added a Fullscreen(GUI) check box, which on clicking enters fullscreen, and on clicking again exits fullscreen.

### Rationale behind Changes
Currently users have to edit their PCSX2.ini file, adding `MainWindowFullscreen = true`. Whilst this works, it requires a restart of the program/knowing you're supposed to do that. This simplifies things to a check box.

### Suggested Testing Steps
1. Open PCSX2 and open the **View tab**.
2. Click **Fullscreen (GUI)**
3. The program should enter Fullscreen mode.
4. Click **Fullscreen (GUI)** again, the program should exit fullscreen mode.
5. Opening and closing the program in either mode keeps the program in that state.

### Did you use AI to help find, test, or implement this issue or feature?
no