### PR TITLE
GS:DX12: Index pipelines in correct shader cache table.

### DIFF
--- a/pcsx2/GS/Renderers/DX12/D3D12ShaderCache.cpp
+++ b/pcsx2/GS/Renderers/DX12/D3D12ShaderCache.cpp
@@ -605,6 +605,6 @@ bool D3D12ShaderCache::AddPipelineToBlob(const CacheIndexKey& key, ID3D12Pipelin
 		return false;
 	}
 
-	m_shader_index.emplace(key, data);
+	m_pipeline_index.emplace(key, data);
 	return true;
 }


### PR DESCRIPTION
### Description of Changes
Index pipelines in correct shader cache table.

### Rationale behind Changes
Pipeline blobs were indexed in shader table, which could potentially cause them to be recreated when not necessary.

Perf impact is probably not huge since this would likely be a one time cost per PCSX2 instance, after which the pipeline is indexed in GSDevice12.

### Suggested Testing Steps
Test DX12 with shader cache enabled to make sure it still works.

### Did you use AI to help find, test, or implement this issue or feature?
No.