### PR TITLE
gitignore: Ignore Kate project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,9 @@ oprofile_data/
 *.kdev4
 /.kdev4*
 
+# Kate Projects
+.kateproject*
+
 # Resources and docs in /bin are tracked
 /bin/**/*.dll
 /bin/**/*.dmp


### PR DESCRIPTION
### Description of Changes
Adds an entry to .gitignore for Kate project files.

### Rationale behind Changes
We already have other IDE project files in our .gitignore so people can choose their preference and not muddy up the repo. Adding Kate to that list.

### Suggested Testing Steps
Add a ".kateproject" file to the root of the repo, git should not see it.

### Did you use AI to help find, test, or implement this issue or feature?
nay