### PR TITLE
Qt: Flush pending settings changes on shutdown

### DIFF
--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -1490,8 +1490,8 @@ void Host::CommitBaseSettingChanges()
 	if (!connected)
 	{
 		QObject::connect(QCoreApplication::instance(), &QCoreApplication::aboutToQuit, []() {
-			delete s_settings_save_timer;
-			s_settings_save_timer = nullptr;
+			if (s_settings_save_timer)
+				QtHost::SaveSettings();
 		});
 
 		connected = true;


### PR DESCRIPTION
### Description of Changes

Flush pending base settings changes during application shutdown instead of discarding the settings save timer.

If a delayed save is pending when `aboutToQuit` is emitted, `QtHost::SaveSettings()` is now called before shutdown completes.

### Rationale behind Changes

Base settings writes are delayed by one second to combine frequent changes. Previously, the shutdown handler deleted the pending timer without saving, so settings changed shortly before exiting could be lost.

Flushing the pending save preserves the latest configuration while retaining the existing delayed-save behavior during normal operation.

### Suggested Testing Steps

1. Change a base setting and exit PCSX2 immediately, before the one-second save delay expires.
2. Restart PCSX2 and verify that the changed setting was preserved.
3. Change a setting, wait for the normal delayed save, and verify that shutdown still works normally.
4. Exit when no settings save is pending and verify that shutdown completes without errors.

### Did you use AI to help find, test, or implement this issue or feature?

Yes. Codex was used to review and to help draft the PR.