### PR TITLE
Qt: Use effective card values when swapping memory cards

### DIFF
--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
@@ -326,17 +326,17 @@ void MemoryCardSettingsWidget::swapCards()
 {
 	const std::string card1Key = getSlotFilenameKey(0);
 	const std::string card2Key = getSlotFilenameKey(1);
-	std::optional<std::string> card1Name = dialog()->getStringValue(CONFIG_SECTION, card1Key.c_str(), std::nullopt);
-	std::optional<std::string> card2Name = dialog()->getStringValue(CONFIG_SECTION, card2Key.c_str(), std::nullopt);
-	if (!card1Name.has_value() || card1Name->empty() || !card2Name.has_value() || card2Name->empty())
+	const std::string card1Name = dialog()->getEffectiveStringValue(CONFIG_SECTION, card1Key.c_str(), FileMcd_GetDefaultName(0).c_str());
+	const std::string card2Name = dialog()->getEffectiveStringValue(CONFIG_SECTION, card2Key.c_str(), FileMcd_GetDefaultName(1).c_str());
+	if (card1Name.empty() || card2Name.empty())
 	{
 		QMessageBox::critical(
 			QtUtils::GetRootWidget(this), tr("Error"), tr("Both slots must have a card selected to swap."));
 		return;
 	}
 
-	dialog()->setStringSettingValue(CONFIG_SECTION, card1Key.c_str(), card2Name->c_str());
-	dialog()->setStringSettingValue(CONFIG_SECTION, card2Key.c_str(), card1Name->c_str());
+	dialog()->setStringSettingValue(CONFIG_SECTION, card1Key.c_str(), card2Name.c_str());
+	dialog()->setStringSettingValue(CONFIG_SECTION, card2Key.c_str(), card1Name.c_str());
 	refresh();
 }
 


### PR DESCRIPTION
swapCards() read the slot filenames with getStringValue(), which only looks at the current settings layer. In per-game settings, cards assigned only at the global level aren't present in that layer, so the swap bailed out with "Both slots must have a card selected to swap." even though the slots show cards.

Read the effective values (the same ones the slot widgets display) so the swap works against globally-assigned cards too.

Fixes #10723

### Description of Changes
swapCards() read the slot filenames with getStringValue(), which only looks at the current settings layer. In per-game settings, cards assigned only at the global level aren't present in that layer, so the swap bailed out with "Both slots must have a card selected to swap." even though the slot widgets clearly show cards. The swap now reads the effective values via getEffectiveStringValue() — the same source the slot widgets use to display — so it works against globally-assigned cards too.

### Rationale behind Changes
The display path (refresh()) already uses getEffectiveStringValue() (per-game override → global → default), which is why the cards appear in the per-game view. The swap path was the lone spot still reading only the per-game layer, producing a confusing error. Routing it through the same effective lookup makes the two consistent and lets users rearrange globally-assigned cards at the per-game level ([#10723](https://github.com/PCSX2/pcsx2/issues/10723)).

### Suggested Testing Steps

1. Create and format two memory cards.
2. Assign both in global settings (Slot 1 / Slot 2).
3. Open a game's per-game memory card settings (don't override anything).
4. Click Swap Memory Cards.
5. Before: error "Both slots must have a card selected to swap." After: the two cards swap (saved as per-game overrides).
6. Confirm swapping in global settings still works as before.

### Did you use AI to help find, test, or implement this issue or feature?
Yes — AI assistance was used to trace the root cause (getStringValue vs getEffectiveStringValue) and to build-validate the change locally (clang-17, Qt 6.11.1) replicating the Linux/Qt CI. The fix mirrors the existing display logic and I can explain the reasoning in full.