### PR TITLE
Qt: Disable Convert in the memory card context menu for PS1 cards

### DIFF
--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
@@ -291,7 +291,13 @@ void MemoryCardSettingsWidget::listContextMenuRequested(const QPoint& pos)
 		menu.addSeparator();
 
 		connect(menu.addAction(tr("Rename")), &QAction::triggered, this, &MemoryCardSettingsWidget::renameCard);
-		connect(menu.addAction(tr("Convert")), &QAction::triggered, this, &MemoryCardSettingsWidget::convertCard);
+
+		const std::optional<AvailableMcdInfo> cardInfo(FileMcd_GetCardInfo(selectedCard.toStdString()));
+		const bool isPS1 = (cardInfo.has_value() && cardInfo.value().file_type == MemoryCardFileType::PS1);
+		QAction* const convertAction = menu.addAction(tr("Convert"));
+		convertAction->setEnabled(!isPS1);
+		connect(convertAction, &QAction::triggered, this, &MemoryCardSettingsWidget::convertCard);
+
 		connect(menu.addAction(tr("Delete")), &QAction::triggered, this, &MemoryCardSettingsWidget::deleteCard);
 		menu.addSeparator();
 	}


### PR DESCRIPTION
Partially fixes [#13340](https://github.com/PCSX2/pcsx2/issues/13340)

The Convert toolbar button is already disabled for PS1 cards, but the right-click context menu always added an enabled Convert action, letting the user start a conversion that isn't valid for PS1 cards. Gate the context menu action on the same card-type check so it matches the button.

### Description of Changes
The "Convert" toolbar button in the Memory Cards settings is already disabled for PS1 cards (m_ui.convertCard->setEnabled(hasSelection && !isPS1)), but the right-click context menu always added an enabled "Convert" action. This let the user start a conversion that isn't valid for PS1 cards. The context menu action is now gated on the same card-type check, so it matches the button.

### Rationale behind Changes
This addresses one of the items reported in [#13340](https://github.com/PCSX2/pcsx2/issues/13340) (the "Convert" option being available for PS1 cards via right-click). It keeps the two entry points — the button and the context menu — consistent, using the same FileMcd_GetCardInfo / MemoryCardFileType::PS1 check already used to drive the button state.

### Suggested Testing Steps

Open Settings → Memory Cards.
Create/select a PS1 memory card.
Note the Convert toolbar button is disabled (existing behavior).
Right-click the PS1 card in the list → the Convert entry should now be greyed out (before: it was enabled).
Select a PS2 card and right-click → Convert remains enabled (unchanged).

### Did you use AI to help find, test, or implement this issue or feature?
Yes — AI assistance was used to locate the relevant code, and to build-validate the change locally (clang-17, Qt 6.11.1) replicating the Linux/Qt CI. The fix mirrors the existing button logic and I can explain the reasoning in full.