### PR TITLE
IR5900: Fix recMemCheck to not cache loaded reg

### DIFF
--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -101,56 +101,59 @@ static void iopRecError(int err);
 static ZydisFormatterFunc s_old_print_address;
 static ZydisFormatterFunc s_old_print_disp;
 
-static int Address2Symbol(u64 address, char* buf)
+static bool Address2Symbol(u64 address, SmallString &buf)
 {
-	u32 len = 0;
 
 #define A(x) ((u64)(x))
 
 	if (address >= A(iopMem->Main) && address < A(iopMem->P))
 	{
-		len = sprintf(buf, "iopMem+0x%08X", static_cast<u32>(address - A(iopMem->Main)));
+		buf.append_format("iopMem+0x{:08X}", static_cast<u32>(address - A(iopMem->Main)));
 	}
 	else if (address >= A(&psxRegs.GPR) && address < A(&psxRegs.CP0))
 	{
-		len = sprintf(buf, "psxRegs.GPR.%s", R3000A::disRNameGPR[static_cast<u32>(address - A(&psxRegs)) / 4u]);
+		buf.append_format("psxRegs.GPR.{}", R3000A::disRNameGPR[static_cast<u32>(address - A(&psxRegs)) / 4u]);
 	}
 	else if (address == A(&psxRegs.pc))
 	{
-		len = sprintf(buf, "psxRegs.pc");
+		buf.append("psxRegs.pc");
 	}
 	else if (address == A(&psxRegs.cycle))
 	{
-		len = sprintf(buf, "psxRegs.cycle");
+		buf.append("psxRegs.cycle");
 	}
 	else if (address == A(&psxRegs.iopNextEventCycle))
 	{
-		len = sprintf(buf, "psxRegs.iopNextEventCycle");
+		buf.append("psxRegs.iopNextEventCycle");
+	}
+	else
+	{
+		return false;
 	}
 
 #undef A
 
-	return len;
+	return true;
 }
 
 static ZyanStatus ZydisFormatterPrintDisplacement(const ZydisFormatter* formatter,
 	ZydisFormatterBuffer* buffer, ZydisFormatterContext* context)
 {
-	char buf[128];
-	u32 len = 0;
 	u64 address = (u64)R3000A_TEXTPTR + context->operand->mem.disp.value;
+	bool did_print = false;
+	SmallString buf;
 
 	// hardcoded RTEXTPTR
 	if (context->operand->mem.base == ZYDIS_REGISTER_RBX) {
-		len = Address2Symbol(address, buf);
+		did_print = Address2Symbol(address, buf);
 	}
 
-	if (len > 0)
+	if (did_print)
 	{
 		ZYAN_CHECK(ZydisFormatterBufferAppend(buffer, ZYDIS_TOKEN_SYMBOL));
 		ZyanString* string;
 		ZYAN_CHECK(ZydisFormatterBufferGetString(buffer, &string));
-		return ZyanStringAppendFormat(string, "-%s+&%s", "R3000A_TEXTPTR", buf);
+		return ZyanStringAppendFormat(string, "-%s+&%s", "R3000A_TEXTPTR", buf.c_str());
 	}
 
 	return s_old_print_disp(formatter, buffer, context);
@@ -163,17 +166,17 @@ static ZyanStatus ZydisFormatterPrintAddressAbsolute(const ZydisFormatter* forma
 	ZYAN_CHECK(ZydisCalcAbsoluteAddress(context->instruction, context->operand,
 		context->runtime_address, &address));
 
-	char buf[128];
-	u32 len = 0;
+	SmallString buf;
+	bool did_print = false;
 
-	len = Address2Symbol(address, buf);
+	did_print = Address2Symbol(address, buf);
 
-	if (len > 0)
+	if (did_print)
 	{
 		ZYAN_CHECK(ZydisFormatterBufferAppend(buffer, ZYDIS_TOKEN_SYMBOL));
 		ZyanString* string;
 		ZYAN_CHECK(ZydisFormatterBufferGetString(buffer, &string));
-		return ZyanStringAppendFormat(string, "&%s", buf);
+		return ZyanStringAppendFormat(string, "&%s", buf.c_str());
 	}
 
 	return s_old_print_address(formatter, buffer, context);

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -99,6 +99,62 @@ static void iopRecError(int err);
 
 #ifdef DUMP_BLOCKS
 static ZydisFormatterFunc s_old_print_address;
+static ZydisFormatterFunc s_old_print_disp;
+
+static int Address2Symbol(u64 address, char* buf)
+{
+	u32 len = 0;
+
+#define A(x) ((u64)(x))
+
+	if (address >= A(iopMem->Main) && address < A(iopMem->P))
+	{
+		len = sprintf(buf, "iopMem+0x%08X", static_cast<u32>(address - A(iopMem->Main)));
+	}
+	else if (address >= A(&psxRegs.GPR) && address < A(&psxRegs.CP0))
+	{
+		len = sprintf(buf, "psxRegs.GPR.%s", R3000A::disRNameGPR[static_cast<u32>(address - A(&psxRegs)) / 4u]);
+	}
+	else if (address == A(&psxRegs.pc))
+	{
+		len = sprintf(buf, "psxRegs.pc");
+	}
+	else if (address == A(&psxRegs.cycle))
+	{
+		len = sprintf(buf, "psxRegs.cycle");
+	}
+	else if (address == A(&psxRegs.iopNextEventCycle))
+	{
+		len = sprintf(buf, "psxRegs.iopNextEventCycle");
+	}
+
+#undef A
+
+	return len;
+}
+
+static ZyanStatus ZydisFormatterPrintDisplacement(const ZydisFormatter* formatter,
+	ZydisFormatterBuffer* buffer, ZydisFormatterContext* context)
+{
+	char buf[128];
+	u32 len = 0;
+	u64 address = (u64)R3000A_TEXTPTR + context->operand->mem.disp.value;
+
+	// hardcoded RTEXTPTR
+	if (context->operand->mem.base == ZYDIS_REGISTER_RBX) {
+		len = Address2Symbol(address, buf);
+	}
+
+	if (len > 0)
+	{
+		ZYAN_CHECK(ZydisFormatterBufferAppend(buffer, ZYDIS_TOKEN_SYMBOL));
+		ZyanString* string;
+		ZYAN_CHECK(ZydisFormatterBufferGetString(buffer, &string));
+		return ZyanStringAppendFormat(string, "-%s+&%s", "R3000A_TEXTPTR", buf);
+	}
+
+	return s_old_print_disp(formatter, buffer, context);
+}
 
 static ZyanStatus ZydisFormatterPrintAddressAbsolute(const ZydisFormatter* formatter,
 	ZydisFormatterBuffer* buffer, ZydisFormatterContext* context)
@@ -110,30 +166,7 @@ static ZyanStatus ZydisFormatterPrintAddressAbsolute(const ZydisFormatter* forma
 	char buf[128];
 	u32 len = 0;
 
-#define A(x) ((u64)(x))
-
-	if (address >= A(iopMem->Main) && address < A(iopMem->P))
-	{
-		len = snprintf(buf, sizeof(buf), "iopMem+0x%08X", static_cast<u32>(address - A(iopMem->Main)));
-	}
-	else if (address >= A(&psxRegs.GPR) && address < A(&psxRegs.CP0))
-	{
-		len = snprintf(buf, sizeof(buf), "psxRegs.GPR.%s", R3000A::disRNameGPR[static_cast<u32>(address - A(&psxRegs)) / 4u]);
-	}
-	else if (address == A(&psxRegs.pc))
-	{
-		len = snprintf(buf, sizeof(buf), "psxRegs.pc");
-	}
-	else if (address == A(&psxRegs.cycle))
-	{
-		len = snprintf(buf, sizeof(buf), "psxRegs.cycle");
-	}
-	else if (address == A(&psxRegs.iopNextEventCycle))
-	{
-		len = snprintf(buf, sizeof(buf), "psxRegs.iopNextEventCycle");
-	}
-
-#undef A
+	len = Address2Symbol(address, buf);
 
 	if (len > 0)
 	{
@@ -918,8 +951,6 @@ static void recReserve()
 		pxFailRel("Failed to allocate R3000 InstCache array.");
 }
 
-#define R3000A_TEXTPTR (&psxRegs.GPR.r[33])
-
 void recResetIOP()
 {
 	DevCon.WriteLn("iR3000A Recompiler reset.");
@@ -1473,6 +1504,8 @@ void psxRecompileNextInstruction(bool delayslot, bool swapped_delayslot)
 			ZydisFormatterInit(&disas_formatter, ZYDIS_FORMATTER_STYLE_INTEL);
 			s_old_print_address = (ZydisFormatterFunc)&ZydisFormatterPrintAddressAbsolute;
 			ZydisFormatterSetHook(&disas_formatter, ZYDIS_FORMATTER_FUNC_PRINT_ADDRESS_ABS, (const void**)&s_old_print_address);
+			s_old_print_disp = (ZydisFormatterFunc)&ZydisFormatterPrintDisplacement;
+			ZydisFormatterSetHook(&disas_formatter, ZYDIS_FORMATTER_FUNC_PRINT_DISP, (const void**)&s_old_print_disp);
 		}
 	}
 #endif

--- a/pcsx2/x86/iR3000A.h
+++ b/pcsx2/x86/iR3000A.h
@@ -16,6 +16,8 @@ static const int psxInstCycles_Peephole_Store = 0;
 static const int psxInstCycles_Store = 0;
 static const int psxInstCycles_Load = 0;
 
+#define R3000A_TEXTPTR (&psxRegs.GPR.r[33])
+
 // to be consistent with EE
 #define PSX_HI XMMGPR_HI
 #define PSX_LO XMMGPR_LO

--- a/pcsx2/x86/ix86-32/iR5900.cpp
+++ b/pcsx2/x86/ix86-32/iR5900.cpp
@@ -1592,7 +1592,8 @@ void recMemcheck(u32 op, u32 bits, bool store)
 	iFlushCall(FLUSH_EVERYTHING | FLUSH_PC);
 
 	// compute accessed address
-	_eeMoveGPRtoR(ecx, (op >> 21) & 0x1F);
+	// Do not cache reg, we'll call outside jit here
+	_eeMoveGPRtoR(ecx, (op >> 21) & 0x1F, false);
 	if (static_cast<s16>(op) != 0)
 		xADD(ecx, static_cast<s16>(op));
 	if (bits == 128)

--- a/pcsx2/x86/ix86-32/iR5900.cpp
+++ b/pcsx2/x86/ix86-32/iR5900.cpp
@@ -121,6 +121,116 @@ static void pauseAAA()
 
 #ifdef DUMP_BLOCKS
 static ZydisFormatterFunc s_old_print_address;
+static ZydisFormatterFunc s_old_print_disp;
+
+static int Address2Symbol(u64 address, char* buf)
+{
+	u32 len = 0;
+
+#define A(x) ((u64)(x))
+
+	if (address >= A(eeMem->Main) && address < A(eeMem->Scratch))
+	{
+		len = sprintf(buf, "eeMem+0x%08X", static_cast<u32>(address - A(eeMem->Main)));
+	}
+	else if (address >= A(eeMem->Scratch) && address < A(eeMem->ROM))
+	{
+		len = sprintf(buf, "eeScratchpad+0x%08X", static_cast<u32>(address - A(eeMem->Scratch)));
+	}
+	else if (address >= A(&cpuRegs.GPR) && address < A(&cpuRegs.HI))
+	{
+		const u32 offset = static_cast<u32>(address - A(&cpuRegs)) % 16u;
+		if (offset != 0)
+			len = sprintf(buf, "cpuRegs.GPR.%s+%u", GPR_REG[static_cast<u32>(address - A(&cpuRegs)) / 16u], offset);
+		else
+			len = sprintf(buf, "cpuRegs.GPR.%s", GPR_REG[static_cast<u32>(address - A(&cpuRegs)) / 16u]);
+	}
+	else if (address >= A(&cpuRegs.HI) && address < A(&cpuRegs.CP0))
+	{
+		const u32 offset = static_cast<u32>(address - A(&cpuRegs.HI)) % 16u;
+		if (offset != 0)
+			len = sprintf(buf, "cpuRegs.%s+%u", (address >= A(&cpuRegs.LO) ? "LO" : "HI"), offset);
+		else
+			len = sprintf(buf, "cpuRegs.%s", (address >= A(&cpuRegs.LO) ? "LO" : "HI"));
+	}
+	else if (address == A(&cpuRegs.pc))
+	{
+		len = sprintf(buf, "cpuRegs.pc");
+	}
+	else if (address == A(&cpuRegs.cycle))
+	{
+		len = sprintf(buf, "cpuRegs.cycle");
+	}
+	else if (address == A(&cpuRegs.nextEventCycle))
+	{
+		len = sprintf(buf, "cpuRegs.nextEventCycle");
+	}
+	else if (address >= A(fpuRegs.fpr) && address < A(fpuRegs.fprc))
+	{
+		len = sprintf(buf, "fpuRegs.f%02u", static_cast<u32>(address - A(fpuRegs.fpr)) / 4u);
+	}
+	else if (address >= A(&VU0.VF[0]) && address < A(&VU0.VI[0]))
+	{
+		const u32 offset = static_cast<u32>(address - A(&VU0.VF[0])) % 16u;
+		if (offset != 0)
+			len = sprintf(buf, "VU0.VF[%02u]+%u", static_cast<u32>(address - A(&VU0.VF[0])) / 16u, offset);
+		else
+			len = sprintf(buf, "VU0.VF[%02u]", static_cast<u32>(address - A(&VU0.VF[0])) / 16u);
+	}
+	else if (address >= A(&VU0.VI[0]) && address < A(&VU0.ACC))
+	{
+		const u32 offset = static_cast<u32>(address - A(&VU0.VI[0])) % 16u;
+		const u32 vi = static_cast<u32>(address - A(&VU0.VI[0])) / 16u;
+		if (offset != 0)
+			len = sprintf(buf, "VU0.%s+%u", COP2_REG_CTL[vi], offset);
+		else
+			len = sprintf(buf, "VU0.%s", COP2_REG_CTL[vi]);
+	}
+	else if (address >= A(&VU0.ACC) && address < A(&VU0.q))
+	{
+		const u32 offset = static_cast<u32>(address - A(&VU0.ACC));
+		if (offset != 0)
+			len = sprintf(buf, "VU0.ACC+%u", offset);
+		else
+			len = sprintf(buf, "VU0.ACC");
+	}
+	else if (address >= A(&VU0.q) && address < A(&VU0.idx))
+	{
+		const u32 offset = static_cast<u32>(address - A(&VU0.q)) % 16u;
+		const char* reg = (address >= A(&VU0.p)) ? "p" : "q";
+		if (offset != 0)
+			len = sprintf(buf, "VU0.%s+%u", reg, offset);
+		else
+			len = sprintf(buf, "VU0.%s", reg);
+	}
+
+#undef A
+
+	return len;
+}
+
+static ZyanStatus ZydisFormatterPrintDisplacement(const ZydisFormatter* formatter,
+	ZydisFormatterBuffer* buffer, ZydisFormatterContext* context)
+{
+	char buf[128];
+	u32 len = 0;
+	u64 address = (u64)R5900_TEXTPTR + context->operand->mem.disp.value;
+
+	// hardcoded RTEXTPTR
+	if (context->operand->mem.base == ZYDIS_REGISTER_RBX) {
+		len = Address2Symbol(address, buf);
+	}
+
+	if (len > 0)
+	{
+		ZYAN_CHECK(ZydisFormatterBufferAppend(buffer, ZYDIS_TOKEN_SYMBOL));
+		ZyanString* string;
+		ZYAN_CHECK(ZydisFormatterBufferGetString(buffer, &string));
+		return ZyanStringAppendFormat(string, "-%s+&%s", "R5900_TEXTPTR", buf);
+	}
+
+	return s_old_print_disp(formatter, buffer, context);
+}
 
 static ZyanStatus ZydisFormatterPrintAddressAbsolute(const ZydisFormatter* formatter,
 	ZydisFormatterBuffer* buffer, ZydisFormatterContext* context)
@@ -132,84 +242,7 @@ static ZyanStatus ZydisFormatterPrintAddressAbsolute(const ZydisFormatter* forma
 	char buf[128];
 	u32 len = 0;
 
-#define A(x) ((u64)(x))
-
-	if (address >= A(eeMem->Main) && address < A(eeMem->Scratch))
-	{
-		len = snprintf(buf, sizeof(buf), "eeMem+0x%08X", static_cast<u32>(address - A(eeMem->Main)));
-	}
-	else if (address >= A(eeMem->Scratch) && address < A(eeMem->ROM))
-	{
-		len = snprintf(buf, sizeof(buf), "eeScratchpad+0x%08X", static_cast<u32>(address - A(eeMem->Scratch)));
-	}
-	else if (address >= A(&cpuRegs.GPR) && address < A(&cpuRegs.HI))
-	{
-		const u32 offset = static_cast<u32>(address - A(&cpuRegs)) % 16u;
-		if (offset != 0)
-			len = snprintf(buf, sizeof(buf), "cpuRegs.GPR.%s+%u", GPR_REG[static_cast<u32>(address - A(&cpuRegs)) / 16u], offset);
-		else
-			len = snprintf(buf, sizeof(buf), "cpuRegs.GPR.%s", GPR_REG[static_cast<u32>(address - A(&cpuRegs)) / 16u]);
-	}
-	else if (address >= A(&cpuRegs.HI) && address < A(&cpuRegs.CP0))
-	{
-		const u32 offset = static_cast<u32>(address - A(&cpuRegs.HI)) % 16u;
-		if (offset != 0)
-			len = snprintf(buf, sizeof(buf), "cpuRegs.%s+%u", (address >= A(&cpuRegs.LO) ? "LO" : "HI"), offset);
-		else
-			len = snprintf(buf, sizeof(buf), "cpuRegs.%s", (address >= A(&cpuRegs.LO) ? "LO" : "HI"));
-	}
-	else if (address == A(&cpuRegs.pc))
-	{
-		len = snprintf(buf, sizeof(buf), "cpuRegs.pc");
-	}
-	else if (address == A(&cpuRegs.cycle))
-	{
-		len = snprintf(buf, sizeof(buf), "cpuRegs.cycle");
-	}
-	else if (address == A(&cpuRegs.nextEventCycle))
-	{
-		len = snprintf(buf, sizeof(buf), "cpuRegs.nextEventCycle");
-	}
-	else if (address >= A(fpuRegs.fpr) && address < A(fpuRegs.fprc))
-	{
-		len = snprintf(buf, sizeof(buf), "fpuRegs.f%02u", static_cast<u32>(address - A(fpuRegs.fpr)) / 4u);
-	}
-	else if (address >= A(&VU0.VF[0]) && address < A(&VU0.VI[0]))
-	{
-		const u32 offset = static_cast<u32>(address - A(&VU0.VF[0])) % 16u;
-		if (offset != 0)
-			len = snprintf(buf, sizeof(buf), "VU0.VF[%02u]+%u", static_cast<u32>(address - A(&VU0.VF[0])) / 16u, offset);
-		else
-			len = snprintf(buf, sizeof(buf), "VU0.VF[%02u]", static_cast<u32>(address - A(&VU0.VF[0])) / 16u);
-	}
-	else if (address >= A(&VU0.VI[0]) && address < A(&VU0.ACC))
-	{
-		const u32 offset = static_cast<u32>(address - A(&VU0.VI[0])) % 16u;
-		const u32 vi = static_cast<u32>(address - A(&VU0.VI[0])) / 16u;
-		if (offset != 0)
-			len = snprintf(buf, sizeof(buf), "VU0.%s+%u", COP2_REG_CTL[vi], offset);
-		else
-			len = snprintf(buf, sizeof(buf), "VU0.%s", COP2_REG_CTL[vi]);
-	}
-	else if (address >= A(&VU0.ACC) && address < A(&VU0.q))
-	{
-		const u32 offset = static_cast<u32>(address - A(&VU0.ACC));
-		if (offset != 0)
-			len = snprintf(buf, sizeof(buf), "VU0.ACC+%u", offset);
-		else
-			len = snprintf(buf, sizeof(buf), "VU0.ACC");
-	}
-	else if (address >= A(&VU0.q) && address < A(&VU0.idx))
-	{
-		const u32 offset = static_cast<u32>(address - A(&VU0.q)) % 16u;
-		const char* reg = (address >= A(&VU0.p)) ? "p" : "q";
-		if (offset != 0)
-			len = snprintf(buf, sizeof(buf), "VU0.%s+%u", reg, offset);
-		else
-			len = snprintf(buf, sizeof(buf), "VU0.%s", reg);
-	}
-
-#undef A
+	len = Address2Symbol(address, buf);
 
 	if (len > 0)
 	{
@@ -2562,6 +2595,8 @@ StartRecomp:
 
 	s_old_print_address = (ZydisFormatterFunc)&ZydisFormatterPrintAddressAbsolute;
 	ZydisFormatterSetHook(&disas_formatter, ZYDIS_FORMATTER_FUNC_PRINT_ADDRESS_ABS, (const void**)&s_old_print_address);
+	s_old_print_disp = (ZydisFormatterFunc)&ZydisFormatterPrintDisplacement;
+	ZydisFormatterSetHook(&disas_formatter, ZYDIS_FORMATTER_FUNC_PRINT_DISP, (const void**)&s_old_print_disp);
 
 #if 0
 	const bool dump_block = (startpc == 0x00000000);

--- a/pcsx2/x86/ix86-32/iR5900.cpp
+++ b/pcsx2/x86/ix86-32/iR5900.cpp
@@ -123,110 +123,114 @@ static void pauseAAA()
 static ZydisFormatterFunc s_old_print_address;
 static ZydisFormatterFunc s_old_print_disp;
 
-static int Address2Symbol(u64 address, char* buf)
+static bool Address2Symbol(u64 address, SmallString &buf)
 {
-	u32 len = 0;
 
 #define A(x) ((u64)(x))
 
 	if (address >= A(eeMem->Main) && address < A(eeMem->Scratch))
 	{
-		len = sprintf(buf, "eeMem+0x%08X", static_cast<u32>(address - A(eeMem->Main)));
+		buf.append_format("eeMem+0x{:08X}", static_cast<u32>(address - A(eeMem->Main)));
 	}
 	else if (address >= A(eeMem->Scratch) && address < A(eeMem->ROM))
 	{
-		len = sprintf(buf, "eeScratchpad+0x%08X", static_cast<u32>(address - A(eeMem->Scratch)));
+
+		buf.append_format("eeScratchpad+0x{:08X}", static_cast<u32>(address - A(eeMem->Scratch)));
 	}
 	else if (address >= A(&cpuRegs.GPR) && address < A(&cpuRegs.HI))
 	{
 		const u32 offset = static_cast<u32>(address - A(&cpuRegs)) % 16u;
 		if (offset != 0)
-			len = sprintf(buf, "cpuRegs.GPR.%s+%u", GPR_REG[static_cast<u32>(address - A(&cpuRegs)) / 16u], offset);
+			buf.append_format("cpuRegs.GPR.{}+{}", GPR_REG[static_cast<u32>(address - A(&cpuRegs)) / 16u], offset);
 		else
-			len = sprintf(buf, "cpuRegs.GPR.%s", GPR_REG[static_cast<u32>(address - A(&cpuRegs)) / 16u]);
+			buf.append_format("cpuRegs.GPR.{}", GPR_REG[static_cast<u32>(address - A(&cpuRegs)) / 16u]);
 	}
 	else if (address >= A(&cpuRegs.HI) && address < A(&cpuRegs.CP0))
 	{
 		const u32 offset = static_cast<u32>(address - A(&cpuRegs.HI)) % 16u;
 		if (offset != 0)
-			len = sprintf(buf, "cpuRegs.%s+%u", (address >= A(&cpuRegs.LO) ? "LO" : "HI"), offset);
+			buf.append_format("cpuRegs.{}+{}", (address >= A(&cpuRegs.LO) ? "LO" : "HI"), offset);
 		else
-			len = sprintf(buf, "cpuRegs.%s", (address >= A(&cpuRegs.LO) ? "LO" : "HI"));
+			buf.append_format("cpuRegs.{}", (address >= A(&cpuRegs.LO) ? "LO" : "HI"));
 	}
 	else if (address == A(&cpuRegs.pc))
 	{
-		len = sprintf(buf, "cpuRegs.pc");
+		buf.append_format("cpuRegs.pc");
 	}
 	else if (address == A(&cpuRegs.cycle))
 	{
-		len = sprintf(buf, "cpuRegs.cycle");
+		buf.append_format("cpuRegs.cycle");
 	}
 	else if (address == A(&cpuRegs.nextEventCycle))
 	{
-		len = sprintf(buf, "cpuRegs.nextEventCycle");
+		buf.append_format("cpuRegs.nextEventCycle");
 	}
 	else if (address >= A(fpuRegs.fpr) && address < A(fpuRegs.fprc))
 	{
-		len = sprintf(buf, "fpuRegs.f%02u", static_cast<u32>(address - A(fpuRegs.fpr)) / 4u);
+		buf.append_format("fpuRegs.f{:02}", static_cast<u32>(address - A(fpuRegs.fpr)) / 4u);
 	}
 	else if (address >= A(&VU0.VF[0]) && address < A(&VU0.VI[0]))
 	{
 		const u32 offset = static_cast<u32>(address - A(&VU0.VF[0])) % 16u;
 		if (offset != 0)
-			len = sprintf(buf, "VU0.VF[%02u]+%u", static_cast<u32>(address - A(&VU0.VF[0])) / 16u, offset);
+			buf.append_format("VU0.VF[{:02}]+{}", static_cast<u32>(address - A(&VU0.VF[0])) / 16u, offset);
 		else
-			len = sprintf(buf, "VU0.VF[%02u]", static_cast<u32>(address - A(&VU0.VF[0])) / 16u);
+			buf.append_format("VU0.VF[{:02}]", static_cast<u32>(address - A(&VU0.VF[0])) / 16u);
 	}
 	else if (address >= A(&VU0.VI[0]) && address < A(&VU0.ACC))
 	{
 		const u32 offset = static_cast<u32>(address - A(&VU0.VI[0])) % 16u;
 		const u32 vi = static_cast<u32>(address - A(&VU0.VI[0])) / 16u;
 		if (offset != 0)
-			len = sprintf(buf, "VU0.%s+%u", COP2_REG_CTL[vi], offset);
+			buf.append_format("VU0.{}+{}", COP2_REG_CTL[vi], offset);
 		else
-			len = sprintf(buf, "VU0.%s", COP2_REG_CTL[vi]);
+			buf.append_format("VU0.{}", COP2_REG_CTL[vi]);
 	}
 	else if (address >= A(&VU0.ACC) && address < A(&VU0.q))
 	{
 		const u32 offset = static_cast<u32>(address - A(&VU0.ACC));
 		if (offset != 0)
-			len = sprintf(buf, "VU0.ACC+%u", offset);
+			buf.append_format("VU0.ACC+{}", offset);
 		else
-			len = sprintf(buf, "VU0.ACC");
+			buf.append("VU0.ACC");
 	}
 	else if (address >= A(&VU0.q) && address < A(&VU0.idx))
 	{
 		const u32 offset = static_cast<u32>(address - A(&VU0.q)) % 16u;
 		const char* reg = (address >= A(&VU0.p)) ? "p" : "q";
 		if (offset != 0)
-			len = sprintf(buf, "VU0.%s+%u", reg, offset);
+			buf.append_format("VU0.{}+{}", reg, offset);
 		else
-			len = sprintf(buf, "VU0.%s", reg);
+			buf.append_format("VU0.{}", reg);
+	}
+	else
+	{
+		return false;
 	}
 
 #undef A
 
-	return len;
+	return true;
 }
 
 static ZyanStatus ZydisFormatterPrintDisplacement(const ZydisFormatter* formatter,
 	ZydisFormatterBuffer* buffer, ZydisFormatterContext* context)
 {
-	char buf[128];
-	u32 len = 0;
 	u64 address = (u64)R5900_TEXTPTR + context->operand->mem.disp.value;
+	bool did_print = false;
+	SmallString buf;
 
 	// hardcoded RTEXTPTR
 	if (context->operand->mem.base == ZYDIS_REGISTER_RBX) {
-		len = Address2Symbol(address, buf);
+		did_print = Address2Symbol(address, buf);
 	}
 
-	if (len > 0)
+	if (did_print)
 	{
 		ZYAN_CHECK(ZydisFormatterBufferAppend(buffer, ZYDIS_TOKEN_SYMBOL));
 		ZyanString* string;
 		ZYAN_CHECK(ZydisFormatterBufferGetString(buffer, &string));
-		return ZyanStringAppendFormat(string, "-%s+&%s", "R5900_TEXTPTR", buf);
+		return ZyanStringAppendFormat(string, "-%s+&%s", "R5900_TEXTPTR", buf.c_str());
 	}
 
 	return s_old_print_disp(formatter, buffer, context);
@@ -239,17 +243,17 @@ static ZyanStatus ZydisFormatterPrintAddressAbsolute(const ZydisFormatter* forma
 	ZYAN_CHECK(ZydisCalcAbsoluteAddress(context->instruction, context->operand,
 		context->runtime_address, &address));
 
-	char buf[128];
-	u32 len = 0;
+	bool did_print = false;
+	SmallString buf;
 
-	len = Address2Symbol(address, buf);
+	did_print = Address2Symbol(address, buf);
 
-	if (len > 0)
+	if (did_print)
 	{
 		ZYAN_CHECK(ZydisFormatterBufferAppend(buffer, ZYDIS_TOKEN_SYMBOL));
 		ZyanString* string;
 		ZYAN_CHECK(ZydisFormatterBufferGetString(buffer, &string));
-		return ZyanStringAppendFormat(string, "&%s", buf);
+		return ZyanStringAppendFormat(string, "&%s", buf.c_str());
 	}
 
 	return s_old_print_address(formatter, buffer, context);


### PR DESCRIPTION
### Description of Changes
Stops the EE reg move in recMemCheck from caching the register in a host register.

Also enhances the Zydis output to add symbols to text pointer relative offsets.

### Rationale behind Changes
We call outside the JIT in this function, so any cached register will get stomped on.

### Suggested Testing Steps
Check that memory breakpoints still work.

### Did you use AI to help find, test, or implement this issue or feature?
No.