### PR TITLE
Qt: Add hotkey support for toggling individual pnach cheats during gameplay

### DIFF
--- a/pcsx2/Hotkeys.cpp
+++ b/pcsx2/Hotkeys.cpp
@@ -358,30 +358,453 @@ DEFINE_HOTKEY("ToggleMouseLock", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_
 			Host::SetMouseLock(!Host::GetBoolSettingValue("EmuCore", "EnableMouseLock"));
 	})
 
-DEFINE_HOTKEY("ToggleBerserkerFilter", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Toggle Berserker Filter"), [](s32 pressed) {
-	if (!pressed && VMManager::HasValidVM())
-	{
-		Host::RunOnCPUThread([]() {
+
+DEFINE_HOTKEY("ToggleCheatSlot1", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Toggle Cheat Slot 1"), [](s32 pressed) {
+        if (!pressed && VMManager::HasValidVM())
+        {
+                Host::RunOnCPUThread([]() {
                         SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
                         if (!si)
                                 return;
-                        const char* cheat_name = "Sem filtro vermelho Berserker";
+                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot1", "");
+                        if (cheat_name.empty())
+                                return;
                         std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
                         auto it = std::find(enabled.begin(), enabled.end(), cheat_name);
                         if (it != enabled.end())
                         {
-                                si->RemoveFromStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name);
-                                Host::AddKeyedOSDMessage("BerserkerFilter", "Berserker Filter: OFF");
+                                si->RemoveFromStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot1", fmt::format("Cheat Slot 1 ({}): OFF", cheat_name));
                         }
                         else
                         {
-                                si->AddToStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name);
-                                Host::AddKeyedOSDMessage("BerserkerFilter", "Berserker Filter: ON");
+                                si->AddToStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot1", fmt::format("Cheat Slot 1 ({}): ON", cheat_name));
                         }
                         si->Save();
                         VMManager::ReloadPatches(true, true, true, true);
-                
                 });
-	}
+        }
 })
+
+DEFINE_HOTKEY("ToggleCheatSlot2", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Toggle Cheat Slot 2"), [](s32 pressed) {
+        if (!pressed && VMManager::HasValidVM())
+        {
+                Host::RunOnCPUThread([]() {
+                        SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
+                        if (!si)
+                                return;
+                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot2", "");
+                        if (cheat_name.empty())
+                                return;
+                        std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
+                        auto it = std::find(enabled.begin(), enabled.end(), cheat_name);
+                        if (it != enabled.end())
+                        {
+                                si->RemoveFromStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot2", fmt::format("Cheat Slot 2 ({}): OFF", cheat_name));
+                        }
+                        else
+                        {
+                                si->AddToStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot2", fmt::format("Cheat Slot 2 ({}): ON", cheat_name));
+                        }
+                        si->Save();
+                        VMManager::ReloadPatches(true, true, true, true);
+                });
+        }
+})
+
+DEFINE_HOTKEY("ToggleCheatSlot3", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Toggle Cheat Slot 3"), [](s32 pressed) {
+        if (!pressed && VMManager::HasValidVM())
+        {
+                Host::RunOnCPUThread([]() {
+                        SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
+                        if (!si)
+                                return;
+                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot3", "");
+                        if (cheat_name.empty())
+                                return;
+                        std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
+                        auto it = std::find(enabled.begin(), enabled.end(), cheat_name);
+                        if (it != enabled.end())
+                        {
+                                si->RemoveFromStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot3", fmt::format("Cheat Slot 3 ({}): OFF", cheat_name));
+                        }
+                        else
+                        {
+                                si->AddToStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot3", fmt::format("Cheat Slot 3 ({}): ON", cheat_name));
+                        }
+                        si->Save();
+                        VMManager::ReloadPatches(true, true, true, true);
+                });
+        }
+})
+
+DEFINE_HOTKEY("ToggleCheatSlot4", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Toggle Cheat Slot 4"), [](s32 pressed) {
+        if (!pressed && VMManager::HasValidVM())
+        {
+                Host::RunOnCPUThread([]() {
+                        SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
+                        if (!si)
+                                return;
+                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot4", "");
+                        if (cheat_name.empty())
+                                return;
+                        std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
+                        auto it = std::find(enabled.begin(), enabled.end(), cheat_name);
+                        if (it != enabled.end())
+                        {
+                                si->RemoveFromStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot4", fmt::format("Cheat Slot 4 ({}): OFF", cheat_name));
+                        }
+                        else
+                        {
+                                si->AddToStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot4", fmt::format("Cheat Slot 4 ({}): ON", cheat_name));
+                        }
+                        si->Save();
+                        VMManager::ReloadPatches(true, true, true, true);
+                });
+        }
+})
+
+DEFINE_HOTKEY("ToggleCheatSlot5", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Toggle Cheat Slot 5"), [](s32 pressed) {
+        if (!pressed && VMManager::HasValidVM())
+        {
+                Host::RunOnCPUThread([]() {
+                        SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
+                        if (!si)
+                                return;
+                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot5", "");
+                        if (cheat_name.empty())
+                                return;
+                        std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
+                        auto it = std::find(enabled.begin(), enabled.end(), cheat_name);
+                        if (it != enabled.end())
+                        {
+                                si->RemoveFromStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot5", fmt::format("Cheat Slot 5 ({}): OFF", cheat_name));
+                        }
+                        else
+                        {
+                                si->AddToStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot5", fmt::format("Cheat Slot 5 ({}): ON", cheat_name));
+                        }
+                        si->Save();
+                        VMManager::ReloadPatches(true, true, true, true);
+                });
+        }
+})
+
+DEFINE_HOTKEY("ToggleCheatSlot6", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Toggle Cheat Slot 6"), [](s32 pressed) {
+        if (!pressed && VMManager::HasValidVM())
+        {
+                Host::RunOnCPUThread([]() {
+                        SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
+                        if (!si)
+                                return;
+                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot6", "");
+                        if (cheat_name.empty())
+                                return;
+                        std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
+                        auto it = std::find(enabled.begin(), enabled.end(), cheat_name);
+                        if (it != enabled.end())
+                        {
+                                si->RemoveFromStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot6", fmt::format("Cheat Slot 6 ({}): OFF", cheat_name));
+                        }
+                        else
+                        {
+                                si->AddToStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot6", fmt::format("Cheat Slot 6 ({}): ON", cheat_name));
+                        }
+                        si->Save();
+                        VMManager::ReloadPatches(true, true, true, true);
+                });
+        }
+})
+
+DEFINE_HOTKEY("ToggleCheatSlot7", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Toggle Cheat Slot 7"), [](s32 pressed) {
+        if (!pressed && VMManager::HasValidVM())
+        {
+                Host::RunOnCPUThread([]() {
+                        SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
+                        if (!si)
+                                return;
+                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot7", "");
+                        if (cheat_name.empty())
+                                return;
+                        std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
+                        auto it = std::find(enabled.begin(), enabled.end(), cheat_name);
+                        if (it != enabled.end())
+                        {
+                                si->RemoveFromStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot7", fmt::format("Cheat Slot 7 ({}): OFF", cheat_name));
+                        }
+                        else
+                        {
+                                si->AddToStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot7", fmt::format("Cheat Slot 7 ({}): ON", cheat_name));
+                        }
+                        si->Save();
+                        VMManager::ReloadPatches(true, true, true, true);
+                });
+        }
+})
+
+DEFINE_HOTKEY("ToggleCheatSlot8", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Toggle Cheat Slot 8"), [](s32 pressed) {
+        if (!pressed && VMManager::HasValidVM())
+        {
+                Host::RunOnCPUThread([]() {
+                        SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
+                        if (!si)
+                                return;
+                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot8", "");
+                        if (cheat_name.empty())
+                                return;
+                        std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
+                        auto it = std::find(enabled.begin(), enabled.end(), cheat_name);
+                        if (it != enabled.end())
+                        {
+                                si->RemoveFromStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot8", fmt::format("Cheat Slot 8 ({}): OFF", cheat_name));
+                        }
+                        else
+                        {
+                                si->AddToStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot8", fmt::format("Cheat Slot 8 ({}): ON", cheat_name));
+                        }
+                        si->Save();
+                        VMManager::ReloadPatches(true, true, true, true);
+                });
+        }
+})
+
+DEFINE_HOTKEY("ToggleCheatSlot9", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Toggle Cheat Slot 9"), [](s32 pressed) {
+        if (!pressed && VMManager::HasValidVM())
+        {
+                Host::RunOnCPUThread([]() {
+                        SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
+                        if (!si)
+                                return;
+                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot9", "");
+                        if (cheat_name.empty())
+                                return;
+                        std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
+                        auto it = std::find(enabled.begin(), enabled.end(), cheat_name);
+                        if (it != enabled.end())
+                        {
+                                si->RemoveFromStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot9", fmt::format("Cheat Slot 9 ({}): OFF", cheat_name));
+                        }
+                        else
+                        {
+                                si->AddToStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot9", fmt::format("Cheat Slot 9 ({}): ON", cheat_name));
+                        }
+                        si->Save();
+                        VMManager::ReloadPatches(true, true, true, true);
+                });
+        }
+})
+
+DEFINE_HOTKEY("ToggleCheatSlot10", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Toggle Cheat Slot 10"), [](s32 pressed) {
+        if (!pressed && VMManager::HasValidVM())
+        {
+                Host::RunOnCPUThread([]() {
+                        SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
+                        if (!si)
+                                return;
+                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot10", "");
+                        if (cheat_name.empty())
+                                return;
+                        std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
+                        auto it = std::find(enabled.begin(), enabled.end(), cheat_name);
+                        if (it != enabled.end())
+                        {
+                                si->RemoveFromStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot10", fmt::format("Cheat Slot 10 ({}): OFF", cheat_name));
+                        }
+                        else
+                        {
+                                si->AddToStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot10", fmt::format("Cheat Slot 10 ({}): ON", cheat_name));
+                        }
+                        si->Save();
+                        VMManager::ReloadPatches(true, true, true, true);
+                });
+        }
+})
+
+DEFINE_HOTKEY("ToggleCheatSlot11", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Toggle Cheat Slot 11"), [](s32 pressed) {
+        if (!pressed && VMManager::HasValidVM())
+        {
+                Host::RunOnCPUThread([]() {
+                        SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
+                        if (!si)
+                                return;
+                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot11", "");
+                        if (cheat_name.empty())
+                                return;
+                        std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
+                        auto it = std::find(enabled.begin(), enabled.end(), cheat_name);
+                        if (it != enabled.end())
+                        {
+                                si->RemoveFromStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot11", fmt::format("Cheat Slot 11 ({}): OFF", cheat_name));
+                        }
+                        else
+                        {
+                                si->AddToStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot11", fmt::format("Cheat Slot 11 ({}): ON", cheat_name));
+                        }
+                        si->Save();
+                        VMManager::ReloadPatches(true, true, true, true);
+                });
+        }
+})
+
+DEFINE_HOTKEY("ToggleCheatSlot12", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Toggle Cheat Slot 12"), [](s32 pressed) {
+        if (!pressed && VMManager::HasValidVM())
+        {
+                Host::RunOnCPUThread([]() {
+                        SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
+                        if (!si)
+                                return;
+                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot12", "");
+                        if (cheat_name.empty())
+                                return;
+                        std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
+                        auto it = std::find(enabled.begin(), enabled.end(), cheat_name);
+                        if (it != enabled.end())
+                        {
+                                si->RemoveFromStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot12", fmt::format("Cheat Slot 12 ({}): OFF", cheat_name));
+                        }
+                        else
+                        {
+                                si->AddToStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot12", fmt::format("Cheat Slot 12 ({}): ON", cheat_name));
+                        }
+                        si->Save();
+                        VMManager::ReloadPatches(true, true, true, true);
+                });
+        }
+})
+
+DEFINE_HOTKEY("ToggleCheatSlot13", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Toggle Cheat Slot 13"), [](s32 pressed) {
+        if (!pressed && VMManager::HasValidVM())
+        {
+                Host::RunOnCPUThread([]() {
+                        SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
+                        if (!si)
+                                return;
+                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot13", "");
+                        if (cheat_name.empty())
+                                return;
+                        std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
+                        auto it = std::find(enabled.begin(), enabled.end(), cheat_name);
+                        if (it != enabled.end())
+                        {
+                                si->RemoveFromStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot13", fmt::format("Cheat Slot 13 ({}): OFF", cheat_name));
+                        }
+                        else
+                        {
+                                si->AddToStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot13", fmt::format("Cheat Slot 13 ({}): ON", cheat_name));
+                        }
+                        si->Save();
+                        VMManager::ReloadPatches(true, true, true, true);
+                });
+        }
+})
+
+DEFINE_HOTKEY("ToggleCheatSlot14", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Toggle Cheat Slot 14"), [](s32 pressed) {
+        if (!pressed && VMManager::HasValidVM())
+        {
+                Host::RunOnCPUThread([]() {
+                        SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
+                        if (!si)
+                                return;
+                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot14", "");
+                        if (cheat_name.empty())
+                                return;
+                        std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
+                        auto it = std::find(enabled.begin(), enabled.end(), cheat_name);
+                        if (it != enabled.end())
+                        {
+                                si->RemoveFromStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot14", fmt::format("Cheat Slot 14 ({}): OFF", cheat_name));
+                        }
+                        else
+                        {
+                                si->AddToStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot14", fmt::format("Cheat Slot 14 ({}): ON", cheat_name));
+                        }
+                        si->Save();
+                        VMManager::ReloadPatches(true, true, true, true);
+                });
+        }
+})
+
+DEFINE_HOTKEY("ToggleCheatSlot15", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Toggle Cheat Slot 15"), [](s32 pressed) {
+        if (!pressed && VMManager::HasValidVM())
+        {
+                Host::RunOnCPUThread([]() {
+                        SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
+                        if (!si)
+                                return;
+                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot15", "");
+                        if (cheat_name.empty())
+                                return;
+                        std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
+                        auto it = std::find(enabled.begin(), enabled.end(), cheat_name);
+                        if (it != enabled.end())
+                        {
+                                si->RemoveFromStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot15", fmt::format("Cheat Slot 15 ({}): OFF", cheat_name));
+                        }
+                        else
+                        {
+                                si->AddToStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot15", fmt::format("Cheat Slot 15 ({}): ON", cheat_name));
+                        }
+                        si->Save();
+                        VMManager::ReloadPatches(true, true, true, true);
+                });
+        }
+})
+
+DEFINE_HOTKEY("ToggleCheatSlot16", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Toggle Cheat Slot 16"), [](s32 pressed) {
+        if (!pressed && VMManager::HasValidVM())
+        {
+                Host::RunOnCPUThread([]() {
+                        SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
+                        if (!si)
+                                return;
+                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot16", "");
+                        if (cheat_name.empty())
+                                return;
+                        std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
+                        auto it = std::find(enabled.begin(), enabled.end(), cheat_name);
+                        if (it != enabled.end())
+                        {
+                                si->RemoveFromStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot16", fmt::format("Cheat Slot 16 ({}): OFF", cheat_name));
+                        }
+                        else
+                        {
+                                si->AddToStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name.c_str());
+                                Host::AddKeyedOSDMessage("CheatSlot16", fmt::format("Cheat Slot 16 ({}): ON", cheat_name));
+                        }
+                        si->Save();
+                        VMManager::ReloadPatches(true, true, true, true);
+                });
+        }
+})
+
 END_HOTKEY_LIST()

--- a/pcsx2/Hotkeys.cpp
+++ b/pcsx2/Hotkeys.cpp
@@ -366,7 +366,7 @@ DEFINE_HOTKEY("ToggleCheatSlot1", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE
                         SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
                         if (!si)
                                 return;
-                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot1", "");
+                        const std::string cheat_name = Host::GetStringSettingValue("CheatHotkeys", "CheatToggleSlot1", "");
                         if (cheat_name.empty())
                                 return;
                         std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
@@ -394,7 +394,7 @@ DEFINE_HOTKEY("ToggleCheatSlot2", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE
                         SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
                         if (!si)
                                 return;
-                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot2", "");
+                        const std::string cheat_name = Host::GetStringSettingValue("CheatHotkeys", "CheatToggleSlot2", "");
                         if (cheat_name.empty())
                                 return;
                         std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
@@ -422,7 +422,7 @@ DEFINE_HOTKEY("ToggleCheatSlot3", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE
                         SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
                         if (!si)
                                 return;
-                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot3", "");
+                        const std::string cheat_name = Host::GetStringSettingValue("CheatHotkeys", "CheatToggleSlot3", "");
                         if (cheat_name.empty())
                                 return;
                         std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
@@ -450,7 +450,7 @@ DEFINE_HOTKEY("ToggleCheatSlot4", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE
                         SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
                         if (!si)
                                 return;
-                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot4", "");
+                        const std::string cheat_name = Host::GetStringSettingValue("CheatHotkeys", "CheatToggleSlot4", "");
                         if (cheat_name.empty())
                                 return;
                         std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
@@ -478,7 +478,7 @@ DEFINE_HOTKEY("ToggleCheatSlot5", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE
                         SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
                         if (!si)
                                 return;
-                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot5", "");
+                        const std::string cheat_name = Host::GetStringSettingValue("CheatHotkeys", "CheatToggleSlot5", "");
                         if (cheat_name.empty())
                                 return;
                         std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
@@ -506,7 +506,7 @@ DEFINE_HOTKEY("ToggleCheatSlot6", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE
                         SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
                         if (!si)
                                 return;
-                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot6", "");
+                        const std::string cheat_name = Host::GetStringSettingValue("CheatHotkeys", "CheatToggleSlot6", "");
                         if (cheat_name.empty())
                                 return;
                         std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
@@ -534,7 +534,7 @@ DEFINE_HOTKEY("ToggleCheatSlot7", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE
                         SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
                         if (!si)
                                 return;
-                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot7", "");
+                        const std::string cheat_name = Host::GetStringSettingValue("CheatHotkeys", "CheatToggleSlot7", "");
                         if (cheat_name.empty())
                                 return;
                         std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
@@ -562,7 +562,7 @@ DEFINE_HOTKEY("ToggleCheatSlot8", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE
                         SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
                         if (!si)
                                 return;
-                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot8", "");
+                        const std::string cheat_name = Host::GetStringSettingValue("CheatHotkeys", "CheatToggleSlot8", "");
                         if (cheat_name.empty())
                                 return;
                         std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
@@ -590,7 +590,7 @@ DEFINE_HOTKEY("ToggleCheatSlot9", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE
                         SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
                         if (!si)
                                 return;
-                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot9", "");
+                        const std::string cheat_name = Host::GetStringSettingValue("CheatHotkeys", "CheatToggleSlot9", "");
                         if (cheat_name.empty())
                                 return;
                         std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
@@ -618,7 +618,7 @@ DEFINE_HOTKEY("ToggleCheatSlot10", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLAT
                         SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
                         if (!si)
                                 return;
-                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot10", "");
+                        const std::string cheat_name = Host::GetStringSettingValue("CheatHotkeys", "CheatToggleSlot10", "");
                         if (cheat_name.empty())
                                 return;
                         std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
@@ -646,7 +646,7 @@ DEFINE_HOTKEY("ToggleCheatSlot11", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLAT
                         SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
                         if (!si)
                                 return;
-                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot11", "");
+                        const std::string cheat_name = Host::GetStringSettingValue("CheatHotkeys", "CheatToggleSlot11", "");
                         if (cheat_name.empty())
                                 return;
                         std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
@@ -674,7 +674,7 @@ DEFINE_HOTKEY("ToggleCheatSlot12", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLAT
                         SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
                         if (!si)
                                 return;
-                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot12", "");
+                        const std::string cheat_name = Host::GetStringSettingValue("CheatHotkeys", "CheatToggleSlot12", "");
                         if (cheat_name.empty())
                                 return;
                         std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
@@ -702,7 +702,7 @@ DEFINE_HOTKEY("ToggleCheatSlot13", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLAT
                         SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
                         if (!si)
                                 return;
-                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot13", "");
+                        const std::string cheat_name = Host::GetStringSettingValue("CheatHotkeys", "CheatToggleSlot13", "");
                         if (cheat_name.empty())
                                 return;
                         std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
@@ -730,7 +730,7 @@ DEFINE_HOTKEY("ToggleCheatSlot14", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLAT
                         SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
                         if (!si)
                                 return;
-                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot14", "");
+                        const std::string cheat_name = Host::GetStringSettingValue("CheatHotkeys", "CheatToggleSlot14", "");
                         if (cheat_name.empty())
                                 return;
                         std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
@@ -758,7 +758,7 @@ DEFINE_HOTKEY("ToggleCheatSlot15", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLAT
                         SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
                         if (!si)
                                 return;
-                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot15", "");
+                        const std::string cheat_name = Host::GetStringSettingValue("CheatHotkeys", "CheatToggleSlot15", "");
                         if (cheat_name.empty())
                                 return;
                         std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
@@ -786,7 +786,7 @@ DEFINE_HOTKEY("ToggleCheatSlot16", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLAT
                         SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
                         if (!si)
                                 return;
-                        const std::string cheat_name = Host::GetStringSettingValue("Hotkeys", "CheatToggleSlot16", "");
+                        const std::string cheat_name = Host::GetStringSettingValue("CheatHotkeys", "CheatToggleSlot16", "");
                         if (cheat_name.empty())
                                 return;
                         std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);

--- a/pcsx2/Hotkeys.cpp
+++ b/pcsx2/Hotkeys.cpp
@@ -11,6 +11,8 @@
 #include "Recording/InputRecording.h"
 #include "SPU2/spu2.h"
 #include "VMManager.h"
+#include "INISettingsInterface.h"
+#include "Patch.h"
 #include "SIO/Memcard/MemoryCardFile.h"
 
 #include "common/Assertions.h"
@@ -246,7 +248,7 @@ DEFINE_HOTKEY("ReloadPatches", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NO
 		{
 			Host::RunOnCPUThread([]() {
 				Host::AddKeyedOSDMessage("ReloadPatchHotkey", "Reloading Patches...");
-				VMManager::ReloadPatches(true, false, true, true);
+				VMManager::ReloadPatches(true, true, true, true);
 			});
 		}
 	})
@@ -355,4 +357,31 @@ DEFINE_HOTKEY("ToggleMouseLock", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_
 		if (!pressed)
 			Host::SetMouseLock(!Host::GetBoolSettingValue("EmuCore", "EnableMouseLock"));
 	})
+
+DEFINE_HOTKEY("ToggleBerserkerFilter", TRANSLATE_NOOP("Hotkeys", "System"), TRANSLATE_NOOP("Hotkeys", "Toggle Berserker Filter"), [](s32 pressed) {
+	if (!pressed && VMManager::HasValidVM())
+	{
+		Host::RunOnCPUThread([]() {
+                        SettingsInterface* si = Host::Internal::GetGameSettingsLayer();
+                        if (!si)
+                                return;
+                        const char* cheat_name = "Sem filtro vermelho Berserker";
+                        std::vector<std::string> enabled = si->GetStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY);
+                        auto it = std::find(enabled.begin(), enabled.end(), cheat_name);
+                        if (it != enabled.end())
+                        {
+                                si->RemoveFromStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name);
+                                Host::AddKeyedOSDMessage("BerserkerFilter", "Berserker Filter: OFF");
+                        }
+                        else
+                        {
+                                si->AddToStringList(Patch::CHEATS_CONFIG_SECTION, Patch::PATCH_ENABLE_CONFIG_KEY, cheat_name);
+                                Host::AddKeyedOSDMessage("BerserkerFilter", "Berserker Filter: ON");
+                        }
+                        si->Save();
+                        VMManager::ReloadPatches(true, true, true, true);
+                
+                });
+	}
+})
 END_HOTKEY_LIST()


### PR DESCRIPTION
### Description of Changes

Adds 16 configurable hotkey slots (`ToggleCheatSlot1` to `ToggleCheatSlot16`) under Controllers → Hotkeys → System. Each slot reads the target cheat name from a dedicated `[CheatHotkeys]` section in `PCSX2.ini`. When triggered, the hotkey toggles the named cheat on or off in real time and displays an OSD message confirming the state.

**Configuration Example**

Pnach file (`9685E636.pnach`):
```
[60fps]
patch=1,EE,003B408C,extended,01
[No Red Filter]
patch=1,EE,D03DC4C2,extended,FFFD
patch=1,EE,003D87EC,byte,00
```

`PCSX2.ini`:
```
[Hotkeys]
ToggleCheatSlot1 = SDL-0/LeftStick
ToggleCheatSlot2 = SDL-0/RightStick
[CheatHotkeys]
CheatToggleSlot1 = No Red Filter
CheatToggleSlot2 = 60fps
```

> **Important:** The cheat name in `[CheatHotkeys]` must match **exactly** the name between brackets in the pnach file — case sensitive, space sensitive.

### Rationale behind Changes

Users currently have no way to toggle individual pnach cheats during gameplay without opening a menu. This is particularly useful for cheats that need to be toggled mid-game (e.g. 60fps patches that break cutscenes, visual filters that should only be active during specific gameplay moments).

Resolves: #12374, #4514, #5567, #10147, #11945, #841

### Suggested Testing Steps

1. Create a pnach cheat with a named section (see example above)
2. Add the hotkey mapping under `[Hotkeys]` in `PCSX2.ini`
3. Add the cheat name under `[CheatHotkeys]` in `PCSX2.ini`
4. Assign the hotkey button in Controllers → Hotkeys → System → Toggle Cheat Slot 1
5. Launch a game with the cheat enabled and press the mapped button
6. Verify the OSD shows "Cheat Slot 1 (No Red Filter): OFF" and the cheat is disabled
7. Press again and verify "ON" and the cheat re-enables

### Did you use AI to help find, test, or implement this issue or feature?

Yes. Claude Sonnet 4.6 (Anthropic) was used throughout the implementation process for code guidance, debugging, and build system support. The author is not a developer and has no prior C++ or emulator development experience. The feature was researched and implemented over approximately 3 weeks of iterative sessions (June 19 – July 12, 2026), combining manual testing, runtime debugging with PCSX2 EE Debugger, Cheat Engine and RenderDoc, and AI-assisted code implementation.

<img width="1800" height="1107" alt="Captura de tela 2026-07-13 002228" src="https://github.com/user-attachments/assets/0529df37-bd1b-4324-ac36-1919aeb18b9e" />
<img width="1000" height="512" alt="Captura de tela 2026-07-13 001735" src="https://github.com/user-attachments/assets/50f4d025-a0e6-4e0d-85d0-8c95ffa90485" />
<img width="970" height="455" alt="Captura de tela 2026-07-13 001813" src="https://github.com/user-attachments/assets/194cfa27-e01d-431d-aa4f-cf8a7cac2ceb" />
<img width="1182" height="770" alt="Captura de tela 2026-07-13 002551" src="https://github.com/user-attachments/assets/6909698d-29eb-497e-a703-572cfbf0e093" />
<img width="3812" height="1940" alt="Captura de tela 2026-07-13 001926" src="https://github.com/user-attachments/assets/1ecf21b8-1877-43d7-b564-f7ca03338064" />
