### PR TITLE
Qt: Disable VK Rov barrier toggle on other renderers.

### DIFF
--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -1056,6 +1056,9 @@ void GraphicsSettingsWidget::updateRendererDependentOptions()
 	if (m_advanced.rov)
 		m_advanced.rov->setDisabled(!is_hardware || is_ogl);
 
+	if (m_advanced.rovBarriersVK)
+		m_advanced.rovBarriersVK->setDisabled(!is_hardware || !is_vk);
+
 	// populate adapters
 	std::vector<GSAdapterInfo> adapters = GSGetAdapterInfo(type);
 	const GSAdapterInfo* current_adapter_info = nullptr;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Qt: Disable VK Rov barrier toggle on other renderers.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Usability.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Test if Rov Barriers Vulkan option only toggles on Vulkan renderer.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation as to how you used it. Please see the Large Language Model (LLM) Usage Policy for more information: https://pcsx2.net/docs/contributing/#large-language-model-llm-usage-policy -->
No.