### PR TITLE
Qt: Recreate hidden settings windows after external changes

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -1730,6 +1730,18 @@ void MainWindow::requestExit(bool allow_confirm)
 
 void MainWindow::checkForSettingChanges()
 {
+	if (m_settings_window && !m_settings_window->isVisible())
+	{
+		m_settings_window->deleteLater();
+		m_settings_window = nullptr;
+	}
+
+	if (m_controller_settings_window && !m_controller_settings_window->isVisible())
+	{
+		m_controller_settings_window->deleteLater();
+		m_controller_settings_window = nullptr;
+	}
+
 	if (m_display_surface)
 		updateDisplayWidgetCursor();
 


### PR DESCRIPTION
### Description of Changes

Invalidate cached global and controller settings windows when settings are applied while those windows are hidden.

The windows will be recreated the next time they are opened, ensuring their widgets are populated from the current configuration.

### Rationale behind Changes

The Qt settings windows are kept alive after being closed. When settings are changed through Big Picture Mode, the backing configuration is updated, but the cached Qt widgets can retain their previous values.

Recreating only hidden settings windows refreshes their state without interrupting a visible Qt settings session.

### Suggested Testing Steps

1. Open and close the Qt settings window.
2. Change a setting through Big Picture Mode.
3. Reopen the Qt settings window and verify that it displays the updated value.
4. Repeat the process with the controller settings window.
5. Verify that changing settings through a visible Qt settings window still works normally.
6. Repeat the transitions several times and check for duplicate windows or crashes.

### Did you use AI to help find, test, or implement this issue or feature?

Yes. Codex was used to review and to help draft the PR.