### PR TITLE
GHActions: Clean old stuff out of ccache

### DIFF
--- a/.github/workflows/linux_build_qt.yml
+++ b/.github/workflows/linux_build_qt.yml
@@ -95,8 +95,8 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .ccache
-          key: ${{ inputs.os }} ${{ inputs.platform }} ${{ inputs.compiler }} ccache ${{ steps.ccache_cache_timestamp.outputs.timestamp }}
-          restore-keys: ${{ inputs.os }} ${{ inputs.platform }} ${{ inputs.compiler }} ccache
+          key: ${{ inputs.os }} ${{ inputs.platform }} ${{ inputs.compiler }} ${{ inputs.cmakeBuildType }} ccache ${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          restore-keys: ${{ inputs.os }} ${{ inputs.platform }} ${{ inputs.compiler }} ${{ inputs.cmakeBuildType }} ccache
 
       - name: Install Packages
         run: |

--- a/.github/workflows/linux_build_qt.yml
+++ b/.github/workflows/linux_build_qt.yml
@@ -163,6 +163,12 @@ jobs:
         working-directory: ./build
         run: ninja unittests
 
+      - name: Clean Caches
+        run: |
+          ccache -s
+          ccache --evict-older-than 1d
+          ccache -s
+
       - name: Package AppImage
         if: inputs.buildAppImage == true
         env:

--- a/.github/workflows/linux_build_qt.yml
+++ b/.github/workflows/linux_build_qt.yml
@@ -134,7 +134,7 @@ jobs:
         run: |
           cmake -B build -G Ninja \
             -DCMAKE_BUILD_TYPE="${{ inputs.cmakeBuildType }}" \
-            -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
+            -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ case(inputs.cmakeBuildType == 'Debug', 'OFF', 'ON') }} \
             -DCMAKE_PREFIX_PATH="$HOME/deps" \
             -DCMAKE_C_COMPILER=clang-17 \
             -DCMAKE_CXX_COMPILER=clang++-17 \

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -164,6 +164,12 @@ jobs:
         working-directory: build
         run: make -j$(getconf _NPROCESSORS_ONLN) unittests
 
+      - name: Clean Caches
+        run: |
+          ccache -s
+          ccache --evict-older-than 1d
+          ccache -s
+
       - name: Prepare Build Artifacts
         run: |
           mv build/pcsx2*/PCSX2.app PCSX2.app

--- a/.github/workflows/release_cut_new.yml
+++ b/.github/workflows/release_cut_new.yml
@@ -103,6 +103,21 @@ jobs:
       stableBuild: ${{ github.event_name == 'workflow_dispatch' && inputs.is_prerelease == 'false' }}
     secrets: inherit
 
+  build_linux_debug:
+    if: github.repository == 'PCSX2/pcsx2'
+    needs:
+      - cut-release
+    name: "Linux"
+    uses: ./.github/workflows/linux_build_qt.yml
+    with:
+      jobName: "Generate debug build caches"
+      artifactPrefixName: "PCSX2-linux-Qt-x64-debug"
+      compiler: clang
+      cmakeflags: ""
+      buildAppImage: false
+      cmakeBuildType: Debug
+    secrets: inherit
+
   build_linux_flatpak:
     if: github.repository == 'PCSX2/pcsx2'
     needs:


### PR DESCRIPTION
### Description of Changes
Adds a CI step to clean stuff out of ccache caches if it hasn't been needed for a day.
(The clean runs *after* the build, so anything that was needed by the most recent build will be kept.)

Also fixes caches for AppImage debug builds, since I noticed they were previously shared with release builds, and turns off LTO for debug builds for faster cached builds.

### Rationale behind Changes
We currently rely on our 100MB cache size limit to clear old stuff out of the ccache cache.  This means all our ccache caches are near 100MB, which is kind of wasteful.

### Suggested Testing Steps
Look at the size of the output cache for this PR

### Did you use AI to help find, test, or implement this issue or feature?
No