### PR TITLE
Qt: Add View menu toggle for main window fullscreen

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -347,6 +347,7 @@ void MainWindow::connectSignals()
 	connect(m_ui.actionViewToolbar, &QAction::toggled, this, &MainWindow::onViewToolbarActionToggled);
 	connect(m_ui.actionViewLockToolbar, &QAction::toggled, this, &MainWindow::onViewLockToolbarActionToggled);
 	connect(m_ui.actionViewStatusBar, &QAction::toggled, this, &MainWindow::onViewStatusBarActionToggled);
+	connect(m_ui.actionViewMainWindowFullscreen, &QAction::toggled, this, &MainWindow::onViewMainWindowFullscreenActionToggled);
 	connect(m_ui.actionViewGameList, &QAction::triggered, this, &MainWindow::onViewGameListActionTriggered);
 	connect(m_ui.actionViewGameGrid, &QAction::triggered, this, &MainWindow::onViewGameGridActionTriggered);
 	connect(m_ui.actionViewSystemDisplay, &QAction::triggered, this, &MainWindow::onViewSystemDisplayTriggered);
@@ -935,6 +936,8 @@ void MainWindow::restoreStateFromConfig()
 		if (Host::ContainsBaseSettingValue("UI", "MainWindowFullscreen"))
 		{
 			const bool fullscreen = Host::GetBaseBoolSettingValue("UI", "MainWindowFullscreen");
+			QSignalBlocker sb(m_ui.actionViewMainWindowFullscreen);
+			m_ui.actionViewMainWindowFullscreen->setChecked(fullscreen);
 			if (fullscreen)
 				showFullScreen();
 		}
@@ -1775,6 +1778,16 @@ void MainWindow::onViewStatusBarActionToggled(bool checked)
 	Host::SetBaseBoolSettingValue("UI", "ShowStatusBar", checked);
 	Host::CommitBaseSettingChanges();
 	m_ui.statusBar->setVisible(checked);
+}
+
+void MainWindow::onViewMainWindowFullscreenActionToggled(bool checked)
+{
+	Host::SetBaseBoolSettingValue("UI", "MainWindowFullscreen", checked);
+	Host::CommitBaseSettingChanges();
+	if (checked)
+		showFullScreen();
+	else
+		showNormal();
 }
 
 void MainWindow::onViewGameListActionTriggered()

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -163,6 +163,7 @@ private Q_SLOTS:
 	void onViewToolbarActionToggled(bool checked);
 	void onViewLockToolbarActionToggled(bool checked);
 	void onViewStatusBarActionToggled(bool checked);
+	void onViewMainWindowFullscreenActionToggled(bool checked);
 	void onViewGameListActionTriggered();
 	void onViewGameGridActionTriggered();
 	void onViewSystemDisplayTriggered();

--- a/pcsx2-qt/MainWindow.ui
+++ b/pcsx2-qt/MainWindow.ui
@@ -166,6 +166,7 @@
     <addaction name="actionViewLockToolbar"/>
     <addaction name="actionViewStatusBar"/>
     <addaction name="actionViewStatusBarVerbose"/>
+    <addaction name="actionViewMainWindowFullscreen"/>
     <addaction name="separator"/>
     <addaction name="actionViewGameList"/>
     <addaction name="actionViewGameGrid"/>
@@ -754,6 +755,14 @@
    </property>
    <property name="text">
     <string>&amp;Verbose Status</string>
+   </property>
+  </action>
+  <action name="actionViewMainWindowFullscreen">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Fullscreen Main &amp;Window</string>
    </property>
   </action>
   <action name="actionViewGameList">


### PR DESCRIPTION
### Description of Changes
Adds a checkable "Fullscreen Main Window" entry to the View menu. Toggling it shows/restores the main window in fullscreen and persists the existing UI/MainWindowFullscreen setting. The menu item is also synchronized with the saved setting on startup.

### Rationale behind Changes
The MainWindowFullscreen setting was added in [#13249](https://github.com/Cho1409/pcsx2/issues/13249), but until now it could only be enabled by manually editing PCSX2.ini. This exposes it through the GUI so it can be turned on/off without hand-editing the config file. Closes [#14405](https://github.com/PCSX2/pcsx2/issues/14405).

### Suggested Testing Steps

1. Open the main window (game list).
2. Use View → Fullscreen Main Window and confirm the window enters fullscreen; toggle again to restore.
3. Enable it, close PCSX2, and reopen — the main window should start in fullscreen and the menu item should be checked.
4. Disable it and confirm MainWindowFullscreen = false is written and the window starts normally on next launch.

### Did you use AI to help find, test, or implement this issue or feature?
Yes — as an assistant for locating the relevant code, researching how the existing MainWindowFullscreen setting is read/written, and validating the build. I understand and can fully explain the change; the menu action follows the same pattern as the existing View toggles (toolbar/status bar).