### PR TITLE
GameList: Honor custom title when Prefer English Titles is enabled

### DIFF
--- a/pcsx2/GameList.cpp
+++ b/pcsx2/GameList.cpp
@@ -790,6 +790,7 @@ bool GameList::ScanFile(std::string path, std::time_t timestamp, std::unique_loc
 	if (custom_title)
 	{
 		entry.title = std::move(custom_title.value());
+		entry.title_en.clear();
 	}
 	const auto custom_region = custom_attributes_ini.GetOptionalIntValue(EncodeIniKey(entry.path).c_str(), "Region");
 	if (custom_region)


### PR DESCRIPTION
A custom title from custom_properties.ini was only written to Entry::title, but the game list displays Entry::GetTitle(), which returns title_en when "Prefer English Titles" is enabled and the game has a separate English database name. The custom title was therefore ignored in that mode (e.g. Monster Hunter 2).

Also set title_en to the custom title so the override is shown regardless of the language preference.

Fixes #11850

### Description of Changes
A custom title from custom_properties.ini was only written to Entry::title, but the game list displays Entry::GetTitle(), which returns title_en when "Prefer English Titles" is enabled and the game has a separate English database name. The custom title was therefore ignored in that mode (e.g. Monster Hunter 2 showing its DB English name instead of the user's title). This also sets title_en to the custom title, so the override is honored regardless of the language preference.

### Rationale behind Changes
A user-provided custom title is an explicit override and should be shown no matter the language preference. The display path already had everything it needed; the override simply wasn't being applied to the field GetTitle() falls back to under the English preference. Games without a separate English title were unaffected, which is why only certain titles (those with a distinct title_en) exhibited the bug.

### Suggested Testing Steps

1. Enable Settings → Interface → Prefer English Titles.
2. Pick a game that has a distinct English database title (e.g. Monster Hunter 2).
3. Set a custom Title in its per-game settings (Summary).
4. Before: the grid/list still shows the English DB title. After: it shows the custom title.
5. Disable "Prefer English Titles" and confirm the custom title still shows (unchanged).
6. A game without a custom title still respects the English preference normally.

### Did you use AI to help find, test, or implement this issue or feature?
Yes — AI assistance was used to trace the root cause through Entry::GetTitle() and to build-validate the change locally (clang-17, Qt 6.11.1) replicating the Linux/Qt CI. The fix is two lines mirroring the existing override and I can explain the reasoning in full.