### PR TITLE
PINE: Create a symlink to the socket for emulator-agnostic clients

### DIFF
--- a/pcsx2/PINE.cpp
+++ b/pcsx2/PINE.cpp
@@ -68,6 +68,7 @@
 #endif
 
 #define PINE_EMULATOR_NAME "pcsx2"
+#define PINE_GENERIC_EMULATOR_NAME "pine_ps2"
 
 #ifdef _WIN32
 
@@ -102,6 +103,10 @@ namespace PINEServer
 #else
 	// absolute path of the socket. Stored in XDG_RUNTIME_DIR, if unset /tmp
 	static std::string s_socket_name;
+	// The absolute path of a symlink pointing to the socket. We provide both so
+	// that clients can choose whether they want to connect to any PS2 emulator
+	// or just PCSX2 specifically.
+	static std::string s_generic_socket_name;
 	static int s_sock = -1;
 	// the message socket used in thread's accept().
 	static int s_msgsock = -1;
@@ -294,24 +299,26 @@ bool PINEServer::Initialize(int slot)
 	}
 
 #else
-	char* runtime_dir = nullptr;
+	const char* runtime_dir = nullptr;
 #ifdef __APPLE__
 	runtime_dir = std::getenv("TMPDIR");
 #else
 	runtime_dir = std::getenv("XDG_RUNTIME_DIR");
 #endif
+
 	// fallback in case macOS or other OSes don't implement the XDG base
 	// spec
-	if (runtime_dir == nullptr)
-		s_socket_name = "/tmp/" PINE_EMULATOR_NAME ".sock";
-	else
-	{
-		s_socket_name = runtime_dir;
-		s_socket_name += "/" PINE_EMULATOR_NAME ".sock";
-	}
+	if (!runtime_dir)
+		runtime_dir = "/tmp";
+
+	s_socket_name = fmt::format("{}/{}.sock", runtime_dir, PINE_EMULATOR_NAME);
+	s_generic_socket_name = fmt::format("{}/{}.sock", runtime_dir, PINE_GENERIC_EMULATOR_NAME);
 
 	if (slot != PINE_DEFAULT_SLOT)
+	{
 		s_socket_name += "." + std::to_string(slot);
+		s_generic_socket_name += "." + std::to_string(slot);
+	}
 
 	struct sockaddr_un server;
 
@@ -328,9 +335,18 @@ bool PINEServer::Initialize(int slot)
 	// we unlink the socket so that when releasing this thread the socket gets
 	// freed even if we didn't close correctly the loop
 	unlink(s_socket_name.c_str());
+	unlink(s_generic_socket_name.c_str());
+
 	if (bind(s_sock, (struct sockaddr*)&server, sizeof(struct sockaddr_un)))
 	{
 		Console.WriteLn(Color_Red, "PINE: Error while binding to socket! Shutting down...");
+		Deinitialize();
+		return false;
+	}
+
+	if (symlink(s_socket_name.c_str(), s_generic_socket_name.c_str()) != 0)
+	{
+		Console.WriteLn(Color_Red, "PINE: Error while creating symlink for socket! Shutting down...");
 		Deinitialize();
 		return false;
 	}
@@ -485,6 +501,12 @@ void PINEServer::Deinitialize()
 	s_end.store(true, std::memory_order_release);
 
 #ifndef _WIN32
+	if (!s_generic_socket_name.empty())
+	{
+		unlink(s_generic_socket_name.c_str());
+		s_generic_socket_name = {};
+	}
+
 	if (!s_socket_name.empty())
 	{
 		unlink(s_socket_name.c_str());


### PR DESCRIPTION
### Description of Changes
Make the PINE server create a symlink called `pine_ps2.sock` in the same directory as the socket file, pointing to said socket file.

### Rationale behind Changes
There's currently no way for a PINE client to say that they want to connect to any PS2 emulator, they have to look for PCSX2's socket specifically.

I think this creates a bit of a problem for the adoption of the protocol, since if someone adds support for PINE to another PS2 emulator, they will either have to accept that no existing clients will work with their server, or they will have to name their socket file `pcsx2.sock`, which seems silly.

I originally opened an issue about this in the PINE repository and thought it was going to be harder to fix, but thinking about it, we can just create a generic symlink for future emulator-agnostic clients to connect to instead.

Creating a symlink provides the benefit that we will still support clients that only look for `pcsx2.sock`. In addition, emulator-agnostic clients can be written so that they fall back to looking for `pcsx2.sock` if `pine_ps2.sock` is not found, so they can still support older servers.

I don't have any specific plans to implement PINE in other emulators, it just occurred to me that this is probably something the protocol should support.

Of course, all of the above doesn't affect Windows, for which I guess the best solution would be for all PS2 emulators to just use the same port.

### Suggested Testing Steps
Make sure I haven't broken PINE on macOS.

### Did you use AI to help find, test, or implement this issue or feature?
No.