### PR TITLE
GS: Update target TEX0 on a move if buffer width is increased.

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -5296,7 +5296,8 @@ bool GSTextureCache::Move(u32 SBP, u32 SBW, u32 SPSM, int sx, int sy, u32 DBP, u
 			req_resize = true;
 
 			// If it was matched to an old target, make sure to clear the other type and update its information.
-			if (dst->m_was_dst_matched)
+			// Also update information if the buffer width of the new data is larger than the existing target.
+			if (dst->m_was_dst_matched || (Common::AlignUpPow2(w, 64) / GSLocalMemory::m_psm[new_TEX0.PSM].pgs.x) > dst->m_TEX0.TBW)
 			{
 				dst->m_TEX0 = new_TEX0;
 			}


### PR DESCRIPTION
### Description of Changes
Update target TEX0 on a move if buffer width is increased.

Suggested by @refractionpcsx2 

### Rationale behind Changes
Partly fixes issue https://github.com/PCSX2/pcsx2/issues/14578 (does not fix the upscaling shadow issue)

### Suggested Testing Steps
Test the dump in the issue with PR on a HW renderer. The blob creates should appear normally.

Master
<img width="512" height="448" alt="02105_f00002_fr1_00700_C_32" src="https://github.com/user-attachments/assets/335bf47f-e263-48ee-9c54-001ee7fc37ab" />

PR
<img width="512" height="448" alt="02105_f00002_fr1_00700_C_32" src="https://github.com/user-attachments/assets/52a012fd-e08c-4f60-93c8-b659c9a4d158" />

So far tested in a dup run at max blend.

### Did you use AI to help find, test, or implement this issue or feature?
No.