### PR TITLE
GS/GL: Fix recent aa1 shader regressions.

### DIFF
--- a/bin/resources/shaders/opengl/tfx_vgs.glsl
+++ b/bin/resources/shaders/opengl/tfx_vgs.glsl
@@ -324,7 +324,8 @@ void main()
 	// Use bottom minus top for delta regardless of which vertex we are expanding.
 	vec2 line_delta = is_bottom ? (vtx.p.xy - other.p.xy) : (other.p.xy - vtx.p.xy);
 	vec2 line_vector = normalize(line_delta / VertexScale);
-if VS_EXPAND == VS_EXPAND_LINE_AA1
+	vec2 line_expand = vec2(line_vector.y, -line_vector.x);
+#if VS_EXPAND == VS_EXPAND_LINE_AA1
 	line_expand *= 2.0f * LineAA1Width;
 #endif
 	vec2 line_width = (line_expand * PointSize) / 2;

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 102; // Last changed in PR 14480
+static constexpr u32 SHADER_CACHE_VERSION = 103; // Last changed in PR 14602


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/GL: Fix recent aa1 shader regressions.
Line was accidentally removed and macro typo.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Regression fix from https://github.com/PCSX2/pcsx2/pull/14480

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Not needed but for verification test anything with AA1 (FF for example).

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation as to how you used it. Please see the Large Language Model (LLM) Usage Policy for more information: https://pcsx2.net/docs/contributing/#large-language-model-llm-usage-policy -->
No