### PR TITLE
GS:HW: Fix regression with prefer_reuse texture fetching flag.

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSDevice.cpp
+++ b/pcsx2/GS/Renderers/Common/GSDevice.cpp
@@ -805,7 +805,7 @@ GSTexture* GSDevice::CreateTexture(int w, int h, int mipmap_levels, GSTexture::F
 {
 	pxAssert(mipmap_levels != 0 && (mipmap_levels < 0 || mipmap_levels <= GetMipmapLevelsForSize(w, h)));
 	const int levels = mipmap_levels < 0 ? GetMipmapLevelsForSize(w, h) : mipmap_levels;
-	return FetchSurface(GSTexture::Texture, w, h, levels, format, false, m_features.prefer_new_textures && prefer_reuse);
+	return FetchSurface(GSTexture::Texture, w, h, levels, format, false, !m_features.prefer_new_textures || prefer_reuse);
 }
 
 GSTexture* GSDevice::CreateTexture(const GSVector2i& size, int mipmap_levels, GSTexture::Format format, bool prefer_reuse)


### PR DESCRIPTION
### Description of Changes
Fix the boolean value of the prefer_reuse GSDevice::FetchSurface().

Bug and fix identified by @t654132 here https://github.com/PCSX2/pcsx2/issues/14696.

### Rationale behind Changes
Fixes high VRAM usage due to unnecessary texture creation.

### Suggested Testing Steps
Test VRAM usage on PR vs. 2.7.435 to make sure they are about the same.

### Did you use AI to help find, test, or implement this issue or feature?
No.