### PR TITLE
Misc: Fix some valgrind errors

### DIFF
--- a/pcsx2-qt/Debugger/Memory/MemoryView.h
+++ b/pcsx2-qt/Debugger/Memory/MemoryView.h
@@ -50,15 +50,15 @@ private:
 	QWidget* parent;
 	MemoryViewType displayType = MemoryViewType::BYTE;
 	bool littleEndian = true;
-	u32 rowCount;
-	u32 rowVisible;
-	s32 rowHeight;
+	u32 rowCount = 0;
+	u32 rowVisible = 0;
+	s32 rowHeight = 0;
 
 	// Stuff used for selection handling
 	// This gets set every paint and depends on the window size / current display mode (1byte,2byte,etc)
-	s32 valuexAxis; // Where the hexadecimal view begins
-	s32 textXAxis; // Where the text view begins
-	s32 row1YAxis; // Where the first row starts
+	s32 valuexAxis = 0; // Where the hexadecimal view begins
+	s32 textXAxis = 0; // Where the text view begins
+	s32 row1YAxis = 0; // Where the first row starts
 	s32 segmentXAxis[16]; // Where the segments begin
 	bool selectedText = false; // Whether the user has clicked on text or hex
 
@@ -89,9 +89,9 @@ public:
 	{
 	}
 
-	u32 startAddress;
-	u32 selectedAddress;
-	s32 selectedIndex;
+	u32 startAddress = 0;
+	u32 selectedAddress = 0;
+	s32 selectedIndex = 0;
 
 	void UpdateStartAddress(u32 start);
 	void UpdateSelectedAddress(u32 selected, bool page = false);

--- a/pcsx2/Host/AudioStream.cpp
+++ b/pcsx2/Host/AudioStream.cpp
@@ -819,13 +819,3 @@ void AudioStreamParameters::LoadSave(SettingsWrapper& wrap, const char* section)
 		expand_high_cutoff = std::min<u8>(expand_high_cutoff, 100);
 	}
 }
-
-bool AudioStreamParameters::operator!=(const AudioStreamParameters& rhs) const
-{
-	return (std::memcmp(this, &rhs, sizeof(*this)) != 0);
-}
-
-bool AudioStreamParameters::operator==(const AudioStreamParameters& rhs) const
-{
-	return (std::memcmp(this, &rhs, sizeof(*this)) == 0);
-}

--- a/pcsx2/Host/AudioStreamTypes.h
+++ b/pcsx2/Host/AudioStreamTypes.h
@@ -5,6 +5,8 @@
 
 #include "common/Pcsx2Defs.h"
 
+#include <compare>
+
 class SettingsWrapper;
 
 enum class AudioBackend : u8
@@ -75,6 +77,5 @@ struct AudioStreamParameters
 
 	void LoadSave(SettingsWrapper& wrap, const char* section);
 
-	bool operator==(const AudioStreamParameters& rhs) const;
-	bool operator!=(const AudioStreamParameters& rhs) const;
+	friend auto operator<=>(const AudioStreamParameters& lhs, const AudioStreamParameters& rhs) = default;
 };


### PR DESCRIPTION
### Description of Changes
Fix some uninitialized reads.

### Rationale behind Changes

Valgrind was reporting some uninitialized reads:
```
==70261== Conditional jump or move depends on uninitialised value(s)
==70261==    at 0x4A54118: MemoryViewTable::DrawTable(QPainter&, QPalette const&, int, DebugInterface&) (pcsx2-qt/Debugger/Memory/MemoryView.cpp:81)
==70261==    by 0x4A570D7: MemoryView::paintEvent(QPaintEvent*) (pcsx2-qt/Debugger/Memory/MemoryView.cpp:758)
==70261==    by 0x1331BB57: QWidget::event(QEvent*) (in /home/thomas/projects/pcsx2/deps/lib/libQt6Widgets.so.6.11.1)
==70261==    by 0x132A9B39: QApplicationPrivate::notify_helper(QObject*, QEvent*) (in /home/thomas/projects/pcsx2/deps/lib/libQt6Widgets.so.6.11.1)
==70261==    by 0x146DDE37: QCoreApplication::notifyInternal2(QObject*, QEvent*) (in /home/thomas/projects/pcsx2/deps/lib/libQt6Core.so.6.11.1)
==70261==    by 0x133113E7: QWidgetPrivate::sendPaintEvent(QRegion const&) (in /home/thomas/projects/pcsx2/deps/lib/libQt6Widgets.so.6.11.1)
==70261==    by 0x13311DBD: QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) (in /home/thomas/projects/pcsx2/deps/lib/libQt6Widgets.so.6.11.1)
==70261==    by 0x1331337A: QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) (in /home/thomas/projects/pcsx2/deps/lib/libQt6Widgets.so.6.11.1)
==70261==    by 0x13311A6C: QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) (in /home/thomas/projects/pcsx2/deps/lib/libQt6Widgets.so.6.11.1)
==70261==    by 0x1331337A: QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) (in /home/thomas/projects/pcsx2/deps/lib/libQt6Widgets.so.6.11.1)
==70261==    by 0x13311A6C: QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) (in /home/thomas/projects/pcsx2/deps/lib/libQt6Widgets.so.6.11.1)
==70261==    by 0x1331337A: QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) (in /home/thomas/projects/pcsx2/deps/lib/libQt6Widgets.so.6.11.1)
```
and
```
==70261== Conditional jump or move depends on uninitialised value(s)
==70261==    at 0x1248677E: bcmp (vg_replace_strmem.c:1237)
==70261==    by 0x478825A: AudioStreamParameters::operator!=(AudioStreamParameters const&) const (pcsx2/Host/AudioStream.cpp:825)
==70261==    by 0x450104D: SPU2::CheckForConfigChanges(Pcsx2Config const&) (pcsx2/SPU2/spu2.cpp:360)
==70261==    by 0x44965CB: VMManager::CheckForConfigChanges(Pcsx2Config const&) (pcsx2/VMManager.cpp:3114)
==70261==    by 0x449F852: VMManager::ApplyCoreSettings() (pcsx2/VMManager.cpp:797)
==70261==    by 0x449D15F: VMManager::HandleELFChange(bool) (pcsx2/VMManager.cpp:1187)
==70261==    by 0x449D3C6: SaveStateBase::vmFreeze() (pcsx2/VMManager.cpp:1846)
==70261==    by 0x444D76A: SaveStateBase::FreezeInternals(Error*) (pcsx2/SaveState.cpp:179)
==70261==    by 0x444F3ED: LoadInternalStructuresState (pcsx2/SaveState.cpp:1159)
==70261==    by 0x444F3ED: SaveState_UnzipFromDisk(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Error*) (pcsx2/SaveState.cpp:1208)
==70261==    by 0x449BE34: VMManager::DoLoadState(char const*, Error*) (pcsx2/VMManager.cpp:1905)
==70261==    by 0x4499F61: VMManager::Initialize(VMBootParameters const&, Error*) (pcsx2/VMManager.cpp:1639)
==70261==    by 0x4498334: VMManager::InitializeAsync(VMBootParameters const&, std::function<void (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::function<void ()>)>, std::function<void (VMBootResult, Error const&)>) (pcsx2/VMManager.cpp:1315)
```

In the latter case, you can't memcmp whole structs like that, since the compiler inserts padding which is uninitialized.

### Suggested Testing Steps

N/A

### Did you use AI to help find, test, or implement this issue or feature?
Yes, my agentic AI operating system Valgrind told me to, so I obediently complied.