### PR TITLE
PINE: Disallow access to pages with custom VTLB handlers

### DIFF
--- a/pcsx2/PINE.cpp
+++ b/pcsx2/PINE.cpp
@@ -4,11 +4,11 @@
 #include "BuildVersion.h"
 #include "Common.h"
 #include "Host.h"
-#include "Memory.h"
 #include "Elfheader.h"
 #include "SaveState.h"
 #include "PINE.h"
 #include "VMManager.h"
+#include "vtlb.h"
 #include "common/Error.h"
 #include "common/Threading.h"
 
@@ -538,7 +538,7 @@ PINEServer::IPCBuffer PINEServer::ParseCommand(std::span<u8> buf, std::vector<u8
 				if (!SafetyChecks(buf_cnt, 4, ret_cnt, 1, buf_size)) [[unlikely]]
 					goto error;
 				const u32 a = FromSpan<u32>(buf, buf_cnt);
-				const u8 res = memRead8(a);
+				const u8 res = vtlb_ramRead<mem8_t>(a);
 				ToResultVector(ret_buffer, res, ret_cnt);
 				ret_cnt += 1;
 				buf_cnt += 4;
@@ -551,7 +551,7 @@ PINEServer::IPCBuffer PINEServer::ParseCommand(std::span<u8> buf, std::vector<u8
 				if (!SafetyChecks(buf_cnt, 4, ret_cnt, 2, buf_size)) [[unlikely]]
 					goto error;
 				const u32 a = FromSpan<u32>(buf, buf_cnt);
-				const u16 res = memRead16(a);
+				const u16 res = vtlb_ramRead<mem16_t>(a);
 				ToResultVector(ret_buffer, res, ret_cnt);
 				ret_cnt += 2;
 				buf_cnt += 4;
@@ -564,7 +564,7 @@ PINEServer::IPCBuffer PINEServer::ParseCommand(std::span<u8> buf, std::vector<u8
 				if (!SafetyChecks(buf_cnt, 4, ret_cnt, 4, buf_size)) [[unlikely]]
 					goto error;
 				const u32 a = FromSpan<u32>(buf, buf_cnt);
-				const u32 res = memRead32(a);
+				const u32 res = vtlb_ramRead<mem32_t>(a);
 				ToResultVector(ret_buffer, res, ret_cnt);
 				ret_cnt += 4;
 				buf_cnt += 4;
@@ -577,7 +577,7 @@ PINEServer::IPCBuffer PINEServer::ParseCommand(std::span<u8> buf, std::vector<u8
 				if (!SafetyChecks(buf_cnt, 4, ret_cnt, 8, buf_size)) [[unlikely]]
 					goto error;
 				const u32 a = FromSpan<u32>(buf, buf_cnt);
-				const u64 res = memRead64(a);
+				const u64 res = vtlb_ramRead<mem64_t>(a);
 				ToResultVector(ret_buffer, res, ret_cnt);
 				ret_cnt += 8;
 				buf_cnt += 4;
@@ -590,7 +590,7 @@ PINEServer::IPCBuffer PINEServer::ParseCommand(std::span<u8> buf, std::vector<u8
 				if (!SafetyChecks(buf_cnt, 1 + 4, ret_cnt, 0, buf_size)) [[unlikely]]
 					goto error;
 				const u32 a = FromSpan<u32>(buf, buf_cnt);
-				memWrite8(a, FromSpan<u8>(buf, buf_cnt + 4));
+				vtlb_ramWrite<mem8_t>(a, FromSpan<u8>(buf, buf_cnt + 4));
 				buf_cnt += 5;
 				break;
 			}
@@ -601,7 +601,7 @@ PINEServer::IPCBuffer PINEServer::ParseCommand(std::span<u8> buf, std::vector<u8
 				if (!SafetyChecks(buf_cnt, 2 + 4, ret_cnt, 0, buf_size)) [[unlikely]]
 					goto error;
 				const u32 a = FromSpan<u32>(buf, buf_cnt);
-				memWrite16(a, FromSpan<u16>(buf, buf_cnt + 4));
+				vtlb_ramWrite<mem16_t>(a, FromSpan<u16>(buf, buf_cnt + 4));
 				buf_cnt += 6;
 				break;
 			}
@@ -612,7 +612,7 @@ PINEServer::IPCBuffer PINEServer::ParseCommand(std::span<u8> buf, std::vector<u8
 				if (!SafetyChecks(buf_cnt, 4 + 4, ret_cnt, 0, buf_size)) [[unlikely]]
 					goto error;
 				const u32 a = FromSpan<u32>(buf, buf_cnt);
-				memWrite32(a, FromSpan<u32>(buf, buf_cnt + 4));
+				vtlb_ramWrite<mem32_t>(a, FromSpan<u32>(buf, buf_cnt + 4));
 				buf_cnt += 8;
 				break;
 			}
@@ -623,7 +623,7 @@ PINEServer::IPCBuffer PINEServer::ParseCommand(std::span<u8> buf, std::vector<u8
 				if (!SafetyChecks(buf_cnt, 8 + 4, ret_cnt, 0, buf_size)) [[unlikely]]
 					goto error;
 				const u32 a = FromSpan<u32>(buf, buf_cnt);
-				memWrite64(a, FromSpan<u64>(buf, buf_cnt + 4));
+				vtlb_ramWrite<mem64_t>(a, FromSpan<u64>(buf, buf_cnt + 4));
 				buf_cnt += 12;
 				break;
 			}

--- a/pcsx2/vtlb.cpp
+++ b/pcsx2/vtlb.cpp
@@ -323,24 +323,29 @@ template void vtlb_memWrite<mem32_t>(u32 mem, mem32_t data);
 template void vtlb_memWrite<mem64_t>(u32 mem, mem64_t data);
 
 template <typename DataType>
-bool vtlb_ramRead(u32 addr, DataType* value)
+DataType vtlb_ramRead(u32 addr, bool* result)
 {
 	const auto vmv = vtlbdata.vmap[addr >> VTLB_PAGE_BITS];
-	if (vmv.isHandler(addr))
+	if (vmv.isHandler(addr)) [[unlikely]]
 	{
-		std::memset(value, 0, sizeof(DataType));
-		return false;
+		if (result)
+			*result = false;
+		return {};
 	}
 
-	std::memcpy(value, reinterpret_cast<DataType*>(vmv.assumePtr(addr)), sizeof(DataType));
-	return true;
+	DataType value = {};
+	std::memcpy(&value, reinterpret_cast<DataType*>(vmv.assumePtr(addr)), sizeof(DataType));
+
+	if (result)
+		*result = true;
+	return value;
 }
 
 template <typename DataType>
 bool vtlb_ramWrite(u32 addr, const DataType& data)
 {
 	const auto vmv = vtlbdata.vmap[addr >> VTLB_PAGE_BITS];
-	if (vmv.isHandler(addr))
+	if (vmv.isHandler(addr)) [[unlikely]]
 		return false;
 
 	std::memcpy(reinterpret_cast<DataType*>(vmv.assumePtr(addr)), &data, sizeof(DataType));
@@ -348,11 +353,11 @@ bool vtlb_ramWrite(u32 addr, const DataType& data)
 }
 
 
-template bool vtlb_ramRead<mem8_t>(u32 mem, mem8_t* value);
-template bool vtlb_ramRead<mem16_t>(u32 mem, mem16_t* value);
-template bool vtlb_ramRead<mem32_t>(u32 mem, mem32_t* value);
-template bool vtlb_ramRead<mem64_t>(u32 mem, mem64_t* value);
-template bool vtlb_ramRead<mem128_t>(u32 mem, mem128_t* value);
+template mem8_t vtlb_ramRead<mem8_t>(u32 mem, bool* result);
+template mem16_t vtlb_ramRead<mem16_t>(u32 mem, bool* result);
+template mem32_t vtlb_ramRead<mem32_t>(u32 mem, bool* result);
+template mem64_t vtlb_ramRead<mem64_t>(u32 mem, bool* result);
+template mem128_t vtlb_ramRead<mem128_t>(u32 mem, bool* result);
 template bool vtlb_ramWrite<mem8_t>(u32 mem, const mem8_t& data);
 template bool vtlb_ramWrite<mem16_t>(u32 mem, const mem16_t& data);
 template bool vtlb_ramWrite<mem32_t>(u32 mem, const mem32_t& data);

--- a/pcsx2/vtlb.h
+++ b/pcsx2/vtlb.h
@@ -95,7 +95,7 @@ extern void TAKES_R128 vtlb_memWrite128(u32 mem, r128 value);
 // These routines only access the various RAM, and will not call handlers
 // which has the potential to change hardware state.
 template <typename DataType>
-extern DataType vtlb_ramRead(u32 mem);
+extern DataType vtlb_ramRead(u32 mem, bool* result = nullptr);
 template <typename DataType>
 extern bool vtlb_ramWrite(u32 mem, const DataType& value);
 


### PR DESCRIPTION
### Description of Changes
- Prevent PINE from accessing pages with custom VTLB handlers, such as MMIO registers.
- Rewrite the vtlb_ramRead function template.

### Rationale behind Changes
Calling arbitrary hardware peripherals from the PINE thread is definitely not safe.

The vtlb_ramRead declaration previously didn't match its definition. I ended up changing the definition since it's slightly cleaner, and on my machine it ended up being slightly faster in a little microbenchmark I wrote.

(edit: To clarify, this is an initial fix I wanted to get in until we figure out what to do about #14589)

### Suggested Testing Steps
Test some PINE clients.

### Did you use AI to help find, test, or implement this issue or feature?
No.