### PR TITLE
microVU: mask start_pc when indexing program arrays in mVUsearchProg

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ Please note that a BIOS dump from a legitimately-owned PS2 console is required t
 
 PCSX2 supports translation into other languages using [Crowdin](https://crowdin.com/project/pcsx2-emulator).
 
-See the [Contribution Guide](https://pcsx2.net/docs/contributing/) for more info on how to contribute.
+See the [Contribution Guide](https://pcsx2.net/docs/contributing/) for more info on how to contribute..

--- a/pcsx2/x86/microVU.cpp
+++ b/pcsx2/x86/microVU.cpp
@@ -244,8 +244,9 @@ __fi bool mVUcmpProg(microVU& mVU, microProgram& prog)
 _mVUt __fi void* mVUsearchProg(u32 startPC, uptr pState)
 {
 	microVU& mVU = mVUx;
-	microProgramQuick& quick = mVU.prog.quick[mVU.regs().start_pc / 8];
-	microProgramList*  list  = mVU.prog.prog [mVU.regs().start_pc / 8];
+	const u32 mvu_spc = mVU.regs().start_pc & (mVU.index ? 0x3ff8u : 0xff8u);
+	microProgramQuick& quick = mVU.prog.quick[mvu_spc / 8];
+	microProgramList*  list  = mVU.prog.prog [mvu_spc / 8];
 
 	if (!quick.prog) // If null, we need to search for new program
 	{


### PR DESCRIPTION
mVUexecute masks its startPC parameter with vuLimit before calling
mVUsearchProg, but mVUsearchProg indexes prog.quick[] and prog.prog[]
with the raw regs().start_pc. If a game sets a start_pc outside micro
memory bounds, the index goes far past the array (size 0x800), reads
garbage/zero, and dereferences a null microProgramList — crashing with
an access violation. Real hardware wraps the PC instead.

Observed with start_pc = 0x821810 (index 0x104302) — full-memory crash
dump and WinDbg analysis available. Reproducible in seconds on the
2005-05-15 Call of Cthulhu: Destiny's End prototype by rotating the
camera after gaining control; the crash survives interpreter + software
renderer, which is consistent with the OOB indexing happening in
mVUsearchProg itself.

This masks start_pc the same way mVUexecute masks its parameter.