### PR TITLE
GS/SW: Fix typo in GSScanlineEnvironment comment

### DIFF
--- a/pcsx2/GS/Renderers/SW/GSScanlineEnvironment.h
+++ b/pcsx2/GS/Renderers/SW/GSScanlineEnvironment.h
@@ -121,7 +121,7 @@ struct alignas(32) GSScanlineGlobalData // per batch variables, this is like a p
 
 	// - the data of vm, tex may change, multi-threaded drawing must be finished before that happens, clut and dimx are copies
 	// - tex is a cached texture, it may be recycled to free up memory, its absolute address cannot be compiled into code
-	// - row and column pointers are allocated once and never change or freed, thier address can be used directly
+	// - row and column pointers are allocated once and never change or freed, their address can be used directly
 
 	void* vm;
 	const void* tex[7];


### PR DESCRIPTION
### Description of Changes
Fixes a spelling typo in a code comment in `GSScanlineEnvironment.h`: "thier" → "their". Comment-only change, no functional impact.

### Rationale behind Changes
Minor documentation/readability cleanup.

### Suggested Testing Steps
None required — the change only edits a comment and does not affect compiled code.

### Did you use AI to help find, test, or implement this issue or feature?
Yes. I used Claude Code to scan source comments for common misspellings and to make this single-word comment correction. The change was reviewed and is comment-only.