### PR TITLE
GS/OGL: Increase padding to fill ProgramSelector size

### DIFF
--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -128,12 +128,13 @@ public:
 	{
 		PSSelector ps;
 		VSSelector vs;
-		u8 pad[3];
+		u8 pad[15];
 
 		__fi bool operator==(const ProgramSelector& p) const { return BitEqual(*this, p); }
 		__fi bool operator!=(const ProgramSelector& p) const { return !BitEqual(*this, p); }
 	};
 	static_assert(sizeof(ProgramSelector) == 32, "Program selector is 32 bytes");
+	static_assert(offsetof(ProgramSelector, pad) + sizeof(ProgramSelector::pad) == sizeof(ProgramSelector));
 
 	struct ProgramSelectorHash
 	{


### PR DESCRIPTION
### Description of Changes
Increase the padding array to occupy all of the remaining space in `ProgramSelector`

### Rationale behind Changes
OpenGL's ProgramSelector compares the full size of `ProgramSelector` for equality, instead of testing individual fields.
Un-initialised data would cause otherwise equal programs to return not equal (and would be compiled/loaded again).

Sizing up the padding allows later code to properly zero unused space in the structure.

### Suggested Testing Steps
Test OpenGL on Windows Nvidia or AMD

### Did you use AI to help find, test, or implement this issue or feature?
No