### PR TITLE
GS/HW: Add continuous and oneshot ROV heuristics.

### DIFF
--- a/bin/resources/shaders/dx11/convert.fx
+++ b/bin/resources/shaders/dx11/convert.fx
@@ -693,4 +693,24 @@ float ps_primid_image_init_3(PS_INPUT input) : SV_Target
 }
 #endif
 
+#if defined(PS_ROV_COPY_COLOR) || defined(PS_ROV_COPY_DEPTH)
+	#if PS_ROV_COPY_COLOR
+		Texture2D<float4> RtTexture : register(t2);
+		RWTexture2D<unorm float4> RtTextureRov : register(u0);
+	#endif
+	#if PS_ROV_COPY_DEPTH
+		Texture2D<float> DepthTexture : register(t4);
+		RWTexture2D<float> DepthTextureRov : register(u1);
+	#endif
+	void ps_rov_copy(PS_INPUT input)
+	{
+		#if PS_ROV_COPY_COLOR
+			RtTextureRov[int2(input.p.xy)] = RtTexture.Load(int3(int2(input.p.xy), 0));
+		#endif
+		#if PS_ROV_COPY_DEPTH
+			DepthTextureRov[int2(input.p.xy)] = DepthTexture.Load(int3(int2(input.p.xy), 0));
+		#endif
+	}
+#endif
+
 #endif // PIXEL_SHADER

--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -119,6 +119,7 @@
 #define PS_ABE 0
 #define PS_ROV_COLOR 0
 #define PS_ROV_DEPTH 0
+#define PS_ROV_ONESHOT 0
 #endif
 
 #ifndef VS_EXPAND_NONE
@@ -140,10 +141,15 @@
 #define SW_DEPTH (NEEDS_DEPTH_FOR_AFAIL || NEEDS_DEPTH_FOR_ZTST || NEEDS_DEPTH_FOR_AA1)
 #define ZWRITE (PS_ZFLOOR || PS_ZCLAMP || SW_DEPTH)
 
+#define ROV_COLOR_CONTINUOUS (PS_ROV_COLOR && !PS_ROV_ONESHOT)
+#define ROV_DEPTH_CONTINUOUS (PS_ROV_DEPTH && !PS_ROV_ONESHOT)
+#define ROV_COLOR_ONESHOT (PS_ROV_COLOR && PS_ROV_ONESHOT)
+#define ROV_DEPTH_ONESHOT (PS_ROV_DEPTH && PS_ROV_ONESHOT)
+
 #define PS_RETURN_COLOR_ROV (!PS_NO_COLOR && PS_ROV_COLOR)
-#define PS_RETURN_COLOR (!PS_NO_COLOR && !PS_ROV_COLOR)
+#define PS_RETURN_COLOR (!PS_NO_COLOR && !ROV_COLOR_CONTINUOUS)
 #define PS_RETURN_DEPTH_ROV (PS_ROV_DEPTH == PS_ROV_DEPTH_READ_WRITE)
-#define PS_RETURN_DEPTH (ZWRITE && !PS_ROV_DEPTH)
+#define PS_RETURN_DEPTH (ZWRITE && !ROV_DEPTH_CONTINUOUS)
 #define PS_ROV_EARLYDEPTHSTENCIL (PS_ROV_COLOR && !PS_ROV_DEPTH && !ZWRITE)
 
 struct VS_INPUT
@@ -214,7 +220,7 @@ struct PS_OUTPUT
 
 #if PS_RETURN_DEPTH
 	// In DX12 we do depth feedback loops with a color copy.
-	#if SW_DEPTH && PS_NO_COLOR1 && PS_DEPTH_FEEDBACK_SUPPORT == 2
+	#if SW_DEPTH && PS_NO_COLOR1 && PS_DEPTH_FEEDBACK_SUPPORT == 2 && !PS_ROV_DEPTH
 		#if NUM_RTS > 0
 			float depth_color : SV_Target1;
 		#else
@@ -242,13 +248,22 @@ Texture2D<float> DepthTexture : register(t4);
 #endif
 SamplerState TextureSampler : register(s0);
 
+#if DX12 || !ROV_COLOR_ONESHOT
+	#define RT_ROV_SLOT u0
+	#define DS_ROV_SLOT u1
+#else
+	// For DX11 with oneshot color, the real color RT takes slot 0.
+	#define RT_ROV_SLOT u1
+	#define DS_ROV_SLOT u2
+#endif
+
 #if PS_ROV_COLOR
-RasterizerOrderedTexture2D<unorm float4> RtTextureRov : register(u0);
+RasterizerOrderedTexture2D<unorm float4> RtTextureRov : register(RT_ROV_SLOT);
 static float4 rov_rt_value;
 #endif
 
 #if PS_ROV_DEPTH
-RasterizerOrderedTexture2D<float> DepthTextureRov : register(u1);
+RasterizerOrderedTexture2D<float> DepthTextureRov : register(DS_ROV_SLOT);
 static float rov_depth_value;
 #endif
 
@@ -1587,30 +1602,40 @@ if (bad)
 	PS_OUTPUT output;
 #endif
 
-	// Color write back
-#if PS_RETURN_COLOR
-	output.c0 = o_col0;
-	#if !PS_NO_COLOR1
-		output.c1 = o_col1;
-	#endif
-#elif PS_RETURN_COLOR_ROV
+	// Color ROV write back. Must come before normal write back.
+#if PS_RETURN_COLOR_ROV
 	#if !PS_FBMASK
 		o_col0 = (FbMask == 0xFFu) ? RtLoad(input.p.xy) : o_col0; // channel masking
 	#endif
 	if (!rov_discard_color)
 		RtWrite(input.p.xy, o_col0);
+	else
+		o_col0 = RtLoad(input.p.xy); // Discard in case we're doing oneshot ROV.
 #endif
 
-	// Depth write back
+	// Color write back.
+#if PS_RETURN_COLOR
+	output.c0 = o_col0;
+	#if !PS_NO_COLOR1
+		output.c1 = o_col1;
+	#endif
+#endif
+
+	// Depth ROV write back. Must come before normal dept write back.
+#if PS_RETURN_DEPTH_ROV
+	if (!rov_discard_depth)
+		DepthWrite(input.p.xy, input.p.z);
+	else
+		input.p.z = DepthLoad(input.p.xy); // Discard in case we're doing oneshot ROV.
+#endif
+
+	// Depth write back.
 #if PS_RETURN_DEPTH
 	output.depth = input.p.z;
-	#if SW_DEPTH && PS_NO_COLOR1 && PS_DEPTH_FEEDBACK_SUPPORT == 2
+	#if SW_DEPTH && PS_NO_COLOR1 && PS_DEPTH_FEEDBACK_SUPPORT == 2 && !PS_ROV_DEPTH
 		// Output color clone for feedback.
 		output.depth_color = input.p.z;
 	#endif
-#elif PS_RETURN_DEPTH_ROV
-	if (!rov_discard_depth)
-		DepthWrite(input.p.xy, input.p.z);
 #endif
 
 #if (PS_RETURN_COLOR || PS_RETURN_DEPTH)

--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -1594,7 +1594,9 @@ if (bad)
 		output.c1 = o_col1;
 	#endif
 #elif PS_RETURN_COLOR_ROV
-	o_col0 = (FbMask == 0xFFu) ? RtLoad(input.p.xy) : o_col0; // channel masking
+	#if !PS_FBMASK
+		o_col0 = (FbMask == 0xFFu) ? RtLoad(input.p.xy) : o_col0; // channel masking
+	#endif
 	if (!rov_discard_color)
 		RtWrite(input.p.xy, o_col0);
 #endif

--- a/bin/resources/shaders/vulkan/convert.glsl
+++ b/bin/resources/shaders/vulkan/convert.glsl
@@ -649,4 +649,31 @@ void main()
 }
 #endif
 
+#if defined(PS_ROV_COPY_COLOR) || defined(PS_ROV_COPY_DEPTH)
+	#if PS_ROV_COPY_COLOR
+		layout(set = 1, binding = 2) uniform texture2D RtSampler;
+		layout(set = 1, binding = 5, rgba8) uniform restrict coherent image2D RtImageRov;
+	#endif
+	#if PS_ROV_COPY_DEPTH
+		layout(set = 1, binding = 4) uniform texture2D DepthSampler;
+		layout(set = 1, binding = 6, r32f) uniform restrict coherent image2D DepthImageRov;
+	#endif
+	void ps_rov_copy()
+	{
+		#if PS_ROV_COPY_COLOR
+			vec4 c = texelFetch(RtSampler, ivec2(gl_FragCoord.xy), 0);
+		#endif
+		#if PS_ROV_COPY_DEPTH
+			vec4 d = texelFetch(DepthSampler, ivec2(gl_FragCoord.xy), 0);
+		#endif
+		
+		#if PS_ROV_COPY_COLOR
+			imageStore(RtImageRov, ivec2(gl_FragCoord.xy), c);
+		#endif
+		#if PS_ROV_COPY_DEPTH
+			imageStore(DepthImageRov, ivec2(gl_FragCoord.xy), d);
+		#endif
+	}
+#endif
+
 #endif

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -1966,8 +1966,9 @@ void main()
 	
 	// Writing back color (result already written to o_col0 for non-ROV)
 	#if PS_RETURN_COLOR_ROV
-		o_col0 = mix(o_col0, sample_from_rt(), equal(FbMask, uvec4(0xFFu))); // channel masking
-
+		#if !PS_FBMASK
+			o_col0 = mix(o_col0, sample_from_rt(), equal(FbMask, uvec4(0xFFu))); // channel masking
+		#endif
 		if (!rov_discard_color)
 			imageStore(RtImageRov, ivec2(gl_FragCoord.xy), o_col0);
 	#endif

--- a/bin/resources/shaders/vulkan/tfx.glsl
+++ b/bin/resources/shaders/vulkan/tfx.glsl
@@ -589,10 +589,15 @@ void main()
 #define PS_FEEDBACK_LOOP_IS_NEEDED_DEPTH (AFAIL_NEEDS_DEPTH || ZTST_NEEDS_DEPTH || AA1_NEEDS_DEPTH)
 #define ZWRITE (PS_ZCLAMP || PS_ZFLOOR || SW_DEPTH || PS_FEEDBACK_LOOP_IS_NEEDED_DEPTH)
 
+#define ROV_COLOR_CONTINUOUS (PS_ROV_COLOR && !PS_ROV_ONESHOT)
+#define ROV_DEPTH_CONTINUOUS (PS_ROV_DEPTH && !PS_ROV_ONESHOT)
+#define ROV_COLOR_ONESHOT (PS_ROV_COLOR && PS_ROV_ONESHOT)
+#define ROV_DEPTH_ONESHOT (PS_ROV_DEPTH && PS_ROV_ONESHOT)
+
 #define PS_RETURN_COLOR_ROV (!PS_NO_COLOR && PS_ROV_COLOR)
-#define PS_RETURN_COLOR (!PS_NO_COLOR && !PS_ROV_COLOR)
+#define PS_RETURN_COLOR (!PS_NO_COLOR && !ROV_COLOR_CONTINUOUS)
 #define PS_RETURN_DEPTH_ROV (PS_ROV_DEPTH == PS_ROV_DEPTH_READ_WRITE)
-#define PS_RETURN_DEPTH (ZWRITE && !PS_ROV_DEPTH)
+#define PS_RETURN_DEPTH (ZWRITE && !ROV_DEPTH_CONTINUOUS)
 #define PS_ROV_EARLYDEPTHSTENCIL (PS_ROV_COLOR && !PS_ROV_DEPTH && !ZWRITE)
 
 #define NEEDS_TEX (PS_TFX != 4)
@@ -678,7 +683,8 @@ layout(set = 1, binding = 1) uniform texture2D Palette;
 		#endif
 	#else
 		// Must consider each case separately since the input attachment indices must be consecutive.
-		#if (PS_FEEDBACK_LOOP_IS_NEEDED_RT && !PS_ROV_COLOR) && (PS_FEEDBACK_LOOP_IS_NEEDED_DEPTH && !PS_ROV_DEPTH)
+		#if (PS_FEEDBACK_LOOP_IS_NEEDED_RT && !PS_ROV_COLOR) && \
+			(PS_FEEDBACK_LOOP_IS_NEEDED_DEPTH && !PS_ROV_DEPTH)
 			layout(input_attachment_index = 0, set = 1, binding = 2) uniform subpassInput RtSampler;
 			layout(input_attachment_index = 1, set = 1, binding = 4) uniform subpassInput DepthSampler;
 			vec4 sample_from_rt() { return subpassLoad(RtSampler); }
@@ -1763,6 +1769,7 @@ void main()
 	if ((int(gl_FragCoord.y) & 1) == (PS_SCANMSK & 1))
 		DISCARD;
 #endif
+
 #if PS_DATE >= 5
 
 #if PS_WRITE_RG == 1
@@ -1964,21 +1971,28 @@ void main()
 			DISCARD_DEPTH; // No depth update for triangle edges.
 	#endif
 	
-	// Writing back color (result already written to o_col0 for non-ROV)
+	// Color ROV write back.
 	#if PS_RETURN_COLOR_ROV
 		#if !PS_FBMASK
 			o_col0 = mix(o_col0, sample_from_rt(), equal(FbMask, uvec4(0xFFu))); // channel masking
 		#endif
 		if (!rov_discard_color)
 			imageStore(RtImageRov, ivec2(gl_FragCoord.xy), o_col0);
+		else
+			o_col0 = sample_from_rt(); // Discard in case we're doing oneshot ROV.
 	#endif
 	
-	// Writing back depth
-	#if PS_RETURN_DEPTH
-		gl_FragDepth = input_z;
-	#elif PS_RETURN_DEPTH_ROV
+	// Depth ROV write back. Must come before normal depth write back.
+	#if PS_RETURN_DEPTH_ROV
 		if (!rov_discard_depth)
 			imageStore(DepthImageRov, ivec2(gl_FragCoord.xy), vec4(input_z, 0, 0, 1.0f));
+		else
+			input_z = sample_from_depth(); // Discard in case we're doing oneshot ROV.
+	#endif
+
+	// Depth write back.
+	#if PS_RETURN_DEPTH
+		gl_FragDepth = input_z;
 	#endif
 
 	#if PS_ROV_COLOR || PS_ROV_DEPTH

--- a/pcsx2-qt/Settings/GraphicsAdvancedSettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsAdvancedSettingsTab.ui
@@ -263,6 +263,55 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="rovOptions">
+     <property name="title">
+      <string>ROV Options</string>
+     </property>
+     <layout class="QGridLayout" name="rovOptionsFormLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="rovContinuousBarriersLabel">
+        <property name="text">
+         <string>Continuous Barrier Threshold:</string>
+        </property>
+        <property name="buddy">
+         <cstring>rovContinuousBarriers</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QSpinBox" name="rovContinuousBarriers">
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>999999999</number>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="rovOneshotBarriersLabel">
+        <property name="text">
+         <string>Oneshot Barrier Threshold:</string>
+        </property>
+        <property name="buddy">
+         <cstring>rovOneshotBarriers</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QSpinBox" name="rovOneshotBarriers">
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>999999999</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="debuggingOptions">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -373,6 +422,8 @@
   <tabstop>rovBarriersVK</tabstop>
   <tabstop>ntscFrameRate</tabstop>
   <tabstop>palFrameRate</tabstop>
+  <tabstop>rovContinuousBarriers</tabstop>
+  <tabstop>rovOneshotBarriers</tabstop>
   <tabstop>overrideTextureBarriers</tabstop>
   <tabstop>useDebugDevice</tabstop>
   <tabstop>disableFramebufferFetch</tabstop>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -241,6 +241,8 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_advanced.spinCPUDuringReadbacks, "EmuCore/GS", "HWSpinCPUForReadbacks", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_advanced.spinGPUDuringReadbacks, "EmuCore/GS", "HWSpinGPUForReadbacks", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_advanced.rovBarriersVK, "EmuCore/GS", "HWROVBarriersVK", false);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_advanced.rovContinuousBarriers, "EmuCore/GS", "HWROVContinuousbarriers", 5000);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_advanced.rovOneshotBarriers, "EmuCore/GS", "HWROVOneshotBarriers", 50);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_advanced.texturePreloading, "EmuCore/GS", "texture_preloading", static_cast<int>(TexturePreloadingLevel::Off));
 
 	setTabVisible(m_advanced_tab, QtHost::ShouldShowAdvancedSettings());
@@ -788,6 +790,12 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 
 		dialog()->registerWidgetHelp(m_advanced.palFrameRate, tr("PAL Frame Rate"), tr("50.00 Hz"),
 			tr("Determines what frame rate PAL games run at."));
+
+		dialog()->registerWidgetHelp(m_advanced.rovContinuousBarriers, tr("ROV Continuous Barriers"), tr("5000"),
+			tr("Determines the minimum barriers per frame to activate continuous ROV mode."));
+
+		dialog()->registerWidgetHelp(m_advanced.rovOneshotBarriers, tr("ROV Oneshot Barriers"), tr("50"),
+			tr("Determines the minimum barriers in a draw to activate oneshot ROV mode."));
 	}
 }
 

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -743,6 +743,9 @@ struct Pcsx2Config
 		static constexpr int DEFAULT_SHADEBOOST_GAMMA = 50;
 		static constexpr int DEFAULT_SHADEBOOST_SATURATION = 50;
 
+		static constexpr u32 DEFAULT_ROV_CONTINUOUS_BARRIERS = 5000;
+		static constexpr u32 DEFAULT_ROV_ONESHOT_BARRIERS = 50;
+
 		union
 		{
 			u64 bitsets[2];
@@ -895,6 +898,8 @@ struct Pcsx2Config
 		TriFiltering TriFilter = DEFAULT_TRILINEAR_FILTERING_MODE;
 		s8 OverrideTextureBarriers = -1;
 		GSDepthFeedbackMode DepthFeedbackMode = GSDepthFeedbackMode::Auto;
+		u32 HWROVContinuousBarriers = DEFAULT_ROV_CONTINUOUS_BARRIERS;
+		u32 HWROVOneshotBarriers = DEFAULT_ROV_ONESHOT_BARRIERS;
 
 		u8 CAS_Sharpness = 50;
 		u8 ShadeBoost_Brightness = DEFAULT_SHADEBOOST_BRIGHTNESS;

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2624,6 +2624,7 @@ void GSState::FlushPrim()
 		m_quad_check_valid_shuffle = false;
 		m_drawlist.clear();
 		m_drawlist_bbox.clear();
+		m_draw_coarse_rasterize.clear();
 
 		if (GSConfig.ShouldDump(s_n, g_perfmon.GetFrame()))
 		{

--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -5090,13 +5090,13 @@ __forceinline bool GSState::EarlyDetectShuffle(u32 prim)
 	return false;
 }
 
-__fi GSVector4 GSState::GetXYWindow(const GSVertex& v)
+GSVector4 GSState::GetXYWindow(const GSVertex& v)
 {
 	return GSVector4(GetVertexXY(v) - m_context->scissor.xyof.xyxy()) / 16.0f;
 }
 
 template<bool fst>
-__fi GSVector4 GSState::GetTexCoordsImpl(const GSVertex& v, float q)
+GSVector4 GSState::GetTexCoordsImpl(const GSVertex& v, float q)
 {
 	if constexpr (fst)
 	{
@@ -5112,12 +5112,12 @@ __fi GSVector4 GSState::GetTexCoordsImpl(const GSVertex& v, float q)
 }
 
 template<bool fst>
-__fi GSVector4 GSState::GetTexCoordsImpl(const GSVertex& v)
+GSVector4 GSState::GetTexCoordsImpl(const GSVertex& v)
 {
 	return GetTexCoordsImpl<fst>(v, v.RGBAQ.Q);
 }
 
-__fi GSVector4 GSState::GetTexCoords(const GSVertex& v, float q)
+GSVector4 GSState::GetTexCoords(const GSVertex& v, float q)
 {
 	if (PRIM->FST)
 	{
@@ -5129,7 +5129,7 @@ __fi GSVector4 GSState::GetTexCoords(const GSVertex& v, float q)
 	}
 }
 
-__fi GSVector4 GSState::GetTexCoords(const GSVertex& v)
+GSVector4 GSState::GetTexCoords(const GSVertex& v)
 {
 	return GetTexCoords(v, v.RGBAQ.Q);
 }

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -392,6 +392,7 @@ public:
 	PRIM_OVERLAP m_prim_overlap = PRIM_OVERLAP_UNKNOW;
 	std::vector<size_t> m_drawlist;
 	std::vector<GSVector4i> m_drawlist_bbox;
+	std::vector<GSVector4i> m_draw_coarse_rasterize;
 
 	struct GSPCRTCRegs
 	{

--- a/pcsx2/GS/GSUtil.cpp
+++ b/pcsx2/GS/GSUtil.cpp
@@ -22,6 +22,9 @@
 #include <wil/com.h>
 #endif
 
+#include <algorithm>
+#include <bit>
+
 namespace {
 struct GSUtilMaps
 {
@@ -361,5 +364,430 @@ bool GSUtil::IsValidPSM(int psm)
 			return true;
 		default:
 			return false;
+	}
+}
+
+template<bool swap_xy, typename T>
+static __forceinline T SwapXY(T rect)
+{
+	return swap_xy ? rect.yxwz() : rect;
+}
+
+template<typename T>
+static __forceinline T ExpandRect(const T& rect, const int expand)
+{
+	return rect + T(-expand, -expand, expand, expand);
+}
+
+// Type representing a W x H grid with boolean entries, as a bitfield.
+template<u32 W, u32 H, typename BitfieldType>
+requires ((W <= sizeof(BitfieldType) * 8) && (W % (sizeof(BitfieldType) * 8) == 0))
+class BitGrid
+{
+public:
+	static constexpr u32 BITWIDTH = sizeof(BitfieldType) * 8;
+	static constexpr BitfieldType ALLMASK = ~static_cast<BitfieldType>(0);
+
+	// A single boolean at (x, y).
+	bool Get(u32 x, u32 y) const
+	{
+		return GetBitfield(y, x) & (1 << (x & (BITWIDTH - 1)));
+	}
+
+	// The run of BITWIDTH booleans at (x, y). x is rounded.
+	BitfieldType& GetBitfield(u32 x, u32 y)
+	{
+		return grid[(W / BITWIDTH) * y + (x / BITWIDTH)];
+	}
+
+	// The run of BITWIDTH booleans at (x, y). x is rounded.
+	BitfieldType GetBitfield(u32 x, u32 y) const
+	{
+		return grid[(W / BITWIDTH) * y + (x / BITWIDTH)];
+	}
+private:
+	std::array<BitfieldType, W * H / (sizeof(BitfieldType) * 8)> grid{};
+};
+
+
+// Get the coarse coverage for a single scanline.
+template<u32 W, u32 H, typename BitfieldType>
+static __forceinline void CoarseRasterizeScanline(const u32 x0, const u32 x1, const u32 y,
+	BitGrid<W, H, BitfieldType>& grid)
+{
+	constexpr BitfieldType ALLMASK = BitGrid<W, H, BitfieldType>::ALLMASK;
+	constexpr u32 BITWIDTH = BitGrid<W, H, BitfieldType>::BITWIDTH;
+
+	const BitfieldType first_mask = (ALLMASK << (x0 & (BITWIDTH - 1)));
+	const BitfieldType last_mask = (ALLMASK >> (BITWIDTH - (x1 & (BITWIDTH - 1))));
+
+	if constexpr (W <= BITWIDTH)
+	{
+		// There's only one bitfield per scanline here.
+		grid.GetBitfield(0, y) |= first_mask & (x1 < BITWIDTH ? last_mask : ALLMASK);
+		return;
+	}
+
+	const u32 x0_floor = x0 & ~(BITWIDTH - 1);
+	const u32 x1_ceil = (x1 + (BITWIDTH - 1)) & ~(BITWIDTH - 1);
+	for (u32 x = x0_floor; x < x1_ceil; x += BITWIDTH)
+	{
+		const BitfieldType mask0 = (x <= x0) ? first_mask : ALLMASK;
+		const BitfieldType mask1 = (x >= (x1 & ~(BITWIDTH - 1))) ? last_mask : ALLMASK;
+		grid.GetBitfield(y, x) |= mask0 & mask1;
+	}
+}
+
+// Get the coarse coverage for a triangle section.
+template<u32 W, u32 H, typename BitfieldType>
+static void CoarseRasterizeTriangleSection(int top, int bottom,
+	const GSVector2& x_top, const float y_top, const GSVector2& ddx,
+	const GSVector2i& tile_size, const GSVector2i& tile_shift, const int expand, BitGrid<W, H, BitfieldType>& grid)
+{
+	top -= expand;
+	bottom += expand;
+
+	const int top_floor = top & ~(tile_size.y - 1);
+	const int bottom_ceil = (bottom + tile_size.y - 1) & ~(tile_size.y - 1);
+
+	for (int y = top_floor; y < bottom_ceil; y += tile_size.y)
+	{
+		const int y0 = std::clamp(y, top, bottom - 1);
+		const int y1 = std::clamp(y + tile_size.y, top, bottom - 1);
+
+		const float dy0 = static_cast<float>(y0) - y_top;
+		const float dy1 = static_cast<float>(y1) - y_top;
+
+		const GSVector2 x0 = x_top + ddx * dy0;
+		const GSVector2 x1 = x_top + ddx * dy1;
+
+		const int x0_left = static_cast<int>(std::floor(x0.x)) - expand;
+		const int x0_right = static_cast<int>(std::ceil(x0.y)) + expand;
+		const int x1_left = static_cast<int>(std::floor(x1.x)) - expand;
+		const int x1_right = static_cast<int>(std::ceil(x1.y)) + expand;
+
+		int x_left = std::min(x0_left, x1_left);
+		int x_right = std::max(x0_right, x1_right);
+
+		x_left = std::clamp<int>(x_left >> tile_shift.x, 0, W);
+		x_right = std::clamp<int>((x_right >> tile_shift.x) + 1, 0, W);
+
+		const int y_tile = y0 >> tile_shift.y;
+
+		if (0 < x_right && x_left < x_right && x_left < W && 0 <= y_tile && y_tile < H)
+			CoarseRasterizeScanline<W, H, BitfieldType>(x_left, x_right, y_tile, grid);
+	}
+}
+
+// Get the coarse coverage for a given rect.
+template<u32 W, u32 H, typename BitfieldType>
+static __forceinline void CoarseRasterizeRect(GSVector4i rect, const GSVector2i& tile_size,
+	const GSVector2i& tile_shift, const int expand, BitGrid<W, H, BitfieldType>& grid)
+{
+	rect = ExpandRect(rect, expand).ralign<Align_Outside>(tile_size);
+
+	const u32 x0 = std::clamp<int>(rect.x >> tile_shift.x, 0, W);
+	const u32 y0 = std::clamp<int>(rect.y >> tile_shift.y, 0, H);
+	const u32 x1 = std::clamp<int>(rect.z >> tile_shift.x, 0, W);
+	const u32 y1 = std::clamp<int>(rect.w >> tile_shift.y, 0, H);
+
+	for (u32 y = y0; y < y1; y++)
+		CoarseRasterizeScanline<W, H, BitfieldType>(x0, x1, y, grid);
+}
+
+// Lookup table to sort vertices by Y.
+static const u8 s_ysort[8][4] =
+{
+	{0, 1, 2, 0}, // y0 <= y1 <= y2
+	{1, 0, 2, 0}, // y1 < y0 <= y2
+	{0, 0, 0, 0},
+	{1, 2, 0, 0}, // y1 <= y2 < y0
+	{0, 2, 1, 0}, // y0 <= y2 < y1
+	{0, 0, 0, 0},
+	{2, 0, 1, 0}, // y2 < y0 <= y1
+	{2, 1, 0, 0}, // y2 < y1 < y0
+};
+
+// Get the coarse coverage for a triangle (code modified from SW renderer).
+template<u32 W, u32 H, typename BitfieldType>
+static __forceinline void CoarseRasterizeTriangle(const GSVector4* RESTRICT p,
+	const GSVector2i& tile_size, const GSVector2i& tile_shift,
+	const int expand, BitGrid<W, H, BitfieldType>& grid)
+{
+	GSVector4 y0011 = GSVector4::loadl(&p[0]).yyyy(GSVector4::loadl(&p[1]));
+	GSVector4 y1221 = GSVector4::loadl(&p[1]).yyyy(GSVector4::loadl(&p[2])).xzzx();
+
+	int m1 = (y0011 > y1221).mask() & 7;
+
+	int i[3];
+
+	i[0] = s_ysort[m1][0];
+	i[1] = s_ysort[m1][1];
+	i[2] = s_ysort[m1][2];
+
+	const GSVector4 v0 = GSVector4::loadl(&p[i[0]]);
+	const GSVector4 v1 = GSVector4::loadl(&p[i[1]]);
+	const GSVector4 v2 = GSVector4::loadl(&p[i[2]]);
+
+	y0011 = v0.yyyy(v1);
+	y1221 = v1.yyyy(v2).xzzx();
+
+	m1 = (y0011 == y1221).mask() & 7;
+
+	// if (i == 0) => y0 < y1 < y2
+	// if (i == 1) => y0 == y1 < y2
+	// if (i == 4) => y0 < y1 == y2
+
+	if (m1 == 7)
+		return; // y0 == y1 == y2
+
+	const GSVector4 tbf = y0011.xzxz(y1221).ceil();
+	const GSVector4 tbmax = tbf.max(GSVector4(0));
+	const GSVector4 tbmin = tbf.min(GSVector4(H << tile_shift.y));
+	const GSVector4i tb = GSVector4i(tbmax.xzyw(tbmin)); // max(y0, t) max(y1, t) min(y1, b) min(y2, b)
+
+	GSVector4 dv0 = v1 - v0;
+	GSVector4 dv1 = v2 - v0;
+	GSVector4 dv2 = v2 - v1;
+
+	GSVector4 cross = dv0 * dv1.yxwz();
+
+	cross = (cross - cross.yxwz()).yyyy();
+
+	int m2 = cross.upl(cross == GSVector4::zero()).mask();
+
+	if (m2 & 2)
+		return; // Degenerate triangle
+
+	m2 &= 1;
+
+	GSVector4 dxy01 = dv0.xyxy(dv1);
+
+	GSVector4 dx = dxy01.xzxy(dv2);
+	GSVector4 dy = dxy01.ywyx(dv2);
+
+	GSVector4 ddx[3];
+
+	ddx[0] = dx / dy;
+	ddx[1] = ddx[0].yxzw();
+	ddx[2] = ddx[0].xzyw();
+
+	if (m1 & 1)
+	{
+		if (tb.y < tb.w)
+		{
+			const GSVector2 x0(p[i[1 - m2]].x, p[i[m2]].x);
+			const float y0 = p[i[1 - m2]].y;
+			const GSVector2 ddx1(ddx[!m2 << 1].y, ddx[!m2 << 1].z);
+
+			CoarseRasterizeTriangleSection(tb.x, tb.w, x0, y0, ddx1, tile_size, tile_shift, expand, grid);
+		}
+	}
+	else
+	{
+		if (tb.x < tb.z)
+		{
+			const GSVector2 x0(v0.x, v0.x);
+			const float y0 = v0.y;
+			const GSVector2 ddx1(ddx[m2].x, ddx[m2].y);
+
+			CoarseRasterizeTriangleSection(tb.x, tb.z, x0, y0, ddx1, tile_size, tile_shift, expand, grid);
+		}
+
+		if (tb.y < tb.w)
+		{
+			const GSVector2 x0 = GSVector2(v0.x, v0.x) + GSVector2(ddx[m2].x, ddx[m2].y) * GSVector2(dv0.y);
+			const float y0 = v1.y;
+			const GSVector2 ddx1(ddx[!m2 << 1].y, ddx[!m2 << 1].z);
+
+			CoarseRasterizeTriangleSection(tb.y, tb.w, x0, y0, ddx1, tile_size, tile_shift, expand, grid);
+		}
+	}
+}
+
+// Convert the grid of booleans to a list of tiles.
+template<u32 W, u32 H, typename BitfieldType, bool SWAP_XY>
+static __forceinline void ConvertGridToTiles(const GSVector4i& area, const GSVector2i& tile_shift,
+	const BitGrid<W, H, BitfieldType>& grid, std::vector<GSVector4i>& tiles_out)
+{
+	tiles_out.reserve(W * H);
+	const GSVector4i tileoffset = area.xyxy();
+	constexpr u32 BITWIDTH = BitGrid<W, H, BitfieldType>::BITWIDTH;
+	for (u32 y = 0; y < H; y++)
+	{
+		for (u32 x = 0; x < W; x += BITWIDTH)
+		{
+			if (grid.GetBitfield(x, y))
+			{
+				const BitfieldType bitfield = grid.GetBitfield(x, y);
+				u32 x0 = 0;
+				while (x0 <= BITWIDTH)
+				{
+					x0 += std::countr_zero<BitfieldType>(bitfield >> x0);
+					const u32 x1 = x0 + std::countr_one<BitfieldType>(bitfield >> x0);
+
+					if (x0 < x1)
+					{
+						GSVector4i tile(x0 << tile_shift.x, y << tile_shift.y, x1 << tile_shift.x, (y + 1) << tile_shift.y);
+						tile = (tile + tileoffset).rintersect(area);
+						if (!tile.rempty())
+							tiles_out.push_back(SwapXY<SWAP_XY>(tile));
+						x0 = x1;
+					}
+					else
+					{
+						break;
+					}
+				}
+			}
+		}
+	}
+}
+
+static constexpr u32 MIN_TILE_SHIFT = 4; // Minimum of 16x16 tile size.
+
+template<u32 W, u32 H>
+static __forceinline void RoundTileSize(const GSVector4i& area, GSVector2i& tile_size, GSVector2i& tile_shift)
+{
+	tile_size = GSVector2i((area.width() + W - 1) / W, (area.height() + H - 1) / H);
+	tile_shift = GSVector2i(MIN_TILE_SHIFT);
+	while ((1 << tile_shift.x) < tile_size.x)
+		tile_shift.x++;
+	while ((1 << tile_shift.y) < tile_size.y)
+		tile_shift.y++;
+	tile_size = GSVector2i(1 << tile_shift.x, 1 << tile_shift.y);
+}
+
+template<u32 W, u32 H, typename BitfieldType, bool SWAP_XY>
+static __forceinline void CoarseRasterizeRects(GSVector4i area, const GSVector4i* rects, const u32 num_rects,
+	const int expand, std::vector<GSVector4i>& tiles_out)
+{
+	area = SwapXY<SWAP_XY>(area);
+
+	// Get the tile size.
+	GSVector2i tile_size, tile_shift;
+	RoundTileSize<W, H>(area, tile_size, tile_shift);
+
+	// Rasterize rects into the bit grid.
+	BitGrid<W, H, BitfieldType> grid;
+	const GSVector4i offset = area.xyxy();
+	for (u32 i = 0; i < num_rects; i++)
+	{
+		const GSVector4i rect = SwapXY<SWAP_XY>(rects[i]) - offset;
+		CoarseRasterizeRect<W, H, BitfieldType>(rect, tile_size, tile_shift, expand, grid);
+	}
+
+	// Convert grid to tiles.
+	ConvertGridToTiles<W, H, BitfieldType, SWAP_XY>(area, tile_shift, grid, tiles_out);
+}
+
+template<u32 W, u32 H, typename BitfieldType, bool SWAP_XY>
+static __forceinline void CoarseRasterizeTriangles(
+	GSVector4i area, const GSVector4* RESTRICT pos, const u32 npos,
+	const int expand, std::vector<GSVector4i>& tiles_out)
+{
+	area = SwapXY<SWAP_XY>(area);
+
+	// Get the tile size.
+	GSVector2i tile_size, tile_shift;
+	RoundTileSize<W, H>(area, tile_size, tile_shift);
+
+	// Rasterize triangles into the bit grid.
+	BitGrid<W, H, BitfieldType> grid;
+	GSVector4 offset(area.xyxy());
+	for (u32 i = 0; i < npos; i += 3)
+	{
+		const GSVector4 p[3] = {
+			SwapXY<SWAP_XY>(pos[i + 0]).xyxy() - offset,
+			SwapXY<SWAP_XY>(pos[i + 1]).xyxy() - offset,
+			SwapXY<SWAP_XY>(pos[i + 2]).xyxy() - offset,
+		};
+
+		GSVector4 bbox = p[0].min(p[1]).xyzw(p[0].max(p[1]));
+		bbox = bbox.min(p[2]).xyzw(bbox.max(p[2]));
+		GSVector4i bboxi(bbox.floor().xyzw(bbox.ceil()));
+
+		if (bboxi.width() <= tile_size.x || bboxi.height() <= tile_size.y)
+		{
+			// Don't rasterize small triangles; the extra accuracy is likely wasted.
+			CoarseRasterizeRect<W, H, BitfieldType>(bboxi, tile_size, tile_shift, expand, grid);
+		}
+		else
+		{
+			CoarseRasterizeTriangle<W, H, BitfieldType>(p, tile_size, tile_shift, expand, grid);
+		}
+	}
+	
+	// Convert grid to tiles.
+	ConvertGridToTiles<W, H, BitfieldType, SWAP_XY>(area, tile_shift, grid, tiles_out);
+}
+
+void GSUtil::CoarseRasterizeRects(const GSVector4i& area, const GSVector4i* rects, const u32 num_rects,
+	const u32 grid_size, const int expand, std::vector<GSVector4i>& tiles_out)
+{
+	switch (grid_size)
+	{
+		case 8:
+			if (area.width() >= area.height())
+				::CoarseRasterizeRects<8, 8, u8, false>(area, rects, num_rects, expand, tiles_out);
+			else
+				::CoarseRasterizeRects<8, 8, u8, true>(area, rects, num_rects, expand, tiles_out);
+			break;
+		case 16:
+			if (area.width() >= area.height())
+				::CoarseRasterizeRects<16, 16, u16, false>(area, rects, num_rects, expand, tiles_out);
+			else
+				::CoarseRasterizeRects<16, 16, u16, true>(area, rects, num_rects, expand, tiles_out);
+			break;
+		case 32:
+			if (area.width() >= area.height())
+				::CoarseRasterizeRects<32, 32, u32, false>(area, rects, num_rects, expand, tiles_out);
+			else
+				::CoarseRasterizeRects<32, 32, u32, true>(area, rects, num_rects, expand, tiles_out);
+			break;
+		case 64:
+			if (area.width() >= area.height())
+				::CoarseRasterizeRects<64, 64, u64, false>(area, rects, num_rects, expand, tiles_out);
+			else
+				::CoarseRasterizeRects<64, 64, u64, true>(area, rects, num_rects, expand, tiles_out);
+			break;
+		default:
+			pxAssert(false);
+			break;
+	}
+}
+
+void GSUtil::CoarseRasterizeTriangles(GSVector4i area, const GSVector4* RESTRICT pos, const u32 num_pos,
+	const u32 grid_size, const int expand, std::vector<GSVector4i>& tiles_out)
+{
+	switch (grid_size)
+	{
+		case 8:
+			if (area.width() >= area.height())
+				::CoarseRasterizeTriangles<8, 8, u8, false>(area, pos, num_pos, expand, tiles_out);
+			else
+				::CoarseRasterizeTriangles<8, 8, u8, true>(area, pos, num_pos, expand, tiles_out);
+			break;
+		case 16:
+			if (area.width() >= area.height())
+				::CoarseRasterizeTriangles<16, 16, u16, false>(area, pos, num_pos, expand, tiles_out);
+			else
+				::CoarseRasterizeTriangles<16, 16, u16, true>(area, pos, num_pos, expand, tiles_out);
+			break;
+		case 32:
+			if (area.width() >= area.height())
+				::CoarseRasterizeTriangles<32, 32, u32, false>(area, pos, num_pos, expand, tiles_out);
+			else
+				::CoarseRasterizeTriangles<32, 32, u32, true>(area, pos, num_pos, expand, tiles_out);
+			break;
+		case 64:
+			if (area.width() >= area.height())
+				::CoarseRasterizeTriangles<64, 64, u64, false>(area, pos, num_pos, expand, tiles_out);
+			else
+				::CoarseRasterizeTriangles<64, 64, u64, true>(area, pos, num_pos, expand, tiles_out);
+			break;
+		default:
+			pxAssert(false);
+			break;
 	}
 }

--- a/pcsx2/GS/GSUtil.h
+++ b/pcsx2/GS/GSUtil.h
@@ -78,6 +78,12 @@ public:
 	{
 		return GetClassVertexCount(GetPrimClass(prim));
 	}
+
+	// Functions to CPU rasterize geometry into a coarse grid to cut down on GPU copies.
+	static void CoarseRasterizeRects(const GSVector4i& area, const GSVector4i* rects, const u32 num_rects,
+		const u32 grid_size, const int expand, std::vector<GSVector4i>& tiles_out);
+	static void CoarseRasterizeTriangles(GSVector4i area, const GSVector4* RESTRICT pos, const u32 num_pos,
+		const u32 grid_size, const int expand, std::vector<GSVector4i>& tiles_out);
 };
 
 // Class that represents an octogonal bounding area with sides at 45 degree increments.

--- a/pcsx2/GS/GSVector.h
+++ b/pcsx2/GS/GSVector.h
@@ -67,6 +67,40 @@ public:
 		return { x / v.x, y / v.y };
 	}
 
+	constexpr GSVector2T operator+(const GSVector2T& v) const
+	{
+		return { x + v.x, y + v.y };
+	}
+
+	constexpr GSVector2T operator-(const GSVector2T& v) const
+	{
+		return { x - v.x, y - v.y };
+	}
+
+	GSVector2T& operator*=(const GSVector2T& v)
+	{
+		*this = *this * v;
+		return *this;
+	}
+
+	GSVector2T& operator/=(const GSVector2T& v)
+	{
+		*this = *this / v;
+		return *this;
+	}
+
+	GSVector2T& operator+=(const GSVector2T& v)
+	{
+		*this = *this + v;
+		return *this;
+	}
+
+	GSVector2T& operator-=(const GSVector2T& v)
+	{
+		*this = *this + v;
+		return *this;
+	}
+
 	GSVector2T min(const GSVector2T& v) const
 	{
 		return { std::min(x, v.x), std::min(y, v.y) };

--- a/pcsx2/GS/GSVector4.h
+++ b/pcsx2/GS/GSVector4.h
@@ -229,6 +229,11 @@ public:
 		return rgba32(rgba) * GSVector4::cxpr(1.0f / 255.0f);
 	}
 
+	__forceinline static GSVector4 unorm16(u32 rgba)
+	{
+		return rgba32(rgba) * GSVector4::cxpr(1.0f / 65535.0f);
+	}
+
 	__forceinline GSVector4 abs() const
 	{
 		return *this & cast(GSVector4i::x7fffffff());

--- a/pcsx2/GS/GSVector4_arm64.h
+++ b/pcsx2/GS/GSVector4_arm64.h
@@ -196,6 +196,11 @@ public:
 		return rgba32(rgba) * GSVector4::cxpr(1.0f / 255.0f);
 	}
 
+	__forceinline static GSVector4 unorm16(u32 rgba)
+	{
+		return rgba32(rgba) * GSVector4::cxpr(1.0f / 65535.0f);
+	}
+
 	__forceinline GSVector4 abs() const
 	{
 		return GSVector4(vabsq_f32(v4s));

--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -1542,7 +1542,7 @@ static const char* GetTexHazardName(u32 tex_hazard)
 	return "Unknown";
 }
 
-static const char* GetPSROVDepthname(GSHWDrawConfig::PS_ROV_DEPTH rov_depth)
+static const char* GetPSROVDepthName(GSHWDrawConfig::PS_ROV_DEPTH rov_depth)
 {
 	switch (rov_depth)
 	{
@@ -1611,8 +1611,8 @@ static void DumpPSSelector(DrawConfigWriter& out, const GSHWDrawConfig::PSSelect
 	out.WriteLn("aa1: {} ({})", GetPSAA1Name(ps.aa1), static_cast<u32>(ps.aa1));
 	out.WriteLn("abe: {}", static_cast<u32>(ps.abe));
 	out.WriteLn("sw_aniso: {}", ps.sw_aniso);
-	out.WriteLn("rov_color: {}", ps.rov_color);
-	out.WriteLn("rov_depth: {} ({})", GetPSROVDepthname(ps.rov_depth), static_cast<u32>(ps.rov_depth));
+	out.WriteLn("rov_color: {}", static_cast<u32>(ps.rov_color));
+	out.WriteLn("rov_depth: {} ({})", GetPSROVDepthName(ps.rov_depth), static_cast<u32>(ps.rov_depth));
 	out.WriteLn("ztst: {} ({})", GSUtil::GetZTSTName(ps.ztst), static_cast<u32>(ps.ztst));
 	out.WriteLn("zfloor: {}", static_cast<u32>(ps.zfloor));
 }

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -797,6 +797,7 @@ struct alignas(16) GSHWDrawConfig
 				// ROVs
 				u32 rov_color : 1;
 				PS_ROV_DEPTH rov_depth : 2;
+				u32 rov_oneshot : 1;
 			};
 
 			struct
@@ -889,17 +890,53 @@ struct alignas(16) GSHWDrawConfig
 
 		__fi bool HasDepthOutput() const
 		{
-			return zfloor || zclamp || IsFeedbackLoopDepth() || (rov_depth == PS_ROV_DEPTH::READ_WRITE);
+			return zfloor || zclamp || IsFeedbackLoopDepth() ||
+				(rov_depth == PS_ROV_DEPTH::READ_WRITE);
 		}
 
 		__fi bool HasColorROV() const
 		{
-			return rov_color != 0;
+			return rov_color;
 		}
 
 		__fi bool HasDepthROV() const
 		{
 			return rov_depth != PS_ROV_DEPTH::NONE;
+		}
+
+		__fi bool HasOneshotROV() const
+		{
+			return rov_oneshot;
+		}
+
+		bool HasOneshotColorROV() const
+		{
+			return HasColorROV() && HasOneshotROV();
+		}
+
+		bool HasOneshotDepthROV() const
+		{
+			return HasDepthROV() && HasOneshotROV();
+		}
+
+		bool HasContinuousColorROV() const
+		{
+			return HasColorROV() && !HasOneshotROV();
+		}
+
+		bool HasContinuousDepthROV() const
+		{
+			return HasDepthROV() && !HasOneshotROV();
+		}
+
+		bool HasContinuousROV() const
+		{
+			return HasContinuousColorROV() || HasContinuousDepthROV();
+		}
+
+		bool HasROV() const
+		{
+			return HasColorROV() || HasDepthROV();
 		}
 
 		__fi bool HasDepthROVWrite() const
@@ -1248,6 +1285,7 @@ struct alignas(16) GSHWDrawConfig
 	u32 indices_per_prim;  ///< Number of indices that make up one primitive
 	const std::vector<size_t>* drawlist;          ///< For reducing barriers on sprites
 	const std::vector<GSVector4i>* drawlist_bbox; ///< For RT copy when barriers not available.
+	const std::vector<GSVector4i>* draw_coarse_rasterize; ///< For cutting down on copy area.
 	GSVector4i scissor; ///< Scissor rect
 	GSVector4i drawarea; ///< Area in the framebuffer which will be modified.
 	GSVector4i samplearea; ///< Area in the texture which will be sampled.

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -565,6 +565,8 @@ bool GSDevice11::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 	dsd.BackFace.StencilDepthFailOp = D3D11_STENCIL_OP_KEEP;
 
 	m_dev->CreateDepthStencilState(&dsd, m_date.dss.put());
+	if (m_features.rov)
+		m_dev->CreateDepthStencilState(&dsd, m_rov_copy.dss.put());
 
 	// blend
 
@@ -574,6 +576,8 @@ bool GSDevice11::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 		memset(&blend, 0, sizeof(blend));
 
 		m_dev->CreateBlendState(&blend, m_date.bs.put());
+		if (m_features.rov)
+			m_dev->CreateBlendState(&blend, m_rov_copy.bs.put());
 	}
 
 	for (size_t i = 0; i < std::size(m_date.primid_init_ps); i++)
@@ -586,6 +590,27 @@ bool GSDevice11::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 		m_date.primid_init_ps[i] = m_shader_cache.GetPixelShader(m_dev.get(), *convert_hlsl, sm_ps.GetPtr(), entry_point.c_str());
 		if (!m_date.primid_init_ps[i])
 			return false;
+	}
+
+	if (m_features.rov)
+	{
+		for (u32 rt = 0; rt < 2; rt++)
+		{
+			for (u32 ds = 0; ds < 2; ds++)
+			{
+				if (!rt && !ds)
+					continue;
+
+				ShaderMacro sm_ps;
+				sm_ps.AddMacro("PIXEL_SHADER", 1);
+				sm_ps.AddMacro("PS_ROV_COPY_COLOR", fmt::format("{}", rt));
+				sm_ps.AddMacro("PS_ROV_COPY_DEPTH", fmt::format("{}", ds));
+
+				m_rov_copy.ps[rt][ds] = m_shader_cache.GetPixelShader(m_dev.get(), *convert_hlsl, sm_ps.GetPtr(), "ps_rov_copy");
+				if (!m_rov_copy.ps[rt][ds])
+					return false;
+			}
+		}
 	}
 
 	if (m_features.cas_sharpening && !CreateCASShaders())
@@ -604,7 +629,7 @@ bool GSDevice11::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 
 	// 1x1 dummy texture.
 	const GSTexture::Usage null_usage = m_uav_texture ? GSTexture::ShaderWriteTarget : GSTexture::Feedback;
-	m_null_texture = CreateSurface(null_usage, 1, 1, 1, GSTexture::Format::Color);
+	m_null_texture = static_cast<GSTexture11*>(CreateSurface(null_usage, 1, 1, 1, GSTexture::Format::Color));
 	if (!m_null_texture)
 		return false;
 
@@ -614,7 +639,9 @@ bool GSDevice11::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 void GSDevice11::Destroy()
 {
 	delete m_null_texture;
-	
+	delete m_rov_rt;
+	delete m_rov_ds;
+
 	GSDevice::Destroy();
 	DestroySwapChain();
 	DestroyTimestampQueries();
@@ -1863,6 +1890,107 @@ void GSDevice11::DoMultiStretchRects(const MultiStretchRect* rects, u32 num_rect
 	DrawIndexedPrimitive();
 }
 
+void GSDevice11::SetupOneshotROV(const GSHWDrawConfig& config, GSTexture* rt, GSTexture* ds,
+	const std::vector<GSVector4i>& rects, const GSVector2i& size)
+{
+	g_perfmon.Put(GSPerfMon::TextureCopies, 1);
+	g_perfmon.Put(GSPerfMon::TextureCopiesROV, 1);
+	g_perfmon.Put(GSPerfMon::DrawCallsROV, 1);
+
+	bool rt_copy = config.ps.HasOneshotColorROV();
+	bool ds_copy = config.ps.HasOneshotDepthROV();
+
+	// Create ROV textures
+	if ((!m_rov_rt || m_rov_rt->GetSize() != size))
+	{
+		if (m_rov_rt)
+			Recycle(m_rov_rt);
+		m_rov_rt = static_cast<GSTexture11*>(CreateShaderWriteTarget(size, GSTexture::Format::Color, false));
+#if PCSX2_DEVBUILD
+		m_rov_rt->SetDebugName(fmt::format("RT for oneshot ROV {}x{}", size.x, size.y));
+#endif
+	}
+	if ((!m_rov_ds || m_rov_ds->GetSize() != size))
+	{
+		if (m_rov_ds)
+			Recycle(m_rov_ds);
+		m_rov_ds = static_cast<GSTexture11*>(CreateShaderWriteTarget(size, GSTexture::Format::DepthColor, false));
+#if PCSX2_DEVBUILD
+		m_rov_ds->SetDebugName(fmt::format("DS for oneshot ROV {}x{}", size.x, size.y));
+#endif
+	}
+
+	// Avoid copies if the original is cleared.
+	if (rt_copy && rt->GetState() == GSTexture::State::Cleared)
+	{
+		m_rov_rt->SetClearColor(rt->GetClearColor());
+		CommitClear(m_rov_rt);
+		rt_copy = false;
+	}
+	if (ds_copy && ds->GetState() == GSTexture::State::Cleared)
+	{
+		m_rov_ds->SetClearDepth(ds->GetClearDepth());
+		CommitClear(m_rov_ds);
+		ds_copy = false;
+	}
+
+	if (!(rt_copy || ds_copy))
+		return; // Copy handled with clear.
+
+	// Vertices
+	const u32 num_rects = static_cast<u32>(rects.size());
+	const GSVector4i size_rect(GSVector4i::loadh(size));
+	const u32 vertex_reserve_size = num_rects * 4;
+	const u32 index_reserve_size = num_rects * 6;
+	GSVertexPT1* verts = static_cast<GSVertexPT1*>(IAMapVertexBuffer(sizeof(GSVertexPT1), vertex_reserve_size));
+	u16* idx = IAMapIndexBuffer(index_reserve_size);
+	u32 icount = 0;
+	u32 vcount = 0;
+	for (u32 i = 0; i < num_rects; i++)
+	{
+		const GSVector4 dst = (GSVector4(rects[i]) / GSVector4(size_rect).zwzw()) * 2.0f - 1.0f;
+
+		const u32 vstart = vcount;
+		verts[vcount++] = {GSVector4(dst.x, -dst.y, 0.5f, 1.0f), {}};
+		verts[vcount++] = {GSVector4(dst.z, -dst.y, 0.5f, 1.0f), {}};
+		verts[vcount++] = {GSVector4(dst.x, -dst.w, 0.5f, 1.0f), {}};
+		verts[vcount++] = {GSVector4(dst.z, -dst.w, 0.5f, 1.0f), {}};
+
+		if (i > 0)
+			idx[icount++] = vstart;
+
+		idx[icount++] = vstart;
+		idx[icount++] = vstart + 1;
+		idx[icount++] = vstart + 2;
+		idx[icount++] = vstart + 3;
+		idx[icount++] = vstart + 3;
+	};
+
+	// IA
+	IAUnmapVertexBuffer(sizeof(GSVertexPT1), vcount);
+	IAUnmapIndexBuffer(icount);
+	IASetIndexBuffer(m_ib.get());
+	IASetInputLayout(m_convert.il.get());
+	IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+
+	// OM
+	OMSetDepthStencilState(m_rov_copy.dss.get(), 0);
+	OMSetBlendState(m_rov_copy.bs.get(), 0);
+	OMSetRenderTargets(nullptr, nullptr, nullptr, m_rov_rt, m_rov_ds, &size_rect);
+
+	// VS
+	VSSetShader(m_convert.vs.get(), nullptr);
+
+	// PS
+	if (rt_copy)
+		PSSetShaderResource(TEXTURE_RT, rt);
+	if (ds_copy)
+		PSSetShaderResource(TEXTURE_DEPTH, ds);
+	PSSetShader(m_rov_copy.ps[rt_copy ? 1 : 0][ds_copy ? 1 : 0].get(), m_state.ps_cb);
+
+	DrawIndexedPrimitive();
+}
+
 void GSDevice11::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex, GSVector4* dRect, const GSRegPMODE& PMODE, const GSRegEXTBUF& EXTBUF, u32 c, const Filter filter)
 {
 	const GSVector4 full_r(0.0f, 0.0f, 1.0f, 1.0f);
@@ -2081,6 +2209,7 @@ void GSDevice11::SetupPS(const PSSelector& sel, const GSHWDrawConfig::PSConstant
 		sm.AddMacro("PS_ANISOTROPIC_FILTERING", sel.sw_aniso);
 		sm.AddMacro("PS_ROV_COLOR", sel.rov_color);
 		sm.AddMacro("PS_ROV_DEPTH", static_cast<u32>(sel.rov_depth));
+		sm.AddMacro("PS_ROV_ONESHOT", sel.rov_oneshot);
 
 		wil::com_ptr_nothrow<ID3D11PixelShader> ps = m_shader_cache.GetPixelShader(m_dev.get(), m_tfx_source, sm.GetPtr(), "ps_main");
 		i = m_ps.try_emplace(sel, std::move(ps)).first;
@@ -3049,11 +3178,11 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 {
 	const GSVector2i rtsize = (config.rt ? config.rt : config.ds)->GetSize();
 	GSTexture* colclip_rt = g_gs_device->GetColorClipTexture();
-	GSTexture* draw_rt = config.ps.HasColorROV() ? nullptr : config.rt;
+	GSTexture* draw_rt = config.ps.HasContinuousColorROV() ? nullptr : config.rt;
 	GSTexture* draw_ds_as_rt = m_ds_as_rt;
-	GSTexture* draw_ds = config.ps.HasDepthROV() ? nullptr : config.ds;
-	GSTexture* draw_rt_rov = config.ps.HasColorROV() ? config.rt : nullptr;
-	GSTexture* draw_ds_rov = config.ps.HasDepthROV() ? config.ds : nullptr;
+	GSTexture* draw_ds = config.ps.HasContinuousDepthROV() ? nullptr : config.ds;
+	GSTexture* draw_rt_rov = config.ps.HasContinuousColorROV() ? config.rt : nullptr;
+	GSTexture* draw_ds_rov = config.ps.HasContinuousDepthROV() ? config.ds : nullptr;
 	GSTexture* draw_rt_clone = nullptr;
 	GSTexture* draw_ds_clone = nullptr;
 	GSTexture* primid_texture = nullptr;
@@ -3125,6 +3254,14 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 	else if (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::Stencil ||
 			 (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::StencilOne && !need_barrier))
 		SetupDATE(colclip_rt ? colclip_rt : config.rt, config.ds, config.datm, config.drawarea);
+
+	if (config.ps.HasOneshotROV())
+	{
+		SetupOneshotROV(config, draw_rt, draw_ds, *config.draw_coarse_rasterize, rtsize);
+		// In DX11, we need to use a dummy RT for the first OM slot.
+		if (!draw_rt)
+			draw_rt = draw_rt_clone = CreateRenderTarget(draw_ds->GetSize(), GSTexture::Format::Color, false, true);
+	}
 
 	if (config.vs.expand != GSHWDrawConfig::VSExpand::None)
 	{
@@ -3244,7 +3381,10 @@ void GSDevice11::RenderHW(GSHWDrawConfig& config)
 			Console.Warning("D3D11: Failed to allocate temp texture for DS copy.");
 	}
 
-	OMSetRenderTargets(draw_rt, draw_ds_as_rt, draw_ds, draw_rt_rov, draw_ds_rov, &config.scissor, read_only_dsv);
+	if (config.ps.HasOneshotROV())
+		OMSetRenderTargets(draw_rt, draw_ds_as_rt, draw_ds, m_rov_rt, m_rov_ds, &config.scissor, read_only_dsv);
+	else
+		OMSetRenderTargets(draw_rt, draw_ds_as_rt, draw_ds, draw_rt_rov, draw_ds_rov, &config.scissor, read_only_dsv);
 	SetRenderHWShaderResources(config, primid_texture);
 	SetupOM(config.depth, OMBlendSelector(config.colormask, config.blend), config.blend.constant);
 
@@ -3396,7 +3536,7 @@ void GSDevice11::SendHWDraw(const GSHWDrawConfig& config,
 
 	Draw(config);
 
-	if (config.ps.HasColorROV() || config.ps.HasDepthROV())
+	if (config.ps.HasROV())
 		g_perfmon.Put(GSPerfMon::DrawCallsROV, 1);
 }
 

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.h
@@ -140,7 +140,9 @@ private:
 	wil::com_ptr_nothrow<ID3D11ShaderResourceView> m_expand_vb_srv;
 	wil::com_ptr_nothrow<ID3D11ShaderResourceView> m_expand_ib_vs_srv;
 
-	GSTexture* m_null_texture;
+	GSTexture11* m_null_texture = nullptr;
+	GSTexture11* m_rov_rt = nullptr;
+	GSTexture11* m_rov_ds = nullptr;
 
 	D3D_FEATURE_LEVEL m_feature_level = D3D_FEATURE_LEVEL_10_0;
 	u32 m_vb_pos = 0; // bytes
@@ -270,6 +272,13 @@ private:
 
 	struct
 	{
+		wil::com_ptr_nothrow<ID3D11DepthStencilState> dss;
+		wil::com_ptr_nothrow<ID3D11BlendState> bs;
+		wil::com_ptr_nothrow<ID3D11PixelShader> ps[2][2];
+	} m_rov_copy;
+
+	struct
+	{
 		wil::com_ptr_nothrow<ID3D11Buffer> cb;
 		wil::com_ptr_nothrow<ID3D11ComputeShader> cs_upscale;
 		wil::com_ptr_nothrow<ID3D11ComputeShader> cs_sharpen;
@@ -373,6 +382,9 @@ public:
 	void DoMultiStretchRects(const MultiStretchRect* rects, u32 num_rects, const GSVector2& ds);
 
 	void SetupDATE(GSTexture* rt, GSTexture* ds, SetDATM datm, const GSVector4i& bbox);
+
+	void SetupOneshotROV(const GSHWDrawConfig& config, GSTexture* rt, GSTexture* ds,
+		const std::vector<GSVector4i>& rects, const GSVector2i& size);
 
 	void* IAMapVertexBuffer(u32 stride, u32 count);
 	void IAUnmapVertexBuffer(u32 stride, u32 count);

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -3961,6 +3961,30 @@ void GSDevice12::BeginRenderPass(D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE color_b
 		(m_current_depth_target && m_current_depth_read_only) ? (D3D12_RENDER_PASS_FLAG_BIND_READ_ONLY_DEPTH) : D3D12_RENDER_PASS_FLAG_NONE);
 }
 
+void GSDevice12::BeginTFXRenderPass(const GSHWDrawConfig& config, GSTexture12* rt, GSTexture12* ds, bool need_barrier)
+{
+	const PipelineSelector& pipe = m_pipeline_selector;
+
+	const GSVector4 clear_color = rt ?
+		(pipe.ps.colclip_hw ? GSVector4::unorm16(rt->GetClearColor()) : rt->GetClearForFormat()) :
+		GSVector4::zero();
+
+	const bool stencil_DATE = config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::Stencil ||
+		config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::StencilOne;
+
+	BeginRenderPass(GetLoadOpForTexture(rt),
+		rt ? D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE : D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
+		GetLoadOpForTexture(ds),
+		ds ? D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE : D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
+		ds ? (stencil_DATE ? D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_PRESERVE :
+			D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_DISCARD) :
+		D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS,
+		ds ? ((stencil_DATE && need_barrier) ? D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE :
+			D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_DISCARD) :
+		D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
+		clear_color, ds ? ds->GetClearDepth() : 0.0f, 1);
+}
+
 void GSDevice12::EndRenderPass()
 {
 	if (!m_in_render_pass)
@@ -4613,29 +4637,7 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 
 	// Begin render pass if new target or out of the area.
 	if (!InRenderPass())
-	{
-		GSVector4 clear_color = draw_rt ? draw_rt->GetClearForFormat() : GSVector4::zero();
-		if (pipe.ps.colclip_hw)
-		{
-			// Denormalize clear color for hw colclip.
-			clear_color *= GSVector4::cxpr(255.0f / 65535.0f, 255.0f / 65535.0f, 255.0f / 65535.0f, 1.0f);
-		}
-
-		const bool stencil_DATE = config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::Stencil ||
-		                          config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::StencilOne;
-
-		BeginRenderPass(GetLoadOpForTexture(draw_rt),
-			draw_rt ? D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE : D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
-			GetLoadOpForTexture(draw_ds),
-			draw_ds ? D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE : D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
-			draw_ds ? (stencil_DATE ? D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_PRESERVE :
-									  D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_DISCARD) :
-					  D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS,
-			draw_ds ? ((stencil_DATE && need_barrier) ? D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE :
-														D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_DISCARD) :
-					  D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
-			clear_color, draw_ds ? draw_ds->GetClearDepth() : 0.0f, 1);
-	}
+		BeginTFXRenderPass(config, draw_rt, draw_ds, need_barrier);
 
 	// rt -> colclip hw blit if enabled
 	if (colclip_rt && (config.colclip_mode == GSHWDrawConfig::ColClipMode::ConvertOnly || config.colclip_mode == GSHWDrawConfig::ColClipMode::ConvertAndResolve) && config.rt->GetState() == GSTexture::State::Dirty)

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -1997,6 +1997,138 @@ void GSDevice12::DoMultiStretchRects(
 		DrawIndexedPrimitive();
 }
 
+void GSDevice12::SetupOneshotROV(const GSHWDrawConfig& config, GSTexture12* rt, GSTexture12* ds,
+	const std::vector<GSVector4i>& rects, const GSVector2i& size)
+{
+	g_perfmon.Put(GSPerfMon::TextureCopies, 1);
+	g_perfmon.Put(GSPerfMon::TextureCopiesROV, 1);
+	g_perfmon.Put(GSPerfMon::DrawCallsROV, 1);
+
+	bool rt_copy = config.ps.HasOneshotColorROV();
+	bool ds_copy = config.ps.HasOneshotDepthROV();
+
+	// Create ROV textures
+	if (rt_copy && (!m_rov_rt || m_rov_rt->GetSize() != size))
+	{
+		if (m_rov_rt)
+			Recycle(m_rov_rt.release());
+		m_rov_rt.reset(static_cast<GSTexture12*>(CreateShaderWriteTarget(size, GSTexture::Format::Color, false)));
+#if PCSX2_DEVBUILD
+		m_rov_rt->SetDebugName(fmt::format("RT for oneshot ROV {}x{}", size.x, size.y));
+#endif
+	}
+	if (ds_copy && (!m_rov_ds || m_rov_ds->GetSize() != size))
+	{
+		if (m_rov_ds)
+			Recycle(m_rov_ds.release());
+		m_rov_ds.reset(static_cast<GSTexture12*>(CreateShaderWriteTarget(size, GSTexture::Format::DepthColor, false)));
+#if PCSX2_DEVBUILD
+		m_rov_ds->SetDebugName(fmt::format("DS for oneshot ROV {}x{}", size.x, size.y));
+#endif
+	}
+
+	// Avoid copies if the original is cleared.
+	if (rt_copy && rt->GetState() == GSTexture::State::Cleared)
+	{
+		m_rov_rt->SetClearColor(rt->GetClearColor());
+		m_rov_rt->CommitClear();
+		rt_copy = false;
+	}
+	if (ds_copy && ds->GetState() == GSTexture::State::Cleared)
+	{
+		m_rov_ds->SetClearDepth(ds->GetClearDepth());
+		m_rov_ds->CommitClear();
+		ds_copy = false;
+	}
+
+	if (!(rt_copy || ds_copy))
+		return; // Copy handled with clear.
+
+	// Vertices / IA
+	const u32 num_rects = static_cast<u32>(rects.size());
+	const u32 vertex_reserve_size = num_rects * 4 * sizeof(GSVertexPT1);
+	const u32 index_reserve_size = num_rects * 6 * sizeof(u16);
+	if (!m_vertex_stream_buffer.ReserveMemory(vertex_reserve_size, sizeof(GSVertexPT1)) ||
+		!m_index_stream_buffer.ReserveMemory(index_reserve_size, sizeof(u16)))
+	{
+		ExecuteCommandListAndRestartRenderPass(false, "Uploading bytes to vertex buffer");
+		if (!m_vertex_stream_buffer.ReserveMemory(vertex_reserve_size, sizeof(GSVertexPT1)) ||
+			!m_index_stream_buffer.ReserveMemory(index_reserve_size, sizeof(u16)))
+		{
+			pxFailRel("Failed to reserve space for vertices");
+		}
+	}
+
+	const GSVector4i size_rect(GSVector4i::loadh(size));
+	GSVertexPT1* verts = reinterpret_cast<GSVertexPT1*>(m_vertex_stream_buffer.GetCurrentHostPointer());
+	u16* idx = reinterpret_cast<u16*>(m_index_stream_buffer.GetCurrentHostPointer());
+	u32 icount = 0;
+	u32 vcount = 0;
+	for (u32 i = 0; i < num_rects; i++)
+	{
+		const GSVector4 dst = (GSVector4(rects[i]) / GSVector4(size_rect).zwzw()) * 2.0f - 1.0f;
+
+		const u32 vstart = vcount;
+		verts[vcount++] = {GSVector4(dst.x, -dst.y, 0.5f, 1.0f), {}};
+		verts[vcount++] = {GSVector4(dst.z, -dst.y, 0.5f, 1.0f), {}};
+		verts[vcount++] = {GSVector4(dst.x, -dst.w, 0.5f, 1.0f), {}};
+		verts[vcount++] = {GSVector4(dst.z, -dst.w, 0.5f, 1.0f), {}};
+
+		if (i > 0)
+			idx[icount++] = vstart;
+
+		idx[icount++] = vstart;
+		idx[icount++] = vstart + 1;
+		idx[icount++] = vstart + 2;
+		idx[icount++] = vstart + 3;
+		idx[icount++] = vstart + 3;
+	}
+
+	m_vertex.start = m_vertex_stream_buffer.GetCurrentOffset() / sizeof(GSVertexPT1);
+	m_vertex.count = vcount;
+	m_index.start = m_index_stream_buffer.GetCurrentOffset() / sizeof(u16);
+	m_index.count = icount;
+	m_vertex_stream_buffer.CommitMemory(vcount * sizeof(GSVertexPT1));
+	m_index_stream_buffer.CommitMemory(icount * sizeof(u16));
+	SetVertexBuffer(m_vertex_stream_buffer.GetGPUPointer(), m_vertex_stream_buffer.GetSize(), sizeof(GSVertexPT1));
+	SetIndexBuffer(m_index_stream_buffer.GetGPUPointer(), m_index_stream_buffer.GetSize(), DXGI_FORMAT_R16_UINT);
+	SetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+
+	// Pipeline
+	SetPipeline(m_rov_copy_pipelines[rt ? (rt_copy ? 2 : 1) : 0][ds ? (ds_copy ? 2 : 1) : 0].get());
+
+	// Shader resources
+	PSSetROVs(m_rov_rt.get(), m_rov_ds.get(), rt_copy, ds_copy);
+	if (rt_copy)
+		PSSetShaderResource(TEXTURE_RT, rt, false, ResourceType::FBL);
+	if (ds_copy)
+		PSSetShaderResource(TEXTURE_DEPTH, ds, false, ResourceType::SRV);
+
+	// Check if the barrier is already handled with a transition.
+	bool rt_needs_barrier = rt_copy && (rt->GetResourceState() == GSTexture12::ResourceState::RenderTarget);
+
+	// RTs / render pass
+	OMSetRenderTargets(rt, nullptr, ds, size_rect, ds_copy, size);
+	if (!InRenderPass())
+		BeginTFXRenderPass(config, rt, ds, false);
+
+	// RT barrier. DS barrier is handled with transition to read-only depth.
+	if (rt_needs_barrier)
+		FeedbackBarrier(rt);
+
+	// Draw
+	if (ApplyTFXState())
+		DrawIndexedPrimitive();
+
+	EndRenderPass();
+
+	// UAV barriers
+	if (rt_copy)
+		m_rov_rt->TransitionSubresourceToState(GetCommandList(), 0, m_rov_rt->GetResourceState(), m_rov_rt->GetResourceState());
+	if (ds_copy)
+		m_rov_ds->TransitionSubresourceToState(GetCommandList(), 0, m_rov_ds->GetResourceState(), m_rov_ds->GetResourceState());
+}
+
 void GSDevice12::BeginRenderPassForStretchRect(
 	GSTexture12* dTex, const GSVector4i& dtex_rc, const GSVector4i& dst_rc, bool allow_discard)
 {
@@ -2956,6 +3088,59 @@ bool GSDevice12::CompileConvertPipelines()
 		}
 	}
 
+	// ROV copy pipelines for oneshot
+	if (m_features.rov)
+	{
+		for (u32 rt = 0; rt < 3; rt++)
+		{
+			for (u32 ds = 0; ds < 3; ds++)
+			{
+				const u32 rt_copy = (rt == 2) ? 1 : 0;
+				const u32 ds_copy = (ds == 2) ? 1 : 0;
+				if (!rt_copy && !ds_copy)
+					continue;
+				
+				ShaderMacro sm;
+				sm.AddMacro("PIXEL_SHADER", "1");
+				sm.AddMacro("PS_ROV_COPY_COLOR", rt_copy);
+				sm.AddMacro("PS_ROV_COPY_DEPTH", ds_copy);
+
+				ComPtr<ID3DBlob> ps(m_shader_cache.GetPixelShader(*source, sm.GetPtr(), "ps_rov_copy"));
+				if (!ps)
+					return false;
+
+				gpb.SetRootSignature(m_tfx_root_signature.get());
+				gpb.SetPixelShader(ps.get());
+				gpb.ClearRenderTargets();
+				if (rt)
+				{
+					gpb.SetRenderTarget(0, DXGI_FORMAT_R8G8B8A8_UNORM);
+					gpb.SetBlendState(0, false, D3D12_BLEND_ONE, D3D12_BLEND_ONE, D3D12_BLEND_OP_ADD, D3D12_BLEND_ZERO,
+						D3D12_BLEND_ZERO, D3D12_BLEND_OP_ADD, 0);
+				}
+				if (ds)
+				{
+					gpb.SetDepthStencilFormat(DXGI_FORMAT_D32_FLOAT_S8X24_UINT);
+					gpb.SetDepthState(false, false, D3D12_COMPARISON_FUNC_ALWAYS);
+				}
+				gpb.SetNoStencilState();
+
+				m_rov_copy_pipelines[rt][ds] = gpb.Create(m_device.get(), m_shader_cache, false);
+				if (!m_rov_copy_pipelines[rt][ds])
+					return false;
+
+				constexpr std::array<const char*, 3> debug_str = {
+					"None",
+					"Attached",
+					"Copied",
+				};
+
+				D3D12::SetObjectName(m_rov_copy_pipelines[rt][ds].get(),
+					TinyString::from_format("ROV copy pipeline (RT={}, DS={})", debug_str[rt], debug_str[ds]));
+			}
+		}
+	}
+
 	return true;
 }
 
@@ -3181,6 +3366,18 @@ void GSDevice12::DestroyResources()
 		m_null_texture.reset();
 	}
 
+	if (m_rov_rt)
+	{
+		m_rov_rt->Destroy(false);
+		m_rov_rt.reset();
+	}
+
+	if (m_rov_ds)
+	{
+		m_rov_ds->Destroy(false);
+		m_rov_ds.reset();
+	}
+
 	m_shader_cache.Close();
 
 	m_timestamp_query_buffer.reset();
@@ -3298,6 +3495,7 @@ const ID3DBlob* GSDevice12::GetTFXPixelShader(const GSHWDrawConfig::PSSelector& 
 	sm.AddMacro("PS_ANISOTROPIC_FILTERING", sel.sw_aniso);
 	sm.AddMacro("PS_ROV_COLOR", sel.rov_color);
 	sm.AddMacro("PS_ROV_DEPTH", static_cast<u32>(sel.rov_depth));
+	sm.AddMacro("PS_ROV_ONESHOT", sel.rov_oneshot);
 
 	ComPtr<ID3DBlob> ps(m_shader_cache.GetPixelShader(m_tfx_source, sm.GetPtr(), "ps_main"));
 	it = m_tfx_pixel_shaders.emplace(sel, std::move(ps)).first;
@@ -4396,10 +4594,10 @@ void GSDevice12::FeedbackBarrier(const GSTexture12* texture)
 void GSDevice12::RenderHW(GSHWDrawConfig& config)
 {
 	GSTexture12* colclip_rt = static_cast<GSTexture12*>(g_gs_device->GetColorClipTexture());
-	GSTexture12* draw_rt = config.ps.HasColorROV() ? nullptr : static_cast<GSTexture12*>(config.rt);
-	GSTexture12* draw_ds = config.ps.HasDepthROV() ? nullptr : static_cast<GSTexture12*>(config.ds);
-	GSTexture12* draw_rt_rov = config.ps.HasColorROV() ? static_cast<GSTexture12*>(config.rt) : nullptr;
-	GSTexture12* draw_ds_rov = config.ps.HasDepthROV() ? static_cast<GSTexture12*>(config.ds) : nullptr;
+	GSTexture12* draw_rt = config.ps.HasContinuousColorROV() ? nullptr : static_cast<GSTexture12*>(config.rt);
+	GSTexture12* draw_ds = config.ps.HasContinuousDepthROV() ? nullptr : static_cast<GSTexture12*>(config.ds);
+	GSTexture12* draw_rt_rov = config.ps.HasContinuousColorROV() ? static_cast<GSTexture12*>(config.rt) : nullptr;
+	GSTexture12* draw_ds_rov = config.ps.HasContinuousDepthROV() ? static_cast<GSTexture12*>(config.ds) : nullptr;
 	GSTexture12* draw_rt_clone = nullptr;
 
 	const bool feedback = draw_rt && (config.require_one_barrier || (config.require_full_barrier && m_features.texture_barrier) || (config.tex && config.tex == config.rt));
@@ -4441,7 +4639,7 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 			g_gs_device->SetColorClipTexture(nullptr);
 
 			colclip_rt = nullptr;
-			draw_rt = config.ps.HasColorROV() ? nullptr : static_cast<GSTexture12*>(config.rt);
+			draw_rt = config.ps.HasContinuousColorROV() ? nullptr : static_cast<GSTexture12*>(config.rt);
 		}
 		else
 		{
@@ -4547,6 +4745,10 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 		draw_rt = colclip_rt;
 	}
 
+	// Setup oneshot ROV
+	if (config.ps.HasOneshotROV())
+		SetupOneshotROV(config, draw_rt, draw_ds, *config.draw_coarse_rasterize, rtsize);
+
 	// Clear texture binding when it's bound to RT or DS.
 	if (!config.tex && ((draw_rt && static_cast<GSTexture12*>(draw_rt)->GetSRVDescriptor() == m_tfx_textures[0]) ||
 		(draw_ds && static_cast<GSTexture12*>(draw_ds)->GetSRVDescriptor() == m_tfx_textures[0])))
@@ -4617,11 +4819,14 @@ void GSDevice12::RenderHW(GSHWDrawConfig& config)
 			Console.Warning("D3D12: Failed to allocate temp texture for RT copy.");
 	}
 
-	PSSetROVs(draw_rt_rov, draw_ds_rov, config.ps.HasColorOutput(), config.ps.HasDepthROVWrite());
+	if (config.ps.HasOneshotROV())
+		PSSetROVs(m_rov_rt.get(), m_rov_ds.get(), config.ps.HasColorOutput(), config.ps.HasDepthROVWrite());
+	else
+		PSSetROVs(draw_rt_rov, draw_ds_rov, config.ps.HasColorOutput(), config.ps.HasDepthROVWrite());
 
 	// For depth testing and sampling, use a read only dsv, otherwise use a write dsv
 	OMSetRenderTargets(draw_rt, draw_ds_as_rt, draw_ds, config.scissor,
-		config.tex && (config.tex == draw_ds || config.ps.IsFeedbackLoopDepth()) && !config.depth.zwe && !config.ps.HasDepthROV(),
+		config.tex && (config.tex == draw_ds || config.ps.IsFeedbackLoopDepth()) && !config.depth.zwe && !config.ps.HasContinuousDepthROV(),
 		config.rt ? config.rt->GetSize() : config.ds->GetSize());
 
 	// DX12 equivalent of vkCmdClearAttachments for StencilOne
@@ -4807,7 +5012,7 @@ void GSDevice12::SendHWDraw(const PipelineSelector& pipe, const GSHWDrawConfig& 
 	if (BindDrawPipeline(pipe))
 		Draw(config);
 
-	if (config.ps.HasColorROV() || config.ps.HasDepthROV())
+	if (config.ps.HasROV())
 		g_perfmon.Put(GSPerfMon::DrawCallsROV, 1);
 }
 
@@ -4816,14 +5021,14 @@ void GSDevice12::UpdateHWPipelineSelector(GSHWDrawConfig& config)
 	m_pipeline_selector.vs.key = config.vs.key;
 	m_pipeline_selector.ps.key_hi = config.ps.key_hi;
 	m_pipeline_selector.ps.key_lo = config.ps.key_lo;
-	m_pipeline_selector.dss.key = config.ps.HasDepthROV() ? GSHWDrawConfig::DepthStencilSelector::NoDepth().key : config.depth.key;
-	m_pipeline_selector.bs.key = config.ps.HasColorROV() ? GSHWDrawConfig::BlendState().key : config.blend.key;
+	m_pipeline_selector.dss.key = config.ps.HasContinuousDepthROV() ? GSHWDrawConfig::DepthStencilSelector::NoDepth().key : config.depth.key;
+	m_pipeline_selector.bs.key = config.ps.HasContinuousColorROV() ? GSHWDrawConfig::BlendState().key : config.blend.key;
 	m_pipeline_selector.bs.constant = 0; // don't dupe states with different alpha values
-	m_pipeline_selector.cms.key = config.ps.HasColorROV() ? GSHWDrawConfig::ColorMaskSelector().key : config.colormask.key;
+	m_pipeline_selector.cms.key = config.ps.HasContinuousColorROV() ? GSHWDrawConfig::ColorMaskSelector().key : config.colormask.key;
 	m_pipeline_selector.topology = static_cast<u32>(config.topology);
-	m_pipeline_selector.rt = config.rt != nullptr && !config.ps.HasColorROV();
-	m_pipeline_selector.ds = config.ds != nullptr && !config.ps.HasDepthROV();
-	m_pipeline_selector.ds_as_rt = m_ds_as_rt != nullptr && !config.ps.HasDepthROV();
+	m_pipeline_selector.rt = config.rt != nullptr && !config.ps.HasContinuousColorROV();
+	m_pipeline_selector.ds = config.ds != nullptr && !config.ps.HasContinuousDepthROV();
+	m_pipeline_selector.ds_as_rt = m_ds_as_rt != nullptr && !config.ps.HasContinuousDepthROV();
 }
 
 void GSDevice12::UploadHWDrawVerticesAndIndices(GSHWDrawConfig& config)

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.h
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.h
@@ -410,6 +410,7 @@ private:
 	std::array<ComPtr<ID3D12PipelineState>, 2> m_colclip_setup_pipelines{}; // [depth]
 	std::array<ComPtr<ID3D12PipelineState>, 2> m_colclip_finish_pipelines{}; // [depth]
 	std::array<std::array<ComPtr<ID3D12PipelineState>, 4>, 2> m_primid_image_setup_pipelines{}; // [depth][datm]
+	std::array<std::array<ComPtr<ID3D12PipelineState>, 3>, 3> m_rov_copy_pipelines{}; // [color][depth]
 	ComPtr<ID3D12PipelineState> m_fxaa_pipeline;
 	ComPtr<ID3D12PipelineState> m_shadeboost_pipeline;
 	ComPtr<ID3D12PipelineState> m_imgui_pipeline;
@@ -567,6 +568,9 @@ public:
 
 	void SetupDATE(GSTexture* rt, GSTexture* ds, SetDATM datm, const GSVector4i& bbox);
 	GSTexture12* SetupPrimitiveTrackingDATE(GSHWDrawConfig& config, PipelineSelector& pipe);
+
+	void SetupOneshotROV(const GSHWDrawConfig& config, GSTexture12* rt, GSTexture12* ds,
+		const std::vector<GSVector4i>& rects, const GSVector2i& size);
 
 	void IASetVertexBuffer(const void* vertex, size_t stride, size_t count);
 	void IASetIndexBuffer(const void* index, size_t count);
@@ -733,6 +737,8 @@ private:
 	const ID3D12PipelineState* m_current_pipeline = nullptr;
 
 	std::unique_ptr<GSTexture12> m_null_texture;
+	std::unique_ptr<GSTexture12> m_rov_rt;
+	std::unique_ptr<GSTexture12> m_rov_ds;
 
 	// current pipeline selector - we save this in the struct to avoid re-zeroing it every draw
 	PipelineSelector m_pipeline_selector = {};

--- a/pcsx2/GS/Renderers/DX12/GSDevice12.h
+++ b/pcsx2/GS/Renderers/DX12/GSDevice12.h
@@ -634,6 +634,7 @@ public:
 		D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE stencil_begin = D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS,
 		D3D12_RENDER_PASS_ENDING_ACCESS_TYPE stencil_end = D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS,
 		GSVector4 clear_color = GSVector4::zero(), float clear_depth = 0.0f, u8 clear_stencil = 0);
+	void BeginTFXRenderPass(const GSHWDrawConfig& config, GSTexture12* rt, GSTexture12* ds, bool need_barrier);
 	void EndRenderPass();
 
 	void SetViewport(const D3D12_VIEWPORT& viewport);

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -121,6 +121,8 @@ void GSRendererHW::VSync(u32 field, bool registers_written, bool idle_frame)
 		}
 
 		g_texture_cache->IncAge();
+
+		NextFrameBarriers();
 	}
 	else
 	{
@@ -7574,16 +7576,12 @@ void GSRendererHW::DetermineROVUsage(GSTextureCache::Target* rt, GSTextureCache:
 {
 	const GSDevice::FeatureSupport& features = g_gs_device->Features();
 
-	if (!(GSConfig.HWROV && features.rov))
+	if (!(GSConfig.HWROV && features.rov && !features.framebuffer_fetch))
 		return;
+
+	PutBarriers(static_cast<u32>(m_drawlist.size())); // Record barriers for ROV heuristic.
 
 	GL_PUSH("HW: ROV Setup");
-
-	if (features.framebuffer_fetch)
-	{
-		GL_INS("ROV: Disabled because have FB-fetch");
-		return;
-	}
 
 	if (rt && rt->m_texture == m_conf.tex && !m_conf.ps.tex_is_fb)
 	{
@@ -7602,92 +7600,96 @@ void GSRendererHW::DetermineROVUsage(GSTextureCache::Target* rt, GSTextureCache:
 
 	bool full_barrier = m_conf.require_full_barrier;
 
-	// Heuristically determine what ROVs would be needed to eliminate passes based on the current config.
-	bool barriers_color = m_conf.require_full_barrier && m_conf.ps.IsFeedbackLoopRT();
-	bool barriers_depth = m_conf.require_full_barrier && m_conf.ps.IsFeedbackLoopDepth();
+	bool feedback_color = m_conf.require_full_barrier && m_conf.ps.IsFeedbackLoopRT();
+	bool feedback_depth = m_conf.require_full_barrier && m_conf.ps.IsFeedbackLoopDepth();
 
 	if (m_conf.alpha_second_pass.enable)
 	{
 		full_barrier |= m_conf.alpha_second_pass.require_full_barrier;
-		barriers_color |= m_conf.alpha_second_pass.require_full_barrier && m_conf.alpha_second_pass.ps.IsFeedbackLoopRT();
-		barriers_depth |= m_conf.alpha_second_pass.require_full_barrier && m_conf.alpha_second_pass.ps.IsFeedbackLoopDepth();
+		feedback_color |= m_conf.alpha_second_pass.require_full_barrier && m_conf.alpha_second_pass.ps.IsFeedbackLoopRT();
+		feedback_depth |= m_conf.alpha_second_pass.require_full_barrier && m_conf.alpha_second_pass.ps.IsFeedbackLoopDepth();
 	}
 
-	// If already ROV, just continue the usage.
-	const bool color_is_rov = rt && rt->m_texture->IsShaderWriteMode();
-	const bool depth_is_rov = ds && ds->m_texture->IsShaderWrite();
+	const u32 barriers = full_barrier ? m_drawlist.size() : 0;
 
-	bool use_rov_color = (color_write && barriers_color) || color_is_rov;
-	bool use_rov_depth = (depth_write && barriers_depth) || depth_is_rov;
-
-	// In certain cases, ROV in color or depth will force ROV in the other for correctness.
-	if (rt && ds)
-		GetForcedROVUsage(use_rov_color, use_rov_depth);
-
-	// Get the number of barriers that would be used with the current config.
-	u32 barriers = 1; 
-	if (full_barrier)
+	// Activate continuous ROV mode.
+	if (GetAvgFrameBarriers() >= GSConfig.HWROVContinuousBarriers)
 	{
-		if (m_drawlist.size() > 0)
+		const bool color_is_rov = rt && rt->m_texture->IsShaderWriteMode();
+		const bool depth_is_rov = ds && ds->m_texture->IsShaderWrite();
+
+		bool use_rov_color = (color_write && feedback_color) || color_is_rov;
+		bool use_rov_depth = (depth_write && feedback_depth) || depth_is_rov;
+
+		// In certain cases, ROV in color or depth will force ROV in the other for correctness.
+		if (rt && ds)
+			GetForcedROVUsage(use_rov_color, use_rov_depth);
+
+		// Heuristic: only activate ROV if we save at least one draw call by doing so.
+		const bool activate = (use_rov_color != color_is_rov || use_rov_depth != depth_is_rov) && barriers >= 2;
+
+		if (color_is_rov || depth_is_rov || activate)
 		{
-			barriers = static_cast<u32>(m_drawlist.size()); // Already computed
-		}
-		else
-		{
-#if PCSX2_DEVBUILD
-			barriers = INT_MAX; // Compute the full drawlist for logging purposes.
-#else
-			barriers = 2; // Tells drawlist computation to stop after reaching 2.
-#endif
-			GetPrimitiveOverlapDrawlist(false, false, 1.0f, &barriers);
+			if (activate)
+			{
+				GL_ROV("ROV activated: Draw=%05lld | C=%016p | D=%016p | Bar=%d | C=[%d=>%d] | D=[%d=>%d].",
+					s_n, rt ? rt->m_texture : nullptr, ds ? ds->m_texture : nullptr, barriers,
+					color_is_rov, use_rov_color, depth_is_rov, use_rov_depth);
+			}
+			else
+			{
+				GL_ROV("ROV continued: Draw=%05lld | C=%016p | D=%016p | Bar=%d | C=%d | D=%d.",
+					s_n, rt ? rt->m_texture : nullptr, ds ? ds->m_texture : nullptr, barriers,
+					color_is_rov, depth_is_rov);
+			}
+
+			GL_INS("ROV: Color ROV %s / depth ROV %s",
+				use_rov_color ? "enabled" : "disabled", use_rov_depth ? "enabled" : "disabled");
+
+			ConfigureROV(use_rov_color, use_rov_depth, false);
+			return;
 		}
 	}
 
-	// Heuristic: only activate ROV if we save at least one draw call by doing so.
-	const bool activate = (use_rov_color != color_is_rov || use_rov_depth != depth_is_rov) && barriers >= 2;
-
-	if (!color_is_rov && !depth_is_rov && !activate)
+	// Activate oneshot ROV mode.
+	if (barriers >= GSConfig.HWROVOneshotBarriers)
 	{
-		// Not enough barriers or no feedback to activate, and ROV is not already active.
-		GL_ROV("No ROV usage: Draw=%05lld | C=%016p | D=%016p | BAR=%d.",
-			s_n, rt ? rt->m_texture : nullptr, ds ? ds->m_texture : nullptr, barriers);
+		GL_ROV("ROV oneshot: Draw=%05lld | Bar=[%d>=%d]", s_n, barriers, GSConfig.HWROVOneshotBarriers);
+		bool use_rov_color = color_write && feedback_color;
+		bool use_rov_depth = depth_write && feedback_depth;
+
+		// In certain cases, ROV in color or depth will force ROV in the other for correctness.
+		if (rt && ds)
+			GetForcedROVUsage(use_rov_color, use_rov_depth);
+
+		ConfigureROV(use_rov_color, use_rov_depth, true);
 		return;
 	}
-	
-	if (activate)
-	{
-		GL_ROV("ROV activated: Draw=%05lld | C=%016p | D=%016p | BAR=%d | C=[%d=>%d] | D=[%d=>%d].",
-			s_n, rt ? rt->m_texture : nullptr, ds ? ds->m_texture : nullptr, barriers,
-			color_is_rov, use_rov_color, depth_is_rov, use_rov_depth);
-	}
-	else
-	{
-		GL_ROV("ROV continued: Draw=%05lld | C=%016p | D=%016p | BAR=%d | C=%d | D=%d.",
-			s_n, rt ? rt->m_texture : nullptr, ds ? ds->m_texture : nullptr, barriers,
-			color_is_rov, depth_is_rov);
-	}
 
-	GL_INS("ROV: Color ROV %s / depth ROV %s",
-		use_rov_color ? "enabled" : "disabled", use_rov_depth ? "enabled" : "disabled");
-
-	// Do the actual pipeline config.
-	ConfigureROV(use_rov_color, use_rov_depth);
+	// Not enough barriers or no feedback to activate, and ROV is not already active.
+	GL_ROV("No ROV usage: Draw=%05lld | C=%016p | D=%016p | Bar=%d.",
+		s_n, rt ? rt->m_texture : nullptr, ds ? ds->m_texture : nullptr, barriers);
 }
 
-void GSRendererHW::ConfigureROV(bool color_rov, bool depth_rov)
+void GSRendererHW::ConfigureROV(bool rov_color, bool rov_depth, bool rov_oneshot)
 {
+	m_conf.ps.rov_oneshot = (rov_color || rov_depth) && rov_oneshot;
+
 	// Do the actual config for depth.
-	if (depth_rov)
+	if (rov_depth)
 	{
-		m_conf.depth = GSHWDrawConfig::DepthStencilSelector::NoDepth(); // Disable real depth.
 		const bool depth_write = m_cached_ctx.DepthWrite();
 		GL_INS("ROV: Using %s depth ROV", depth_write ? "read/write" : "read-only");
+		if (!rov_oneshot)
+			m_conf.depth = GSHWDrawConfig::DepthStencilSelector::NoDepth(); // Disable real depth.
+		m_conf.ps.rov_depth = depth_write ?
+			GSHWDrawConfig::PS_ROV_DEPTH::READ_WRITE :
+			GSHWDrawConfig::PS_ROV_DEPTH::READ_ONLY;
 		ConfigureDepthFeedback(true);
-		m_conf.ps.rov_depth = depth_write ? GSHWDrawConfig::PS_ROV_DEPTH::READ_WRITE : GSHWDrawConfig::PS_ROV_DEPTH::READ_ONLY;
 	}
 
 	// Do the actual config for color.
-	if (color_rov)
+	if (rov_color)
 	{
 		// FbMask setup
 		if (m_conf.colormask.wrgba != 0)
@@ -7798,7 +7800,7 @@ void GSRendererHW::ConfigureROV(bool color_rov, bool depth_rov)
 			m_conf.ps.afail = static_cast<GSHWDrawConfig::PS_AFAIL>(m_cached_ctx.TEST.AFAIL);
 			if (m_cached_ctx.DepthWrite() && m_cached_ctx.TEST.AFAIL == AFAIL_RGB_ONLY)
 			{
-				pxAssert(depth_rov); // Should have enabled depth ROV for depth feedback loop.
+				pxAssert(rov_depth); // Should have enabled depth ROV for depth feedback loop.
 				m_conf.ps.afail = PS_AFAIL::RGB_ONLY_SW_Z;
 			}
 			m_conf.cb_ps.FogColor_AREF.a = ps_aref;
@@ -7815,14 +7817,14 @@ void GSRendererHW::ConfigureROV(bool color_rov, bool depth_rov)
 	}
 
 	// Remove regular barriers.
-	if (color_rov || depth_rov)
+	if (rov_color || rov_depth)
 	{
 		m_conf.require_full_barrier = false;
 		m_conf.require_one_barrier = false;
 	}
 }
 
-void GSRendererHW::ConvertTextureTypeROVSingle(GSTextureCache::Target* tgt, bool shader_write)
+void GSRendererHW::ConvertTextureTypeContinuousROVSingle(GSTextureCache::Target* tgt, bool shader_write)
 {
 	const bool depth = (tgt->m_type == GSTextureCache::DepthStencil);
 
@@ -7885,31 +7887,82 @@ void GSRendererHW::ConvertTextureTypeROVSingle(GSTextureCache::Target* tgt, bool
 	}
 }
 
-void GSRendererHW::ConvertTextureTypeROV(GSTextureCache::Target* rt, GSTextureCache::Target* ds)
+void GSRendererHW::ConvertTextureTypeContinuousROV(GSTextureCache::Target* rt, GSTextureCache::Target* ds)
 {
 	// Convert depth to the proper type/format.
 	if (ds)
 	{
 		// Note: we must use m_conf.ds because it might be the temporary Z texture.
-		if (m_conf.ps.HasDepthROV() && !m_conf.ds->IsShaderWrite())
+		if (m_conf.ps.HasContinuousDepthROV() && !m_conf.ds->IsShaderWrite())
 		{
 			GL_PUSH("HW: Convert DepthStencil -> DepthColor for ROV.");
-			ConvertTextureTypeROVSingle(ds, true);
+			ConvertTextureTypeContinuousROVSingle(ds, true);
 		}
-		else if (!m_conf.ps.HasDepthROV() && !m_conf.ds->IsDepthStencil())
+		else if (!m_conf.ps.HasContinuousDepthROV() && !m_conf.ds->IsDepthStencil())
 		{
 			GL_PUSH("HW: Convert DepthColor -> DepthStencil for non-ROV.");
-			ConvertTextureTypeROVSingle(ds, false);
+			ConvertTextureTypeContinuousROVSingle(ds, false);
 		}
 	}
 
 	// Convert color to the proper type. This only adds the shader read/write flag and doesn't remove it,
 	// since adding the read/write flag doesn't lose any pipeline capabilities.
-	if (rt && m_conf.ps.HasColorROV() && !rt->m_texture->IsShaderWrite())
+	if (rt && m_conf.ps.HasContinuousColorROV() && !rt->m_texture->IsShaderWrite())
 	{
 		GL_PUSH("HW: Convert RenderTarget -> RenderTarget (shader write) for ROV.");
-		ConvertTextureTypeROVSingle(rt, true);
+		ConvertTextureTypeContinuousROVSingle(rt, true);
 	}
+}
+
+void GSRendererHW::CoarseRasterizeDraw(const GSVector4i& drawarea, const float scale, const int expand, const u32 num_tiles)
+{
+	const GSVertex* RESTRICT vertex = m_vertex->buff;
+	const u16* RESTRICT index = m_index->buff;
+
+	if (m_vt.m_primclass == GS_SPRITE_CLASS)
+	{
+		std::vector<GSVector4i> bboxes;
+
+		for (u32 i = 0; i < m_index->tail; i += 2)
+		{
+			const GSVector4 p0 = GetXYWindow(vertex[index[i + 0]]) * scale;
+			const GSVector4 p1 = GetXYWindow(vertex[index[i + 1]]) * scale;
+			const GSVector4 bbox = p0.min(p1).floor().xyzw(p0.max(p1).ceil());
+			bboxes.push_back(GSVector4i(bbox));
+		}
+
+		GSUtil::CoarseRasterizeRects(m_conf.drawarea, bboxes.data(), static_cast<u32>(bboxes.size()),
+			num_tiles, static_cast<int>(std::ceil(expand * scale)), m_draw_coarse_rasterize);
+	}
+	else if (m_vt.m_primclass == GS_TRIANGLE_CLASS)
+	{
+		std::vector<GSVector4> pos;
+
+		for (u32 i = 0; i < m_index->tail; i++)
+			pos.push_back(GetXYWindow(vertex[index[i]]) * scale);
+
+		GSUtil::CoarseRasterizeTriangles(m_conf.drawarea, pos.data(), static_cast<u32>(pos.size()),
+			num_tiles, static_cast<int>(std::ceil(expand * scale)), m_draw_coarse_rasterize);
+	}
+	else
+	{
+		GL_INS("HW: Warning: Unsupported primclass for coarse rasterize; using full draw area.");
+		m_draw_coarse_rasterize.push_back(drawarea);
+	}
+
+	m_conf.draw_coarse_rasterize = &m_draw_coarse_rasterize;
+
+#if PCSX2_DEVBUILD
+	const float full_area = static_cast<float>(drawarea.width() * drawarea.height());
+	float tiled_area = 0.0f;
+	for (const GSVector4i& tile : m_draw_coarse_rasterize)
+		tiled_area += static_cast<float>(tile.width() * tile.height());
+	GL_INS("HW: Coarse rasterized %u prims into %u tiles (%.2f%% pixels saved)", m_index->tail,
+		static_cast<u32>(m_draw_coarse_rasterize.size()), 100.0f * (1.0f - tiled_area / full_area));
+#else
+	GL_INS("HW: Coarse rasterized %u prims into %u tiles", m_index->tail,
+		static_cast<u32>(m_draw_coarse_rasterize.size()));
+#endif
 }
 
 __ri static constexpr bool IsRedundantClamp(u8 clamp, u32 clamp_min, u32 clamp_max, u32 tsize)
@@ -9473,13 +9526,13 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 		m_conf.ps.rta_correction = rt->m_rt_alpha_scale;
 	}
 
-	// Call before computing the full drawlist in case ROV is used and we don't need it.
-	DetermineROVUsage(rt, ds);
-	ConvertTextureTypeROV(rt, ds);
-
 	// Barriers must be determined before indices are modified via HandleFlatShadedVertices/SetupIA.
 	// This also computes the drawlist if needed.
 	DetermineBarriers(rt, tex);
+
+	// Call after computing the drawlist so we know the barrier count.
+	DetermineROVUsage(rt, ds);
+	ConvertTextureTypeContinuousROV(rt, ds);
 
 	// Perform second pass setup here once barriers are determined.
 	EmulateAlphaTestSecondPass();
@@ -9502,11 +9555,18 @@ __ri void GSRendererHW::DrawPrims(GSTextureCache::Target* rt, GSTextureCache::Ta
 
 	m_conf.scissor = (date_options.enabled && !date_options.barrier) ? m_conf.drawarea : scissor;
 
+	if (m_conf.ps.HasOneshotROV())
+	{
+		CoarseRasterizeDraw(m_conf.drawarea, (rt ? rt : ds)->GetScale(),
+			(IsCoverageAlphaSupported() && !no_rt) ? 1 : 0);
+	}
+	
 	HandleFlatShadedVertices();
 
 	SetupIA(rtscale, vs_scale_x, vs_scale_y, m_channel_shuffle_width != 0, no_rt);
 
-	if (m_conf.ds && m_conf.ps.IsFeedbackLoopDepth() && !g_gs_device->Features().depth_feedback && !m_conf.ps.HasDepthROV())
+	if (m_conf.ds && m_conf.ps.IsFeedbackLoopDepth() && !g_gs_device->Features().depth_feedback &&
+		!m_conf.ps.HasROV())
 	{
 		GL_PUSH("HW: Creating temporary R32 RT for depth feedback");
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.h
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.h
@@ -253,11 +253,14 @@ private:
 		const GSVector2i& unscaled_size, float& vs_scale_x, float& vs_scale_y);
 	void DetermineBarriers(GSTextureCache::Target* rt, GSTextureCache::Source* tex);
 
-	void GetForcedROVUsage(bool& color_cov, bool& depth_rov); // Whether having color or depth with the current config forces the other.
+	void GetForcedROVUsage(bool& rov_color, bool& rov_depth); // Whether having color or depth with the current config forces the other.
 	void DetermineROVUsage(GSTextureCache::Target* rt, GSTextureCache::Target* ds); // Heuristics to determine whether to enable/disable ROV
-	void ConfigureROV(bool color_rov, bool depth_rov); // Actual config for ROV
-	void ConvertTextureTypeROV(GSTextureCache::Target* rt, GSTextureCache::Target* ds); // Convert to RW capable textures if needed.
-	void ConvertTextureTypeROVSingle(GSTextureCache::Target* tgt, bool shader_write); // Helper to do the above.
+	void ConfigureROV(bool rov_color, bool rov_depth, bool rov_oneshot); // Actual config for ROV
+	void ConvertTextureTypeContinuousROV(GSTextureCache::Target* rt, GSTextureCache::Target* ds); // Convert to RW capable textures if needed.
+	void ConvertTextureTypeContinuousROVSingle(GSTextureCache::Target* tgt, bool shader_write); // Helper to do the above.
+	
+	void CoarseRasterizeDraw(const GSVector4i& drawarea, const float scale,
+		const int expand = 1, const u32 num_tiles = 32); // Do a coarse rasterization of the current draw into tiles.
 
 	void SetTCOffset();
 	bool NextDrawColClip() const;
@@ -295,6 +298,22 @@ private:
 	bool IsDepthAlwaysPassing();
 	bool IsUsingCsInBlend();
 	bool IsUsingAsInBlend();
+
+	void PutBarriers(u32 barriers)
+	{
+		m_frame_barriers[m_frame_barriers_i] += barriers;
+	}
+	void NextFrameBarriers()
+	{
+		m_frame_barriers_sum += m_frame_barriers[m_frame_barriers_i];
+		m_frame_barriers_i = (m_frame_barriers_i + 1) % (NUM_FRAMES_RECORD_BARRIERS + 1);
+		m_frame_barriers_sum -= m_frame_barriers[m_frame_barriers_i];
+		m_frame_barriers[m_frame_barriers_i] = 0;
+	}
+	u32 GetAvgFrameBarriers()
+	{
+		return m_frame_barriers_sum / NUM_FRAMES_RECORD_BARRIERS;
+	}
 
 	// CRC Hacks
 	bool IsBadFrame();
@@ -345,6 +364,11 @@ private:
 	std::vector<GSVertexSW> m_sw_vertex_buffer;
 	std::unique_ptr<GSTextureCacheSW::Texture> m_sw_texture[7 + 1];
 	std::unique_ptr<GSVirtualAlignedClass<32>> m_sw_rasterizer;
+
+	static constexpr u32 NUM_FRAMES_RECORD_BARRIERS = 4;
+	std::array<u32, NUM_FRAMES_RECORD_BARRIERS + 1> m_frame_barriers{};
+	u32 m_frame_barriers_i = 0;
+	u32 m_frame_barriers_sum = 0;
 
 public:
 	GSRendererHW();

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
@@ -250,6 +250,8 @@ public:
 	// Functions and Pipeline States
 	MRCOwned<id<MTLComputePipelineState>> m_cas_pipeline[2];
 	std::vector<MRCOwned<id<MTLRenderPipelineState>>> m_convert_pipeline;
+	MRCOwned<id<MTLRenderPipelineState>> m_rov_copy_one_pipeline[2]; // [color]
+	MRCOwned<id<MTLRenderPipelineState>> m_rov_copy_both_pipeline;
 	MRCOwned<id<MTLRenderPipelineState>> m_present_pipeline[static_cast<int>(PresentShader::Count)];
 	MRCOwned<id<MTLRenderPipelineState>> m_merge_pipeline[4];
 	MRCOwned<id<MTLRenderPipelineState>> m_interlace_pipeline[NUM_INTERLACE_SHADERS];
@@ -335,6 +337,8 @@ public:
 	GSTexture* m_ds_as_rt_gstexture = nullptr;
 	MRCOwned<id<MTLTexture>> m_rov_dummy_texture;
 	struct { u32 w, h; } m_rov_dummy_texture_size = {};
+	std::unique_ptr<GSTextureMTL> m_rov_rt;
+	std::unique_ptr<GSTextureMTL> m_rov_ds;
 
 	struct DebugEntry
 	{
@@ -383,6 +387,8 @@ public:
 	void BeginRenderPass(NSString* name, GSTexture* color, MTLLoadAction color_load, GSTexture* depth, MTLLoadAction depth_load, GSTexture* stencil = nullptr, MTLLoadAction stencil_load = MTLLoadActionDontCare, bool rt1 = false);
 	/// Begin a new full-ROV render pass (may reuse existing)
 	void BeginFullROV(NSString* name, uint32_t width, uint32_t height);
+	/// Begin a render pass for combined color+depth ROV copy
+	void BeginROVCopy(GSTextureMTL* color, GSTextureMTL* depth);
 	/// Call at the end of each frame
 	void FrameCompleted();
 
@@ -464,6 +470,7 @@ public:
 
 	// MARK: Render HW
 
+	void SetupOneshotROV(const GSHWDrawConfig& config, GSTextureMTL* rt, GSTextureMTL* ds, const std::vector<GSVector4i>& rects, const GSVector2i& size);
 	void SetupDestinationAlpha(GSTexture* rt, GSTexture* ds, const GSVector4i& r, SetDATM datm);
 	void PrepareROVTexture(GSTexture** ptex);
 	void RenderHW(GSHWDrawConfig& config) override;

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -505,6 +505,8 @@ void GSDeviceMTL::BeginRenderPass(NSString* name, GSTexture* color, MTLLoadActio
 		color1.texture = GetRT1DepthTexture(md);
 		if (m_features.framebuffer_fetch)
 			color1.clearColor = MTLClearColorMake(depth_load == MTLLoadActionClear ? depth_clear.x : -1, 0, 0, 0);
+		else
+			color1.loadAction = MTLLoadActionLoad;
 	}
 
 	PrepareBeginRenderPass();
@@ -571,6 +573,27 @@ void GSDeviceMTL::BeginFullROV(NSString* name, uint32_t width, uint32_t height)
 	m_current_render.encoder = MRCRetain([GetRenderCmdBuf() renderCommandEncoderWithDescriptor:desc]);
 	m_current_render.name = (__bridge void*)name;
 	[m_current_render.encoder setLabel:name];
+	if (!m_dev.features.unified_memory)
+		[m_current_render.encoder waitForFence:m_draw_sync_fence
+		                          beforeStages:MTLRenderStageVertex];
+}
+
+void GSDeviceMTL::BeginROVCopy(GSTextureMTL* color, GSTextureMTL* depth)
+{
+	pxAssert(!m_features.framebuffer_fetch);
+	color->SetState(GSTexture::State::Dirty);
+	depth->SetState(GSTexture::State::Dirty);
+	MTLRenderPassDescriptor* desc = m_render_pass_desc[1 | 8];
+	MTLRenderPassColorAttachmentDescriptor* color0 = desc.colorAttachments[0];
+	color0.loadAction = MTLLoadActionDontCare;
+	color0.texture = color->GetTexture();
+	MTLRenderPassColorAttachmentDescriptor* color1 = desc.colorAttachments[1];
+	color1.loadAction = MTLLoadActionDontCare;
+	color1.storeAction = MTLStoreActionStore;
+	color1.texture = depth->GetTexture();
+	PrepareBeginRenderPass();
+	m_current_render.encoder = MRCRetain([GetRenderCmdBuf() renderCommandEncoderWithDescriptor:desc]);
+	[m_current_render.encoder setLabel:@"ROV Copy"];
 	if (!m_dev.features.unified_memory)
 		[m_current_render.encoder waitForFence:m_draw_sync_fence
 		                          beforeStages:MTLRenderStageVertex];
@@ -1116,20 +1139,23 @@ bool GSDeviceMTL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 		const bool depth   = i & 2;
 		const bool stencil = i & 4;
 		const bool rt1     = i & 8;
-		if (rt1 && m_features.depth_feedback)
-			continue;
-		if (rt1 && !depth)
-			continue;
+		if (!m_features.rov || i != 9) // Color + RT1 is used for ROV oneshot double-clear
+		{
+			if (rt1 && m_features.depth_feedback)
+				continue;
+			if (rt1 && !depth)
+				continue;
+		}
 		if (stencil && m_features.framebuffer_fetch)
 			continue;
 		auto desc = MRCTransfer([MTLRenderPassDescriptor new]);
 		[[desc   depthAttachment] setStoreAction:MTLStoreActionStore];
 		[[desc stencilAttachment] setStoreAction:MTLStoreActionStore];
-		if (rt1)
+		if (rt1 && m_features.framebuffer_fetch)
 		{
 			MTLRenderPassColorAttachmentDescriptor* color1 = [[desc colorAttachments] objectAtIndexedSubscript:1];
 			[color1 setStoreAction:MTLStoreActionDontCare];
-			[color1 setLoadAction:m_features.framebuffer_fetch ? MTLLoadActionClear : MTLLoadActionLoad];
+			[color1 setLoadAction:MTLLoadActionClear];
 		}
 		m_render_pass_desc[i] = desc;
 	}
@@ -1304,8 +1330,22 @@ bool GSDeviceMTL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 		setFnConstantB(m_fn_constants, shader.DepthOutput(), GSMTLConstantIndex_DEPTH_OUT);
 		m_convert_pipeline[shader.Index()] = MakePipeline(pdesc, vs_convert, LoadShader(shader_name), name);
 	}
+
 	pdesc.colorAttachments[0].writeMask = MTLColorWriteMaskAll;
 	pdesc.depthAttachmentPixelFormat = MTLPixelFormatInvalid;
+	pdesc.stencilAttachmentPixelFormat = MTLPixelFormatInvalid;
+
+	if (m_features.rov)
+	{
+		pdesc.colorAttachments[0].pixelFormat = MTLPixelFormatRGBA8Unorm;
+		pdesc.colorAttachments[1].pixelFormat = MTLPixelFormatR32Float;
+		m_rov_copy_both_pipeline = MakePipeline(pdesc, vs_convert, LoadShader(@"ps_rov_copy_both"), @"ROV Copy Both");
+		pdesc.colorAttachments[1].pixelFormat = MTLPixelFormatInvalid;
+		m_rov_copy_one_pipeline[1] = MakePipeline(pdesc, vs_convert, LoadShader(@"ps_rov_copy_color"), @"ROV Copy Color");
+		pdesc.colorAttachments[0].pixelFormat = MTLPixelFormatR32Float;
+		m_rov_copy_one_pipeline[0] = MakePipeline(pdesc, vs_convert, LoadShader(@"ps_rov_copy_depth"), @"ROV Copy Depth");
+	}
+
 	for (size_t i = 0; i < std::size(m_present_pipeline); i++)
 	{
 		PresentShader conv = static_cast<PresentShader>(i);
@@ -1845,6 +1885,101 @@ void GSDeviceMTL::DrawMultiStretchRects(const MultiStretchRect* rects, u32 num_r
 	flush(num_rects);
 }}
 
+void GSDeviceMTL::SetupOneshotROV(const GSHWDrawConfig& config, GSTextureMTL* rt, GSTextureMTL* ds, const std::vector<GSVector4i>& rects, const GSVector2i& size_i)
+{
+	g_perfmon.Put(GSPerfMon::TextureCopies, 1);
+	g_perfmon.Put(GSPerfMon::TextureCopiesROV, 1);
+	g_perfmon.Put(GSPerfMon::DrawCallsROV, 1);
+
+	bool rt_copy = config.ps.HasOneshotColorROV();
+	bool ds_copy = config.ps.HasOneshotDepthROV();
+
+	// Create ROV textures
+	if (rt_copy && (!m_rov_rt || m_rov_rt->GetSize() != size_i))
+	{
+		if (m_rov_rt)
+			Recycle(m_rov_rt.release());
+		m_rov_rt.reset(static_cast<GSTextureMTL*>(CreateShaderWriteTarget(size_i, GSTexture::Format::Color, false)));
+#if PCSX2_DEVBUILD
+		m_rov_rt->SetDebugName(fmt::format("RT for oneshot ROV {}x{}", size_i.x, size_i.y));
+#endif
+	}
+	if (ds_copy && (!m_rov_ds || m_rov_ds->GetSize() != size_i))
+	{
+		if (m_rov_ds)
+			Recycle(m_rov_ds.release());
+		m_rov_ds.reset(static_cast<GSTextureMTL*>(CreateShaderWriteTarget(size_i, GSTexture::Format::DepthColor, false)));
+#if PCSX2_DEVBUILD
+		m_rov_ds->SetDebugName(fmt::format("DS for oneshot ROV {}x{}", size_i.x, size_i.y));
+#endif
+	}
+
+	// Avoid copies if the original is cleared.
+	if (rt_copy && rt->GetState() == GSTexture::State::Cleared)
+	{
+		m_rov_rt->SetClearColor(rt->GetClearColor());
+		m_rov_rt->FlushClears();
+		rt_copy = false;
+	}
+	if (ds_copy && ds->GetState() == GSTexture::State::Cleared)
+	{
+		m_rov_ds->SetClearDepth(ds->GetClearDepth());
+		m_rov_ds->FlushClears();
+		ds_copy = false;
+	}
+
+	if (!(rt_copy || ds_copy))
+		return; // Copy handled with clear.
+
+	// Vertices / IA
+	const u32 num_rects = static_cast<u32>(rects.size());
+	const Map allocation = Allocate(m_vertex_upload_buf, sizeof(ConvertShaderVertex) * 4 * num_rects);
+	std::array<GSVector4, 4>* write = static_cast<std::array<GSVector4, 4>*>(allocation.cpu_buffer);
+
+	const GSVector2 size(static_cast<float>(size_i.x), static_cast<float>(size_i.y));
+	for (const GSVector4i& rect_i : rects)
+	{
+		GSVector4 rect(rect_i);
+		*write++ = CalcStrechRectPoints(rect, rect, size);
+	}
+
+	// Render pass
+	if (rt_copy && ds_copy)
+	{
+		BeginROVCopy(m_rov_rt.get(), m_rov_ds.get());
+		MRESetTexture(rt, 0);
+		MRESetTexture(ds, 1);
+		MRESetPipeline(m_rov_copy_both_pipeline);
+		// BeginROVCopy always starts a new render pass, so no need to clear scissor or set dss
+	}
+	else
+	{
+		GSTextureMTL* src = rt_copy ? rt : ds;
+		GSTextureMTL* dst = rt_copy ? m_rov_rt.get() : m_rov_ds.get();
+		BeginRenderPass(@"ROV Copy", dst, MTLLoadActionDontCare, nullptr, MTLLoadActionDontCare, nullptr, MTLLoadActionDontCare, false);
+		MRESetTexture(src, GSMTLTextureIndexNonHW);
+		MRESetPipeline(m_rov_copy_one_pipeline[rt_copy]);
+		MREClearScissor();
+		MRESetDSS(DepthStencilSelector::NoDepth());
+	}
+
+	const id<MTLRenderCommandEncoder> enc = m_current_render.encoder;
+	[enc setVertexBuffer:allocation.gpu_buffer
+	              offset:allocation.gpu_offset
+	             atIndex:GSMTLBufferIndexVertices];
+
+	[enc drawIndexedPrimitives:MTLPrimitiveTypeTriangle
+	                indexCount:num_rects * 6
+	                 indexType:MTLIndexTypeUInt16
+	               indexBuffer:m_expand_index_buffer
+	         indexBufferOffset:0
+	             instanceCount:1
+	                baseVertex:0
+	              baseInstance:0];
+
+	EndRenderPass();
+}
+
 void GSDeviceMTL::UpdateCLUTTexture(GSTexture* sTex, float sScale, u32 offsetX, u32 offsetY, GSTexture* dTex, u32 dOffset, u32 dSize)
 {
 	GSMTLCLUTConvertPSUniform uniform = { sScale, {offsetX, offsetY}, dOffset };
@@ -2062,6 +2197,7 @@ void GSDeviceMTL::MRESetHWPipelineState(GSHWDrawConfig::VSSelector vssel, GSHWDr
 		setFnConstantI(m_fn_constants, pssel.sw_aniso,              GSMTLConstantIndex_PS_SW_ANISO);
 		setFnConstantB(m_fn_constants, pssel.rov_color,             GSMTLConstantIndex_PS_ROV_COLOR);
 		setFnConstantI(m_fn_constants, pssel.rov_depth,             GSMTLConstantIndex_PS_ROV_DEPTH);
+		setFnConstantB(m_fn_constants, pssel.rov_oneshot,           GSMTLConstantIndex_PS_ROV_ONESHOT);
 		bool eft = pssel.HasColorROV() && !pssel.HasDepthROV() && !pssel.HasDepthOutput();
 		auto newps = LoadShader(eft ? @"ps_main_rov_eft" : @"ps_main");
 		ps = newps;
@@ -2347,6 +2483,13 @@ __fi void GSDeviceMTL::PrepareROVTexture(GSTexture** ptex)
 
 void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 { @autoreleasepool {
+	if (config.ps.HasOneshotROV())
+	{
+		// Do this first since it requires a different vertex upload from the main draw.
+		const GSVector2i rtsize = (config.rt ? config.rt : config.ds)->GetSize();
+		SetupOneshotROV(config, static_cast<GSTextureMTL*>(config.rt), static_cast<GSTextureMTL*>(config.ds), *config.draw_coarse_rasterize, rtsize);
+	}
+
 	if (config.tex && (config.ds == config.tex || config.rt == config.tex))
 		EndRenderPass(); // Barrier
 
@@ -2481,7 +2624,7 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 	}
 
 	// Try to reduce render pass restarts
-	if (!config.ps.HasColorROV() && !config.ds && m_current_render.color_target == rt && stencil == m_current_render.stencil_target && m_current_render.depth_target != config.tex)
+	if (!config.ps.HasContinuousColorROV() && !config.ds && m_current_render.color_target == rt && stencil == m_current_render.stencil_target && m_current_render.depth_target != config.tex)
 		config.ds = m_current_render.depth_target;
 	if (!rt && config.ds == m_current_render.depth_target && m_current_render.color_target != config.tex)
 		rt = m_current_render.color_target;
@@ -2496,12 +2639,12 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 	}
 
 	const bool feedback_depth = config.ps.IsFeedbackLoopDepth();
-	const bool rt1 = feedback_depth && !m_features.depth_feedback && !config.ps.HasDepthROV();
+	const bool rt1 = feedback_depth && !m_features.depth_feedback && !config.ps.HasContinuousDepthROV();
 	GSTexture* rt_bind = rt;
 	GSTexture* ds_bind = config.ds;
 	GSTexture* rt_size = rt_bind ? rt_bind : ds_bind;
-	if (config.ps.HasColorROV() && rt_bind) PrepareROVTexture(&rt_bind);
-	if (config.ps.HasDepthROV() && ds_bind) PrepareROVTexture(&ds_bind);
+	if (config.ps.HasContinuousColorROV() && rt_bind) PrepareROVTexture(&rt_bind);
+	if (config.ps.HasContinuousDepthROV() && ds_bind) PrepareROVTexture(&ds_bind);
 	if (!rt_bind && !ds_bind && !stencil)
 		BeginFullROV(@"RenderHWROV", rt_size->GetWidth(), rt_size->GetHeight());
 	else
@@ -2511,13 +2654,13 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 	if (usesStencil(config.destination_alpha))
 		[mtlenc setStencilReferenceValue:1];
 	MREInitHWDraw(config, allocation);
-	if (config.ps.HasColorROV() && m_dev.features.rov_requires_r32)
+	if (config.ps.HasContinuousColorROV() && m_dev.features.rov_requires_r32)
 		MRESetTexture(reinterpret_cast<GSTextureMTL*>(rt)->GetROVTexture(), GSMTLTextureIndexRenderTarget);
 	else if (config.require_one_barrier || config.require_full_barrier || config.ps.HasColorROV())
-		MRESetTexture(rt, GSMTLTextureIndexRenderTarget);
+		MRESetTexture(config.ps.HasOneshotColorROV() ? m_rov_rt.get() : rt, GSMTLTextureIndexRenderTarget);
 	if (config.ps.HasDepthROV())
 	{
-		MRESetTexture(config.ds, GSMTLTextureIndexDepthTarget);
+		MRESetTexture(config.ps.HasOneshotDepthROV() ? m_rov_ds.get() : config.ds, GSMTLTextureIndexDepthTarget);
 	}
 	else if (feedback_depth)
 	{
@@ -2646,6 +2789,8 @@ void GSDeviceMTL::SendHWDraw(GSHWDrawConfig& config, id<MTLRenderCommandEncoder>
 
 	EncodeDraw(enc, topology, config.nindices, buffer, off, 0);
 	g_perfmon.Put(GSPerfMon::DrawCalls, 1);
+	if (config.ps.HasROV())
+		g_perfmon.Put(GSPerfMon::DrawCallsROV, 1);
 }
 
 // tbh I'm not a fan of the current debug groups

--- a/pcsx2/GS/Renderers/Metal/GSMTLSharedHeader.h
+++ b/pcsx2/GS/Renderers/Metal/GSMTLSharedHeader.h
@@ -230,4 +230,5 @@ enum GSMTLFnConstants
 	GSMTLConstantIndex_PS_SW_ANISO,
 	GSMTLConstantIndex_PS_ROV_COLOR,
 	GSMTLConstantIndex_PS_ROV_DEPTH,
+	GSMTLConstantIndex_PS_ROV_ONESHOT,
 };

--- a/pcsx2/GS/Renderers/Metal/convert.metal
+++ b/pcsx2/GS/Renderers/Metal/convert.metal
@@ -564,3 +564,23 @@ fragment float4 ps_shadeboost(float4 p [[position]], DirectReadTextureIn<float> 
 
 	return float4(csb, 1);
 }
+
+struct ROVCopyBothOut
+{
+	float4 color [[color(0)]];
+	float  depth [[color(1)]];
+};
+
+fragment float4 ps_rov_copy_color(float4 p [[position]], texture2d<float> tex [[texture(GSMTLTextureIndexNonHW)]])
+{
+	return tex.read(uint2(p.xy));
+}
+fragment float ps_rov_copy_depth(float4 p [[position]], depth2d<float> tex [[texture(GSMTLTextureIndexNonHW)]])
+{
+	return tex.read(uint2(p.xy));
+}
+fragment ROVCopyBothOut ps_rov_copy_both(float4 p [[position]], texture2d<float> ctex [[texture(0)]], depth2d<float> dtex [[texture(1)]])
+{
+	uint2 pos = uint2(p.xy);
+	return { ctex.read(pos), dtex.read(pos) };
+}

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -78,6 +78,7 @@ constant bool PS_ABE                [[function_constant(GSMTLConstantIndex_PS_AB
 constant uint PS_SW_ANISO           [[function_constant(GSMTLConstantIndex_PS_SW_ANISO)]];
 constant bool PS_ROV_COLOR          [[function_constant(GSMTLConstantIndex_PS_ROV_COLOR)]];
 constant uint PS_ROV_DEPTH_RAW      [[function_constant(GSMTLConstantIndex_PS_ROV_DEPTH)]];
+constant bool PS_ROV_ONESHOT        [[function_constant(GSMTLConstantIndex_PS_ROV_ONESHOT)]];
 
 using GSShader::VSExpand;
 using AFAIL = GSShader::PS_AFAIL;
@@ -123,10 +124,16 @@ constant bool NEEDS_DEPTH_FOR_AFAIL = PS_AFAIL == AFAIL::FB_ONLY || PS_AFAIL == 
 constant bool NEEDS_DEPTH_FOR_ZTST  = PS_ZTST == ZTST::GEQUAL || PS_ZTST == ZTST::GREATER;
 constant bool NEEDS_DEPTH_FOR_AA1   = PS_AA1 == AA1::TRIANGLE_SW_Z;
 constant bool SW_DEPTH = NEEDS_DEPTH_FOR_AFAIL || NEEDS_DEPTH_FOR_ZTST || NEEDS_DEPTH_FOR_AA1;
+constant bool DISCARD_COLOR = PS_AFAIL == AFAIL::ZB_ONLY;
+constant bool DISCARD_DEPTH = PS_AA1 == AA1::TRIANGLE_SW_Z || PS_AFAIL == AFAIL::RGB_ONLY_SW_Z || PS_AFAIL == AFAIL::FB_ONLY;
+constant bool DISCARD_FULL = NEEDS_DEPTH_FOR_ZTST || (PS_SCANMSK & 2) || PS_AFAIL == AFAIL::KEEP || PS_DATE >= 5 || PS_DATE == 3;
 
-constant bool PS_OUTPUT_COLOR0 = !PS_NO_COLOR  && !PS_ROV_COLOR;
+constant bool ROV_COLOR_CONTINUOUS = (PS_ROV_COLOR && !PS_ROV_ONESHOT);
+constant bool ROV_DEPTH_CONTINUOUS = (PS_ROV_DEPTH != ROV_DEPTH::NONE && !PS_ROV_ONESHOT);
+
+constant bool PS_OUTPUT_COLOR0 = !PS_NO_COLOR  && !ROV_COLOR_CONTINUOUS;
 constant bool PS_OUTPUT_COLOR1 = !PS_NO_COLOR1 && !PS_ROV_COLOR;
-constant bool PS_ZOUTPUT = (PS_ZCLAMP || PS_ZFLOOR || SW_DEPTH) && PS_ROV_DEPTH == ROV_DEPTH::NONE;
+constant bool PS_ZOUTPUT = (PS_ZCLAMP || PS_ZFLOOR || SW_DEPTH) && !ROV_DEPTH_CONTINUOUS;
 constant bool PS_ZOUTPUT_LESS = PS_ZOUTPUT && !SW_DEPTH;
 constant bool PS_ZOUTPUT_ANY  = PS_ZOUTPUT && SW_DEPTH;
 constant bool PS_ZOUTPUT_COLOR = PS_ZOUTPUT_ANY && !DEPTH_FEEDBACK;
@@ -1793,12 +1800,31 @@ fragment MainPSOut ps_main(
 		else
 			rt_rov.write(out.c0, coord);
 	}
+	if (PS_ROV_ONESHOT)
+	{
+		if (DISCARD_FULL && main.color_discarded && main.depth_discarded)
+			discard_fragment();
+		else if (DISCARD_COLOR && main.color_discarded)
+			out.c0 = main.current_color;
+		else if (DISCARD_DEPTH && main.depth_discarded)
+			out.depth = main.current_depth;
+	}
 	return out;
 }
 
+struct MainPSOutEFT
+{
+	float4 c0 [[color(0), index(0), function_constant(PS_OUTPUT_COLOR0)]];
+	MainPSOutEFT(MainResult res)
+	{
+		if (PS_OUTPUT_COLOR0)
+			c0 = res.c0;
+	}
+};
+
 // Metal doesn't let you toggle eft with function constants so we need a separate function for it
 [[early_fragment_tests]]
-fragment void ps_main_rov_eft(
+fragment MainPSOutEFT ps_main_rov_eft(
 	MainPSIn in [[stage_in]],
 	constant GSMTLMainPSUniform& cb [[buffer(GSMTLBufferIndexHWUniforms)]],
 	sampler s [[sampler(0)]],
@@ -1822,8 +1848,12 @@ fragment void ps_main_rov_eft(
 		main.current_color = unpack_unorm4x8_to_float(rt_u32.read(coord).x);
 	else
 		main.current_color = rt_rov.read(coord);
-	MainPSOut out = main.ps_main();
-	if (!main.color_discarded)
+	MainResult out = main.ps_main();
+	if (main.color_discarded)
+	{
+		out.c0 = main.current_color;
+	}
+	else
 	{
 		if (!PS_FBMASK)
 			out.c0 = select(out.c0, main.current_color, cb.fbmask == 0xff);
@@ -1832,6 +1862,7 @@ fragment void ps_main_rov_eft(
 		else
 			rt_rov.write(out.c0, coord);
 	}
+	return out;
 }
 
 #if PRIMID_SUPPORT

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -5591,6 +5591,46 @@ void GSDeviceVK::BeginClearRenderPass(VkRenderPass rp, const GSVector4i& rect, f
 	BeginClearRenderPass(rp, rect, &cv, 1);
 }
 
+void GSDeviceVK::BeginTFXRenderPass(const GSHWDrawConfig& config, GSTextureVK* rt, GSTextureVK* ds, const GSVector2i& rtsize)
+{
+	const PipelineSelector& pipe = m_pipeline_selector;
+
+	const VkAttachmentLoadOp rt_op = GetLoadOpForTexture(rt);
+	const VkAttachmentLoadOp ds_op = GetLoadOpForTexture(ds);
+	const VkRenderPass rp = GetTFXRenderPass(pipe.rt, pipe.ds, pipe.ps.colclip_hw,
+		config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::Stencil, pipe.IsRTFeedbackLoop(),
+		pipe.IsTestingAndSamplingDepth(), rt_op, ds_op);
+	const bool is_clearing_rt = (rt_op == VK_ATTACHMENT_LOAD_OP_CLEAR || ds_op == VK_ATTACHMENT_LOAD_OP_CLEAR);
+
+	// Only draw to the active area of the colclip hw target. Except when depth is cleared, we need to use the full
+	// buffer size, otherwise it'll only clear the draw part of the depth buffer.
+	const bool use_drawarea =
+		pipe.ps.colclip_hw &&
+		(config.colclip_mode == GSHWDrawConfig::ColClipMode::ConvertAndResolve) &&
+		ds_op != VK_ATTACHMENT_LOAD_OP_CLEAR;
+	const GSVector4i render_area = use_drawarea ? config.drawarea : GSVector4i::loadh(rtsize);
+
+	if (is_clearing_rt)
+	{
+		// when we're clearing, we set the draw area to the whole fb, otherwise part of it will be undefined
+		alignas(16) VkClearValue cvs[2];
+		u32 cv_count = 0;
+		if (rt)
+		{
+			const GSVector4 clear_color = pipe.ps.colclip_hw ? GSVector4::unorm16(rt->GetClearColor()) : rt->GetClearForFormat();
+			GSVector4::store<true>(&cvs[cv_count++].color, clear_color);
+		}
+		if (ds)
+			cvs[cv_count++].depthStencil = { ds->GetClearDepth(), 0 };
+
+		BeginClearRenderPass(rp, render_area, cvs, cv_count);
+	}
+	else
+	{
+		BeginRenderPass(rp, render_area);
+	}
+}
+
 void GSDeviceVK::EndRenderPass()
 {
 	if (m_current_render_pass == VK_NULL_HANDLE)
@@ -6276,45 +6316,7 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 
 	// Begin render pass if new target or out of the area.
 	if (!InRenderPass())
-	{
-		const VkAttachmentLoadOp rt_op = GetLoadOpForTexture(draw_rt);
-		const VkAttachmentLoadOp ds_op = GetLoadOpForTexture(draw_ds);
-		const VkRenderPass rp = GetTFXRenderPass(pipe.rt, pipe.ds, pipe.ps.colclip_hw,
-			config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::Stencil, pipe.IsRTFeedbackLoop(),
-			pipe.IsTestingAndSamplingDepth(), rt_op, ds_op);
-		const bool is_clearing_rt = (rt_op == VK_ATTACHMENT_LOAD_OP_CLEAR || ds_op == VK_ATTACHMENT_LOAD_OP_CLEAR);
-
-		// Only draw to the active area of the colclip hw target. Except when depth is cleared, we need to use the full
-		// buffer size, otherwise it'll only clear the draw part of the depth buffer.
-		const GSVector4i render_area = (pipe.ps.colclip_hw && (config.colclip_mode == GSHWDrawConfig::ColClipMode::ConvertAndResolve) && ds_op != VK_ATTACHMENT_LOAD_OP_CLEAR)
-		                             ? config.drawarea
-		                             : GSVector4i::loadh(rtsize);
-
-		if (is_clearing_rt)
-		{
-			// when we're clearing, we set the draw area to the whole fb, otherwise part of it will be undefined
-			alignas(16) VkClearValue cvs[2];
-			u32 cv_count = 0;
-			if (draw_rt)
-			{
-				GSVector4 clear_color = draw_rt->GetClearForFormat();
-				if (pipe.ps.colclip_hw)
-				{
-					// Denormalize clear color for hw colclip.
-					clear_color *= GSVector4::cxpr(255.0f / 65535.0f, 255.0f / 65535.0f, 255.0f / 65535.0f, 1.0f);
-				}
-				GSVector4::store<true>(&cvs[cv_count++].color, clear_color);
-			}
-			if (draw_ds)
-				cvs[cv_count++].depthStencil = {draw_ds->GetClearDepth(), 0};
-
-			BeginClearRenderPass(rp, render_area, cvs, cv_count);
-		}
-		else
-		{
-			BeginRenderPass(rp, render_area);
-		}
-	}
+		BeginTFXRenderPass(config, draw_rt, draw_ds, rtsize);
 
 	if (config.destination_alpha == GSHWDrawConfig::DestinationAlphaMode::StencilOne)
 	{

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -3181,6 +3181,139 @@ void GSDeviceVK::DoMultiStretchRects(
 		DrawIndexedPrimitive();
 }
 
+void GSDeviceVK::SetupOneshotROV(const GSHWDrawConfig& config, GSTextureVK* rt, GSTextureVK* ds,
+	const std::vector<GSVector4i>& rects, const GSVector2i& size)
+{
+	g_perfmon.Put(GSPerfMon::TextureCopies, 1);
+	g_perfmon.Put(GSPerfMon::TextureCopiesROV, 1);
+	g_perfmon.Put(GSPerfMon::DrawCallsROV, 1);
+
+	bool rt_copy = config.ps.HasOneshotColorROV();
+	bool ds_copy = config.ps.HasOneshotDepthROV();
+
+	// Create ROV textures
+	if (rt_copy && (!m_rov_rt || m_rov_rt->GetSize() != size))
+	{
+		if (m_rov_rt)
+			Recycle(m_rov_rt.release());
+		m_rov_rt.reset(static_cast<GSTextureVK*>(CreateShaderWriteTarget(size, GSTexture::Format::Color, false)));
+#if PCSX2_DEVBUILD
+		m_rov_rt->SetDebugName(fmt::format("RT for oneshot ROV {}x{}", size.x, size.y));
+#endif
+	}
+	if (ds_copy && (!m_rov_ds || m_rov_ds->GetSize() != size))
+	{
+		if (m_rov_ds)
+			Recycle(m_rov_ds.release());
+		m_rov_ds.reset(static_cast<GSTextureVK*>(CreateShaderWriteTarget(size, GSTexture::Format::DepthColor, false)));
+#if PCSX2_DEVBUILD
+		m_rov_ds->SetDebugName(fmt::format("DS for oneshot ROV {}x{}", size.x, size.y));
+#endif
+	}
+
+	// Avoid copies if the original is cleared.
+	if (rt_copy && rt->GetState() == GSTexture::State::Cleared)
+	{
+		m_rov_rt->SetClearColor(rt->GetClearColor());
+		m_rov_rt->CommitClear();
+		rt_copy = false;
+	}
+	if (ds_copy && ds->GetState() == GSTexture::State::Cleared)
+	{
+		m_rov_ds->SetClearDepth(ds->GetClearDepth());
+		m_rov_rt->CommitClear();
+		ds_copy = false;
+	}
+
+	if (!(rt_copy || ds_copy))
+		return; // Copy handled with clear.
+
+	// Vertices / IA
+	const u32 num_rects = static_cast<u32>(rects.size());
+	const u32 vertex_reserve_size = num_rects * 4 * sizeof(GSVertexPT1);
+	const u32 index_reserve_size = num_rects * 6 * sizeof(u16);
+	if (!m_vertex_stream_buffer.ReserveMemory(vertex_reserve_size, sizeof(GSVertexPT1)) ||
+		!m_index_stream_buffer.ReserveMemory(index_reserve_size, sizeof(u16)))
+	{
+		ExecuteCommandBufferAndRestartRenderPass(false, "Uploading bytes to vertex buffer");
+		if (!m_vertex_stream_buffer.ReserveMemory(vertex_reserve_size, sizeof(GSVertexPT1)) ||
+			!m_index_stream_buffer.ReserveMemory(index_reserve_size, sizeof(u16)))
+		{
+			pxFailRel("Failed to reserve space for vertices");
+		}
+	}
+
+	const GSVector4i size_rect(GSVector4i::loadh(size));
+	GSVertexPT1* verts = reinterpret_cast<GSVertexPT1*>(m_vertex_stream_buffer.GetCurrentHostPointer());
+	u16* idx = reinterpret_cast<u16*>(m_index_stream_buffer.GetCurrentHostPointer());
+	u32 icount = 0;
+	u32 vcount = 0;
+	for (u32 i = 0; i < num_rects; i++)
+	{
+		const GSVector4 dst = (GSVector4(rects[i]) / GSVector4(size_rect).zwzw()) * 2.0f - 1.0f;
+
+		const u32 vstart = vcount;
+		verts[vcount++] = {GSVector4(dst.x, -dst.y, 0.5f, 1.0f), {}};
+		verts[vcount++] = {GSVector4(dst.z, -dst.y, 0.5f, 1.0f), {}};
+		verts[vcount++] = {GSVector4(dst.x, -dst.w, 0.5f, 1.0f), {}};
+		verts[vcount++] = {GSVector4(dst.z, -dst.w, 0.5f, 1.0f), {}};
+
+		if (i > 0)
+			idx[icount++] = vstart;
+
+		idx[icount++] = vstart;
+		idx[icount++] = vstart + 1;
+		idx[icount++] = vstart + 2;
+		idx[icount++] = vstart + 3;
+		idx[icount++] = vstart + 3;
+	}
+
+	m_vertex.start = m_vertex_stream_buffer.GetCurrentOffset() / sizeof(GSVertexPT1);
+	m_vertex.count = vcount;
+	m_index.start = m_index_stream_buffer.GetCurrentOffset() / sizeof(u16);
+	m_index.count = icount;
+	m_vertex_stream_buffer.CommitMemory(vcount * sizeof(GSVertexPT1));
+	m_index_stream_buffer.CommitMemory(icount * sizeof(u16));
+	SetIndexBuffer(m_index_stream_buffer.GetBuffer());
+
+	// Pipeline
+	SetPipeline(m_rov_copy_pipelines[rt ? (rt_copy ? 2 : 1) : 0][ds ? (ds_copy ? 2 : 1) : 0]);
+
+	// Check if the barrier is already handled with a transition.
+	bool rt_needs_barrier = rt_copy && (rt->GetLayout() == GSTextureVK::Layout::FeedbackLoop);
+	bool ds_needs_barrier = ds_copy && (ds->GetLayout() == GSTextureVK::Layout::FeedbackLoop);
+
+	// Shader resources
+	PSSetROVs(m_rov_rt.get(), m_rov_ds.get(), rt_copy, ds_copy);
+	if (rt_copy)
+		PSSetShaderResource(TFX_TEXTURE_RT, rt, false);
+	if (ds_copy)
+		PSSetShaderResource(TFX_TEXTURE_DEPTH, ds, false);
+	
+	// RTs / render pass
+	m_pipeline_selector.feedback_loop_flags |=
+	    (rt_copy ? FeedbackLoopFlag_ReadAndWriteRT : FeedbackLoopFlag_None) |
+	    (ds_copy ? FeedbackLoopFlag_ReadDepth : FeedbackLoopFlag_None);
+	OMSetRenderTargets(rt, ds, size_rect, static_cast<FeedbackLoopFlag>(m_pipeline_selector.feedback_loop_flags), size);
+	if (!InRenderPass())
+		BeginTFXRenderPass(config, rt, ds, size);
+
+	// Barriers
+	FeedbackBarrier(rt_needs_barrier ? rt : nullptr, ds_needs_barrier ? ds : nullptr);
+
+	// Draw
+	if (ApplyTFXState())
+		DrawIndexedPrimitive();
+
+	EndRenderPass();
+
+	// UAV barriers
+	if (rt_copy)
+		m_rov_rt->TransitionSubresourcesToLayout(GetCurrentCommandBuffer(), 0, 1, m_rov_rt->GetLayout(), m_rov_rt->GetLayout());
+	if (ds_copy)
+		m_rov_ds->TransitionSubresourcesToLayout(GetCurrentCommandBuffer(), 0, 1, m_rov_ds->GetLayout(), m_rov_ds->GetLayout());
+}
+
 void GSDeviceVK::BeginRenderPassForStretchRect(
 	GSTextureVK* dTex, const GSVector4i& dtex_rc, const GSVector4i& dst_rc, bool allow_discard)
 {
@@ -4288,6 +4421,72 @@ bool GSDeviceVK::CompileConvertPipelines()
 		}
 	}
 
+	// ROV copy pipelines for oneshot
+	if (m_features.rov)
+	{
+		for (u32 rt = 0; rt < 3; rt++)
+		{
+			for (u32 ds = 0; ds < 3; ds++)
+			{
+				const u32 rt_copy = (rt == 2) ? 1 : 0;
+				const u32 ds_copy = (ds == 2) ? 1 : 0;
+				if (!rt_copy && !ds_copy)
+				{
+					m_rov_copy_pipelines[rt][ds] = VK_NULL_HANDLE;
+					continue;
+				}
+				
+				std::string macro =
+					fmt::format("#define PS_ROV_COPY_COLOR {}\n", rt_copy) +
+					fmt::format("#define PS_ROV_COPY_DEPTH {}\n", ds_copy) +
+					"#extension GL_ARB_shader_image_load_store : require\n";
+
+				std::string shader_with_header = macro + *source;
+
+				VkShaderModule ps = GetUtilityFragmentShader(shader_with_header, "ps_rov_copy");
+				if (ps == VK_NULL_HANDLE)
+					return false;
+				
+				ScopedGuard ps_guard([this, &ps]() { vkDestroyShaderModule(m_device, ps, nullptr); });
+
+				gpb.SetPipelineLayout(m_tfx_pipeline_layout);
+				gpb.SetFragmentShader(ps);
+				gpb.ClearBlendAttachments();
+				VkRenderPass rp = GetRenderPass(
+					LookupNativeFormat(rt ? GSTexture::Format::Color : GSTexture::Format::Invalid),
+					LookupNativeFormat(ds ? GSTexture::Format::DepthStencil : GSTexture::Format::Invalid),
+					rt_copy ? VK_ATTACHMENT_LOAD_OP_LOAD : VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+					rt_copy ? VK_ATTACHMENT_STORE_OP_STORE : VK_ATTACHMENT_STORE_OP_DONT_CARE,
+					ds_copy ? VK_ATTACHMENT_LOAD_OP_LOAD : VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+					ds_copy ? VK_ATTACHMENT_STORE_OP_STORE : VK_ATTACHMENT_STORE_OP_DONT_CARE,
+					VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
+					rt_copy, ds_copy);
+				gpb.SetRenderPass(rp, 0);
+				if (rt)
+				{
+					gpb.SetBlendAttachment(0, false, VK_BLEND_FACTOR_ONE, VK_BLEND_FACTOR_ZERO, VK_BLEND_OP_ADD,
+						VK_BLEND_FACTOR_ZERO, VK_BLEND_FACTOR_ZERO, VK_BLEND_OP_ADD, 0);
+				}
+				gpb.SetNoDepthTestState();
+				gpb.SetNoStencilState();
+
+				m_rov_copy_pipelines[rt][ds] =
+					gpb.Create(m_device, g_vulkan_shader_cache->GetPipelineCache(true), false);
+				if (!m_rov_copy_pipelines[rt][ds])
+					return false;
+
+				constexpr std::array<const char*, 3> debug_str = {
+					"None",
+					"Attached",
+					"Copied",
+				};
+
+				Vulkan::SetObjectName(m_device, m_rov_copy_pipelines[rt][ds],
+					"ROV copy pipeline (RT=%s, DS=%s)", debug_str[rt], debug_str[ds]);
+			}
+		}
+	}
+
 	return true;
 }
 
@@ -4816,6 +5015,14 @@ void GSDeviceVK::DestroyResources()
 				vkDestroyPipeline(m_device, m_primid_image_setup_pipelines[ds][datm], nullptr);
 		}
 	}
+	for (u32 rt = 0; rt < 3; rt++)
+	{
+		for (u32 ds = 0; ds < 3; ds++)
+		{
+			if (m_rov_copy_pipelines[rt][ds] != VK_NULL_HANDLE)
+				vkDestroyPipeline(m_device, m_rov_copy_pipelines[rt][ds], nullptr);
+		}
+	}
 	if (m_fxaa_pipeline != VK_NULL_HANDLE)
 		vkDestroyPipeline(m_device, m_fxaa_pipeline, nullptr);
 	if (m_shadeboost_pipeline != VK_NULL_HANDLE)
@@ -4869,6 +5076,18 @@ void GSDeviceVK::DestroyResources()
 	{
 		m_null_texture->Destroy(false);
 		m_null_texture.reset();
+	}
+
+	if (m_rov_rt)
+	{
+		m_rov_rt->Destroy(false);
+		m_rov_rt.reset();
+	}
+
+	if (m_rov_ds)
+	{
+		m_rov_ds->Destroy(false);
+		m_rov_ds.reset();
 	}
 
 	for (FrameResources& resources : m_frame_resources)
@@ -5001,6 +5220,7 @@ VkShaderModule GSDeviceVK::GetTFXFragmentShader(const GSHWDrawConfig::PSSelector
 	AddMacro(ss, "PS_ANISOTROPIC_FILTERING", sel.sw_aniso);
 	AddMacro(ss, "PS_ROV_COLOR", sel.rov_color);
 	AddMacro(ss, "PS_ROV_DEPTH", static_cast<u32>(sel.rov_depth));
+	AddMacro(ss, "PS_ROV_ONESHOT", sel.rov_oneshot);
 	ss << m_tfx_source;
 
 	VkShaderModule mod = g_vulkan_shader_cache->GetFragmentShader(ss.str());
@@ -6016,10 +6236,10 @@ GSTextureVK* GSDeviceVK::SetupPrimitiveTrackingDATE(GSHWDrawConfig& config)
 void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 {
 	const GSVector2i rtsize(config.rt ? config.rt->GetSize() : config.ds->GetSize());
-	GSTextureVK* draw_rt = config.ps.HasColorROV() ? nullptr : static_cast<GSTextureVK*>(config.rt);
-	GSTextureVK* draw_ds = config.ps.HasDepthROV() ? nullptr : static_cast<GSTextureVK*>(config.ds);
-	GSTextureVK* draw_rt_rov = config.ps.HasColorROV() ? static_cast<GSTextureVK*>(config.rt) : nullptr;
-	GSTextureVK* draw_ds_rov = config.ps.HasDepthROV() ? static_cast<GSTextureVK*>(config.ds) : nullptr;
+	GSTextureVK* draw_rt = config.ps.HasContinuousColorROV() ? nullptr : static_cast<GSTextureVK*>(config.rt);
+	GSTextureVK* draw_ds = config.ps.HasContinuousDepthROV() ? nullptr : static_cast<GSTextureVK*>(config.ds);
+	GSTextureVK* draw_rt_rov = config.ps.HasContinuousColorROV() ? static_cast<GSTextureVK*>(config.rt) : nullptr;
+	GSTextureVK* draw_ds_rov = config.ps.HasContinuousDepthROV() ? static_cast<GSTextureVK*>(config.ds) : nullptr;
 	GSTextureVK* draw_rt_clone = nullptr;
 	GSTextureVK* colclip_rt = static_cast<GSTextureVK*>(g_gs_device->GetColorClipTexture());
 
@@ -6113,7 +6333,7 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 			g_gs_device->SetColorClipTexture(nullptr);
 
 			colclip_rt = nullptr;
-			draw_rt = config.ps.HasColorROV() ? nullptr : static_cast<GSTextureVK*>(config.rt);
+			draw_rt = config.ps.HasContinuousColorROV() ? nullptr : static_cast<GSTextureVK*>(config.rt);
 		}
 		else
 		{
@@ -6188,6 +6408,9 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 		}
 		draw_rt = colclip_rt;
 	}
+
+	if (config.ps.HasOneshotROV())
+		SetupOneshotROV(config, draw_rt, draw_ds, *config.draw_coarse_rasterize, rtsize);
 
 	// clear texture binding when it's bound to RT or DS.
 	if (!config.tex && ((config.rt && static_cast<GSTextureVK*>(config.rt) == m_tfx_textures[0]) ||
@@ -6299,7 +6522,10 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 		}
 	}
 	
-	PSSetROVs(draw_rt_rov, draw_ds_rov, config.ps.HasColorOutput(), config.ps.HasDepthROVWrite());
+	if (config.ps.HasOneshotROV())
+		PSSetROVs(m_rov_rt.get(), m_rov_ds.get(), config.ps.HasColorOutput(), config.ps.HasDepthROVWrite());
+	else
+		PSSetROVs(draw_rt_rov, draw_ds_rov, config.ps.HasColorOutput(), config.ps.HasDepthROVWrite());
 
 	OMSetRenderTargets(draw_rt, draw_ds, config.scissor, static_cast<FeedbackLoopFlag>(pipe.feedback_loop_flags), rtsize);
 
@@ -6442,13 +6668,13 @@ void GSDeviceVK::UpdateHWPipelineSelector(GSHWDrawConfig& config, PipelineSelect
 	pipe.vs.key = config.vs.key;
 	pipe.ps.key_hi = config.ps.key_hi;
 	pipe.ps.key_lo = config.ps.key_lo;
-	pipe.dss.key = config.ps.HasDepthROV() ? GSHWDrawConfig::DepthStencilSelector::NoDepth().key : config.depth.key;
-	pipe.bs.key = config.ps.HasColorROV() ? GSHWDrawConfig::BlendState().key : config.blend.key;
+	pipe.dss.key = config.ps.HasContinuousDepthROV() ? GSHWDrawConfig::DepthStencilSelector::NoDepth().key : config.depth.key;
+	pipe.bs.key = config.ps.HasContinuousColorROV() ? GSHWDrawConfig::BlendState().key : config.blend.key;
 	pipe.bs.constant = 0; // don't dupe states with different alpha values
-	pipe.cms.key = config.ps.HasColorROV() ? GSHWDrawConfig::ColorMaskSelector().key : config.colormask.key;
+	pipe.cms.key = config.ps.HasContinuousColorROV() ? GSHWDrawConfig::ColorMaskSelector().key : config.colormask.key;
 	pipe.topology = static_cast<u32>(config.topology);
-	pipe.rt = config.rt != nullptr && !config.ps.HasColorROV();
-	pipe.ds = config.ds != nullptr && !config.ps.HasDepthROV();
+	pipe.rt = config.rt != nullptr && !config.ps.HasContinuousColorROV();
+	pipe.ds = config.ds != nullptr && !config.ps.HasContinuousDepthROV();
 	pipe.line_width = config.line_expand;
 	pipe.feedback_loop_flags = FeedbackLoopFlag_None;
 	if (m_features.texture_barrier && (config.require_one_barrier || config.require_full_barrier))
@@ -6585,6 +6811,6 @@ void GSDeviceVK::SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt, 
 
 	Draw(config);
 
-	if (config.ps.HasColorROV() || config.ps.HasDepthROV())
+	if (config.ps.HasROV())
 		g_perfmon.Put(GSPerfMon::DrawCallsROV, 1);
 }

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -5385,11 +5385,6 @@ void GSDeviceVK::PSSetROVs(GSTexture* rt, GSTexture* ds, bool write_rt, bool wri
 			vkRt->SetState(GSTexture::State::Dirty);
 		}
 	}
-	else
-	{
-		// Unbind to avoid conflicts with OM targets.
-		PSSetShaderResource(TFX_TEXTURE_RT_ROV, nullptr, false);
-	}
 
 	if (vkDs)
 	{
@@ -5408,11 +5403,6 @@ void GSDeviceVK::PSSetROVs(GSTexture* rt, GSTexture* ds, bool write_rt, bool wri
 		{
 			vkDs->SetState(GSTexture::State::Dirty);
 		}
-	}
-	else
-	{
-		// Unbind to avoid conflicts with OM targets.
-		PSSetShaderResource(TFX_TEXTURE_DEPTH_ROV, nullptr, false);
 	}
 
 	if (GSConfig.HWROVBarriersVK)
@@ -5767,11 +5757,20 @@ bool GSDeviceVK::ApplyTFXState(bool already_execed)
 
 		// Clear out the RT/DS binding if feedback loop isn't on, because it'll be in the wrong state and make
 		// the validation layer cranky. Not a big deal since we need to write it anyway.
-		std::array<TFX_TEXTURES, 2> texture_types = { TFX_TEXTURE_RT, TFX_TEXTURE_DEPTH };
-		for (u32 texture_type : texture_types)
+		std::array<TFX_TEXTURES, 2> texture_types_feedback = { TFX_TEXTURE_RT, TFX_TEXTURE_DEPTH };
+		for (u32 texture_type : texture_types_feedback)
 		{
 			const GSTextureVK::Layout tex_layout = m_tfx_textures[texture_type]->GetLayout();
 			if (tex_layout != GSTextureVK::Layout::FeedbackLoop && tex_layout != GSTextureVK::Layout::ShaderReadOnly)
+				m_tfx_textures[texture_type] = m_null_texture.get();
+		}
+
+		// Clear out storage image bindings if ROV is not being used.
+		std::array<TFX_TEXTURES, 2> texture_types_storage = { TFX_TEXTURE_RT_ROV, TFX_TEXTURE_DEPTH_ROV };
+		for (u32 texture_type : texture_types_storage)
+		{
+			const GSTextureVK::Layout tex_layout = m_tfx_textures[texture_type]->GetLayout();
+			if (tex_layout != GSTextureVK::Layout::ReadWriteImage)
 				m_tfx_textures[texture_type] = m_null_texture.get();
 		}
 	}
@@ -6286,11 +6285,6 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 			m_dirty_flags |= static_cast<u32>(DIRTY_FLAG_TFX_TEXTURE_RT_ROV);
 		}
 	}
-	else if (!draw_rt_clone)
-	{
-		// Unbind to avoid conflicts with framebuffer
-		PSSetShaderResource(TFX_TEXTURE_RT, nullptr, false);
-	}
 	
 	if (pipe.IsDepthFeedbackLoop() && draw_ds)
 	{
@@ -6303,11 +6297,6 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 			PSSetShaderResource(TFX_TEXTURE_DEPTH_ROV, nullptr, false);
 			m_dirty_flags |= static_cast<u32>(DIRTY_FLAG_TFX_TEXTURE_DEPTH_ROV);
 		}
-	}
-	else
-	{
-		// Unbind to avoid conflicts with framebuffer
-		PSSetShaderResource(TFX_TEXTURE_DEPTH, nullptr, false);
 	}
 	
 	PSSetROVs(draw_rt_rov, draw_ds_rov, config.ps.HasColorOutput(), config.ps.HasDepthROVWrite());

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -6518,6 +6518,27 @@ VkDependencyFlags GSDeviceVK::GetFeedbackBarrierDependencyFlags() const
 	                                 VK_DEPENDENCY_BY_REGION_BIT;
 }
 
+void GSDeviceVK::FeedbackBarrier(GSTextureVK* rt, GSTextureVK* ds)
+{
+	const VkDependencyFlags barrier_flags = GetFeedbackBarrierDependencyFlags();
+
+	if (rt)
+	{
+		VkImageMemoryBarrier barrier = GetColorBufferFeedbackBarrier(rt);
+		vkCmdPipelineBarrier(GetCurrentCommandBuffer(),
+			VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+			VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, barrier_flags, 0, nullptr, 0, nullptr, 1, &barrier);
+	}
+
+	if (ds)
+	{
+		VkImageMemoryBarrier barrier = GetDepthStencilBufferFeedbackBarrier(ds);
+		vkCmdPipelineBarrier(GetCurrentCommandBuffer(),
+			VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
+			VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, barrier_flags, 0, nullptr, 0, nullptr, 1, &barrier);
+	}
+}
+
 void GSDeviceVK::SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt, GSTextureVK* draw_ds,
 	bool one_barrier, bool full_barrier)
 {
@@ -6531,38 +6552,8 @@ void GSDeviceVK::SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt, 
 	if ((one_barrier || full_barrier) && !(config.IsFeedbackLoopRT(m_pipeline_selector.ps) || config.IsFeedbackLoopDepth(m_pipeline_selector.ps))) [[unlikely]]
 		Console.Warning("VK: Possible unnecessary barrier detected.");
 #endif
-	VkDependencyFlags barrier_flags = GetFeedbackBarrierDependencyFlags();
 
-	std::array<VkImageMemoryBarrier, 2> barriers;
-	u32 n_barriers = 0;
-	if (full_barrier || one_barrier)
-	{
-		if (draw_rt)
-		{
-			barriers[0] = GetColorBufferFeedbackBarrier(draw_rt);
-			n_barriers++;
-		}
-		if (draw_ds)
-		{
-			barriers[1] = GetDepthStencilBufferFeedbackBarrier(draw_ds);
-			n_barriers++;
-		}
-	}
-
-	const auto IssueBarriers = [&]() {
-		if (draw_rt)
-		{
-			vkCmdPipelineBarrier(GetCurrentCommandBuffer(),
-				VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-				VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, barrier_flags, 0, nullptr, 0, nullptr, 1, &barriers[0]);
-		}
-		if (draw_ds)
-		{
-			vkCmdPipelineBarrier(GetCurrentCommandBuffer(),
-				VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
-				VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, barrier_flags, 0, nullptr, 0, nullptr, 1, &barriers[1]);
-		}
-	};
+	const int n_barriers = (draw_rt ? 1 : 0) + (draw_ds ? 1 : 0);
 
 	if (full_barrier)
 	{
@@ -6576,7 +6567,7 @@ void GSDeviceVK::SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt, 
 
 		for (u32 n = 0, p = 0; n < draw_list_size; n++)
 		{
-			IssueBarriers();
+			FeedbackBarrier(draw_rt, draw_ds);
 
 			const u32 count = config.drawlist->at(n) * indices_per_prim;
 			Draw(config, p, count);
@@ -6589,7 +6580,7 @@ void GSDeviceVK::SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt, 
 	if (one_barrier)
 	{
 		g_perfmon.Put(GSPerfMon::Barriers, n_barriers);
-		IssueBarriers();
+		FeedbackBarrier(draw_rt, draw_ds);
 	}
 
 	Draw(config);

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -644,6 +644,7 @@ public:
 	VkImageMemoryBarrier GetColorBufferFeedbackBarrier(GSTextureVK* rt) const;
 	VkImageMemoryBarrier GetDepthStencilBufferFeedbackBarrier(GSTextureVK* ds) const;
 	VkDependencyFlags GetFeedbackBarrierDependencyFlags() const;
+	void FeedbackBarrier(GSTextureVK* rt, GSTextureVK* ds);
 	void SendHWDraw(const GSHWDrawConfig& config, GSTextureVK* draw_rt, GSTextureVK* draw_ds,
 		bool one_barrier, bool full_barrier);
 

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -686,6 +686,7 @@ public:
 	void BeginClearRenderPass(VkRenderPass rp, const GSVector4i& rect, const VkClearValue* cv, u32 cv_count);
 	void BeginClearRenderPass(VkRenderPass rp, const GSVector4i& rect, u32 clear_color);
 	void BeginClearRenderPass(VkRenderPass rp, const GSVector4i& rect, float depth, u8 stencil);
+	void BeginTFXRenderPass(const GSHWDrawConfig& config, GSTextureVK* rt, GSTextureVK* ds, const GSVector2i& rtsize);
 	void EndRenderPass();
 
 	void SetViewport(const VkViewport& viewport);

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -444,6 +444,7 @@ private:
 	VkPipeline m_colclip_finish_pipelines[2][2] = {}; // [depth][feedback_loop]
 	VkRenderPass m_primid_image_setup_render_passes[2][2] = {}; // [depth][clear]
 	VkPipeline m_primid_image_setup_pipelines[2][4] = {}; // [depth][datm]
+	VkPipeline m_rov_copy_pipelines[3][3] = {}; // [color][depth]
 	VkPipeline m_fxaa_pipeline = {};
 	VkPipeline m_shadeboost_pipeline = {};
 
@@ -603,6 +604,8 @@ public:
 	void DrawMultiStretchRects(
 		const MultiStretchRect* rects, u32 num_rects, GSTexture* dTex, ShaderConvertSelector shader) override;
 	void DoMultiStretchRects(const MultiStretchRect* rects, u32 num_rects, GSTextureVK* dTex, ShaderConvertSelector shader);
+	void SetupOneshotROV(const GSHWDrawConfig& config, GSTextureVK* rt, GSTextureVK* ds,
+		const std::vector<GSVector4i>& rects, const GSVector2i& size);
 
 	void BeginRenderPassForStretchRect(
 		GSTextureVK* dTex, const GSVector4i& dtex_rc, const GSVector4i& dst_rc, bool allow_discard = true);
@@ -778,6 +781,8 @@ private:
 	VkPipeline m_current_pipeline = VK_NULL_HANDLE;
 
 	std::unique_ptr<GSTextureVK> m_null_texture;
+	std::unique_ptr<GSTextureVK> m_rov_rt;
+	std::unique_ptr<GSTextureVK> m_rov_ds;
 	VkFramebuffer m_null_framebuffer;
 
 	// current pipeline selector - we save this in the struct to avoid re-zeroing it every draw

--- a/pcsx2/ImGui/FullscreenUI_Settings.cpp
+++ b/pcsx2/ImGui/FullscreenUI_Settings.cpp
@@ -3414,6 +3414,12 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 			"EmuCore/GS", "FrameRateNTSC", 59.94f, 10.0f, 300.0f, "%.2f Hz");
 		DrawFloatRangeSetting(bsi, FSUI_ICONSTR(ICON_FA_TV, "PAL Frame Rate"), FSUI_CSTR("Determines what frame rate PAL games run at."),
 			"EmuCore/GS", "FrameRatePAL", 50.0f, 10.0f, 300.0f, "%.2f Hz");
+		DrawIntSpinBoxSetting(bsi, FSUI_ICONSTR(ICON_FA_LAYER_GROUP, "ROV Continuous Barrier Threshold"),
+			FSUI_CSTR("Determines the minimum barriers per frame to activate continuous ROV mode."),
+				"EmuCore/GS", "HWROVContinuousBarriers", 5000, 0, 999999999, 1, FSUI_CSTR("%d"));
+		DrawIntSpinBoxSetting(bsi, FSUI_ICONSTR(ICON_FA_LAYER_GROUP, "ROV Oneshot Barrier Threshold"),
+			FSUI_CSTR("Determines the minimum barriers in a draw to activate oneshot ROV mode."),
+				"EmuCore/GS", "HWROVOneshotBarriers", 50, 0, 999999999, 1, FSUI_CSTR("%d"));
 	}
 
 	EndMenuButtons();

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -862,6 +862,8 @@ bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 		OpEqu(UserHacks_BilinearHack) &&
 		OpEqu(OverrideTextureBarriers) &&
 		OpEqu(DepthFeedbackMode) &&
+		OpEqu(HWROVContinuousBarriers) &&
+		OpEqu(HWROVOneshotBarriers) &&
 
 		OpEqu(CAS_Sharpness) &&
 		OpEqu(ShadeBoost_Brightness) &&
@@ -1079,6 +1081,8 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapIntEnumEx(TriFilter, "TriFilter");
 	SettingsWrapBitfieldEx(OverrideTextureBarriers, "OverrideTextureBarriers");
 	SettingsWrapIntEnumEx(DepthFeedbackMode, "DepthFeedbackMode");
+	SettingsWrapIntEnumEx(HWROVContinuousBarriers, "HWROVContinuousBarriers");
+	SettingsWrapIntEnumEx(HWROVOneshotBarriers, "HWROVOneshotBarriers");
 
 	SettingsWrapBitfield(ShadeBoost_Brightness);
 	SettingsWrapBitfield(ShadeBoost_Contrast);

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 108; // Last changed in PR 14688
+static constexpr u32 SHADER_CACHE_VERSION = 109; // Last changed in PR 14607


### PR DESCRIPTION
### Description of Changes
Adds heuristics to determine ROV usage:
- Continuous: If average barrier/frame is above a threshold (default 5000) use ROV continuously.
- Oneshot: If the number of barriers in a draw is above a thresold (default 50), use ROV for a single draw (if not alreayd using continuous mode).

Put render pass starting code in DX12/VK into a separate function.

Adds utility functions for doing coarse CPU rasterization of draws to cut down on copy overhead. Currently, only used for the ROV copies in oneshot mode.

### Rationale behind Changes
Performance in some system/games are negatively impacted by using ROV continuously, so this attempts to provide less aggressive heuristics for such cases.

The coarse rasterization utilies could possibly be used for other copies such as in DX11 feedback. It might also be useful for reducing barriers with more accurate overlap detection.

### Suggested Testing Steps
Use DX12/DX11/VK with ROV enabled in Settings>Graphics>Rendering. The default threshold can be edited in Settings>Graphics>Advanced>ROV Options. Performance testing would be helpful.

Currently, this has been tested with dump runs and performance tested on AMD (thanks @JordanTheToaster).

### Did you use AI to help find, test, or implement this issue or feature?
Yes, to brainstorm some ideas for conservative ROV heuristics and reducing copy overhead.