### PR TITLE
GS/TC: Only bilinear resize depth if downscaled

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -8178,8 +8178,9 @@ bool GSTextureCache::Target::ResizeTexture(int new_unscaled_width, int new_unsca
 		{
 			// Can't do partial copies in DirectX for depth textures, and it's probably not ideal in other
 			// APIs either. So use a fullscreen quad setting depth instead.
-			// Use bilinear to avoid artifacts with upscaling. At native this is equivalent to nearest.
-			g_gs_device->StretchRectAuto(m_texture, tex, GSVector4(rc), Biln);
+			// Use bilinear to avoid artifacts with upscaling during native scaling.
+			const bool req_bilinear = m_downscaled && m_scale < g_gs_renderer->GetUpscaleMultiplier();
+			g_gs_device->StretchRectAuto(m_texture, tex, GSVector4(rc), req_bilinear ? Biln : Nearest);
 		}
 		else
 		{


### PR DESCRIPTION
### Description of Changes
Makes sure resizes are done nearest unless it's a downscaled depth target, where it will use bilinear.

### Rationale behind Changes
using bilinear when a depth target is not scaling will actually break the values of it, which causes some kinda gross artifacts. Similarly the reason bilinear was added was due to Native Scaling in games like Xenosaga Episode 3 looking terrible when scaling back to normal resolution, however this was too aggressive and did cause other problems.

Some of these (like Kingdom Hearts) may have been more obvious after #14681

### Suggested Testing Steps
Test Kingdom Hearts, Xenosaga Episode 3 and Nightmare Before Christmas in native and upscaled compared to master.

### Did you use AI to help find, test, or implement this issue or feature?
No

Kingdom Hearts (Look at the foot shadows, bigger difference in native than here):
Master;
<img width="1194" height="896" alt="image" src="https://github.com/user-attachments/assets/34b0a642-f944-453e-beee-809682e42a37" />
PR:
<img width="1194" height="896" alt="image" src="https://github.com/user-attachments/assets/cdbdb1cb-3593-4227-a68b-2d8fb1020007" />

Nightmare Before Christmas (stone at the top):
Master:
<img width="1194" height="896" alt="image" src="https://github.com/user-attachments/assets/74775811-8076-4cd8-8477-fe7a9faeb4fd" />
PR:
<img width="1194" height="896" alt="image" src="https://github.com/user-attachments/assets/124e79e9-e5b7-487b-80d0-1b5465f98b19" />

Xenosaga Episode III (the water line around the middle rock with the plant guy on top of it):
Master:
<img width="1280" height="960" alt="image" src="https://github.com/user-attachments/assets/672255aa-5a1e-4dd2-9fc8-66adcb4974b6" />
PR:
<img width="1280" height="960" alt="image" src="https://github.com/user-attachments/assets/e91b7f4f-8d80-427f-96c9-812852f16e13" />

