### PR TITLE
GS: Move readback image dump to Transfer Images parameter from Save RT

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2976,7 +2976,7 @@ void GSState::InitReadFIFO(u8* mem, int len)
 	// Read the image all in one go.
 	m_mem.ReadImageX(m_tr.x, m_tr.y, m_tr.buff, m_tr.total, m_env.BITBLTBUF, m_env.TRXPOS, m_env.TRXREG);
 
-	if (GSConfig.SaveRT && GSConfig.ShouldDump(s_n, g_perfmon.GetFrame()))
+	if (GSConfig.SaveTransferImages && GSConfig.ShouldDump(s_n, g_perfmon.GetFrame()))
 	{
 		const std::string s(GetDrawDumpPath(
 			"%05lld_read_%05x_%d_%s_%d_%d_%d_%d.bmp",


### PR DESCRIPTION
### Description of Changes
Moves the GS to EE readback image dumps to the Save Transfer Images dump parameter from Save RT

### Rationale behind Changes
It's a transfer, the Save RT option doesn't make much sense anymore, this was more a legacy thing from before the Save Transfer Images option existed.

### Suggested Testing Steps
Already tested but I guess if you want to, dump something with readbacks with just the Save Transfer Images enabled (and Enable dumping ofc)

### Did you use AI to help find, test, or implement this issue or feature?
No