### PR TITLE
GS/DB/ImGui: Various changes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1960,6 +1960,7 @@ SCAJ-20109:
     halfPixelOffset: 4 # Aligns post bloom.
     nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
+    recommendedAccurateAlphaTest: 1 # Fixes shadows and glasses alpha.
   memcardFilters:
     - "SCAJ-20109"
     - "SCAJ-20052"
@@ -5857,6 +5858,7 @@ SCES-52456:
     halfPixelOffset: 4 # Aligns post bloom.
     nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
+    recommendedAccurateAlphaTest: 1 # Fixes shadows and glasses alpha.
   memcardFilters: # Reads Ratchet 1 & 2 data.
     - "SCES-52456"
     - "SCES-51607"
@@ -7507,6 +7509,7 @@ SCKA-20037:
     halfPixelOffset: 4 # Aligns post bloom.
     nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
+    recommendedAccurateAlphaTest: 1 # Fixes shadows and glasses alpha.
   memcardFilters:
     - "SCKA-20037"
     - "SCKA-20011"
@@ -9387,6 +9390,7 @@ SCPS-15084:
     halfPixelOffset: 4 # Aligns post bloom.
     nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
+    recommendedAccurateAlphaTest: 1 # Fixes shadows and glasses alpha.
   memcardFilters:
     - "SCPS-15084"
     - "SCPS-15056"
@@ -10184,6 +10188,7 @@ SCPS-19309:
     halfPixelOffset: 4 # Aligns post bloom.
     nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
+    recommendedAccurateAlphaTest: 1 # Fixes shadows and glasses alpha.
 SCPS-19310:
   name: "ラチェット&クランク [PlayStation2 the Best]"
   name-sort: "らちぇっとあんどくらんく [PlayStation2 the Best]"
@@ -12069,6 +12074,7 @@ SCUS-97353:
     halfPixelOffset: 4 # Aligns post bloom.
     nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
+    recommendedAccurateAlphaTest: 1 # Fixes shadows and glasses alpha.
   memcardFilters:
     - "SCUS-97353"
     - "SCUS-97268"
@@ -12302,6 +12308,7 @@ SCUS-97411:
     halfPixelOffset: 4 # Aligns post bloom.
     nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
+    recommendedAccurateAlphaTest: 1 # Fixes shadows and glasses alpha.
 SCUS-97412:
   name: "Jak 3 [Demo]"
   region: "NTSC-U"
@@ -12325,6 +12332,7 @@ SCUS-97413:
     halfPixelOffset: 4 # Aligns post bloom.
     nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
+    recommendedAccurateAlphaTest: 1 # Fixes shadows and glasses alpha.
 SCUS-97414:
   name: "EyeToy - AntiGrav"
   region: "NTSC-U"
@@ -12884,6 +12892,7 @@ SCUS-97518:
     halfPixelOffset: 4 # Aligns post bloom.
     nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
+    recommendedAccurateAlphaTest: 1 # Fixes shadows and glasses alpha.
   memcardFilters:
     - "SCUS-97518"
     - "SCUS-97513"
@@ -18668,6 +18677,8 @@ SLES-51713:
 SLES-51714:
   name: "BCV - Battle Construction Vehicles"
   region: "PAL-E"
+  gsHWFixes:
+    recommendedHWAA1: 1 # Fixes line thickness on vehicles and buildings.
 SLES-51715:
   name: "The Seed - War Zone"
   name-sort: "Seed, The - War Zone"
@@ -57490,6 +57501,8 @@ SLPS-25004:
   name-en: "Kensetsu Juuki Kenka Battle - Buchigire Kongou!!"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    recommendedHWAA1: 1 # Fixes line thickness on vehicles and buildings.
 SLPS-25005:
   name: "ロックンメガステージ"
   name-sort: "ろっくんめがすてーじ"
@@ -59868,6 +59881,8 @@ SLPS-25394:
   name-sort: "あなざーせんちゅりーずえぴそーど"
   name-en: "Another Century's Episode"
   region: "NTSC-J"
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes broken effect rendering.
 SLPS-25395:
   name: "センチメンタルプレリュード"
   name-sort: "せんちめんたるぷれりゅーど"
@@ -63979,6 +63994,8 @@ SLPS-73227:
   name-sort: "あなざーせんちゅりーずえぴそーど [PlayStation2 the Best]"
   name-en: "Another Century's Episode [PlayStation2 the Best]"
   region: "NTSC-J"
+  gsHWFixes:
+    textureInsideRT: 1 # Fixes broken effect rendering.
 SLPS-73228:
   name: "風雲　幕末伝 [PlayStation2 the Best]"
   name-sort: "ふううんばくまつでん [PlayStation2 the Best]"
@@ -76490,6 +76507,7 @@ TCES-52456:
     halfPixelOffset: 4 # Aligns post bloom.
     nativeScaling: 1 # Fixes light blooms.
     autoFlush: 2 # Helps fix misaligned bloom.
+    recommendedAccurateAlphaTest: 1 # Fixes shadows and glasses alpha.
 TCES-52582:
   name: "Everybody's Golf 4 [Beta Trial Code]"
   region: "PAL-E"

--- a/pcsx2-qt/Settings/GameSummaryWidget.cpp
+++ b/pcsx2-qt/Settings/GameSummaryWidget.cpp
@@ -364,7 +364,7 @@ void GameSummaryWidget::onSearchHashClicked()
 	if (m_redump_search_keyword.empty())
 		return;
 
-	QtUtils::OpenURL(this, fmt::format("http://redump.org/discs/quicksearch/{}", m_redump_search_keyword).c_str());
+	QtUtils::OpenURL(this, fmt::format("https://redump.info/discs?q={}", m_redump_search_keyword).c_str());
 }
 
 void GameSummaryWidget::onCheckWikiClicked(const std::string& serial)

--- a/pcsx2-qt/Settings/GameSummaryWidget.ui
+++ b/pcsx2-qt/Settings/GameSummaryWidget.ui
@@ -552,7 +552,7 @@
           <bool>false</bool>
          </property>
          <property name="text">
-          <string>Search on Redump.org...</string>
+          <string>Search on Redump.info...</string>
          </property>
         </widget>
        </item>

--- a/pcsx2/Docs/GameIndex.md
+++ b/pcsx2/Docs/GameIndex.md
@@ -183,6 +183,8 @@ The clamp modes are also numerically based.
 * recommendedBlendingLevel    [`0` or `1` or `2` or `3` or `4` or `5`]      {Minimum, Basic, Medium, High, Full(Slow), Maximum (Very Slow)}    Default: Automatic (No value, looks up GameDB)
 * readTCOnClose               [`0` or `1`]          {Off, On}                               Default: Off (`0`) // Tab 3 Hardware Fixes (4th checkbox on right row 2)
 * limit24BitDepth             [`0` or `1`or `2`]    {Disabled, Prioritise Upper Bits, Prioritise Lower Bits}                                Default: Off (`0`)
+* recommendedAccurateAlphaTest             [`0` or `1`]    {Disabled, Advise to use AAT}                                Default: Off (`0`)
+* recommendedHWAA1             [`0` or `1`]    {Disabled, Advise to use AA1}                                Default: Off (`0`)
 
 ### GS Hardware Upscaling Fixes
 

--- a/pcsx2/Docs/gamedb-schema.json
+++ b/pcsx2/Docs/gamedb-schema.json
@@ -229,6 +229,11 @@
               "minimum": 0,
               "maximum": 1
             },
+            "recommendedAccurateAlphaTest": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 1
+            },
             "trilinearFiltering": {
               "type": "integer",
               "minimum": 0,

--- a/pcsx2/Docs/gamedb-schema.json
+++ b/pcsx2/Docs/gamedb-schema.json
@@ -234,6 +234,11 @@
               "minimum": 0,
               "maximum": 1
             },
+            "recommendedHWAA1": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 1
+            },
             "trilinearFiltering": {
               "type": "integer",
               "minimum": 0,

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -717,6 +717,7 @@ void GSDevice11::SetFeatures(IDXGIAdapter1* adapter)
 	Console.WriteLnFmt("D3D11: Conservative Depth: {}", m_conservative_depth ? "Supported" : "Not Supported");
 	Console.WriteLnFmt("D3D11: Depth Testing and Sampling: {}", m_features.test_and_sample_depth ? "Supported" : "Not Supported");
 	Console.WriteLnFmt("D3D11: RGBA16 UNORM Hardware Blending: {}", m_rgba16_unorm_hw_blend ? "Supported" : "Not Supported");
+	Console.WriteLnFmt("D3D11: Rasterizer Ordered Views: {}", m_features.rov ? "Supported" : "Not Supported");
 }
 
 bool GSDevice11::HasSurface() const

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -1441,6 +1441,7 @@ bool GSDevice12::CheckFeatures(const u32& vendor_id)
 	D3D12_FEATURE_DATA_D3D12_OPTIONS options{};
 	m_device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS, &options, sizeof(D3D12_FEATURE_DATA_D3D12_OPTIONS));
 	m_features.rov = options.ROVsSupported;
+	Console.WriteLnFmt("D3D12: Rasterizer Ordered Views: {}", m_features.rov ? "Supported" : "Not Supported");
 
 	Console.WriteLnFmt("D3D12: Tight Alignment: {}", m_allocator->IsTightAlignmentSupported() ? "Supported" : "Not Supported");
 	return true;

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -395,6 +395,7 @@ static const char* s_gs_hw_fix_names[] = {
 	"maximumBlendingLevel",
 	"recommendedBlendingLevel",
 	"recommendedAccurateAlphaTest",
+	"recommendedHWAA1",
 	"getSkipCount",
 	"beforeDraw",
 	"moveHandler",
@@ -953,6 +954,27 @@ void GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions&
 				else
 				{
 					Host::RemoveKeyedOSDMessage("HWAlphaTestWarning");
+				}
+			}
+			break;
+
+			case GSHWFixId::RecommendedHWAA1:
+			{
+				if (!is_sw_renderer && value >= 0 && value <= 1 &&
+					static_cast<int>(config.HWAA1) < value)
+				{
+					Host::AddKeyedOSDMessage("HWAA1Warning",
+						fmt::format(TRANSLATE_FS("GameDatabase",
+										"{0} AA1 is currently disabled.\n"
+										"This game recommends enabling AA1.\n"
+										"You can enable it in Game Properties to improve graphical\n"
+										"accuracy, but this may increase system requirements."),
+							ICON_FA_PAINTBRUSH),
+						Host::OSD_WARNING_DURATION);
+				}
+				else
+				{
+					Host::RemoveKeyedOSDMessage("HWAA1Warning");
 				}
 			}
 			break;

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -394,6 +394,7 @@ static const char* s_gs_hw_fix_names[] = {
 	"minimumBlendingLevel",
 	"maximumBlendingLevel",
 	"recommendedBlendingLevel",
+	"recommendedAccurateAlphaTest",
 	"getSkipCount",
 	"beforeDraw",
 	"moveHandler",
@@ -931,6 +932,27 @@ void GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions&
 				else
 				{
 					Host::RemoveKeyedOSDMessage("HWBlendingWarning");
+				}
+			}
+			break;
+
+			case GSHWFixId::RecommendedAccurateAlphaTest:
+			{
+				if (!is_sw_renderer && value >= 0 && value <= 1 &&
+					static_cast<int>(config.HWAccurateAlphaTest) < value)
+				{
+					Host::AddKeyedOSDMessage("HWAlphaTestWarning",
+						fmt::format(TRANSLATE_FS("GameDatabase",
+										"{0} Accurate Alpha Test is currently disabled.\n"
+										"This game recommends enabling Accurate Alpha Test.\n"
+										"You can enable it in Game Properties to improve graphical\n"
+										"accuracy, but this may increase system requirements."),
+							ICON_FA_PAINTBRUSH),
+						Host::OSD_WARNING_DURATION);
+				}
+				else
+				{
+					Host::RemoveKeyedOSDMessage("HWAlphaTestWarning");
 				}
 			}
 			break;

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -81,6 +81,7 @@ namespace GameDatabaseSchema
 		MinimumBlendingLevel,
 		MaximumBlendingLevel,
 		RecommendedBlendingLevel,
+		RecommendedAccurateAlphaTest,
 		GetSkipCount,
 		BeforeDraw,
 		MoveHandler,

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -82,6 +82,7 @@ namespace GameDatabaseSchema
 		MaximumBlendingLevel,
 		RecommendedBlendingLevel,
 		RecommendedAccurateAlphaTest,
+		RecommendedHWAA1,
 		GetSkipCount,
 		BeforeDraw,
 		MoveHandler,

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -439,7 +439,19 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 				DRAW_LINE(osd_font, font_size, s_hardware_info_cpu_line.c_str(), white_color);
 
 				// GPU
-				s_hardware_info_gpu_line.format("GPU: {}{}", g_gs_device->GetName(), GSConfig.UseDebugDevice ? " (Debug)" : "");
+				const char* gpu_suffix = "";
+				if (GSConfig.UseDebugDevice && GSConfig.HWROV)
+					gpu_suffix = " (Debug & ROV)";
+				else if (GSConfig.UseDebugDevice)
+					gpu_suffix = " (Debug)";
+				else if (GSConfig.HWROV)
+					gpu_suffix = " (ROV)";
+
+				s_hardware_info_gpu_line.format(
+					"GPU: {}{}",
+					g_gs_device->GetName(),
+					gpu_suffix);
+
 				DRAW_LINE(osd_font, font_size, s_hardware_info_gpu_line.c_str(), white_color);
 			}
 


### PR DESCRIPTION
### Description of Changes
Adds print out of ROV support to the log when using DX11 or DX12 reports ROV usage next to the GPU name and adds the ability to add recommendations for the use of AA1 and AAT to the GameDB.

[TheDumps.zip](https://github.com/user-attachments/files/29166305/TheDumps.zip)

### Rationale behind Changes
More information more gooder.

### Suggested Testing Steps
Use the 2 GS dumps provided to test the recommendations. 

### Did you use AI to help find, test, or implement this issue or feature?
No.