### PR TITLE
Core: Fix -Wsign-compare warning in R3000A Interpreter

### DIFF
--- a/pcsx2/R3000AInterpreter.cpp
+++ b/pcsx2/R3000AInterpreter.cpp
@@ -247,7 +247,7 @@ static void doBranch(s32 tar) {
 	}
 
 	// Override the memory size argument to IOPBOOT
-	if(tar == 0xbfc4a000) {
+	if(static_cast<u32>(tar) == 0xbfc4a000) {
 		psxRegs.GPR.n.a0 = Ps2MemSize::ExposedIopRam >> 20;
 	}
 


### PR DESCRIPTION
```
warning: comparison of integers of different signs: 's32' (aka 'int') and 'unsigned int' [-Wsign-compare]
  250 |         if(tar == 0xbfc4a000) {
      |            ~~~ ^  ~~~~~~~~~~
```

### Description of Changes
Added explicit type casting to match 0xbfc4a000 implicit unsigned int type

### Rationale behind Changes
Fixes a warning during compilation

### Did you use AI to help find, test, or implement this issue or feature?
No, I just saw the warning when compiling pcsx2