### PR TITLE
Qt: Sort game list region filter by translated name

### DIFF
--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -34,6 +34,8 @@
 #include <QtWidgets/QStyledItemDelegate>
 #include <QShortcut>
 
+#include <algorithm>
+
 static const char* SUPPORTED_FORMATS_STRING = QT_TRANSLATE_NOOP(GameListWidget,
 	".bin/.iso (ISO Disc Images)\n"
 	".mdf (Media Descriptor File)\n"
@@ -232,10 +234,22 @@ void GameListWidget::initialize()
 		}
 	}
 
+	std::array<GameList::Region, static_cast<size_t>(GameList::Region::Count)> filter_regions;
 	for (u32 region = 0; region < static_cast<u32>(GameList::Region::Count); region++)
+		filter_regions[region] = static_cast<GameList::Region>(region);
+
+	std::sort(filter_regions.begin(), filter_regions.end(), [](GameList::Region lhs, GameList::Region rhs) {
+		if (lhs == GameList::Region::Other || rhs == GameList::Region::Other)
+			return rhs == GameList::Region::Other && lhs != GameList::Region::Other;
+
+		return QtHost::LocaleSensitiveCompare(QString::fromUtf8(GameList::RegionToString(lhs, true)),
+			QString::fromUtf8(GameList::RegionToString(rhs, true))) < 0;
+	});
+
+	for (const GameList::Region region : filter_regions)
 	{
-		m_ui.filterRegion->addItem(GameListModel::getIconForRegion(static_cast<GameList::Region>(region)),
-			GameList::RegionToString(static_cast<GameList::Region>(region), true));
+		m_ui.filterRegion->addItem(GameListModel::getIconForRegion(region),
+			GameList::RegionToString(region, true), static_cast<u32>(region));
 	}
 
 	connect(m_ui.viewGameList, &QPushButton::clicked, this, &GameListWidget::showGameList);
@@ -246,7 +260,8 @@ void GameListWidget::initialize()
 		m_sort_model->setFilterType((index == 0) ? GameList::EntryType::Count : static_cast<GameList::EntryType>(index - 1));
 	});
 	connect(m_ui.filterRegion, &QComboBox::currentIndexChanged, this, [this](int index) {
-		m_sort_model->setFilterRegion((index == 0) ? GameList::Region::Count : static_cast<GameList::Region>(index - 1));
+		const QVariant region_data = m_ui.filterRegion->itemData(index);
+		m_sort_model->setFilterRegion(region_data.isValid() ? static_cast<GameList::Region>(region_data.toUInt()) : GameList::Region::Count);
 	});
 	connect(m_ui.searchText, &QLineEdit::textChanged, this, [this](const QString& text) {
 		m_sort_model->setFilterName(text);


### PR DESCRIPTION
The region filter dropdown was populated in Region enum order and never re-sorted by the displayed string, so "Other" sat between the NTSC and PAL entries and the order didn't follow the active translation.

Sort the regions by their translated name (locale-aware) before inserting, keeping "All Regions" pinned first, and stash the Region enum in each item's user data so the filter slot stays correct regardless of item order.

Fixes #12792

### Description of Changes
The game list's region filter dropdown was built in Region enum order and never re-sorted by the string it actually shows. In GameListWidget::initialize() the regions are now sorted by their translated name (QString::localeAwareCompare) before being added, with "All Regions" left pinned at index 0. Each item now carries its Region enum in user data, and the filter slot reads that back instead of relying on index - 1, so the mapping survives the reordering.

### Rationale behind Changes
Because the items followed enum order, "Other" always landed between the NTSC and PAL groups, and the order never tracked the active translation — exactly what the report shows. Sorting by the displayed (translated) string fixes both. The index - 1 → enum assumption in the slot only held while insertion order matched the enum, so the region is now stored per-item and read from itemData(). Fixes [#12792](https://github.com/Cho1409/pcsx2/issues/12792).

### Suggested Testing Steps

1. Open PCSX2 with at least one game in the list.
2. Open the region dropdown — "All Regions" is first, the rest alphabetical by name.
3. Switch the language to a non-English one and reopen — order follows the translated strings.
4. Pick a few regions and confirm the list filters to the correct region each time.

### Did you use AI to help find, test, or implement this issue or feature?
Yes. AI assistance was used to trace the root cause (dropdown populated in enum order + the index - 1 slot mapping that blocked re-sorting) and to build-validate the change locally (clang-17, Qt 6.11.1) replicating the Linux/Qt CI. The fix mirrors the existing display logic and I can explain the reasoning in full.