### PR TITLE
Pad: Fix enum entries check

### DIFF
--- a/pcsx2/SIO/Pad/PadDualshock2.cpp
+++ b/pcsx2/SIO/Pad/PadDualshock2.cpp
@@ -555,7 +555,7 @@ const Pad::ControllerInfo& PadDualshock2::GetInfo() const
 
 void PadDualshock2::Set(u32 index, float value)
 {
-	if (index > Inputs::LENGTH)
+	if (index >= Inputs::LENGTH)
 	{
 		return;
 	}

--- a/pcsx2/SIO/Pad/PadGuitar.cpp
+++ b/pcsx2/SIO/Pad/PadGuitar.cpp
@@ -258,7 +258,7 @@ const Pad::ControllerInfo& PadGuitar::GetInfo() const
 
 void PadGuitar::Set(u32 index, float value)
 {
-	if (index > Inputs::LENGTH)
+	if (index >= Inputs::LENGTH)
 	{
 		return;
 	}

--- a/pcsx2/SIO/Pad/PadJogcon.cpp
+++ b/pcsx2/SIO/Pad/PadJogcon.cpp
@@ -324,7 +324,7 @@ const Pad::ControllerInfo& PadJogcon::GetInfo() const
 
 void PadJogcon::Set(u32 index, float value)
 {
-	if (index > Inputs::LENGTH)
+	if (index >= Inputs::LENGTH)
 	{
 		return;
 	}

--- a/pcsx2/SIO/Pad/PadNegcon.cpp
+++ b/pcsx2/SIO/Pad/PadNegcon.cpp
@@ -307,7 +307,7 @@ const Pad::ControllerInfo& PadNegcon::GetInfo() const
 
 void PadNegcon::Set(u32 index, float value)
 {
-	if (index > Inputs::LENGTH)
+	if (index >= Inputs::LENGTH)
 	{
 		return;
 	}

--- a/pcsx2/SIO/Pad/PadPopn.cpp
+++ b/pcsx2/SIO/Pad/PadPopn.cpp
@@ -371,7 +371,7 @@ const Pad::ControllerInfo& PadPopn::GetInfo() const
 
 void PadPopn::Set(u32 index, float value)
 {
-	if (index > Inputs::LENGTH)
+	if (index >= Inputs::LENGTH)
 	{
 		return;
 	}


### PR DESCRIPTION
### Description of Changes
Pad: Fix enum entries check
Fixes a check against the number of entries in the Inputs enum in the Set method for all Pad types.
Currently it lets indices from 0 to Inputs::LENGTH in the method, but it should only work from 0 to Inputs::LENGTH - 1

Five equal signs in total.
It ain't much, but it's honest work.

### Rationale behind Changes
There really wasn't any issue with the current system (since the check has looked like that for the last three years) but who knows what could happen in the future? The check is wrong and it shouldn't be
Also approved on Discord!

### Suggested Testing Steps
Check that the equal sign was added to every Pad type, and that controllers still work in games or the Padtest ELF.
The last entry in the enum for PadDualshock2 is for the Right joystick (Left), so I guess check that in particular

### Did you use AI to help find, test, or implement this issue or feature?
No