### PR TITLE
GS/HW: Adjust shuffle predetect for only texture formats under 32bit

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3435,7 +3435,7 @@ void GSRendererHW::Draw()
 		bool shuffle_target = false;
 		const u32 page_alignment = GSLocalMemory::IsPageAlignedMasked(m_cached_ctx.TEX0.PSM, m_r);
 		const bool page_aligned = (page_alignment & 0xF0F0) != 0; // Make sure Y is page aligned.
-		if (!no_rt && page_aligned && m_cached_ctx.ZBUF.ZMSK && GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].bpp == 16 && GSLocalMemory::m_psm[m_cached_ctx.TEX0.PSM].bpp >= 16 &&
+		if (!no_rt && page_aligned && m_cached_ctx.ZBUF.ZMSK && GSLocalMemory::m_psm[m_cached_ctx.FRAME.PSM].bpp == 16 && GSLocalMemory::m_psm[m_cached_ctx.TEX0.PSM].trbpp <= 16 &&
 			(m_vt.m_primclass == GS_SPRITE_CLASS || (m_vt.m_primclass == GS_TRIANGLE_CLASS && (m_index->tail % 6) == 0 && TrianglesAreQuads(true) && m_index->tail > 6)))
 		{
 			// Tail check is to make sure we have enough strips to go all the way across the page, or if it's using a region clamp could be used to draw strips.


### PR DESCRIPTION
### Description of Changes
Only check for shuffles on textures which are 16bit or less in actual depth, not storage format.

### Rationale behind Changes
Regression from #11461, I don't know why I said the texture format should be 32bits, makes no sense, a shuffle is always 16bit or less (on actual format size, rather than storage size), but there seems to be no regressions.

This caused it to errantly think it might be a shuffle on Gran Turismo 4 when generating the split time cars, meaning it had to request the RGB to be valid, which it wasn't on the texture it needed, it was only an alpha, so the lookup failed, making the alpha 0, so the cars were invisible.

### Suggested Testing Steps
Test Gran Turismo 4 + variations, make sure the split time cars work.

### Did you use AI to help find, test, or implement this issue or feature?
No