### PR TITLE
Common: fix WorkSema lost empty-wakeups (VM shutdown deadlock)

### DIFF
--- a/common/Semaphore.cpp
+++ b/common/Semaphore.cpp
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: GPL-3.0+
 
 #include "common/Threading.h"
+
+#include <chrono>
+#include <thread>
 #include "common/Assertions.h"
 #include "common/HostSys.h"
 
@@ -103,7 +106,29 @@ bool Threading::WorkSema::WaitForEmpty()
 			break;
 	}
 	pxAssertMsg(!(value & STATE_FLAG_WAITING_EMPTY), "Multiple threads attempted to wait for empty (not currently supported)");
-	m_empty_sema.Wait();
+	// Defensive: bounded waits with a state recheck rather than one unbounded
+	// Wait(). If the empty-post is ever lost (a second lost-wake instance was
+	// observed in the field on MTVU's semaEvent even after the Reset() handoff
+	// fix, with the worker asleep and the queue drained), the waiter recovers
+	// within ~1ms instead of deadlocking shutdown. Exit conditions:
+	//  - TryWait succeeds: the normal handoff worked.
+	//  - state < 0: the worker is asleep/spinning, i.e. the queue IS empty —
+	//    exactly the condition being waited for. The worker posts before its
+	//    sleep-CAS-then-post sequence completes, so give any in-flight post a
+	//    moment, then drain stale counts so a future WaitForEmpty cannot
+	//    consume one and return early.
+	while (!m_empty_sema.TryWait())
+	{
+		const s32 cur = m_state.load(std::memory_order_acquire);
+		if (cur < 0)
+		{
+			std::this_thread::sleep_for(std::chrono::microseconds(100));
+			while (m_empty_sema.TryWait())
+				;
+			return !IsDead(cur);
+		}
+		std::this_thread::sleep_for(std::chrono::milliseconds(1));
+	}
 	return !IsDead(m_state.load(std::memory_order_relaxed));
 }
 
@@ -121,7 +146,29 @@ bool Threading::WorkSema::WaitForEmptyWithSpin()
 		value = m_state.load(std::memory_order_acquire);
 	}
 	pxAssertMsg(!(value & STATE_FLAG_WAITING_EMPTY), "Multiple threads attempted to wait for empty (not currently supported)");
-	m_empty_sema.Wait();
+	// Defensive: bounded waits with a state recheck rather than one unbounded
+	// Wait(). If the empty-post is ever lost (a second lost-wake instance was
+	// observed in the field on MTVU's semaEvent even after the Reset() handoff
+	// fix, with the worker asleep and the queue drained), the waiter recovers
+	// within ~1ms instead of deadlocking shutdown. Exit conditions:
+	//  - TryWait succeeds: the normal handoff worked.
+	//  - state < 0: the worker is asleep/spinning, i.e. the queue IS empty —
+	//    exactly the condition being waited for. The worker posts before its
+	//    sleep-CAS-then-post sequence completes, so give any in-flight post a
+	//    moment, then drain stale counts so a future WaitForEmpty cannot
+	//    consume one and return early.
+	while (!m_empty_sema.TryWait())
+	{
+		const s32 cur = m_state.load(std::memory_order_acquire);
+		if (cur < 0)
+		{
+			std::this_thread::sleep_for(std::chrono::microseconds(100));
+			while (m_empty_sema.TryWait())
+				;
+			return !IsDead(cur);
+		}
+		std::this_thread::sleep_for(std::chrono::milliseconds(1));
+	}
 	return !IsDead(m_state.load(std::memory_order_relaxed));
 }
 

--- a/common/Semaphore.cpp
+++ b/common/Semaphore.cpp
@@ -134,7 +134,18 @@ void Threading::WorkSema::Kill()
 
 void Threading::WorkSema::Reset()
 {
-	m_state = STATE_RUNNING_0;
+	// Preserve a pending empty-waiter across Reset: a raw store would erase
+	// STATE_FLAG_WAITING_EMPTY without posting m_empty_sema, stranding a
+	// WaitForEmpty() caller forever. Observed in the field as a shutdown
+	// deadlock: MTGS's close/reopen cycle (ThreadEntryPoint calls Reset after
+	// GSclose) raced VMManager::Shutdown's WaitGS -> WaitForEmpty — the
+	// waiter's flag was clobbered, the GS thread then went to sleep without
+	// posting, and the caller waited on m_empty_sema forever. Every other
+	// flag-clearing path posts (Kill, WaitForWork's sleep transition,
+	// CheckForWork); Reset must hand off too.
+	const s32 old = m_state.exchange(STATE_RUNNING_0, std::memory_order_acq_rel);
+	if (old & STATE_FLAG_WAITING_EMPTY)
+		m_empty_sema.Post();
 }
 
 #if !defined(__APPLE__) // macOS implementations are in DarwinThreads


### PR DESCRIPTION
### Description of Changes

Two commits to `common/Semaphore.cpp`:

1. `WorkSema::Reset()` now exchanges the state word and posts `m_empty_sema` if `STATE_FLAG_WAITING_EMPTY` was set, instead of a raw `m_state = STATE_RUNNING_0` store that silently erased the flag.
2. `WaitForEmpty()` / `WaitForEmptyWithSpin()` replace their single unbounded `m_empty_sema.Wait()` with a bounded `TryWait` + state-recheck loop (1 ms cadence), with a stale-post drain on the state<0 exit so a future waiter cannot return prematurely.

### Rationale behind Changes

`Reset()` was the only flag-clearing path that did not post the empty semaphore (`Kill`, `WaitForWork`'s sleep transition and `CheckForWork` all do). If `Reset()` ran while a thread was registered in `WaitForEmpty()`, the waiter's flag was clobbered, the worker's next sleep transition saw no flag and posted nothing, and the waiter slept forever.

This was observed in the field as a deterministic VM shutdown deadlock (macOS x86_64, libretro-based frontend embedding PCSX2): MTGS's close/reopen cycle (`ThreadEntryPoint` calls `s_sem_event.Reset()` after `GSclose`) raced `VMManager::Shutdown` → `WaitGS()` → `WaitForEmpty()`. Sampled stacks of the wedged process showed the CPU thread parked on `m_empty_sema` while the GS thread idled in the entry loop's `WaitForWork()` with the queue drained.

Commit 2 exists because a second lost-wake instance was observed on MTVU's `semaEvent` even after the `Reset()` fix was deployed (waiter parked, worker asleep, ring drained, `m_state == -1`; manually signalling the semaphore un-wedged the full shutdown, proving a single lost wake). That interleaving resisted diagnosis across several live samples, so the wait was made self-healing: any lost post now costs ~1 ms instead of deadlocking shutdown. Happy to drop commit 2 if you'd prefer to track the remaining root cause separately.

### Suggested Testing Steps

Reproducer on the affected setup: boot a game (observed with God of War NTSC-U), then trigger a session shutdown that overlaps a GS close/reopen (in our frontend: quit from a pause menu, which tears down the render surface while `VMManager::Shutdown` runs). Before these changes this deadlocked `Shutdown` 3/3 attempts, with the stacks above; after, 0 wedges across repeated open/quit cycles.

General regression: normal boot/play/save-state/shutdown cycles — the semaphore handoff still completes via the normal post on the happy path, so no behavioural or performance change is expected (and none was observed).

### Did you use AI to help find, test, or implement this issue or feature?

Yes. An AI assistant (Claude) was used to help diagnose the deadlock and draft the patch. The diagnosis was grounded in evidence rather than model output alone: `sample` captures of the live wedged process, reading `WorkSema::m_state` and the mach semaphore ports with lldb, and confirming the single-lost-wake theory by manually signalling the stuck semaphore (which un-wedged the full shutdown). The fix was then built and verified by a human on real hardware against a deterministic reproducer (3/3 deadlocks before, 0 after). I understand the change and am happy to answer questions about it.