### PR TITLE
FullscreenUI: QoL tweaks and achievements nav fixes

### DIFF
--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -183,7 +183,7 @@ namespace Achievements
 	static void DrawLeaderboardEntry(const rc_client_leaderboard_entry_t& entry, bool is_self, float rank_column_width,
 		float name_column_width, float time_column_width, float column_spacing);
 	static void OpenSubset(const rc_client_subset_t* subset);
-	static bool DrawSubsetSidebar(float sidebar_width, bool& sidebar_has_focus, bool leaderboards_only);
+	static bool DrawSubsetSidebar(float sidebar_width, bool& sidebar_has_focus, bool& focus_sidebar, bool leaderboards_only);
 	static void DrawSubsetSidebarFooter(bool sidebar_has_focus);
 	static void OpenLeaderboard(const rc_client_leaderboard_t* lboard);
 	static void LeaderboardFetchNearbyCallback(
@@ -2437,7 +2437,7 @@ bool Achievements::PrepareAchievementsWindow()
 	return true;
 }
 
-bool Achievements::DrawSubsetSidebar(float sidebar_width, bool& sidebar_has_focus, bool leaderboards_only)
+bool Achievements::DrawSubsetSidebar(float sidebar_width, bool& sidebar_has_focus, bool& focus_sidebar, bool leaderboards_only)
 {
 	if (!s_subset_list)
 		return false;
@@ -2452,7 +2452,7 @@ bool Achievements::DrawSubsetSidebar(float sidebar_width, bool& sidebar_has_focu
 
 	bool subset_selected = false;
 
-	if (ImGui::BeginChild("subset_sidebar", ImVec2(sidebar_width, 0.0f), 0, 0))
+	if (ImGui::BeginChild("subset_sidebar", ImVec2(sidebar_width, 0.0f), ImGuiChildFlags_NavFlattened, 0))
 	{
 		sidebar_has_focus = ImGui::IsWindowFocused();
 		ImGuiFullscreen::BeginMenuButtons();
@@ -2474,6 +2474,11 @@ bool Achievements::DrawSubsetSidebar(float sidebar_width, bool& sidebar_has_focu
 			bool visible, hovered;
 			ImGuiFullscreen::MenuButtonFrame(id_str, true, ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY,
 				&visible, &hovered, &bb.Min, &bb.Max, 0, 1.0f);
+
+			if (focus_sidebar && ((s_open_subset && s_open_subset->id == subset->id) || (!s_open_subset && i == 0)))
+			{
+				ImGui::SetItemDefaultFocus();
+			}
 
 			if (s_open_subset && s_open_subset->id == subset->id)
 			{
@@ -2517,6 +2522,10 @@ bool Achievements::DrawSubsetSidebar(float sidebar_width, bool& sidebar_has_focu
 	ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0.0f, 0.0f));
 	ImGui::SameLine();
 	ImGui::PopStyleVar();
+
+	if (focus_sidebar)
+		focus_sidebar = false;
+
 	return subset_selected;
 }
 
@@ -2538,7 +2547,8 @@ void Achievements::DrawSubsetSidebarFooter(bool sidebar_has_focus)
 		{
 			ImGuiFullscreen::SetFullscreenFooterText(std::array{
 				std::make_pair(glyphs.dpad_ud, TRANSLATE_SV("Achievements", "Change Selection")),
-				std::make_pair(glyphs.cancel(circleOK), TRANSLATE_SV("Achievements", "Subsets")),
+				std::make_pair(glyphs.dpad_lr, TRANSLATE_SV("Achievements", "Subsets")),
+				std::make_pair(glyphs.cancel(circleOK), TRANSLATE_SV("Achievements", "Back")),
 			});
 		}
 	}
@@ -2556,7 +2566,8 @@ void Achievements::DrawSubsetSidebarFooter(bool sidebar_has_focus)
 		{
 			ImGuiFullscreen::SetFullscreenFooterText(std::array{
 				std::make_pair(ICON_PF_ARROW_UP ICON_PF_ARROW_DOWN, TRANSLATE_SV("Achievements", "Change Selection")),
-				std::make_pair(ICON_PF_ESC, TRANSLATE_SV("Achievements", "Subsets")),
+				std::make_pair(ICON_PF_ARROW_LEFT, TRANSLATE_SV("Achievements", "Subsets")),
+				std::make_pair(ICON_PF_ESC, TRANSLATE_SV("Achievements", "Back")),
 			});
 		}
 	}
@@ -2627,15 +2638,10 @@ void Achievements::DrawAchievementsWindow()
 
 			const bool wants_close = ImGuiFullscreen::WantsToCloseMenu();
 			if (ImGuiFullscreen::FloatingButton(ICON_FA_SQUARE_XMARK, 10.0f, 10.0f, -1.0f, -1.0f, 1.0f, 0.0f, true, g_large_font) ||
-				(wants_close && (!has_multiple_subsets || sidebar_has_focus)))
+				wants_close)
 			{
 				sidebar_has_focus = false;
 				FullscreenUI::ReturnToPreviousWindow();
-			}
-			else if (has_multiple_subsets && !sidebar_has_focus && wants_close)
-			{
-				sidebar_has_focus = true;
-				focus_sidebar = true;
 			}
 
 			const ImRect title_bb(ImVec2(left, top), ImVec2(right, top + GetLineHeight(g_large_font)));
@@ -2731,9 +2737,8 @@ void Achievements::DrawAchievementsWindow()
 			if (focus_sidebar)
 			{
 				ImGui::SetNextWindowFocus();
-				focus_sidebar = false;
 			}
-			if (DrawSubsetSidebar(sidebar_width, sidebar_has_focus, false))
+			if (DrawSubsetSidebar(sidebar_width, sidebar_has_focus, focus_sidebar, false))
 				ImGui::SetNextWindowFocus();
 		}
 
@@ -2744,8 +2749,14 @@ void Achievements::DrawAchievementsWindow()
 		ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImGui::GetColorU32(ImGuiFullscreen::UIPrimaryColor));
 		ImGui::PushStyleColor(ImGuiCol_HeaderActive, ImGui::GetColorU32(ImGuiFullscreen::UISecondaryColor));
 
-		if (ImGui::BeginChild("achievements_content", ImVec2(content_width, 0.0f), 0, 0))
+		if (ImGui::BeginChild("achievements_content", ImVec2(content_width, 0.0f), ImGuiChildFlags_NavFlattened, 0))
 		{
+			if (has_multiple_subsets && !sidebar_has_focus &&
+				(ImGui::IsKeyPressed(ImGuiKey_GamepadDpadLeft, false) || ImGui::IsKeyPressed(ImGuiKey_LeftArrow, false)))
+			{
+				sidebar_has_focus = true;
+				focus_sidebar = true;
+			}
 
 			static const char* bucket_names[NUM_RC_CLIENT_ACHIEVEMENT_BUCKETS] = {
 				TRANSLATE_NOOP("Achievements", "Unknown"),
@@ -3152,15 +3163,10 @@ void Achievements::DrawLeaderboardsWindow()
 			{
 				const bool wants_close = ImGuiFullscreen::WantsToCloseMenu();
 				if (ImGuiFullscreen::FloatingButton(ICON_FA_SQUARE_XMARK, 10.0f, 10.0f, -1.0f, -1.0f, 1.0f, 0.0f, true, g_large_font) ||
-					(wants_close && (!has_multiple_subsets || sidebar_has_focus)))
+					wants_close)
 				{
 					sidebar_has_focus = false;
 					FullscreenUI::ReturnToPreviousWindow();
-				}
-				else if (has_multiple_subsets && !sidebar_has_focus && wants_close)
-				{
-					sidebar_has_focus = true;
-					focus_sidebar = true;
 				}
 			}
 			else
@@ -3330,9 +3336,8 @@ void Achievements::DrawLeaderboardsWindow()
 				if (focus_sidebar)
 				{
 					ImGui::SetNextWindowFocus();
-					focus_sidebar = false;
 				}
-				if (DrawSubsetSidebar(sidebar_width, sidebar_has_focus, true))
+				if (DrawSubsetSidebar(sidebar_width, sidebar_has_focus, focus_sidebar, true))
 					ImGui::SetNextWindowFocus();
 			}
 
@@ -3343,8 +3348,14 @@ void Achievements::DrawLeaderboardsWindow()
 			ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImGui::GetColorU32(ImGuiFullscreen::UIPrimaryColor));
 			ImGui::PushStyleColor(ImGuiCol_HeaderActive, ImGui::GetColorU32(ImGuiFullscreen::UISecondaryColor));
 
-			if (ImGui::BeginChild("leaderboards_content", ImVec2(content_width, 0.0f), 0, 0))
+			if (ImGui::BeginChild("leaderboards_content", ImVec2(content_width, 0.0f), ImGuiChildFlags_NavFlattened, 0))
 			{
+				if (has_multiple_subsets && !sidebar_has_focus &&
+					(ImGui::IsKeyPressed(ImGuiKey_GamepadDpadLeft, false) || ImGui::IsKeyPressed(ImGuiKey_LeftArrow, false)))
+				{
+					sidebar_has_focus = true;
+					focus_sidebar = true;
+				}
 
 				if (s_restore_leaderboard_scroll)
 				{

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -1563,20 +1563,10 @@ void FullscreenUI::DrawPauseMenu(MainWindowType type)
 		const float image_width = 60.0f;
 		const float image_height = 90.0f;
 		const std::string_view path_string(Path::GetFileName(s_current_disc_path));
-		const ImVec2 title_size(
-			g_large_font.first->CalcTextSizeA(g_large_font.second, std::numeric_limits<float>::max(), -1.0f, s_current_game_title.c_str()));
-		const ImVec2 path_size(path_string.empty() ?
-								   ImVec2(0.0f, 0.0f) :
-								   g_medium_font.first->CalcTextSizeA(g_medium_font.second, std::numeric_limits<float>::max(), -1.0f,
-									   path_string.data(), path_string.data() + path_string.length()));
-		const ImVec2 subtitle_size(g_medium_font.first->CalcTextSizeA(
-			g_medium_font.second, std::numeric_limits<float>::max(), -1.0f, s_current_game_subtitle.c_str()));
 
-		ImVec2 title_pos(display_size.x - LayoutScale(10.0f + image_width + 20.0f) - title_size.x,
-			display_size.y - LayoutScale(LAYOUT_FOOTER_HEIGHT) - LayoutScale(10.0f + image_height));
-		ImVec2 path_pos(display_size.x - LayoutScale(10.0f + image_width + 20.0f) - path_size.x,
-			title_pos.y + g_large_font.second + LayoutScale(4.0f));
-		ImVec2 subtitle_pos(display_size.x - LayoutScale(10.0f + image_width + 20.0f) - subtitle_size.x,
+		ImVec2 title_pos(LayoutScale(10.0f + image_width + 20.0f), LayoutScale(10.0f));
+		ImVec2 path_pos(LayoutScale(10.0f + image_width + 20.0f), title_pos.y + g_large_font.second + LayoutScale(4.0f));
+		ImVec2 subtitle_pos(LayoutScale(10.0f + image_width + 20.0f),
 			(path_string.empty() ? title_pos.y + g_large_font.second : path_pos.y + g_medium_font.second) + LayoutScale(4.0f));
 
 		float rp_height = 0.0f;
@@ -1593,12 +1583,8 @@ void FullscreenUI::DrawPauseMenu(MainWindowType type)
 				// Add a small extra gap if any Rich Presence is displayed
 				rp_height = rp_size.y - g_medium_font.second + LayoutScale(2.0f);
 
-				const ImVec2 rp_pos(display_size.x - LayoutScale(20.0f + 50.0f + 20.0f) - rp_size.x,
-					subtitle_pos.y + g_medium_font.second + LayoutScale(4.0f) - rp_height);
-
-				title_pos.y -= rp_height;
-				path_pos.y -= rp_height;
-				subtitle_pos.y -= rp_height;
+				const ImVec2 rp_pos(LayoutScale(10.0f + image_width + 20.0f),
+					subtitle_pos.y + g_medium_font.second + LayoutScale(4.0f));
 
 				DrawShadowedText(dl, g_medium_font, rp_pos, text_color, rp.data(), rp.data() + rp.length(), wrap_width);
 			}
@@ -1611,8 +1597,7 @@ void FullscreenUI::DrawPauseMenu(MainWindowType type)
 		}
 		DrawShadowedText(dl, g_medium_font, subtitle_pos, text_color, s_current_game_subtitle.c_str());
 
-		const ImVec2 image_min(display_size.x - LayoutScale(10.0f + image_width),
-			display_size.y - LayoutScale(LAYOUT_FOOTER_HEIGHT) - LayoutScale(10.0f + image_height) - rp_height);
+		const ImVec2 image_min(LayoutScale(10.0f), LayoutScale(10.0f));
 		const ImVec2 image_max(image_min.x + LayoutScale(image_width), image_min.y + LayoutScale(image_height) + rp_height);
 		{
 			auto lock = GameList::GetLock();

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -1298,9 +1298,11 @@ void FullscreenUI::DrawLandingTemplate(ImVec2* menu_pos, ImVec2* menu_size)
 #else
 			localtime_r(&utc_time_t, &tm_local);
 #endif
-			heading_str.format(FSUI_FSTR("{:%H:%M}"), tm_local);
+			char buf[256];
+			std::strftime(buf, sizeof(buf), "%X", &tm_local);
+			heading_str.assign(buf);
 
-			const ImVec2 time_size = heading_font.first->CalcTextSizeA(heading_font.second, FLT_MAX, 0.0f, "00:00");
+			const ImVec2 time_size = heading_font.first->CalcTextSizeA(heading_font.second, FLT_MAX, 0.0f, heading_str.c_str());
 			time_pos = ImVec2(heading_size.x - LayoutScale(LAYOUT_MENU_BUTTON_X_PADDING) - time_size.x,
 				LayoutScale(LAYOUT_MENU_BUTTON_Y_PADDING));
 			ImGuiFullscreen::AddTextWithShadow(


### PR DESCRIPTION
### Description of Changes
- Made left/dpad left focus the achievements/leaderboards sidebar, and changed back/esc to always exit the page instead of toggling sidebar focus. (I hope this is the last time I have to touch this for a while 😭)
- Moved game info and cover art to the top left on the pause menu.
- Changed landing page clock to use the system locale time

### Rationale behind Changes
- Fixes achievements/leaderboards navigation so left (dpad or analog left) focuses the sidebar, and Back/ESC always exits. (there were some issues where KBM were stuck in focus)
- Consistent header/title placement across FullscreenUI menus.
- Makes sure the landing page clock matches the user's OS settings.

### Suggested Testing Steps
- Open achievements/leaderboards and use keyboard/gamepad to navigate between the list and the subset sidebar. And see if everything is fine here.
- Pause a game to check that the game info is in the top left corner.
- Check that the landing page clock matches your system format.

### Did you use AI to help find, test, or implement this issue or feature?
No