### PR TITLE
GUI: Text-string alterations for 'Settings > Interface'

### DIFF
--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.cpp
@@ -192,29 +192,29 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsWindow* settings_dialog
 		m_ui.confirmShutdown, tr("Confirm Shutdown"), tr("Checked"),
 		tr("Determines whether a prompt will be displayed to confirm shutting down the virtual machine "
 		   "when the hotkey is pressed."));
-	dialog()->registerWidgetHelp(m_ui.pauseOnStart, tr("Pause On Start"), tr("Unchecked"),
+	dialog()->registerWidgetHelp(m_ui.pauseOnStart, tr("Pause on Start"), tr("Unchecked"),
 		tr("Pauses the emulator when a game is started."));
-	dialog()->registerWidgetHelp(m_ui.pauseOnFocusLoss, tr("Pause On Focus Loss"), tr("Unchecked"),
+	dialog()->registerWidgetHelp(m_ui.pauseOnFocusLoss, tr("Pause on Focus Loss"), tr("Unchecked"),
 		tr("Pauses the emulator when you minimize the window or switch to another application, "
 		   "and unpauses when you switch back."));
-	dialog()->registerWidgetHelp(m_ui.pauseOnControllerDisconnection, tr("Pause On Controller Disconnection"),
+	dialog()->registerWidgetHelp(m_ui.pauseOnControllerDisconnection, tr("Pause on Controller Disconnection"),
 		tr("Unchecked"), tr("Pauses the emulator when a controller with bindings is disconnected."));
-	dialog()->registerWidgetHelp(m_ui.promptOnStateLoadSaveFailure, tr("Prompt On State Load/Save Failure"),
+	dialog()->registerWidgetHelp(m_ui.promptOnStateLoadSaveFailure, tr("Prompt on State Load/Save Failure"),
 		tr("Checked"), tr("Displays a modal dialog when a save state load/save operation fails."));
 	dialog()->registerWidgetHelp(m_ui.preferEnglishGameList, tr("Prefer English Game Titles"), tr("Unchecked"),
 		tr("For games with both a title in the game's native language and one in English, prefer the English title. Affects how game titles are displayed on the game list, window title and Discord Presence"));
 	dialog()->registerWidgetHelp(m_ui.startFullscreen, tr("Start Fullscreen"), tr("Unchecked"),
 		tr("Automatically switches to fullscreen mode when a game is started."));
-	dialog()->registerWidgetHelp(m_ui.hideMouseCursor, tr("Hide Cursor In Fullscreen"), tr("Unchecked"),
+	dialog()->registerWidgetHelp(m_ui.hideMouseCursor, tr("Hide Cursor in Fullscreen Mode"), tr("Unchecked"),
 		tr("Hides the mouse pointer/cursor when the emulator is in fullscreen mode."));
 	dialog()->registerWidgetHelp(m_ui.savestateSelector, tr("Use Save State Selector"), tr("Checked"),
 		tr("Show a save state selector UI when switching slots instead of showing a notification bubble."));
 	dialog()->registerWidgetHelp(
-		m_ui.renderToSeparateWindow, tr("Render To Separate Window"), tr("Unchecked"),
+		m_ui.renderToSeparateWindow, tr("Render to Separate Window"), tr("Unchecked"),
 		tr("Renders the game to a separate window, instead of the main window. If unchecked, the game will display over the game list."));
 	dialog()->registerWidgetHelp(
 		m_ui.hideMainWindow, tr("Hide Main Window When Running"), tr("Unchecked"),
-		tr("Hides the main window (with the game list) when a game is running. Requires Render To Separate Window to be enabled."));
+		tr("Hides the main window (with the game list) when a game is running. Requires Render to Separate Window to be enabled."));
 	dialog()->registerWidgetHelp(
 		m_ui.discordPresence, tr("Enable Discord Presence"), tr("Unchecked"),
 		tr("Shows the game you are currently playing as part of your profile in Discord."));
@@ -228,7 +228,7 @@ InterfaceSettingsWidget::InterfaceSettingsWidget(SettingsWindow* settings_dialog
 		m_ui.disableWindowResizing, tr("Disable Window Resizing"), tr("Unchecked"),
 		tr("Prevents the main window from being resized."));
 	dialog()->registerWidgetHelp(
-		m_ui.startFullscreenUI, tr("Start In Big Picture Mode"), tr("Unchecked"),
+		m_ui.startFullscreenUI, tr("Start in Big Picture Mode"), tr("Unchecked"),
 		tr("Automatically starts Big Picture Mode instead of the regular Qt interface when PCSX2 launches."));
 	dialog()->registerWidgetHelp(
 		m_ui.backgroundBrowse, tr("Game List Background"), tr("None"),

--- a/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
+++ b/pcsx2-qt/Settings/InterfaceSettingsWidget.ui
@@ -39,7 +39,7 @@
       <item row="0" column="1">
        <widget class="QCheckBox" name="pauseOnFocusLoss">
         <property name="text">
-         <string>Pause On Focus Loss</string>
+         <string>Pause on Focus Loss</string>
         </property>
        </widget>
       </item>
@@ -67,21 +67,21 @@
       <item row="1" column="1">
        <widget class="QCheckBox" name="pauseOnStart">
         <property name="text">
-         <string>Pause On Start</string>
+         <string>Pause on Start</string>
         </property>
        </widget>
       </item>
       <item row="2" column="1">
        <widget class="QCheckBox" name="pauseOnControllerDisconnection">
         <property name="text">
-         <string>Pause On Controller Disconnection</string>
+         <string>Pause on Controller Disconnection</string>
         </property>
        </widget>
       </item>
       <item row="3" column="1">
        <widget class="QCheckBox" name="promptOnStateLoadSaveFailure">
         <property name="text">
-         <string>Prompt On State Load/Save Failure</string>
+         <string>Prompt on State Load/Save Failure</string>
         </property>
        </widget>
       </item>
@@ -125,7 +125,7 @@
       <item row="1" column="0">
        <widget class="QCheckBox" name="renderToSeparateWindow">
         <property name="text">
-         <string>Render To Separate Window</string>
+         <string>Render to Separate Window</string>
         </property>
        </widget>
       </item>
@@ -146,14 +146,14 @@
       <item row="2" column="1">
        <widget class="QCheckBox" name="hideMouseCursor">
         <property name="text">
-         <string>Hide Cursor In Fullscreen</string>
+         <string>Hide Cursor in Fullscreen Mode</string>
         </property>
        </widget>
       </item>
       <item row="3" column="0">
        <widget class="QCheckBox" name="startFullscreenUI">
         <property name="text">
-         <string>Start In Big Picture Mode</string>
+         <string>Start in Big Picture Mode</string>
         </property>
        </widget>
       </item>

--- a/pcsx2/ImGui/FullscreenUI_Settings.cpp
+++ b/pcsx2/ImGui/FullscreenUI_Settings.cpp
@@ -2263,16 +2263,16 @@ void FullscreenUI::DrawInterfaceSettingsPage()
 	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_PF_SNOOZE, "Inhibit Screensaver"),
 		FSUI_CSTR("Prevents the screen saver from activating and the host from sleeping while emulation is running."), "EmuCore",
 		"InhibitScreensaver", true);
-	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_PAUSE, "Pause On Start"), FSUI_CSTR("Pauses the emulator when a game is started."), "UI",
+	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_PAUSE, "Pause on Start"), FSUI_CSTR("Pauses the emulator when a game is started."), "UI",
 		"StartPaused", false);
-	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_EYE, "Pause On Focus Loss"),
+	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_EYE, "Pause on Focus Loss"),
 		FSUI_CSTR("Pauses the emulator when you minimize the window or switch to another application, and unpauses when you switch back."),
 		"UI", "PauseOnFocusLoss", false);
-	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_GAMEPAD, "Pause On Controller Disconnection"),
+	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_GAMEPAD, "Pause on Controller Disconnection"),
 		FSUI_CSTR("Pauses the emulator when a controller with bindings is disconnected."), "UI", "PauseOnControllerDisconnection", false);
-	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_RECTANGLE_LIST, "Pause On Menu"),
+	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_RECTANGLE_LIST, "Pause on Menu"),
 		FSUI_CSTR("Pauses the emulator when you open the quick menu, and unpauses when you close it."), "UI", "PauseOnMenu", true);
-	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_FLOPPY_DISK, "Prompt On State Load/Save Failure"),
+	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_FLOPPY_DISK, "Prompt on State Load/Save Failure"),
 		FSUI_CSTR("Display a modal dialog when a save state load/save operation fails."), "UI", "PromptOnStateLoadSaveFailure", true);
 	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_POWER_OFF, "Confirm Shutdown"),
 		FSUI_CSTR("Determines whether a prompt will be displayed to confirm shutting down the emulator/game when the hotkey is pressed."),
@@ -2421,7 +2421,7 @@ void FullscreenUI::DrawInterfaceSettingsPage()
 	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_COMPUTER_MOUSE, "Double-Click Toggles Fullscreen"),
 		FSUI_CSTR("Switches between full screen and windowed when the window is double-clicked."), "UI", "DoubleClickTogglesFullscreen",
 		true);
-	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_ARROW_POINTER, "Hide Cursor In Fullscreen"),
+	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_ARROW_POINTER, "Hide Cursor in Fullscreen Mode"),
 		FSUI_CSTR("Hides the mouse pointer/cursor when the emulator is in fullscreen mode."), "UI", "HideMouseCursor", false);
 	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_TABLET_SCREEN_BUTTON, "Start Big Picture UI"),
 		FSUI_CSTR("Automatically starts Big Picture Mode instead of the regular Qt interface when PCSX2 launches."), "UI", "StartBigPictureMode", false);
@@ -5769,11 +5769,11 @@ TRANSLATE_NOOP("FullscreenUI", "Clear Background Image");
 TRANSLATE_NOOP("FullscreenUI", "Background Opacity");
 TRANSLATE_NOOP("FullscreenUI", "Background Mode");
 TRANSLATE_NOOP("FullscreenUI", "Inhibit Screensaver");
-TRANSLATE_NOOP("FullscreenUI", "Pause On Start");
-TRANSLATE_NOOP("FullscreenUI", "Pause On Focus Loss");
-TRANSLATE_NOOP("FullscreenUI", "Pause On Controller Disconnection");
-TRANSLATE_NOOP("FullscreenUI", "Pause On Menu");
-TRANSLATE_NOOP("FullscreenUI", "Prompt On State Load/Save Failure");
+TRANSLATE_NOOP("FullscreenUI", "Pause on Start");
+TRANSLATE_NOOP("FullscreenUI", "Pause on Focus Loss");
+TRANSLATE_NOOP("FullscreenUI", "Pause on Controller Disconnection");
+TRANSLATE_NOOP("FullscreenUI", "Pause on Menu");
+TRANSLATE_NOOP("FullscreenUI", "Prompt on State Load/Save Failure");
 TRANSLATE_NOOP("FullscreenUI", "Confirm Shutdown");
 TRANSLATE_NOOP("FullscreenUI", "Save State On Shutdown");
 TRANSLATE_NOOP("FullscreenUI", "Create Save State Backups");
@@ -5783,7 +5783,7 @@ TRANSLATE_NOOP("FullscreenUI", "Use Legacy Nintendo Layout in Big Picture Mode")
 TRANSLATE_NOOP("FullscreenUI", "Enable Discord Presence");
 TRANSLATE_NOOP("FullscreenUI", "Start Fullscreen");
 TRANSLATE_NOOP("FullscreenUI", "Double-Click Toggles Fullscreen");
-TRANSLATE_NOOP("FullscreenUI", "Hide Cursor In Fullscreen");
+TRANSLATE_NOOP("FullscreenUI", "Hide Cursor in Fullscreen Mode");
 TRANSLATE_NOOP("FullscreenUI", "Start Big Picture UI");
 TRANSLATE_NOOP("FullscreenUI", "Reset Settings");
 TRANSLATE_NOOP("FullscreenUI", "Change Search Directory");


### PR DESCRIPTION
"Pause On Focus Loss" -> "Pause on Focus Loss"
"Pause On Start" -> "Pause on Start"
"Pause On Menu" -> "Pause on Menu"
"Pause On Controller Disconnection" -> "Pause on Controller Disconnection"
"Prompt On State Load/Save Failure" -> "Prompt on State Load/Save Failure"
"Render To Separate Window" -> "Render to Separate Window"
"Start In Big Picture Mode" -> "Start in Big Picture Mode"
"Hide Cursor In Fullscreen" -> "Hide Cursor in Fullscreen Mode"
