### PR TITLE
GS/TC: Improve clear and preload behaviour

### DIFF
--- a/pcsx2/GS/GSRegs.h
+++ b/pcsx2/GS/GSRegs.h
@@ -5,22 +5,22 @@
 
 // clang-format off
 
-#define VM_SIZE 4194304u
-#define HALF_VM_SIZE (VM_SIZE / 2u)
-#define GS_PAGE_SIZE 8192u
-#define GS_BLOCK_SIZE 256u
-#define GS_COLUMN_SIZE 64u
-#define GS_BLOCKS_PER_PAGE (GS_PAGE_SIZE / GS_BLOCK_SIZE)
-
-#define GS_MAX_PAGES (VM_SIZE / GS_PAGE_SIZE)
-#define GS_MAX_BLOCKS (VM_SIZE / GS_BLOCK_SIZE)
-#define GS_MAX_COLUMNS (VM_SIZE / GS_COLUMN_SIZE)
-
 //if defined, will send much info in reply to the API title info queri from PCSX2
 //default should be undefined
 //#define GSTITLEINFO_API_FORCE_VERBOSE
 
 #include "GSVector.h"
+
+constexpr u32 VM_SIZE = 4194304u;
+constexpr u32 HALF_VM_SIZE = (VM_SIZE / 2u);
+constexpr u32 GS_PAGE_SIZE = 8192u;
+constexpr u32 GS_BLOCK_SIZE = 256u;
+constexpr u32 GS_COLUMN_SIZE = 64u;
+constexpr u32 GS_BLOCKS_PER_PAGE = (GS_PAGE_SIZE / GS_BLOCK_SIZE);
+
+constexpr u32 GS_MAX_PAGES =  (VM_SIZE / GS_PAGE_SIZE);
+constexpr u32 GS_MAX_BLOCKS = (VM_SIZE / GS_BLOCK_SIZE);
+constexpr u32 GS_MAX_COLUMNS = (VM_SIZE / GS_COLUMN_SIZE);
 
 #pragma pack(push, 1)
 

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3225,8 +3225,10 @@ void GSRendererHW::Draw()
 
 		// Be careful of being 1 pixel from filled.
 		const bool page_aligned = (m_r.w % pgs.y) == (pgs.y - 1) || (m_r.w % pgs.y) == 0;
-		const bool is_zero_color_clear = (GetConstantDirectWriteMemClearColor() == 0 && !preserve_rt_color && page_aligned);
-		const bool is_zero_depth_clear = (GetConstantDirectWriteMemClearDepth() == 0 && !preserve_depth && page_aligned);
+		const bool is_full_color_cover = !preserve_rt_color && page_aligned;
+		const bool is_full_depth_cover = !preserve_depth && page_aligned;
+		const bool is_zero_color_clear = (GetConstantDirectWriteMemClearColor() == 0 && is_full_color_cover);
+		const bool is_zero_depth_clear = (GetConstantDirectWriteMemClearDepth() == 0 && is_full_depth_cover);
 		bool gs_mem_cleared = false;
 		// If it's an invalid-sized draw, do the mem clear on the CPU, we don't want to create huge targets.
 		// If clearing to zero, don't bother creating the target. Games tend to clear more than they use, wasting VRAM/bandwidth.
@@ -3261,8 +3263,8 @@ void GSRendererHW::Draw()
 			}
 			gs_mem_cleared |= overwriting_whole_rt && overwriting_whole_ds && (!no_rt || !no_ds);
 			if (overwriting_whole_rt && overwriting_whole_ds &&
-				TryGSMemClear(no_rt, preserve_rt_color, is_zero_color_clear, rt_end_bp,
-					no_ds, preserve_depth, is_zero_depth_clear, ds_end_bp))
+				TryGSMemClear(no_rt, preserve_rt_color, is_full_color_cover, rt_end_bp,
+					no_ds, preserve_depth, is_full_depth_cover, ds_end_bp))
 			{
 				GL_INS("HW: Skipping (%d,%d=>%d,%d) draw at FBP %x/ZBP %x due to invalid height or zero clear.", m_r.x, m_r.y,
 					m_r.z, m_r.w, m_cached_ctx.FRAME.Block(), m_cached_ctx.ZBUF.Block());
@@ -3285,8 +3287,14 @@ void GSRendererHW::Draw()
 					}
 				}
 
-				CleanupDraw(false);
-				return;
+				no_rt |= is_zero_color_clear;
+				no_ds |= is_zero_depth_clear;
+
+				if (no_rt && no_ds)
+				{
+					CleanupDraw(false);
+					return;
+				}
 			}
 		}
 
@@ -9975,9 +9983,11 @@ bool GSRendererHW::DetectDoubleHalfClear(bool& no_rt, bool& no_ds)
 		// path write out FRAME and Z separately, with their associated masks. Limit it to black to avoid false positives.
 		if (write_color == 0)
 		{
+			// Don't check the *entire* size for the end, as some games (X-Men) decide it's done with Z and starts overwriting
+			// the end with other things, which causes a resize, so the end point is no longer in the right place.
+			// So let's just check there's at least one page over the half way point, at worst it means 2 targets overlap.
 			const GSTextureCache::Target* base_tgt = g_texture_cache->GetExactTarget(base * GS_BLOCKS_PER_PAGE,
-				m_cached_ctx.FRAME.FBW, clear_depth ? GSTextureCache::DepthStencil : GSTextureCache::RenderTarget,
-				GSLocalMemory::GetEndBlockAddress(half * GS_BLOCKS_PER_PAGE, m_cached_ctx.FRAME.FBW, m_cached_ctx.FRAME.PSM, m_r));
+				m_cached_ctx.FRAME.FBW, clear_depth ? GSTextureCache::DepthStencil : GSTextureCache::RenderTarget, (half + 1) * GS_BLOCKS_PER_PAGE);
 			if (base_tgt)
 			{
 				GL_INS("HW: DetectDoubleHalfClear(): Invalidating targets at 0x%x/0x%x due to different formats, and clear to black.",

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -3565,16 +3565,62 @@ bool GSTextureCache::PreloadTarget(GIFRegTEX0 TEX0, const GSVector2i& size, cons
 
 				// Make sure there's sufficient compatibility/overlap between the old target and the new target
 				// to warrant loading from the old target.
+				const u32 old_buffer_width = std::max(1U, old_dst->m_TEX0.TBW);
+
 				if (old_dst->m_TEX0.PSM != dst->m_TEX0.PSM ||
 					!old_dst->Overlaps(dst->m_TEX0.TBP0, dst->m_TEX0.TBW, dst->m_TEX0.PSM, dst_valid))
 				{
+					if (old_dst->m_TEX0.TBP0 == dst->m_TEX0.TBP0 && dst_end_block >= old_dst->m_end_block && (!src || !src->m_target || src->m_from_target != old_dst))
+					{
+						InvalidateSourcesFromTarget(old_dst);
+						i = list.erase(j);
+						delete old_dst;
+						continue;
+					}
+					
+					if (old_dst->Overlaps(dst->m_TEX0.TBP0, dst->m_TEX0.TBW, dst->m_TEX0.PSM, dst_valid))
+					{
+						const GSLocalMemory::psm_t& psm_o = GSLocalMemory::m_psm[old_dst->m_TEX0.PSM];
+						if (dst->m_TEX0.TBP0 > old_dst->m_TEX0.TBP0)
+						{
+							const int block_diff = dst->m_TEX0.TBP0 - old_dst->m_TEX0.TBP0;
+							const u32 old_pages_wide = old_buffer_width * 64 / psm_o.pgs.x;
+							if ((block_diff % (GS_BLOCKS_PER_PAGE * old_pages_wide)) == 0) // Check for left alignment.
+							{
+								const int new_height = block_diff / (GS_BLOCKS_PER_PAGE * old_pages_wide) * psm_o.pgs.y;
+								old_dst->m_valid = old_dst->m_valid.rintersect(GSVector4i(old_dst->m_valid.x, old_dst->m_valid.y, old_dst->m_valid.z, new_height));
+								old_dst->ResizeValidity(old_dst->m_valid);
+							}
+						}
+						else // new target is behind the old one, so need to move the start of the old one to the end block of the new.
+						{
+							const int block_diff = dst_end_block - old_dst->m_TEX0.TBP0;
+							const u32 old_pages_wide = old_buffer_width * 64 / psm_o.pgs.x;
+
+							if ((block_diff % (GS_BLOCKS_PER_PAGE * old_pages_wide)) == 0) // Check for left alignment.
+							{
+								const int change_height = block_diff / (GS_BLOCKS_PER_PAGE * old_pages_wide) * psm_o.pgs.y;
+								old_dst->m_valid = old_dst->m_valid.rintersect(GSVector4i(old_dst->m_valid.x, old_dst->m_valid.y, old_dst->m_valid.z, old_dst->m_valid.w - change_height));
+								old_dst->m_TEX0.TBP0 += block_diff;
+
+								const GSVector2i new_scaled_size = GSVector2i(old_dst->m_unscaled_size * old_dst->m_scale);
+								if (GSTexture* tex = g_gs_device->CreateCompatible(dst->m_texture, new_scaled_size, true))
+								{
+									const int height_offset = change_height * old_dst->m_scale;
+									g_gs_device->CopyRect(old_dst->m_texture, tex, GSVector4i(0, height_offset, old_dst->GetUnscaledWidth() * old_dst->m_scale, old_dst->GetUnscaledHeight() * old_dst->m_scale), 0, 0);
+
+									g_gs_device->Recycle(old_dst->m_texture);
+									old_dst->m_texture = tex;
+								}
+							}
+						}
+					}
 					i++;
 					continue;
 				}
 
 				const int page_diff = std::abs(static_cast<int>(old_dst->m_TEX0.TBP0 - dst->m_TEX0.TBP0)) >> 5;
 				const u32 new_buffer_width = std::max(1U, dst->m_TEX0.TBW);
-				const u32 old_buffer_width = std::max(1U, old_dst->m_TEX0.TBW);
 
 				// Handle cases where the buffer widths don't match.
 				if (new_buffer_width != old_buffer_width)
@@ -3592,7 +3638,7 @@ bool GSTextureCache::PreloadTarget(GIFRegTEX0 TEX0, const GSVector2i& size, cons
 						const u32 old_pages_wide = old_buffer_width * 64 / psm_s.pgs.x;
 						if ((block_diff % (32 * old_pages_wide)) == 0) // Check for left alignment.
 						{
-							const int new_height = block_diff / (32 * old_pages_wide) * psm_s.pgs.y;
+							const int new_height = block_diff / (GS_BLOCKS_PER_PAGE * old_pages_wide) * psm_s.pgs.y;
 							old_dst->m_valid = old_dst->m_valid.rintersect(GSVector4i(0, 0, old_dst->GetUnscaledWidth(), new_height));
 							if (old_dst->m_valid.rempty())
 							{

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -4543,10 +4543,13 @@ void GSTextureCache::InvalidateContainedTargets(u32 start_bp, u32 end_bp, u32 wr
 
 			InvalidateSourcesFromTarget(t);
 
-			t->m_valid_alpha_low &= preserve_alpha;
-			t->m_valid_alpha_high &= preserve_alpha;
-			t->m_valid_rgb &= (fb_mask & 0x00FFFFFF) != 0;
-			t->m_was_dst_matched = false;
+			if (type == DepthStencil || start_bp == t->m_TEX0.TBP0 || (start_bp < t->m_TEX0.TBP0 && t->UnwrappedEndBlock() <= end_bp))
+			{
+				t->m_valid_alpha_low &= preserve_alpha;
+				t->m_valid_alpha_high &= preserve_alpha;
+				t->m_valid_rgb &= (fb_mask & 0x00FFFFFF) != 0;
+				t->m_was_dst_matched = false;
+			}
 
 			// Don't keep partial depth buffers around.
 			if ((!t->m_valid_alpha_low && !t->m_valid_alpha_high && !t->m_valid_rgb) || type == DepthStencil)

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -4591,9 +4591,10 @@ void GSTextureCache::InvalidateContainedTargets(u32 start_bp, u32 end_bp, u32 wr
 
 			if (type == DepthStencil || start_bp == t->m_TEX0.TBP0 || (start_bp < t->m_TEX0.TBP0 && t->UnwrappedEndBlock() <= end_bp))
 			{
-				t->m_valid_alpha_low &= preserve_alpha;
-				t->m_valid_alpha_high &= preserve_alpha;
-				t->m_valid_rgb &= (fb_mask & 0x00FFFFFF) != 0;
+				const bool compatible_channel_swizzle = GSLocalMemory::m_psm[t->m_TEX0.PSM].bpp == GSLocalMemory::m_psm[write_psm].bpp;
+				t->m_valid_alpha_low &= preserve_alpha && compatible_channel_swizzle;
+				t->m_valid_alpha_high &= preserve_alpha && compatible_channel_swizzle;
+				t->m_valid_rgb &= (fb_mask & 0x00FFFFFF) != 0 && compatible_channel_swizzle;
 				t->m_was_dst_matched = false;
 			}
 


### PR DESCRIPTION
### Description of Changes
Only clears valid rgb/alpha values if target matches or fully overlaps. Also better handle double half clears, normal clears where one target is zero (no need to draw it), and also improve overlapping preload.

### Rationale behind Changes
In some situations like Gran Turismo 4, it will only be clearing the latter half of the target, leaving the beginning 256 lines, which are the next frame. Before it was marking it as no longer valid, then later copying invalid data in, breaking the target.
Also fixed up some other clear and preload behaviour (yes it was a bit of a trail of nonsense)

### Suggested Testing Steps
Test Gran Turismo 4 for flickering. Check Need for speed games lighting and games below.

### Did you use AI to help find, test, or implement this issue or feature?
No

Fixes #14650 Gran Turismo 4 flashing

Gran Turismo 4:
Master:
<img width="682" height="512" alt="image" src="https://github.com/user-attachments/assets/509a2021-61c9-467a-9f1f-58a3db405262" />

PR:
<img width="682" height="512" alt="image" src="https://github.com/user-attachments/assets/fadb1c2f-ab74-4d33-bc41-57235d2ef9ac" />

Time Crisis 3:
Master:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/7a65ea13-9136-456a-ae4f-87d41524e7d3" />

PR:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/0869330f-7920-459f-9ba9-86ecd20cc729" />

X-Men Origins:
Master:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/1539db93-d4e0-4b5c-81d4-c18462ad0123" />

PR:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/0946f3fe-f2de-496b-8565-14208b111fe9" />
