### PR TITLE
GameList: Apply custom title/region to cached entries

### DIFF
--- a/pcsx2/GameList.cpp
+++ b/pcsx2/GameList.cpp
@@ -65,9 +65,11 @@ namespace GameList
 	static bool GetGameListEntryFromCache(const std::string& path, GameList::Entry* entry);
 	static void ScanDirectory(const char* path, bool recursive, bool only_cache, const std::vector<std::string>& excluded_paths,
 		const PlayedTimeMap& played_time_map, const INISettingsInterface& custom_attributes_ini, ProgressCallback* progress);
-	static bool AddFileFromCache(const std::string& path, std::time_t timestamp, const PlayedTimeMap& played_time_map);
+	static bool AddFileFromCache(const std::string& path, std::time_t timestamp, const PlayedTimeMap& played_time_map,
+		const INISettingsInterface& custom_attributes_ini);
 	static bool ScanFile(std::string path, std::time_t timestamp, std::unique_lock<std::recursive_mutex>& lock,
 		const PlayedTimeMap& played_time_map, const INISettingsInterface& custom_attributes_ini);
+	static void ApplyCustomAttributes(GameList::Entry* entry, const INISettingsInterface& custom_attributes_ini);
 
 	static void LoadCache();
 	static bool LoadEntriesFromCache(std::FILE* stream);
@@ -716,7 +718,7 @@ void GameList::ScanDirectory(const char* path, bool recursive, bool only_cache, 
 		}
 
 		std::unique_lock lock(s_mutex);
-		if (GetEntryForPath(ffd.FileName.c_str()) || AddFileFromCache(ffd.FileName, ffd.ModificationTime, played_time_map) || only_cache)
+		if (GetEntryForPath(ffd.FileName.c_str()) || AddFileFromCache(ffd.FileName, ffd.ModificationTime, played_time_map, custom_attributes_ini) || only_cache)
 		{
 			continue;
 		}
@@ -731,7 +733,23 @@ void GameList::ScanDirectory(const char* path, bool recursive, bool only_cache, 
 	progress->PopState();
 }
 
-bool GameList::AddFileFromCache(const std::string& path, std::time_t timestamp, const PlayedTimeMap& played_time_map)
+void GameList::ApplyCustomAttributes(GameList::Entry* entry, const INISettingsInterface& custom_attributes_ini)
+{
+	auto custom_title = custom_attributes_ini.GetOptionalStringValue(EncodeIniKey(entry->path).c_str(), "Title");
+	if (custom_title)
+		entry->title = std::move(custom_title.value());
+
+	const auto custom_region = custom_attributes_ini.GetOptionalIntValue(EncodeIniKey(entry->path).c_str(), "Region");
+	if (custom_region)
+	{
+		const int custom_region_value = custom_region.value();
+		if (custom_region_value >= 0 && custom_region_value < static_cast<int>(Region::Count))
+			entry->region = static_cast<Region>(custom_region_value);
+	}
+}
+
+bool GameList::AddFileFromCache(const std::string& path, std::time_t timestamp, const PlayedTimeMap& played_time_map,
+	const INISettingsInterface& custom_attributes_ini)
 {
 	Entry entry;
 	if (!GetGameListEntryFromCache(path, &entry) || entry.last_modified_time != timestamp)
@@ -747,6 +765,8 @@ bool GameList::AddFileFromCache(const std::string& path, std::time_t timestamp, 
 		entry.last_played_time = iter->second.last_played_time;
 		entry.total_played_time = iter->second.total_played_time;
 	}
+
+	ApplyCustomAttributes(&entry, custom_attributes_ini);
 
 	s_entries.push_back(std::move(entry));
 	return true;
@@ -786,20 +806,7 @@ bool GameList::ScanFile(std::string path, std::time_t timestamp, std::unique_loc
 		entry.total_played_time = iter->second.total_played_time;
 	}
 
-	auto custom_title = custom_attributes_ini.GetOptionalStringValue(EncodeIniKey(entry.path).c_str(), "Title");
-	if (custom_title)
-	{
-		entry.title = std::move(custom_title.value());
-	}
-	const auto custom_region = custom_attributes_ini.GetOptionalIntValue(EncodeIniKey(entry.path).c_str(), "Region");
-	if (custom_region)
-	{
-		const int custom_region_value = custom_region.value();
-		if (custom_region_value >= 0 && custom_region_value < static_cast<int>(Region::Count))
-		{
-			entry.region = static_cast<Region>(custom_region_value);
-		}
-	}
+	ApplyCustomAttributes(&entry, custom_attributes_ini);
 
 	lock.lock();
 


### PR DESCRIPTION
Custom titles and regions from custom_properties.ini were only applied in ScanFile(), which runs when a game is freshly scanned. On startup entries are loaded from the cache via AddFileFromCache(), which did not apply them, and the cache is written before the custom values are applied, so it stores the original title. The overrides therefore only showed up after a full rescan.

Move the custom attribute application into a shared ApplyCustomAttributes() helper and call it from AddFileFromCache() as well, so cached entries pick up the overrides on startup.

Fixes #10303

### Description of Changes
Custom titles and regions stored in custom_properties.ini were only applied in ScanFile(), which runs when a game is freshly scanned. On startup, entries are loaded from the cache via AddFileFromCache(), which didn't apply them — and the cache is written before the custom values are applied, so it stores the original title. As a result, the overrides only appeared after a full "Rescan All Games". This moves the custom-attribute application into a shared ApplyCustomAttributes() helper and calls it from AddFileFromCache() too, so cached entries pick up the overrides on startup.

### Rationale behind Changes
Renaming a game or overriding its region should persist across restarts without a manual rescan ([#10303](https://github.com/PCSX2/pcsx2/issues/10303)). The cache path was the one spot that skipped applying the overrides; routing both the scan and cache paths through one helper keeps them in sync and avoids duplicating the logic.

### Suggested Testing Steps

1. Add a game directory and let the list populate.
2. Rename a game (or change its region) via right-click → the title updates.
3. Close PCSX2 and relaunch.
4. Before: the game shows its original title until "Rescan All Games". After: the custom title/region is shown immediately on startup.
5. Confirm a fresh rescan still applies overrides as before.

### Did you use AI to help find, test, or implement this issue or feature?
Yes — AI assistance was used to locate the root cause in GameList.cpp and to build-validate the change locally (clang-17, Qt 6.11.1) replicating the Linux/Qt CI. The fix mirrors the existing scan-path logic and I can explain the reasoning in full.