### PR TITLE
GS/DX: Fix typo with primid init output.

### DIFF
--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -198,7 +198,7 @@ struct PS_OUTPUT
 
 #if PS_RETURN_COLOR
 	#if PS_DATE == 1 || PS_DATE == 2
-		float c : SV_Target;
+		float c0 : SV_Target;
 	#else
 		
 		float4 c0 : SV_Target0;


### PR DESCRIPTION
### Description of Changes
Fix a typo in the ouput value of DX shaders for primid init.

### Rationale behind Changes
Fix primid init in DX.

### Suggested Testing Steps
Set the blend level to basic and test games that use DATE (I don't have a specific dump as this bug was found while testing another PR).

### Did you use AI to help find, test, or implement this issue or feature?
No.