### PR TITLE
GS: Disable Z on invalid FRAME/Z combination (Pending HW Test)

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2772,6 +2772,14 @@ void GSRendererHW::Draw()
 		return;
 	}
 
+	if ((m_cached_ctx.FRAME.PSM == PSMCT16) != (m_cached_ctx.ZBUF.PSM == PSMZ16))
+	{
+		// There are two groups of formats that a draw can use, group 2 is PSMCT16 and PSMZ16, those are exclusive to each other, every other combination is group 1.
+		// These are not allowed to be mixed due to a different swizzle, which causes writes to Z to be omitted.
+		m_cached_ctx.ZBUF.ZMSK = 1;
+		m_cached_ctx.TEST.ZTE = 0;
+	}
+
 	// Sometimes everything will get reset and it will draw a single black point in the top left corner,
 	// which can cause invalid targets to be created, so might as well skip it.
 	if (GSVector4i(m_vt.m_min.p.xyxy(m_vt.m_max.p)).eq(GSVector4i::zero()) && m_vt.m_eq.rgba == 0xffff && 

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -1069,8 +1069,12 @@ bool GSRendererSW::GetScanlineGlobalData(SharedData* data)
 	gd.sel.ababcd = 0xff;
 	gd.sel.prim = primclass;
 
+	// There are two groups of formats that a draw can use, group 2 is PSMCT16 and PSMZ16, those are exclusive to each other, every other combination is group 1.
+	// These are not allowed to be mixed due to a different swizzle, which causes writes to Z to be omitted.
+	const bool invalid_combination = (m_context->FRAME.PSM == PSMCT16) != (m_context->ZBUF.PSM == PSMZ16);
+
 	u32 fm = context->FRAME.FBMSK;
-	u32 zm = context->ZBUF.ZMSK || context->TEST.ZTE == 0 ? 0xffffffff : 0;
+	u32 zm = invalid_combination || context->ZBUF.ZMSK || context->TEST.ZTE == 0 ? 0xffffffff : 0;
 	const u32 fm_mask = GSLocalMemory::m_psm[m_context->FRAME.PSM].fmsk;
 
 	// When the format is 24bit (Z or C), DATE ceases to function.
@@ -1123,7 +1127,7 @@ bool GSRendererSW::GetScanlineGlobalData(SharedData* data)
 	bool ftest = gd.sel.atst != ATST_ALWAYS || (context->TEST.DATE && context->FRAME.PSM != PSMCT24);
 
 	bool zwrite = zm != 0xffffffff;
-	bool ztest = context->TEST.ZTE && context->TEST.ZTST > ZTST_ALWAYS;
+	bool ztest = !invalid_combination && context->TEST.ZTE && context->TEST.ZTST > ZTST_ALWAYS;
 	/*
 	printf("%05x %d %05x %d %05x %d %dx%d\n",
 		fwrite || ftest ? m_context->FRAME.Block() : 0xfffff, m_context->FRAME.PSM,


### PR DESCRIPTION
### Description of Changes
Disables Z testing + writing when an invalid Frame/Z combination is selected.

### Rationale behind Changes
Swizzling formats for Z and FRAME have to match on PS2 hardware, so PSMCT16 and PSMZ16 are exclusive to themselves, mixing either of these with another format is disallowed due to the swizzling differences.

It was noticed in Hot Wheels World Race that the top left corner (top line in software) was getting destroyed by a write which does this, causing some corruption in some cases, and heat effects to errantly happen along the top of the screen.  Upon changing this it was noted that all the bugs I had for World Race were gone.  Also a weird glitch on Dog's Life got fixed too.

### Suggested Testing Steps
Test Hot Wheels - World Race, Dog's Life and some other games, Crusty Demons also showed up in early testing when I broke things, so make sure that's still okay.

### Did you use AI to help find, test, or implement this issue or feature?
No

Hot Wheels:
Master:
<img width="597" height="448" alt="image" src="https://github.com/user-attachments/assets/295c9bab-6f14-4da1-8311-cd5fb17f9a77" />
<img width="597" height="448" alt="image" src="https://github.com/user-attachments/assets/81021a04-bfda-4e99-824a-a167ea3cb061" />
<img width="597" height="448" alt="image" src="https://github.com/user-attachments/assets/f0a39fa3-66fd-466d-9431-47763c9ac6ef" />

PR:
<img width="597" height="448" alt="image" src="https://github.com/user-attachments/assets/5c73e712-80ef-4e62-86be-4bae28ab6f99" />
<img width="597" height="448" alt="image" src="https://github.com/user-attachments/assets/bae63dae-af74-44fd-99ac-3affc8913337" />
<img width="597" height="448" alt="image" src="https://github.com/user-attachments/assets/73b0e332-7ea7-4b89-86d1-663f508077bb" />

Dog's Life:
Master:
<img width="596" height="447" alt="image" src="https://github.com/user-attachments/assets/691768d9-8f86-41df-bb46-e2973ade840e" />

PR:
<img width="596" height="447" alt="image" src="https://github.com/user-attachments/assets/e73843a2-a885-482b-b87a-97448c6a0cc8" />
