### PR TITLE
QT: Remove ROV tabstop in graphics advanced section.

### DIFF
--- a/pcsx2-qt/Settings/GraphicsAdvancedSettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsAdvancedSettingsTab.ui
@@ -365,7 +365,6 @@
   <tabstop>gsDumpCompression</tabstop>
   <tabstop>texturePreloading</tabstop>
   <tabstop>exclusiveFullscreenControl</tabstop>
-  <tabstop>rov</tabstop>
   <tabstop>extendedUpscales</tabstop>
   <tabstop>spinGPUDuringReadbacks</tabstop>
   <tabstop>spinCPUDuringReadbacks</tabstop>


### PR DESCRIPTION
### Description of Changes
Remove ROV tabstop in graphics advanced section.

### Rationale behind Changes
No longer used in Graphics>Advanced part of the GUI (ROV was moved to Graphics>Rendering). Avoid compiler warning.

### Suggested Testing Steps
Testing not required. There's likely no functional difference.

### Did you use AI to help find, test, or implement this issue or feature?
No.