### PR TITLE
GS/DX12: Expand the fb optimization hit detection backport from GL/DX11.

### DIFF
--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -4529,22 +4529,19 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 		(draw_ds && static_cast<GSTexture12*>(draw_ds)->GetSRVDescriptor() == m_tfx_textures[0])))
 		PSSetShaderResource(TEXTURE_TEXTURE, nullptr, false);
 
-	if (InRenderPass() && (m_current_render_target == draw_rt || m_current_depth_target == draw_ds))
+	// Avoid restarting the render pass just to switch from rt+depth to rt and vice versa.
+	// Keep the depth even if doing colclip hw draws, because the next draw will probably re-enable depth.
+	if (InRenderPass() && !(draw_rt || draw_rt_rov) && draw_ds && m_current_render_target && config.tex != m_current_render_target && 
+		m_current_render_target->GetSize() == draw_ds->GetSize())
 	{
-		// avoid restarting the render pass just to switch from rt+depth to rt and vice versa
-		// keep the depth even if doing colclip hw draws, because the next draw will probably re-enable depth
-		if (!(draw_rt || draw_rt_rov) && m_current_render_target && config.tex != m_current_render_target &&
-			draw_ds && m_current_render_target->GetSize() == draw_ds->GetSize())
-		{
-			draw_rt = m_current_render_target;
-			m_pipeline_selector.rt = true;
-		}
-		else if (!(draw_ds || draw_ds_rov) && m_current_depth_target && config.tex != m_current_depth_target &&
-			draw_rt && m_current_depth_target->GetSize() == draw_rt->GetSize())
-		{
-			draw_ds = m_current_depth_target;
-			m_pipeline_selector.ds = true;
-		}
+		draw_rt = m_current_render_target;
+		m_pipeline_selector.rt = true;
+	}
+	else if (InRenderPass() && !(draw_ds || draw_ds_rov) && draw_rt && m_current_depth_target && config.tex != m_current_depth_target &&
+		m_current_depth_target->GetSize() == draw_rt->GetSize())
+	{
+		draw_ds = m_current_depth_target;
+		m_pipeline_selector.ds = true;
 	}
 
 	GSTexture12* draw_ds_as_rt = static_cast<GSTexture12*>(m_ds_as_rt);


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
We can actually expand the hit detection even if either color or depth trigger a state change. This allows not the current but subsequent potential state changes to be avoided.

Note this includes the proper RP changes from https://github.com/PCSX2/pcsx2/pull/14555 so maybe merge that PR first, dump run was used with those changes included as a base.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Follow up from https://github.com/PCSX2/pcsx2/pull/14567
Speed, optimizations.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Same games as that pr, single to double digit reductions in render passes.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation as to how you used it. Please see the Large Language Model (LLM) Usage Policy for more information: https://pcsx2.net/docs/contributing/#large-language-model-llm-usage-policy -->
No.