### PR TITLE
GS/DX12: Remove unnecessary UAV state and simplify texture unbinding.

### DIFF
--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -3530,11 +3530,6 @@ void GSDevice12::PSSetUnorderedAccess(GSTexture* rt, GSTexture* ds, bool write_r
 {
 	GSTexture12* d12Rt = static_cast<GSTexture12*>(rt);
 	GSTexture12* d12Ds = static_cast<GSTexture12*>(ds);
-	GSTexture12* oldD12Rt = m_tfx_textures_uav[0] != m_null_texture.get() ? m_tfx_textures_uav[0] : nullptr;
-	GSTexture12* oldD12Ds = m_tfx_textures_uav[1] != m_null_texture.get() ? m_tfx_textures_uav[1] : nullptr;
-
-	if (!(d12Rt || d12Ds || oldD12Rt || oldD12Ds))
-		return;
 
 	pxAssert(!(d12Rt || d12Ds) || m_features.rov);
 
@@ -3672,9 +3667,8 @@ void GSDevice12::UnbindTexture(GSTexture12* tex)
 	// RT UAV / depth UAV
 	for (u32 i = TEXTURE_RT_UAV; i <= TEXTURE_DEPTH_UAV; i++)
 	{
-		if (m_tfx_textures_uav[i - TEXTURE_RT_UAV] == tex)
+		if (m_tfx_textures[i] == tex->GetUAVDescriptor())
 		{
-			m_tfx_textures_uav[i - TEXTURE_RT_UAV] = nullptr;
 			m_tfx_textures[i] = m_null_texture->GetUAVDescriptor();
 			m_dirty_flags |= DIRTY_FLAG_TFX_RT_TEXTURES;
 		}

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.h
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.h
@@ -696,7 +696,6 @@ private:
 
 	std::array<D3D12_GPU_VIRTUAL_ADDRESS, NUM_TFX_CONSTANT_BUFFERS> m_tfx_constant_buffers{};
 	std::array<D3D12DescriptorHandle, NUM_TOTAL_TFX_TEXTURES> m_tfx_textures{};
-	std::array<GSTexture12*, NUM_TFX_UAV_TEXTURES> m_tfx_textures_uav{};
 	D3D12DescriptorHandle m_tfx_sampler;
 	u32 m_tfx_sampler_sel = 0;
 	D3D12DescriptorHandle m_tfx_textures_handle_gpu;


### PR DESCRIPTION
### Description of Changes
Remove unnecessary UAV state and simplify texture unbinding.

### Rationale behind Changes
Code is no longer useful and was from a previous ROV iteration. Additionaly, it appears to cause crashes on some systems with the CPU sprite render user hack and possiblly other cases.

### Suggested Testing Steps
Run the attached dump. Enable manual user hacks in Settings>Game Properties>Graphics, enable CPU sprite render in Settings>Game Properties>Graphics>Hardware Fixes>CPU Sprite Render Size (set to Blended Sprites/Triangles). Toggle the width settings up and down. Do this causes crashes on some AMD and NV systems on current master.

[Devil May Cry_SLES-50358_20260619230408.gs.zst.zip](https://github.com/user-attachments/files/29183089/Devil.May.Cry_SLES-50358_20260619230408.gs.zst.zip)

### Did you use AI to help find, test, or implement this issue or feature?
No.