### PR TITLE
Qt/GameListBackground: Auto adjust gamelist text color

### DIFF
--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -194,6 +194,29 @@ namespace
 
 				painter->drawPixmap(rect.topLeft() + icon_top_left, highlighted_icon);
 			}
+			// Recolor the icon based on the custom background color
+			else if (index.column() == GameListModel::Column_Type)
+			{
+				// Fetch pixmap from cache or construct a new one.
+				const QColor color = option.palette.color(QPalette::Text);
+				const QString key = QString::fromStdString(fmt::format("type-{:016X}-{:08X}", icon.cacheKey(), color.rgba()));
+
+				QPixmap tinted_icon;
+				if (!QPixmapCache::find(key, &tinted_icon))
+				{
+					QImage img = icon.toImage().convertToFormat(QImage::Format_ARGB32_Premultiplied);
+
+					QPainter tinted_painter(&img);
+					tinted_painter.setCompositionMode(QPainter::CompositionMode_SourceAtop);
+					tinted_painter.fillRect(0, 0, img.width(), img.height(), color);
+					tinted_painter.end();
+
+					tinted_icon = QPixmap(QPixmap::fromImage(img));
+					QPixmapCache::insert(key, tinted_icon);
+				}
+
+				painter->drawPixmap(rect.topLeft() + icon_top_left, tinted_icon);
+			}
 			else
 			{
 				painter->drawPixmap(rect.topLeft() + icon_top_left, icon);

--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -446,11 +446,12 @@ void GameListWidget::setCustomBackground()
 	m_background_opacity = Host::GetBaseFloatSettingValue("UI", "GameListBackgroundOpacity", 100.0f);
 
 	// Selected Custom background is valid, connect the signals and start animation in gamelist
-	connect(m_background_movie, &QMovie::frameChanged, this, &GameListWidget::processBackgroundFrames, Qt::UniqueConnection);
+	connect(m_background_movie, &QMovie::frameChanged, this, &GameListWidget::processBackgroundFrames);
 	m_ui.stack->setAutoFillBackground(false);
 
 	m_table_view->viewport()->setAutoFillBackground(false);
 	m_list_view->viewport()->setAutoFillBackground(false);
+	m_background_movie->start();
 	updateCustomBackgroundState(true);
 	m_table_view->setAlternatingRowColors(false);
 	processBackgroundFrames();
@@ -797,6 +798,7 @@ void GameListWidget::showEvent(QShowEvent* event)
 {
 	QWidget::showEvent(event);
 	updateCustomBackgroundState();
+	processBackgroundFrames();
 }
 
 void GameListWidget::hideEvent(QHideEvent* event)
@@ -833,11 +835,8 @@ bool GameListWidget::eventFilter(QObject* watched, QEvent* event)
 		if (!m_background_pixmap.isNull())
 		{
 			QPainter painter(m_ui.stack);
-			const auto* paint_event = static_cast<QPaintEvent*>(event);
-			painter.save();
-			painter.setClipRect(paint_event->rect());
-			painter.drawTiledPixmap(m_ui.stack->rect(), m_background_pixmap);
-			painter.restore();
+			painter.setClipRect(static_cast<QPaintEvent*>(event)->rect());
+			painter.drawPixmap(0, 0, m_background_pixmap);
 			return true;
 		}
 	}

--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -452,20 +452,15 @@ void GameListWidget::setCustomBackground()
 	m_table_view->viewport()->setAutoFillBackground(false);
 	m_list_view->viewport()->setAutoFillBackground(false);
 	m_background_movie->start();
-	updateCustomBackgroundState(true);
+	updateCustomBackgroundState();
 	m_table_view->setAlternatingRowColors(false);
 	processBackgroundFrames();
 }
 
-void GameListWidget::updateCustomBackgroundState(const bool force_start)
+void GameListWidget::updateCustomBackgroundState()
 {
 	if (m_background_movie && m_background_movie->isValid())
-	{
-		if ((isVisible() && (isActiveWindow() || force_start)) && qGuiApp->applicationState() == Qt::ApplicationActive)
-			m_background_movie->setPaused(false);
-		else
-			m_background_movie->setPaused(true);
-	}
+		m_background_movie->setPaused(!(isVisible() && qGuiApp->applicationState() == Qt::ApplicationActive));
 }
 
 void GameListWidget::processBackgroundFrames()

--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -407,7 +407,13 @@ void GameListWidget::setCustomBackground()
 			delete m_background_movie;
 			m_background_movie = nullptr;
 		}
+		// Cache all frames for small images so loops don't keep re-decoding
+		else if (const s64 file_size = FileSystem::GetPathFileSize(path.c_str()); file_size > 0 && file_size < 64 * 1024 * 1024)
+			m_background_movie->setCacheMode(QMovie::CacheAll);
 	}
+
+	// Invalidate frame cache so the next animated frame triggers full reprocessing
+	m_background_last_size = QSize();
 
 	// If there is no valid background then reset fallback to default UI state
 	if (!m_background_movie)
@@ -465,24 +471,28 @@ void GameListWidget::updateCustomBackgroundState()
 
 void GameListWidget::processBackgroundFrames()
 {
-	if (m_background_movie && m_background_movie->isValid() && isVisible())
-	{
-		const int widget_width = m_ui.stack->width();
-		const int widget_height = m_ui.stack->height();
+	if (!m_background_movie || !m_background_movie->isValid() || !isVisible())
+		return;
 
-		if (widget_width <= 0 || widget_height <= 0)
-			return;
+	const QSize widget_size(m_ui.stack->width(), m_ui.stack->height());
+	if (widget_size.isEmpty())
+		return;
 
-		QPixmap pm = m_background_movie->currentPixmap();
-		updateBackgroundTextColor(pm);
+	const int frame_number = m_background_movie->currentFrameNumber();
+	const qreal dpr = devicePixelRatioF();
 
-		const qreal dpr = devicePixelRatioF();
+	if (frame_number == m_background_last_frame && widget_size == m_background_last_size && qFuzzyCompare(dpr, m_background_last_dpr))
+		return;
 
-		QtUtils::resizeAndScalePixmap(&pm, widget_width, widget_height, dpr, m_background_scaling, m_background_opacity);
+	QPixmap pm = m_background_movie->currentPixmap();
+	updateBackgroundTextColor(pm);
+	QtUtils::resizeAndScalePixmap(&pm, widget_size.width(), widget_size.height(), dpr, m_background_scaling, m_background_opacity);
 
-		m_background_pixmap = std::move(pm);
-		m_ui.stack->update();
-	}
+	m_background_pixmap = std::move(pm);
+	m_background_last_frame = frame_number;
+	m_background_last_size = widget_size;
+	m_background_last_dpr = dpr;
+	m_ui.stack->update();
 }
 
 void GameListWidget::updateBackgroundTextColor(const QPixmap& frame)
@@ -560,6 +570,7 @@ void GameListWidget::cancelRefresh()
 void GameListWidget::reloadThemeSpecificImages()
 {
 	m_model->reloadThemeSpecificImages();
+	m_background_last_size = QSize();
 	processBackgroundFrames();
 }
 

--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -419,6 +419,8 @@ void GameListWidget::setCustomBackground()
 
 		m_ui.stack->setPalette(QPalette());
 		m_background_text_color = QColor();
+		m_empty_widget->setPalette(QPalette());
+		m_empty_widget->setAutoFillBackground(false);
 
 		m_ui.stack->update();
 		m_table_view->setAlternatingRowColors(true);
@@ -503,10 +505,20 @@ void GameListWidget::updateBackgroundTextColor(const QPixmap& frame)
 		return;
 	m_background_text_color = text_color;
 
+	QColor highlight_color = qApp->palette().color(QPalette::Highlight);
+	highlight_color.setAlpha(128);
+	const QColor empty_backdrop_color = (text_color == Qt::black) ? QColor(255, 255, 255, 128) : QColor(0, 0, 0, 128);
+
 	QPalette palette;
 	palette.setColor(QPalette::Text, text_color);
 	palette.setColor(QPalette::WindowText, text_color);
+	palette.setColor(QPalette::Highlight, highlight_color);
 	m_ui.stack->setPalette(palette);
+
+	QPalette empty_palette;
+	empty_palette.setColor(QPalette::Window, empty_backdrop_color);
+	m_empty_widget->setPalette(empty_palette);
+	m_empty_widget->setAutoFillBackground(true);
 }
 
 bool GameListWidget::isShowingGameList() const

--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -22,7 +22,10 @@
 #include <QtCore/QSortFilterProxyModel>
 #include <QtCore/QDir>
 #include <QtCore/QString>
+#include <QtGui/QColor>
+#include <QtGui/QImage>
 #include <QtGui/QPainter>
+#include <QtGui/QPalette>
 #include <QtGui/QPixmap>
 #include <QtGui/QPixmapCache>
 #include <QtGui/QWheelEvent>
@@ -391,6 +394,9 @@ void GameListWidget::setCustomBackground()
 		m_table_view->viewport()->setAutoFillBackground(true);
 		m_list_view->viewport()->setAutoFillBackground(true);
 
+		m_ui.stack->setPalette(QPalette());
+		m_background_text_color = QColor();
+
 		m_ui.stack->update();
 		m_table_view->setAlternatingRowColors(true);
 		return;
@@ -447,6 +453,8 @@ void GameListWidget::processBackgroundFrames()
 			return;
 
 		QPixmap pm = m_background_movie->currentPixmap();
+		updateBackgroundTextColor(pm);
+
 		const qreal dpr = devicePixelRatioF();
 
 		QtUtils::resizeAndScalePixmap(&pm, widget_width, widget_height, dpr, m_background_scaling, m_background_opacity);
@@ -454,6 +462,28 @@ void GameListWidget::processBackgroundFrames()
 		m_background_pixmap = std::move(pm);
 		m_ui.stack->update();
 	}
+}
+
+void GameListWidget::updateBackgroundTextColor(const QPixmap& frame)
+{
+	if (frame.isNull())
+		return;
+
+	const QImage sampled = frame.scaled(32, 32, Qt::IgnoreAspectRatio, Qt::FastTransformation).toImage();
+	const QColor average = sampled.scaled(1, 1, Qt::IgnoreAspectRatio, Qt::SmoothTransformation).pixelColor(0, 0);
+	const QColor base = qApp->palette().color(QPalette::Base);
+	const qreal coverage = average.alphaF() * std::clamp(m_background_opacity / 100.0f, 0.0f, 1.0f);
+	const qreal brightness = qGray(average.rgb()) * coverage + qGray(base.rgb()) * (1.0 - coverage);
+	const QColor text_color = (brightness > 127.5) ? Qt::black : Qt::white;
+
+	if (m_background_text_color == text_color)
+		return;
+	m_background_text_color = text_color;
+
+	QPalette palette;
+	palette.setColor(QPalette::Text, text_color);
+	palette.setColor(QPalette::WindowText, text_color);
+	m_ui.stack->setPalette(palette);
 }
 
 bool GameListWidget::isShowingGameList() const
@@ -499,6 +529,7 @@ void GameListWidget::cancelRefresh()
 void GameListWidget::reloadThemeSpecificImages()
 {
 	m_model->reloadThemeSpecificImages();
+	processBackgroundFrames();
 }
 
 void GameListWidget::onRefreshProgress(const QString& status, int current, int total)

--- a/pcsx2-qt/GameList/GameListWidget.h
+++ b/pcsx2-qt/GameList/GameListWidget.h
@@ -133,4 +133,7 @@ private:
 	QColor m_background_text_color;
 	QtUtils::ScalingMode m_background_scaling = QtUtils::ScalingMode::Fit;
 	float m_background_opacity = 100.0f;
+	int m_background_last_frame = -1;
+	QSize m_background_last_size;
+	qreal m_background_last_dpr = 0.0;
 };

--- a/pcsx2-qt/GameList/GameListWidget.h
+++ b/pcsx2-qt/GameList/GameListWidget.h
@@ -9,6 +9,7 @@
 
 #include "pcsx2/GameList.h"
 
+#include <QtGui/QColor>
 #include <QtGui/QMovie>
 #include <QtGui/QPixmap>
 #include <QtWidgets/QListView>
@@ -55,6 +56,7 @@ public:
 	void setCustomBackground();
 	void updateCustomBackgroundState(const bool force_start = false);
 	void processBackgroundFrames();
+	void updateBackgroundTextColor(const QPixmap& frame);
 
 	bool isShowingGameList() const;
 	bool isShowingGameGrid() const;
@@ -128,6 +130,7 @@ private:
 
 	QMovie* m_background_movie = nullptr;
 	QPixmap m_background_pixmap;
+	QColor m_background_text_color;
 	QtUtils::ScalingMode m_background_scaling = QtUtils::ScalingMode::Fit;
 	float m_background_opacity = 100.0f;
 };

--- a/pcsx2-qt/GameList/GameListWidget.h
+++ b/pcsx2-qt/GameList/GameListWidget.h
@@ -54,7 +54,7 @@ public:
 	void cancelRefresh();
 	void reloadThemeSpecificImages();
 	void setCustomBackground();
-	void updateCustomBackgroundState(const bool force_start = false);
+	void updateCustomBackgroundState();
 	void processBackgroundFrames();
 	void updateBackgroundTextColor(const QPixmap& frame);
 

--- a/pcsx2-qt/QtUtils.cpp
+++ b/pcsx2-qt/QtUtils.cpp
@@ -156,7 +156,7 @@ namespace QtUtils
 
 		if (pm->width() == dpr_expected_width &&
 			pm->height() == dpr_expected_height &&
-			pm->devicePixelRatio() == dpr &&
+			qFuzzyCompare(pm->devicePixelRatio(), dpr) &&
 			opacity == 100.0f)
 		{
 			switch (scaling_mode)
@@ -249,7 +249,6 @@ namespace QtUtils
 					QPixmap tileSource = pm->scaled(tileWidth, tileHeight, Qt::KeepAspectRatio, Qt::SmoothTransformation);
 					tileSource.setDevicePixelRatio(dpr);
 					QBrush tileBrush(tileSource);
-					tileBrush.setTextureImage(tileSource.toImage());
 					painter.fillRect(painterRect, tileBrush);
 				}
 				break;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

This PR makes the text color on the game list auto adjust itself based on the custom background's brightness of the image.

Preview:

https://github.com/user-attachments/assets/df70a2f7-1095-4ccb-b7eb-14d700a3a04c

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Huge readability boost (and the reason why i also included the opacity option, but that was kind of a band-aid fix)

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

Test using various custom background images, both static (jpg, png, webp, etc) and animated as well (gif, etc)

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation as to how you used it. Please see the Large Language Model (LLM) Usage Policy for more information: https://pcsx2.net/docs/contributing/#large-language-model-llm-usage-policy -->
noop