### PR TITLE
GS/TC: Check valid area overlap on exact match Tex is RT

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1757,7 +1757,7 @@ GSTextureCache::Source* GSTextureCache::LookupSource(const bool is_color, const 
 						}
 						else
 						{
-							const bool outside_target = !t->Overlaps(bp, bw, psm, r);
+							const bool outside_target = !t->OverlapsValid(bp, bw, psm, r);
 
 							if (!possible_shuffle && outside_target)
 							{
@@ -7836,7 +7836,7 @@ GSTextureCache::Target::~Target()
 
 bool GSTextureCache::Target::OverlapsValid(u32 bp, u32 bw, u32 psm, const GSVector4i& rect) const
 {
-	const u32 valid_start_block = GSLocalMemory::m_psm[m_TEX0.PSM].info.bn(m_valid.x, m_valid.y, m_TEX0.TBP0, m_TEX0.TBW);
+	const u32 valid_start_block = GSLocalMemory::GetStartBlockAddress(m_TEX0.TBP0, m_TEX0.TBW, m_TEX0.PSM, m_valid);
 	return OverlapsHelper(valid_start_block, UnwrappedEndBlock(), bp, bw, psm, rect);
 }
 


### PR DESCRIPTION
### Description of Changes
Checks that the valid area overlaps the requested area when an exact target match is found.

### Rationale behind Changes
If a target has been drawn on with an offset and a texture upload is done earlier in the target, since the valid area is not set, no upload will be done, so if this target gets picked because the block pointer matches, it will just get black. This checks that the rect overlaps the valid area of the target.

### Suggested Testing Steps
Test Devil May Cry, maybe sanity test some other games.

### Did you use AI to help find, test, or implement this issue or feature?
No

Fixes Devil May Cry:
Master:
<img width="597" height="448" alt="image" src="https://github.com/user-attachments/assets/1bb60cf7-3a33-471c-8343-770988e3ddf3" />
PR:
<img width="597" height="448" alt="image" src="https://github.com/user-attachments/assets/ef00fe5f-449a-4808-b147-39206f0c54ec" />
