### PR TITLE
GS:MTL: ROV Support

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -899,7 +899,7 @@ struct alignas(16) GSHWDrawConfig
 
 		__fi bool HasDepthROV() const
 		{
-			return rov_depth == PS_ROV_DEPTH::READ_ONLY || rov_depth == PS_ROV_DEPTH::READ_WRITE;
+			return rov_depth != PS_ROV_DEPTH::NONE;
 		}
 
 		__fi bool HasDepthROVWrite() const

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
@@ -451,6 +451,7 @@ public:
 	void MRESetDSS(id<MTLDepthStencilState> dss);
 	void MRESetSampler(SamplerSelector sel);
 	void MRESetTexture(GSTexture* tex, int pos);
+	void MRESetTexture(id<MTLTexture> tex, int pos);
 	void MRESetVertices(id<MTLBuffer> buffer, size_t offset);
 	void MRESetVSIndices(id<MTLBuffer> buffer, size_t offset);
 	void MRESetScissor(const GSVector4i& scissor);

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
@@ -279,6 +279,7 @@ public:
 	std::unordered_map<PipelineSelectorMTL, MRCOwned<id<MTLRenderPipelineState>>> m_hw_pipeline;
 
 	MRCOwned<MTLRenderPassDescriptor*> m_render_pass_desc[16];
+	MRCOwned<MTLRenderPassDescriptor*> m_full_rov_render_pass_desc;
 
 	MRCOwned<id<MTLSamplerState>> m_sampler_hw[1 << 8];
 
@@ -316,12 +317,14 @@ public:
 		// Clear line (Things below here are tracked by `has` and don't need to be cleared to reset)
 		SamplerSelector sampler_sel;
 		u8 blend_color;
+		struct { u32 w, h; } full_rov_size;
 		GSVector4i scissor;
 		PipelineSelectorMTL pipeline_sel;
 		GSHWDrawConfig::VSConstantBuffer cb_vs;
 		GSHWDrawConfig::PSConstantBuffer cb_ps;
 		MainRenderEncoder(const MainRenderEncoder&) = delete;
 		MainRenderEncoder() = default;
+		bool is_full_rov() const { return encoder && !color_target && !depth_target && !stencil_target; }
 	} m_current_render;
 	MRCOwned<id<MTLCommandBuffer>> m_texture_upload_cmdbuf;
 	MRCOwned<id<MTLBlitCommandEncoder>> m_texture_upload_encoder;
@@ -330,6 +333,8 @@ public:
 	MRCOwned<id<MTLBlitCommandEncoder>> m_vertex_upload_encoder;
 	id<MTLTexture> m_ds_as_rt_texture = nil;
 	GSTexture* m_ds_as_rt_gstexture = nullptr;
+	MRCOwned<id<MTLTexture>> m_rov_dummy_texture;
+	struct { u32 w, h; } m_rov_dummy_texture_size = {};
 
 	struct DebugEntry
 	{
@@ -372,8 +377,12 @@ public:
 	void FlushEncodersForReadback();
 	/// End current render pass without flushing
 	void EndRenderPass();
+	/// Prepare to begin a new render pass
+	void PrepareBeginRenderPass();
 	/// Begin a new render pass (may reuse existing)
 	void BeginRenderPass(NSString* name, GSTexture* color, MTLLoadAction color_load, GSTexture* depth, MTLLoadAction depth_load, GSTexture* stencil = nullptr, MTLLoadAction stencil_load = MTLLoadActionDontCare, bool rt1 = false);
+	/// Begin a new full-ROV render pass (may reuse existing)
+	void BeginFullROV(NSString* name, uint32_t width, uint32_t height);
 	/// Call at the end of each frame
 	void FrameCompleted();
 
@@ -455,6 +464,7 @@ public:
 	// MARK: Render HW
 
 	void SetupDestinationAlpha(GSTexture* rt, GSTexture* ds, const GSVector4i& r, SetDATM datm);
+	void PrepareROVTexture(GSTexture** ptex);
 	void RenderHW(GSHWDrawConfig& config) override;
 	void SendHWDraw(GSHWDrawConfig& config, id<MTLRenderCommandEncoder> enc, id<MTLBuffer> buffer, size_t off,
 		bool one_barrier, bool full_barrier);

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -1295,6 +1295,19 @@ bool GSDeviceMTL::UpdateWindow()
 
 bool GSDeviceMTL::SupportsExclusiveFullscreen() const { return false; }
 
+static const char* GetROVString(const GSMTLDevice::Features& features)
+{
+	if (!features.rov)
+		return "Unsupported";
+	if (features.rov_requires_r32 && features.rov_requires_rt)
+		return "With R32 Reinterpret and RT Texture";
+	if (features.rov_requires_r32)
+		return "With R32 Reinterpret";
+	if (features.rov_requires_rt)
+		return "With RT Texture";
+	return "Supported";
+}
+
 std::string GSDeviceMTL::GetDriverInfo() const
 { @autoreleasepool {
 	std::string desc([[m_dev.dev description] UTF8String]);
@@ -1304,6 +1317,7 @@ std::string GSDeviceMTL::GetDriverInfo() const
 	desc += "\n    Memoryless Textures: " + std::string(m_dev.features.memoryless_textures ? "Supported" : "Unsupported");
 	desc += "\n    Primitive ID:        " + std::string(m_dev.features.primid              ? "Supported" : "Unsupported");
 	desc += "\n    Depth Feedback:      " + std::string(m_dev.features.depth_feedback      ? "Supported" : "Unsupported");
+	desc += "\n    ROV:                 " + std::string(GetROVString(m_dev.features));
 	desc += "\n    Shader Version:      " + std::string(to_string(m_dev.features.shader_version));
 	desc += "\n    Max Texture Size:    " + std::to_string(m_dev.features.max_texsize);
 	return desc;

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -419,6 +419,19 @@ static GSVector4 GetRTLoadInfo(GSTextureMTL* tex, MTLLoadAction* load_action)
 	return {};
 };
 
+void GSDeviceMTL::PrepareBeginRenderPass()
+{
+	m_encoders_in_current_cmdbuf++;
+
+	if (m_late_texture_upload_encoder)
+	{
+		[m_late_texture_upload_encoder endEncoding];
+		m_late_texture_upload_encoder = nullptr;
+	}
+
+	EndRenderPass();
+}
+
 void GSDeviceMTL::BeginRenderPass(NSString* name, GSTexture* color, MTLLoadAction color_load,
 	GSTexture* depth, MTLLoadAction depth_load, GSTexture* stencil, MTLLoadAction stencil_load, bool rt1)
 {
@@ -453,14 +466,6 @@ void GSDeviceMTL::BeginRenderPass(NSString* name, GSTexture* color, MTLLoadActio
 			[m_current_render.encoder setLabel:name];
 		}
 		return;
-	}
-
-	m_encoders_in_current_cmdbuf++;
-
-	if (m_late_texture_upload_encoder)
-	{
-		[m_late_texture_upload_encoder endEncoding];
-		m_late_texture_upload_encoder = nullptr;
 	}
 
 	int idx = 0;
@@ -502,7 +507,7 @@ void GSDeviceMTL::BeginRenderPass(NSString* name, GSTexture* color, MTLLoadActio
 			color1.clearColor = MTLClearColorMake(depth_load == MTLLoadActionClear ? depth_clear.x : -1, 0, 0, 0);
 	}
 
-	EndRenderPass();
+	PrepareBeginRenderPass();
 	m_current_render.encoder = MRCRetain([GetRenderCmdBuf() renderCommandEncoderWithDescriptor:desc]);
 	m_current_render.name = (__bridge void*)name;
 	[m_current_render.encoder setLabel:name];
@@ -514,6 +519,61 @@ void GSDeviceMTL::BeginRenderPass(NSString* name, GSTexture* color, MTLLoadActio
 	m_current_render.stencil_target = stencil;
 	m_current_render.has.rt1_depth |= rt1;
 	pxAssertRel(m_current_render.encoder, "Failed to create render encoder!");
+}
+
+void GSDeviceMTL::BeginFullROV(NSString* name, uint32_t width, uint32_t height)
+{
+	bool needs_new = !m_current_render.is_full_rov()
+	              || width  > m_current_render.full_rov_size.w
+	              || height > m_current_render.full_rov_size.h;
+
+	if (!needs_new)
+	{
+		if (m_current_render.name != (__bridge void*)name)
+		{
+			m_current_render.name = (__bridge void*)name;
+			[m_current_render.encoder setLabel:name];
+		}
+		return;
+	}
+
+	if (m_current_render.is_full_rov())
+	{
+		// Render was too small.  Don't let it shrink in one dimension while growing in the other.
+		width  = std::max(width,  m_current_render.full_rov_size.w);
+		height = std::max(height, m_current_render.full_rov_size.h);
+	}
+
+	m_current_render.full_rov_size.w = width;
+	m_current_render.full_rov_size.h = height;
+
+	MTLRenderPassDescriptor* desc = m_full_rov_render_pass_desc;
+	[desc setRenderTargetWidth:width];
+	[desc setRenderTargetHeight:height];
+
+	if (m_dev.features.rov_requires_rt && (width > m_rov_dummy_texture_size.w || height > m_rov_dummy_texture_size.h))
+	{
+		m_rov_dummy_texture_size.w = std::max(m_rov_dummy_texture_size.w, width);
+		m_rov_dummy_texture_size.h = std::max(m_rov_dummy_texture_size.h, height);
+		MTLTextureDescriptor* tdesc = [MTLTextureDescriptor
+			texture2DDescriptorWithPixelFormat:MTLPixelFormatR8Unorm
+			                             width:m_rov_dummy_texture_size.w
+			                            height:m_rov_dummy_texture_size.h
+			                         mipmapped:NO];
+		[tdesc setUsage:MTLTextureUsageRenderTarget];
+		[tdesc setStorageMode:MTLStorageModePrivate];
+		id<MTLTexture> tex = m_rov_dummy_texture = MRCTransfer([m_dev.dev newTextureWithDescriptor:tdesc]);
+		[tex setLabel:@"ROV Dummy Texture"];
+		[[[desc colorAttachments] objectAtIndexedSubscript:0] setTexture:tex];
+	}
+
+	PrepareBeginRenderPass();
+	m_current_render.encoder = MRCRetain([GetRenderCmdBuf() renderCommandEncoderWithDescriptor:desc]);
+	m_current_render.name = (__bridge void*)name;
+	[m_current_render.encoder setLabel:name];
+	if (!m_dev.features.unified_memory)
+		[m_current_render.encoder waitForFence:m_draw_sync_fence
+		                          beforeStages:MTLRenderStageVertex];
 }
 
 void GSDeviceMTL::FrameCompleted()
@@ -999,6 +1059,7 @@ bool GSDeviceMTL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 	m_features.test_and_sample_depth = true;
 	m_features.depth_feedback = getDepthFeedback(m_dev, m_features.framebuffer_fetch);
 	m_features.aa1 = GSConfig.HWAA1 && m_features.vs_expand;
+	m_features.rov = m_dev.features.rov && !m_dev.features.rov_requires_r32 && !m_features.framebuffer_fetch;
 	m_max_texture_size = m_dev.features.max_texsize;
 
 	// Init metal stuff
@@ -1061,6 +1122,17 @@ bool GSDeviceMTL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 			[color1 setLoadAction:m_features.framebuffer_fetch ? MTLLoadActionClear : MTLLoadActionLoad];
 		}
 		m_render_pass_desc[i] = desc;
+	}
+	if (m_features.rov)
+	{
+		m_full_rov_render_pass_desc = MRCTransfer([MTLRenderPassDescriptor new]);
+		[m_full_rov_render_pass_desc setDefaultRasterSampleCount:1];
+		if (m_dev.features.rov_requires_rt)
+		{
+			MTLRenderPassColorAttachmentDescriptor* color0 = [[m_full_rov_render_pass_desc colorAttachments] objectAtIndexedSubscript:0];
+			[color0 setLoadAction:MTLLoadActionDontCare];
+			[color0 setStoreAction:MTLStoreActionDontCare];
+		}
 	}
 
 	// Init samplers
@@ -1978,7 +2050,10 @@ void GSDeviceMTL::MRESetHWPipelineState(GSHWDrawConfig::VSSelector vssel, GSHWDr
 		setFnConstantI(m_fn_constants, pssel.aa1,                   GSMTLConstantIndex_PS_AA1);
 		setFnConstantB(m_fn_constants, pssel.abe,                   GSMTLConstantIndex_PS_ABE);
 		setFnConstantI(m_fn_constants, pssel.sw_aniso,              GSMTLConstantIndex_PS_SW_ANISO);
-		auto newps = LoadShader(@"ps_main");
+		setFnConstantB(m_fn_constants, pssel.rov_color,             GSMTLConstantIndex_PS_ROV_COLOR);
+		setFnConstantI(m_fn_constants, pssel.rov_depth,             GSMTLConstantIndex_PS_ROV_DEPTH);
+		bool eft = pssel.HasColorROV() && !pssel.HasDepthROV() && !pssel.HasDepthOutput();
+		auto newps = LoadShader(eft ? @"ps_main_rov_eft" : @"ps_main");
 		ps = newps;
 		m_hw_ps.insert(std::make_pair(pssel, std::move(newps)));
 	}
@@ -2016,6 +2091,12 @@ void GSDeviceMTL::MRESetHWPipelineState(GSHWDrawConfig::VSSelector vssel, GSHWDr
 	{
 		MTLRenderPipelineColorAttachmentDescriptor* color1 = [[pdesc colorAttachments] objectAtIndexedSubscript:1];
 		[color1 setPixelFormat:MTLPixelFormatR32Float];
+	}
+	if (m_dev.features.rov_requires_rt && extras.rt == GSTexture::Format::Invalid && !extras.has_depth && !extras.has_stencil)
+	{
+		// Dummy texture
+		[color setPixelFormat:MTLPixelFormatR8Unorm];
+		[color setWriteMask:MTLColorWriteMaskNone];
 	}
 	NSString* pname = [NSString stringWithFormat:@"HW Render %x.%llx.%llx.%x", vssel_mtl.key, pssel.key_hi, pssel.key_lo, extras.fullkey];
 	auto pipeline = MakePipeline(pdesc, vs, ps, pname);
@@ -2108,6 +2189,7 @@ void GSDeviceMTL::MRESetScissor(const GSVector4i& scissor)
 
 void GSDeviceMTL::MREClearScissor()
 {
+	assert(!m_current_render.is_full_rov());
 	if (!m_current_render.has.scissor)
 		return;
 	m_current_render.has.scissor = false;
@@ -2233,6 +2315,15 @@ void GSDeviceMTL::MREInitHWDraw(GSHWDrawConfig& config, const Map& verts)
 	MRESetVertices(verts.gpu_buffer, verts.gpu_offset);
 	if (config.vs.UseVSExpandIndexBuffer())
 		MRESetVSIndices(verts.gpu_buffer, verts.gpu_offset + config.nverts * sizeof(*config.verts));
+}
+
+__fi void GSDeviceMTL::PrepareROVTexture(GSTexture** ptex)
+{
+	GSTextureMTL* tex = static_cast<GSTextureMTL*>(*ptex);
+	FlushClears(tex);
+	tex->m_last_read  = m_current_draw;
+	tex->m_last_write = m_current_draw;
+	*ptex = nullptr;
 }
 
 void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
@@ -2371,7 +2462,7 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 	}
 
 	// Try to reduce render pass restarts
-	if (!config.ds && m_current_render.color_target == rt && stencil == m_current_render.stencil_target && m_current_render.depth_target != config.tex)
+	if (!config.ps.HasColorROV() && !config.ds && m_current_render.color_target == rt && stencil == m_current_render.stencil_target && m_current_render.depth_target != config.tex)
 		config.ds = m_current_render.depth_target;
 	if (!rt && config.ds == m_current_render.depth_target && m_current_render.color_target != config.tex)
 		rt = m_current_render.color_target;
@@ -2386,16 +2477,28 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 	}
 
 	const bool feedback_depth = config.ps.IsFeedbackLoopDepth();
-	const bool rt1 = feedback_depth && !m_features.depth_feedback;
-	BeginRenderPass(@"RenderHW", rt, MTLLoadActionLoad, config.ds, MTLLoadActionLoad, stencil, MTLLoadActionLoad, rt1);
+	const bool rt1 = feedback_depth && !m_features.depth_feedback && !config.ps.HasDepthROV();
+	GSTexture* rt_bind = rt;
+	GSTexture* ds_bind = config.ds;
+	GSTexture* rt_size = rt_bind ? rt_bind : ds_bind;
+	if (config.ps.HasColorROV() && rt_bind) PrepareROVTexture(&rt_bind);
+	if (config.ps.HasDepthROV() && ds_bind) PrepareROVTexture(&ds_bind);
+	if (!rt_bind && !ds_bind && !stencil)
+		BeginFullROV(@"RenderHWROV", rt_size->GetWidth(), rt_size->GetHeight());
+	else
+		BeginRenderPass(@"RenderHW", rt_bind, MTLLoadActionLoad, ds_bind, MTLLoadActionLoad, stencil, MTLLoadActionLoad, rt1);
 	id<MTLRenderCommandEncoder> mtlenc = m_current_render.encoder;
 	FlushDebugEntries(mtlenc);
 	if (usesStencil(config.destination_alpha))
 		[mtlenc setStencilReferenceValue:1];
 	MREInitHWDraw(config, allocation);
-	if (config.require_one_barrier || config.require_full_barrier)
+	if (config.require_one_barrier || config.require_full_barrier || config.ps.HasColorROV())
 		MRESetTexture(rt, GSMTLTextureIndexRenderTarget);
-	if (feedback_depth)
+	if (config.ps.HasDepthROV())
+	{
+		MRESetTexture(config.ds, GSMTLTextureIndexDepthTarget);
+	}
+	else if (feedback_depth)
 	{
 		GSTexture* tex = !m_features.depth_feedback && !m_features.framebuffer_fetch ? m_ds_as_rt : config.ds;
 		MRESetTexture(tex, GSMTLTextureIndexDepthTarget);

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -565,10 +565,8 @@ GSTexture* GSDeviceMTL::CreateSurface(GSTexture::Usage usage, int width, int hei
 
 	MTLTextureUsage mtl_usage = MTLTextureUsageShaderRead;
 
-	if (GSTexture::IsRenderTarget(usage))
-	{
+	if (GSTexture::IsRenderTargetOrDepthStencil(usage))
 		mtl_usage |= MTLTextureUsageRenderTarget;
-	}
 
 	if ((usage & GSTexture::FeedbackTarget) == GSTexture::FeedbackTarget)
 	{
@@ -577,9 +575,7 @@ GSTexture* GSDeviceMTL::CreateSurface(GSTexture::Usage usage, int width, int hei
 	}
 
 	if (GSTexture::IsShaderWrite(usage))
-	{
 		mtl_usage |= MTLTextureUsageShaderWrite;
-	}
 
 	[desc setUsage:mtl_usage];
 

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -624,6 +624,7 @@ GSTexture* GSDeviceMTL::CreateSurface(GSTexture::Usage usage, int width, int hei
 	[desc setStorageMode:MTLStorageModePrivate];
 
 	MTLTextureUsage mtl_usage = MTLTextureUsageShaderRead;
+	bool needs_rov_tex = false;
 
 	if (GSTexture::IsRenderTargetOrDepthStencil(usage))
 		mtl_usage |= MTLTextureUsageRenderTarget;
@@ -634,6 +635,13 @@ GSTexture* GSDeviceMTL::CreateSurface(GSTexture::Usage usage, int width, int hei
 			mtl_usage |= MTLTextureUsagePixelFormatView; // Force color compression off by including PixelFormatView
 	}
 
+	if (usage == GSTexture::ShaderWriteTarget && format == GSTexture::Format::Color && m_dev.features.rov_requires_r32)
+	{
+		// Need to make an R32 view of the texture for ROV
+		mtl_usage |= MTLTextureUsagePixelFormatView;
+		needs_rov_tex = true;
+	}
+
 	if (GSTexture::IsShaderWrite(usage))
 		mtl_usage |= MTLTextureUsageShaderWrite;
 
@@ -642,7 +650,8 @@ GSTexture* GSDeviceMTL::CreateSurface(GSTexture::Usage usage, int width, int hei
 	MRCOwned<id<MTLTexture>> tex = MRCTransfer([m_dev.dev newTextureWithDescriptor:desc]);
 	if (tex)
 	{
-		GSTextureMTL* t = new GSTextureMTL(this, tex, usage, format);
+		MRCOwned<id<MTLTexture>> rov_tex = needs_rov_tex ? MRCTransfer([tex newTextureViewWithPixelFormat:MTLPixelFormatR32Uint]) : nil;
+		GSTextureMTL* t = new GSTextureMTL(this, tex, rov_tex, usage, format);
 		if (GSTexture::IsRenderTarget(usage))
 		{
 			ClearRenderTarget(t, 0);
@@ -1059,13 +1068,14 @@ bool GSDeviceMTL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 	m_features.test_and_sample_depth = true;
 	m_features.depth_feedback = getDepthFeedback(m_dev, m_features.framebuffer_fetch);
 	m_features.aa1 = GSConfig.HWAA1 && m_features.vs_expand;
-	m_features.rov = m_dev.features.rov && !m_dev.features.rov_requires_r32 && !m_features.framebuffer_fetch;
+	m_features.rov = m_dev.features.rov && !m_features.framebuffer_fetch;
 	m_max_texture_size = m_dev.features.max_texsize;
 
 	// Init metal stuff
 	m_fn_constants = MRCTransfer([MTLFunctionConstantValues new]);
-	setFnConstantB(m_fn_constants, m_features.framebuffer_fetch, GSMTLConstantIndex_FRAMEBUFFER_FETCH);
-	setFnConstantB(m_fn_constants, m_features.depth_feedback,    GSMTLConstantIndex_DEPTH_FEEDBACK);
+	setFnConstantB(m_fn_constants, m_features.framebuffer_fetch,    GSMTLConstantIndex_FRAMEBUFFER_FETCH);
+	setFnConstantB(m_fn_constants, m_features.depth_feedback,       GSMTLConstantIndex_DEPTH_FEEDBACK);
+	setFnConstantB(m_fn_constants, m_dev.features.rov_requires_r32, GSMTLConstantIndex_ROV_NEEDS_R32);
 
 	m_draw_sync_fence = MRCTransfer([m_dev.dev newFence]);
 	[m_draw_sync_fence setLabel:@"Draw Sync Fence"];
@@ -2147,6 +2157,15 @@ void GSDeviceMTL::MRESetTexture(GSTexture* tex, int pos)
 	mtex->m_last_read = m_current_draw;
 }
 
+void GSDeviceMTL::MRESetTexture(id<MTLTexture> tex, int pos)
+{
+	GSTexture* gstex = reinterpret_cast<GSTexture*>(tex); // No one actually dereferences this
+	if (!tex || gstex == m_current_render.tex[pos])
+		return;
+	m_current_render.tex[pos] = gstex;
+	[m_current_render.encoder setFragmentTexture:tex atIndex:pos];
+}
+
 void GSDeviceMTL::MRESetVertices(id<MTLBuffer> buffer, size_t offset)
 {
 	if (m_current_render.vertex_buffer != buffer)
@@ -2492,7 +2511,9 @@ void GSDeviceMTL::RenderHW(GSHWDrawConfig& config)
 	if (usesStencil(config.destination_alpha))
 		[mtlenc setStencilReferenceValue:1];
 	MREInitHWDraw(config, allocation);
-	if (config.require_one_barrier || config.require_full_barrier || config.ps.HasColorROV())
+	if (config.ps.HasColorROV() && m_dev.features.rov_requires_r32)
+		MRESetTexture(reinterpret_cast<GSTextureMTL*>(rt)->GetROVTexture(), GSMTLTextureIndexRenderTarget);
+	else if (config.require_one_barrier || config.require_full_barrier || config.ps.HasColorROV())
 		MRESetTexture(rt, GSMTLTextureIndexRenderTarget);
 	if (config.ps.HasDepthROV())
 	{

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -2044,14 +2044,12 @@ static void textureBarrier(id<MTLRenderCommandEncoder> enc)
 
 void GSDeviceMTL::MRESetTexture(GSTexture* tex, int pos)
 {
-	if (tex == m_current_render.tex[pos])
+	if (!tex || tex == m_current_render.tex[pos])
 		return;
 	m_current_render.tex[pos] = tex;
-	if (GSTextureMTL* mtex = static_cast<GSTextureMTL*>(tex))
-	{
-		[m_current_render.encoder setFragmentTexture:mtex->GetTexture() atIndex:pos];
-		mtex->m_last_read = m_current_draw;
-	}
+	GSTextureMTL* mtex = static_cast<GSTextureMTL*>(tex);
+	[m_current_render.encoder setFragmentTexture:mtex->GetTexture() atIndex:pos];
+	mtex->m_last_read = m_current_draw;
 }
 
 void GSDeviceMTL::MRESetVertices(id<MTLBuffer> buffer, size_t offset)

--- a/pcsx2/GS/Renderers/Metal/GSMTLDeviceInfo.h
+++ b/pcsx2/GS/Renderers/Metal/GSMTLDeviceInfo.h
@@ -34,6 +34,9 @@ struct GSMTLDevice
 		bool has_fast_half          : 1;
 		bool memoryless_textures    : 1;
 		bool depth_feedback         : 1;
+		bool rov                    : 1;
+		bool rov_requires_rt        : 1;
+		bool rov_requires_r32       : 1;
 		MetalVersion shader_version;
 		int max_texsize;
 	};

--- a/pcsx2/GS/Renderers/Metal/GSMTLDeviceInfo.mm
+++ b/pcsx2/GS/Renderers/Metal/GSMTLDeviceInfo.mm
@@ -166,6 +166,9 @@ GSMTLDevice::GSMTLDevice(MRCOwned<id<MTLDevice>> dev)
 
 	features.depth_feedback = false;
 
+	features.rov = [dev areRasterOrderGroupsSupported];
+	features.rov_requires_r32 = [dev readWriteTextureSupport] < MTLReadWriteTextureTier2;
+
 	NSString* name = [dev name];
 	if ([name containsString:@"Intel"])
 	{
@@ -193,6 +196,9 @@ GSMTLDevice::GSMTLDevice(MRCOwned<id<MTLDevice>> dev)
 		if (@available(macOS 13, iOS 16, *))
 			if ([dev supportsFamily:MTLGPUFamilyMetal3])
 				features.depth_feedback = true;
+		// ROV doesn't work on AMD GPUs with no render target
+		// Ideally the driver would insert a dummy texture for us (it does on Linux) but the Metal driver doesn't.
+		features.rov_requires_rt = true;
 	}
 	else if ([name containsString:@"NVIDIA"])
 	{
@@ -218,6 +224,9 @@ GSMTLDevice::GSMTLDevice(MRCOwned<id<MTLDevice>> dev)
 		features.slow_color_compression = env[0] == '1' || env[0] == 'y' || env[0] == 'Y';
 	else
 		features.slow_color_compression = [[dev name] containsString:@"AMD"] || [[dev name] isEqualToString:@"Intel HD Graphics 4000"];
+
+	if (char* env = getenv("MTL_ROV_WITH_RT"))
+		features.rov_requires_rt = env[0] == '1' || env[0] == 'y' || env[0] == 'Y';
 
 	features.max_texsize = GetMaxTextureSize(dev);
 

--- a/pcsx2/GS/Renderers/Metal/GSMTLSharedHeader.h
+++ b/pcsx2/GS/Renderers/Metal/GSMTLSharedHeader.h
@@ -165,6 +165,7 @@ enum GSMTLFnConstants
 	GSMTLConstantIndex_CAS_SHARPEN_ONLY,
 	GSMTLConstantIndex_FRAMEBUFFER_FETCH,
 	GSMTLConstantIndex_DEPTH_FEEDBACK,
+	GSMTLConstantIndex_ROV_NEEDS_R32,
 	GSMTLConstantIndex_FST,
 	GSMTLConstantIndex_IIP,
 	GSMTLConstantIndex_VS_POINT_SIZE,

--- a/pcsx2/GS/Renderers/Metal/GSMTLSharedHeader.h
+++ b/pcsx2/GS/Renderers/Metal/GSMTLSharedHeader.h
@@ -227,4 +227,6 @@ enum GSMTLFnConstants
 	GSMTLConstantIndex_PS_AA1,
 	GSMTLConstantIndex_PS_ABE,
 	GSMTLConstantIndex_PS_SW_ANISO,
+	GSMTLConstantIndex_PS_ROV_COLOR,
+	GSMTLConstantIndex_PS_ROV_DEPTH,
 };

--- a/pcsx2/GS/Renderers/Metal/GSTextureMTL.h
+++ b/pcsx2/GS/Renderers/Metal/GSTextureMTL.h
@@ -21,12 +21,13 @@ class GSTextureMTL : public GSTexture
 {
 	GSDeviceMTL* m_dev;
 	MRCOwned<id<MTLTexture>> m_texture;
+	MRCOwned<id<MTLTexture>> m_rov_texture;
 	bool m_has_mipmaps = false;
 
 public:
 	u64 m_last_read = 0;  ///< Last time this texture was read by a draw
 	u64 m_last_write = 0; ///< Last time this texture was written by a draw
-	GSTextureMTL(GSDeviceMTL* dev, MRCOwned<id<MTLTexture>> texture, Usage usage, Format format);
+	GSTextureMTL(GSDeviceMTL* dev, MRCOwned<id<MTLTexture>> texture, MRCOwned<id<MTLTexture>> rov_texture, Usage usage, Format format);
 	~GSTextureMTL();
 
 	/// For making fake backbuffers
@@ -42,6 +43,7 @@ public:
 	void Unmap() override;
 	void GenerateMipmap() override;
 	id<MTLTexture> GetTexture() { return m_texture; }
+	id<MTLTexture> GetROVTexture() { return m_rov_texture; }
 
 #ifdef PCSX2_DEVBUILD
 	void SetDebugName(std::string_view name) override;

--- a/pcsx2/GS/Renderers/Metal/GSTextureMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSTextureMTL.mm
@@ -13,9 +13,10 @@
 // Uploads/downloads need 32-byte alignment for AVX2.
 static constexpr u32 PITCH_ALIGNMENT = 32;
 
-GSTextureMTL::GSTextureMTL(GSDeviceMTL* dev, MRCOwned<id<MTLTexture>> texture, Usage usage, Format format)
+GSTextureMTL::GSTextureMTL(GSDeviceMTL* dev, MRCOwned<id<MTLTexture>> texture, MRCOwned<id<MTLTexture>> rov_texture, Usage usage, Format format)
 	: m_dev(dev)
 	, m_texture(std::move(texture))
+	, m_rov_texture(std::move(rov_texture))
 {
 	m_usage = usage;
 	m_format = format;
@@ -141,6 +142,8 @@ void GSTextureMTL::SetDebugName(std::string_view name)
 			length:static_cast<NSUInteger>(name.length())
 			encoding:NSUTF8StringEncoding];
 		[m_texture setLabel:label];
+		if (m_rov_texture)
+			[m_rov_texture setLabel:[label stringByAppendingString:@".ROV"]];
 	}
 
 	m_debug_name = std::move(name);

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -13,6 +13,7 @@ constant uint SHUFFLE_READWRITE = 3;
 
 constant bool HAS_FBFETCH           [[function_constant(GSMTLConstantIndex_FRAMEBUFFER_FETCH)]];
 constant bool DEPTH_FEEDBACK        [[function_constant(GSMTLConstantIndex_DEPTH_FEEDBACK)]];
+constant bool ROV_NEEDS_R32         [[function_constant(GSMTLConstantIndex_ROV_NEEDS_R32)]];
 constant bool FST                   [[function_constant(GSMTLConstantIndex_FST)]];
 constant bool IIP                   [[function_constant(GSMTLConstantIndex_IIP)]];
 constant bool VS_POINT_SIZE         [[function_constant(GSMTLConstantIndex_VS_POINT_SIZE)]];
@@ -1708,7 +1709,8 @@ constant float ds_fbf = 0;
 #endif
 constant bool NEEDS_DS_TEX   = SW_DEPTH && !DEPTH_FEEDBACK && !NEEDS_DS_FBF && PS_ROV_DEPTH == ROV_DEPTH::NONE;
 constant bool NEEDS_DS_DEPTH = (SW_DEPTH && DEPTH_FEEDBACK || NEEDS_DS_FBF) && PS_ROV_DEPTH == ROV_DEPTH::NONE;
-constant bool NEEDS_RT_ROV = PS_ROV_COLOR;
+constant bool NEEDS_RT_ROV = PS_ROV_COLOR && !ROV_NEEDS_R32;
+constant bool NEEDS_RT_U32 = PS_ROV_COLOR &&  ROV_NEEDS_R32;
 constant bool NEEDS_DS_ROV = PS_ROV_DEPTH != ROV_DEPTH::NONE;
 
 fragment MainPSOut ps_main(
@@ -1730,6 +1732,7 @@ fragment MainPSOut ps_main(
 	texture2d<float> ds_tex    [[texture(GSMTLTextureIndexDepthTarget),  function_constant(NEEDS_DS_TEX)]],
 	depth2d<float>   ds_depth  [[texture(GSMTLTextureIndexDepthTarget),  function_constant(NEEDS_DS_DEPTH)]],
 	texture2d<float, access::read_write> rt_rov [[texture(GSMTLTextureIndexRenderTarget), raster_order_group(0), function_constant(NEEDS_RT_ROV)]],
+	texture2d<uint,  access::read_write> rt_u32 [[texture(GSMTLTextureIndexRenderTarget), raster_order_group(0), function_constant(NEEDS_RT_U32)]],
 	texture2d<float, access::read_write> ds_rov [[texture(GSMTLTextureIndexDepthTarget),  raster_order_group(1), function_constant(NEEDS_DS_ROV)]])
 {
 	PSMain main(in, cb);
@@ -1765,7 +1768,10 @@ fragment MainPSOut ps_main(
 	{
 		if (PS_ROV_COLOR)
 		{
-			main.current_color = rt_rov.read(coord);
+			if (ROV_NEEDS_R32)
+				main.current_color = unpack_unorm4x8_to_float(rt_u32.read(coord).x);
+			else
+				main.current_color = rt_rov.read(coord);
 		}
 		else
 		{
@@ -1788,7 +1794,10 @@ fragment MainPSOut ps_main(
 	{
 		if (!PS_FBMASK)
 			out.c0 = select(out.c0, main.current_color, cb.fbmask == 0xff);
-		rt_rov.write(out.c0, coord);
+		if (ROV_NEEDS_R32)
+			rt_u32.write(pack_float_to_unorm4x8(out.c0), coord);
+		else
+			rt_rov.write(out.c0, coord);
 	}
 	return out;
 }
@@ -1802,7 +1811,8 @@ fragment void ps_main_rov_eft(
 	texture2d<float> tex     [[texture(GSMTLTextureIndexTex),     function_constant(PS_TEX_IS_COLOR)]],
 	depth2d<float>   depth   [[texture(GSMTLTextureIndexTex),     function_constant(PS_TEX_IS_DEPTH)]],
 	texture2d<float> palette [[texture(GSMTLTextureIndexPalette), function_constant(PS_HAS_PALETTE)]],
-	texture2d<float, access::read_write> rt_rov [[texture(GSMTLTextureIndexRenderTarget), raster_order_group(0)]])
+	texture2d<float, access::read_write> rt_rov [[texture(GSMTLTextureIndexRenderTarget), raster_order_group(0), function_constant(NEEDS_RT_ROV)]],
+	texture2d<uint,  access::read_write> rt_u32 [[texture(GSMTLTextureIndexRenderTarget), raster_order_group(0), function_constant(NEEDS_RT_U32)]])
 {
 	PSMain main(in, cb);
 	main.tex_sampler = s;
@@ -1814,13 +1824,19 @@ fragment void ps_main_rov_eft(
 		main.palette = palette;
 
 	uint2 coord = uint2(in.p.xy);
-	main.current_color = rt_rov.read(coord);
+	if (ROV_NEEDS_R32)
+		main.current_color = unpack_unorm4x8_to_float(rt_u32.read(coord).x);
+	else
+		main.current_color = rt_rov.read(coord);
 	MainPSOut out = main.ps_main();
 	if (!main.color_discarded)
 	{
 		if (!PS_FBMASK)
 			out.c0 = select(out.c0, main.current_color, cb.fbmask == 0xff);
-		rt_rov.write(out.c0, coord);
+		if (ROV_NEEDS_R32)
+			rt_u32.write(pack_float_to_unorm4x8(out.c0), coord);
+		else
+			rt_rov.write(out.c0, coord);
 	}
 }
 

--- a/pcsx2/GS/Renderers/Metal/tfx.metal
+++ b/pcsx2/GS/Renderers/Metal/tfx.metal
@@ -75,17 +75,21 @@ constant uint PS_SCANMSK            [[function_constant(GSMTLConstantIndex_PS_SC
 constant uint PS_AA1_RAW            [[function_constant(GSMTLConstantIndex_PS_AA1)]];
 constant bool PS_ABE                [[function_constant(GSMTLConstantIndex_PS_ABE)]];
 constant uint PS_SW_ANISO           [[function_constant(GSMTLConstantIndex_PS_SW_ANISO)]];
+constant bool PS_ROV_COLOR          [[function_constant(GSMTLConstantIndex_PS_ROV_COLOR)]];
+constant uint PS_ROV_DEPTH_RAW      [[function_constant(GSMTLConstantIndex_PS_ROV_DEPTH)]];
 
 using GSShader::VSExpand;
 using AFAIL = GSShader::PS_AFAIL;
 using ATST = GSShader::PS_ATST;
 using GSShader::ZTST;
 using AA1 = GSShader::PS_AA1;
+using ROV_DEPTH = GSShader::PS_ROV_DEPTH;
 constant VSExpand VS_EXPAND_TYPE = static_cast<VSExpand>(VS_EXPAND_TYPE_RAW);
 constant AFAIL PS_AFAIL = static_cast<AFAIL>(PS_AFAIL_RAW);
 constant ATST  PS_ATST  = static_cast<ATST>(PS_ATST_RAW);
 constant ZTST  PS_ZTST  = static_cast<ZTST>(PS_ZTST_RAW);
 constant AA1   PS_AA1   = static_cast<AA1>(PS_AA1_RAW);
+constant ROV_DEPTH PS_ROV_DEPTH = static_cast<ROV_DEPTH>(PS_ROV_DEPTH_RAW);
 
 #if defined(__METAL_MACOS__) && __METAL_VERSION__ >= 220
 	#define PRIMID_SUPPORT 1
@@ -119,9 +123,9 @@ constant bool NEEDS_DEPTH_FOR_ZTST  = PS_ZTST == ZTST::GEQUAL || PS_ZTST == ZTST
 constant bool NEEDS_DEPTH_FOR_AA1   = PS_AA1 == AA1::TRIANGLE_SW_Z;
 constant bool SW_DEPTH = NEEDS_DEPTH_FOR_AFAIL || NEEDS_DEPTH_FOR_ZTST || NEEDS_DEPTH_FOR_AA1;
 
-constant bool PS_COLOR0 = !PS_NO_COLOR;
-constant bool PS_COLOR1 = !PS_NO_COLOR1;
-constant bool PS_ZOUTPUT = PS_ZCLAMP || PS_ZFLOOR || SW_DEPTH;
+constant bool PS_OUTPUT_COLOR0 = !PS_NO_COLOR  && !PS_ROV_COLOR;
+constant bool PS_OUTPUT_COLOR1 = !PS_NO_COLOR1 && !PS_ROV_COLOR;
+constant bool PS_ZOUTPUT = (PS_ZCLAMP || PS_ZFLOOR || SW_DEPTH) && PS_ROV_DEPTH == ROV_DEPTH::NONE;
 constant bool PS_ZOUTPUT_LESS = PS_ZOUTPUT && !SW_DEPTH;
 constant bool PS_ZOUTPUT_ANY  = PS_ZOUTPUT && SW_DEPTH;
 constant bool PS_ZOUTPUT_COLOR = PS_ZOUTPUT_ANY && !DEPTH_FEEDBACK;
@@ -165,21 +169,32 @@ struct MainPSIn
 	uint interior [[function_constant(PS_INTERIOR)]];
 };
 
+struct MainResult
+{
+	float4 c0;
+	float4 c1;
+	float depth;
+};
+
 struct MainPSOut
 {
-	float4 c0 [[color(0), index(0), function_constant(PS_COLOR0)]];
-	float4 c1 [[color(0), index(1), function_constant(PS_COLOR1)]];
+	float4 c0 [[color(0), index(0), function_constant(PS_OUTPUT_COLOR0)]];
+	float4 c1 [[color(0), index(1), function_constant(PS_OUTPUT_COLOR1)]];
 	float depthColor [[color(1), function_constant(PS_ZOUTPUT_COLOR)]];
 	float depthLess [[depth(less), function_constant(PS_ZOUTPUT_LESS)]];
 	float depthAny  [[depth(any),  function_constant(PS_ZOUTPUT_ANY)]];
-	void setDepth(float depth)
+	MainPSOut(MainResult res)
 	{
+		if (PS_OUTPUT_COLOR0)
+			c0 = res.c0;
+		if (PS_OUTPUT_COLOR1)
+			c1 = res.c1;
 		if (PS_ZOUTPUT_LESS)
-			depthLess = depth;
+			depthLess = res.depth;
 		if (PS_ZOUTPUT_ANY)
-			depthAny = depth;
+			depthAny = res.depth;
 		if (PS_ZOUTPUT_COLOR)
-			depthColor = depth;
+			depthColor = res.depth;
 	}
 };
 
@@ -564,10 +579,36 @@ struct PSMain
 	float4 current_color;
 	float current_depth;
 	uint prim_id;
+	bool color_discarded = false;
+	bool depth_discarded = false;
 	const thread MainPSIn& in;
 	constant GSMTLMainPSUniform& cb;
 
 	PSMain(const thread MainPSIn& in, constant GSMTLMainPSUniform& cb): in(in), cb(cb) {}
+
+	void discard()
+	{
+		if (PS_ROV_COLOR || PS_ROV_DEPTH != ROV_DEPTH::NONE)
+			color_discarded = depth_discarded = true;
+		else
+			discard_fragment();
+	}
+
+	void discard_color(thread float4& output)
+	{
+		if (PS_ROV_COLOR)
+			color_discarded = true;
+		else
+			output = current_color;
+	}
+
+	void discard_depth(thread float& output)
+	{
+		if (PS_ROV_DEPTH == ROV_DEPTH::READ_WRITE)
+			depth_discarded = true;
+		else
+			output = current_depth;
+	}
 
 	template <typename... Args>
 	float4 sample_tex(Args... args)
@@ -1454,9 +1495,9 @@ struct PSMain
 		}
 	}
 
-	MainPSOut ps_main()
+	MainResult ps_main()
 	{
-		MainPSOut out = {};
+		MainResult out = {};
 		float input_z = in.p.z;
 		if (PS_ZFLOOR)
 			input_z = floor(input_z * 0x1p32) * 0x1p-32;
@@ -1464,15 +1505,15 @@ struct PSMain
 		if (PS_ZTST == ZTST::GEQUAL || PS_ZTST == ZTST::GREATER)
 		{
 			if (PS_ZTST == ZTST::GEQUAL && input_z < current_depth)
-				discard_fragment();
+				discard();
 			if (PS_ZTST == ZTST::GREATER && input_z <= current_depth)
-				discard_fragment();
+				discard();
 		}
 
 		if (PS_SCANMSK & 2)
 		{
 			if ((uint(in.p.y) & 1) == (PS_SCANMSK & 1))
-				discard_fragment();
+				discard();
 		}
 
 		if (PS_DATE >= 5)
@@ -1482,7 +1523,7 @@ struct PSMain
 			bool bad = PS_RTA_CORRECTION ? ((PS_DATE & 3) == 1 ? (rt_a > (254.5f / 255.f)) : (rt_a < (254.5f / 255.f))) : ((PS_DATE & 3) == 1 ? (rt_a > 0.5) : (rt_a < 0.5));
 
 			if (bad)
-				discard_fragment();
+				discard();
 		}
 
 		if (PS_DATE == 3)
@@ -1491,7 +1532,7 @@ struct PSMain
 			// Note prim_id == stencil_ceil will be the primitive that will update
 			// the bad alpha value so we must keep it.
 			if (float(prim_id) > stencil_ceil)
-				discard_fragment();
+				discard();
 		}
 
 		float4 C = ps_color();
@@ -1500,9 +1541,9 @@ struct PSMain
 
 		if (PS_AA1 != AA1::NONE)
 		{
-			float cov = PS_AA1 == AA1::LINE ?
-				saturate(cb.line_cov_scale * (1.f - abs(in.inv_cov))) : // Blur only outer part of the line by scaling coverage.
-			  saturate(1.f - abs(in.inv_cov));
+			float cov = PS_AA1 == AA1::LINE
+				? saturate(cb.line_cov_scale * (1.f - abs(in.inv_cov))) // Blur only outer part of the line by scaling coverage.
+				: saturate(1.f - abs(in.inv_cov));
 			if (!PS_ABE || floor(C.a) == 128.f) // The coverage is only used if the fragment alpha is 128.
 				C.a = 128.f * cov;
 		}
@@ -1514,7 +1555,7 @@ struct PSMain
 
 		bool atst_pass = atst(C);
 		if (PS_AFAIL == AFAIL::KEEP && !atst_pass)
-			discard_fragment();
+			discard();
 
 		float4 alpha_blend = float4(0.f);
 		if (SW_AD_TO_HW)
@@ -1620,32 +1661,32 @@ struct PSMain
 		if (PS_AFAIL == AFAIL::RGB_ONLY_DSB)
 			alpha_blend.a = float(atst_pass);
 
-		if (PS_COLOR0)
+		if (!PS_NO_COLOR)
 		{
 			out.c0.a = PS_RTA_CORRECTION ? C.a / 128.f : C.a / 255.f;
 			out.c0.rgb = PS_COLCLIP_HW ? float3(C.rgb / 65535.f) : C.rgb / 255.f;
 		}
-		if (PS_COLOR1)
+		if (!PS_NO_COLOR1)
 			out.c1 = alpha_blend;
 
 		if (PS_ZCLAMP)
 			input_z = min(input_z, cb.max_depth);
 
 		if (PS_AA1 == AA1::TRIANGLE_SW_Z && !in.interior)
-			input_z = current_depth; // No depth update for triangle edges.
+			discard_depth(input_z); // No depth update for triangle edges.
 
 		if (!atst_pass)
 		{
 			if (PS_AFAIL == AFAIL::RGB_ONLY_SW_Z || PS_AFAIL == AFAIL::RGB_ONLY)
-				out.c0.a = current_color.a;
+				out.c0.a = current_color.a; // discard alpha
 			else if (PS_AFAIL == AFAIL::ZB_ONLY)
-				out.c0 = current_color;
+				discard_color(out.c0);
 
 			if (PS_AFAIL == AFAIL::RGB_ONLY_SW_Z || PS_AFAIL == AFAIL::FB_ONLY)
-				input_z = current_depth;
+				discard_depth(input_z);
 		}
 
-		out.setDepth(input_z);
+		out.depth = input_z;
 
 		return out;
 	}
@@ -1657,16 +1698,18 @@ fragment float4 fbfetch_test(float4 in [[color(0), raster_order_group(0)]])
 	return in * 2;
 }
 
-constant bool NEEDS_RT_TEX = NEEDS_RT && !HAS_FBFETCH;
-constant bool NEEDS_RT_FBF = NEEDS_RT &&  HAS_FBFETCH;
-constant bool NEEDS_DS_FBF = SW_DEPTH &&  HAS_FBFETCH && !DEPTH_FEEDBACK;
+constant bool NEEDS_RT_TEX = NEEDS_RT && !HAS_FBFETCH && !PS_ROV_COLOR;
+constant bool NEEDS_RT_FBF = NEEDS_RT &&  HAS_FBFETCH && !PS_ROV_COLOR;
+constant bool NEEDS_DS_FBF = SW_DEPTH &&  HAS_FBFETCH && !DEPTH_FEEDBACK && PS_ROV_DEPTH == ROV_DEPTH::NONE;
 #else
-constant bool NEEDS_RT_TEX = NEEDS_RT;
+constant bool NEEDS_RT_TEX = NEEDS_RT && !PS_ROV_COLOR;
 constant bool NEEDS_DS_FBF = false;
 constant float ds_fbf = 0;
 #endif
-constant bool NEEDS_DS_TEX   = SW_DEPTH && !DEPTH_FEEDBACK && !NEEDS_DS_FBF;
-constant bool NEEDS_DS_DEPTH = SW_DEPTH && DEPTH_FEEDBACK || NEEDS_DS_FBF;
+constant bool NEEDS_DS_TEX   = SW_DEPTH && !DEPTH_FEEDBACK && !NEEDS_DS_FBF && PS_ROV_DEPTH == ROV_DEPTH::NONE;
+constant bool NEEDS_DS_DEPTH = (SW_DEPTH && DEPTH_FEEDBACK || NEEDS_DS_FBF) && PS_ROV_DEPTH == ROV_DEPTH::NONE;
+constant bool NEEDS_RT_ROV = PS_ROV_COLOR;
+constant bool NEEDS_DS_ROV = PS_ROV_DEPTH != ROV_DEPTH::NONE;
 
 fragment MainPSOut ps_main(
 	MainPSIn in [[stage_in]],
@@ -1685,7 +1728,9 @@ fragment MainPSOut ps_main(
 	texture2d<float> rt        [[texture(GSMTLTextureIndexRenderTarget), function_constant(NEEDS_RT_TEX)]],
 	texture2d<float> primidtex [[texture(GSMTLTextureIndexPrimIDs),      function_constant(PS_PRIM_CHECKING_READ)]],
 	texture2d<float> ds_tex    [[texture(GSMTLTextureIndexDepthTarget),  function_constant(NEEDS_DS_TEX)]],
-	depth2d<float>   ds_depth  [[texture(GSMTLTextureIndexDepthTarget),  function_constant(NEEDS_DS_DEPTH)]])
+	depth2d<float>   ds_depth  [[texture(GSMTLTextureIndexDepthTarget),  function_constant(NEEDS_DS_DEPTH)]],
+	texture2d<float, access::read_write> rt_rov [[texture(GSMTLTextureIndexRenderTarget), raster_order_group(0), function_constant(NEEDS_RT_ROV)]],
+	texture2d<float, access::read_write> ds_rov [[texture(GSMTLTextureIndexDepthTarget),  raster_order_group(1), function_constant(NEEDS_DS_ROV)]])
 {
 	PSMain main(in, cb);
 	main.tex_sampler = s;
@@ -1706,7 +1751,9 @@ fragment MainPSOut ps_main(
 
 	if (SW_DEPTH)
 	{
-		if (DEPTH_FEEDBACK)
+		if (PS_ROV_DEPTH != ROV_DEPTH::NONE)
+			main.current_depth = ds_rov.read(coord).x;
+		else if (DEPTH_FEEDBACK)
 			main.current_depth = ds_depth.read(coord);
 		else if (NEEDS_DS_FBF)
 			main.current_depth = ds_fbf < 0 ? ds_depth.read(coord) : ds_fbf;
@@ -1714,20 +1761,67 @@ fragment MainPSOut ps_main(
 			main.current_depth = ds_tex.read(coord).x;
 	}
 
-	if (NEEDS_RT)
+	if (NEEDS_RT || (PS_ROV_COLOR && any(cb.fbmask == 0xff)))
 	{
+		if (PS_ROV_COLOR)
+		{
+			main.current_color = rt_rov.read(coord);
+		}
+		else
+		{
 #if FBFETCH_SUPPORT
-		main.current_color = HAS_FBFETCH ? rt_fbf : rt.read(coord);
+			main.current_color = HAS_FBFETCH ? rt_fbf : rt.read(coord);
 #else
-		main.current_color = rt.read(coord);
+			main.current_color = rt.read(coord);
 #endif
+		}
 	}
 	else
 	{
 		main.current_color = 0;
 	}
 
-	return main.ps_main();
+	MainResult out = main.ps_main();
+	if (PS_ROV_DEPTH == ROV_DEPTH::READ_WRITE && !main.depth_discarded)
+		ds_rov.write(out.depth, coord);
+	if (PS_ROV_COLOR && !main.color_discarded)
+	{
+		if (!PS_FBMASK)
+			out.c0 = select(out.c0, main.current_color, cb.fbmask == 0xff);
+		rt_rov.write(out.c0, coord);
+	}
+	return out;
+}
+
+// Metal doesn't let you toggle eft with function constants so we need a separate function for it
+[[early_fragment_tests]]
+fragment void ps_main_rov_eft(
+	MainPSIn in [[stage_in]],
+	constant GSMTLMainPSUniform& cb [[buffer(GSMTLBufferIndexHWUniforms)]],
+	sampler s [[sampler(0)]],
+	texture2d<float> tex     [[texture(GSMTLTextureIndexTex),     function_constant(PS_TEX_IS_COLOR)]],
+	depth2d<float>   depth   [[texture(GSMTLTextureIndexTex),     function_constant(PS_TEX_IS_DEPTH)]],
+	texture2d<float> palette [[texture(GSMTLTextureIndexPalette), function_constant(PS_HAS_PALETTE)]],
+	texture2d<float, access::read_write> rt_rov [[texture(GSMTLTextureIndexRenderTarget), raster_order_group(0)]])
+{
+	PSMain main(in, cb);
+	main.tex_sampler = s;
+	if (PS_TEX_IS_COLOR)
+		main.tex = tex;
+	else
+		main.tex_depth = depth;
+	if (PS_HAS_PALETTE)
+		main.palette = palette;
+
+	uint2 coord = uint2(in.p.xy);
+	main.current_color = rt_rov.read(coord);
+	MainPSOut out = main.ps_main();
+	if (!main.color_discarded)
+	{
+		if (!PS_FBMASK)
+			out.c0 = select(out.c0, main.current_color, cb.fbmask == 0xff);
+		rt_rov.write(out.c0, coord);
+	}
 }
 
 #if PRIMID_SUPPORT


### PR DESCRIPTION
### Description of Changes
Adds ROV support for Metal.

Seems to be broken on Intel UHD 630, but that supports fbfetch so to use it you would have to be messing with advanced settings.

### Rationale behind Changes
ROV support yay
Fixes https://github.com/PCSX2/pcsx2/issues/14641

### Suggested Testing Steps
Test [this gsdump](https://github.com/user-attachments/files/29492463/NFSCarbon.gs.xz.zip) in Metal with ROV enabled.  Note that ROV will do nothing on GPUs with framebuffer fetch unless you also go into advanced settings and disable framebuffer fetch.

If you have an AMD GPU, try running `MTL_ROV_WITH_RT=0 PCSX2.app/Contents/MacOS/PCSX2` and testing again.  This is expected to be broken, so if it isn't, please mention that.  (I've only tested on RDNA1, maybe it's not broken on e.g. RDNA2.)

### Did you use AI to help find, test, or implement this issue or feature?
No