### PR TITLE
Pad: Add analog stick anti-deadzone

### DIFF
--- a/pcsx2/SIO/Pad/Pad.cpp
+++ b/pcsx2/SIO/Pad/Pad.cpp
@@ -122,9 +122,11 @@ void Pad::LoadConfig(const SettingsInterface& si)
 		}
 
 		const float axis_deadzone = si.GetFloatValue(section.c_str(), "Deadzone", Pad::DEFAULT_STICK_DEADZONE);
+		const float axis_anti_deadzone = si.GetFloatValue(section.c_str(), "AntiDeadzone", Pad::DEFAULT_STICK_ANTI_DEADZONE);
 		const float axis_scale = si.GetFloatValue(section.c_str(), "AxisScale", Pad::DEFAULT_STICK_SCALE);
 		const float button_deadzone = si.GetFloatValue(section.c_str(), "ButtonDeadzone", Pad::DEFAULT_BUTTON_DEADZONE);
 		pad->SetAxisScale(axis_deadzone, axis_scale);
+		pad->SetAxisAntiDeadzone(axis_anti_deadzone);
 		pad->SetButtonDeadzone(button_deadzone);
 
 		if (ci->vibration_caps != Pad::VibrationCapabilities::NoVibration)

--- a/pcsx2/SIO/Pad/PadBase.h
+++ b/pcsx2/SIO/Pad/PadBase.h
@@ -43,6 +43,7 @@ public: // Public members
 	virtual void SetRawAnalogs(const std::tuple<u8, u8> left, const std::tuple<u8, u8> right) = 0;
 	virtual void SetRawPressureButton(u32 index, const std::tuple<bool, u8> value) = 0;
 	virtual void SetAxisScale(float deadzone, float scale) = 0;
+	virtual void SetAxisAntiDeadzone(float) {}
 	virtual float GetVibrationScale(u32 motor) const = 0;
 	virtual void SetVibrationScale(u32 motor, float scale) = 0;
 	virtual float GetPressureModifier() const = 0;

--- a/pcsx2/SIO/Pad/PadDualshock2.cpp
+++ b/pcsx2/SIO/Pad/PadDualshock2.cpp
@@ -60,6 +60,9 @@ static const SettingInfo s_settings[] = {
 		TRANSLATE_NOOP(
 			"Pad", "Sets the analog stick deadzone, i.e. the fraction of the stick movement which will be ignored."),
 		"0.00", "0.00", "1.00", "0.01", TRANSLATE_NOOP("Pad", "%.0f%%"), nullptr, nullptr, 100.0f},
+	{SettingInfo::Type::Float, "AntiDeadzone", TRANSLATE_NOOP("Pad", "Analog Anti-Deadzone"),
+		TRANSLATE_NOOP("Pad", "Sets the minimum analog stick output after movement exceeds the deadzone."),
+		"0.00", "0.00", "1.00", "0.01", TRANSLATE_NOOP("Pad", "%.0f%%"), nullptr, nullptr, 100.0f},
 	{SettingInfo::Type::Float, "AxisScale", TRANSLATE_NOOP("Pad", "Analog Sensitivity"),
 		TRANSLATE_NOOP("Pad",
 			"Sets the analog stick axis scaling factor. A value between 130% and 140% is recommended when using recent "
@@ -587,10 +590,11 @@ void PadDualshock2::Set(u32 index, float value)
 		}
 #undef MERGE
 
-		// Deadzone computation.
+		// Deadzone and anti-deadzone computation.
 		const float dz = this->axisDeadzone;
+		const float adz = this->axisAntiDeadzone;
 
-		if (dz > 0.0f)
+		if (dz > 0.0f || adz > 0.0f)
 		{
 #define MERGE_F(pos, neg) ((this->rawInputs[pos] != 0) ? (static_cast<float>(this->rawInputs[pos]) / 255.0f) : (static_cast<float>(this->rawInputs[neg]) / -255.0f))
 			float posX, posY;
@@ -608,18 +612,20 @@ void PadDualshock2::Set(u32 index, float value)
 			// No point checking if we're at dead center (usually keyboard with no buttons pressed).
 			if (posX != 0.0f || posY != 0.0f)
 			{
-				// Compute the angle at the given position in the stick's square bounding box.
-				const float theta = std::atan2(posY, posX);
+				const float magnitude = std::hypot(posX, posY);
+				bool inDeadzone = false;
+				if (dz > 0.0f)
+				{
+					// Compute the position that the edge of the deadzone circle would be at for this angle.
+					const float theta = std::atan2(posY, posX);
+					const float dzX = std::cos(theta) * dz;
+					const float dzY = std::sin(theta) * dz;
+					const bool inX = (posX < 0.0f) ? (posX > dzX) : (posX <= dzX);
+					const bool inY = (posY < 0.0f) ? (posY > dzY) : (posY <= dzY);
+					inDeadzone = inX && inY;
+				}
 
-				// Compute the position that the edge of the circle would be at, given the angle.
-				const float dzX = std::cos(theta) * dz;
-				const float dzY = std::sin(theta) * dz;
-
-				// We're in the deadzone if our position is less than the circle edge.
-				const bool inX = (posX < 0.0f) ? (posX > dzX) : (posX <= dzX);
-				const bool inY = (posY < 0.0f) ? (posY > dzY) : (posY <= dzY);
-				
-				if (inX && inY)
+				if (inDeadzone)
 				{
 					// In deadzone. Set to 127 (center).
 					if (index <= Inputs::PAD_L_LEFT)
@@ -629,7 +635,35 @@ void PadDualshock2::Set(u32 index, float value)
 					else
 					{
 						this->analogs.rx = this->analogs.ry = 127;
-					}	
+					}
+				}
+				else if (adz > 0.0f)
+				{
+					// Remap from the deadzone edge to the edge of the stick's square range. This preserves
+					// direction and full-scale diagonal input while making adz the minimum output magnitude.
+					const float directionX = posX / magnitude;
+					const float directionY = posY / magnitude;
+					const float maximumMagnitude = 1.0f / std::max(std::abs(directionX), std::abs(directionY));
+					const float normalizedMagnitude = std::clamp((magnitude - dz) / (maximumMagnitude - dz), 0.0f, 1.0f);
+					const float outputMagnitude = adz + ((maximumMagnitude - adz) * normalizedMagnitude);
+					posX = directionX * outputMagnitude;
+					posY = directionY * outputMagnitude;
+
+					const auto convert_axis = [](float axis) {
+						const u8 raw = static_cast<u8>(std::lroundf(std::clamp(std::abs(axis) * 255.0f, 0.0f, 255.0f)));
+						return static_cast<u8>((axis >= 0.0f) ? (127u + ((raw + 1u) / 2u)) : (127u - (raw / 2u)));
+					};
+
+					if (index <= Inputs::PAD_L_LEFT)
+					{
+						this->analogs.lx = convert_axis(posX);
+						this->analogs.ly = convert_axis(posY);
+					}
+					else
+					{
+						this->analogs.rx = convert_axis(posX);
+						this->analogs.ry = convert_axis(posY);
+					}
 				}
 			}
 #undef MERGE_F
@@ -737,6 +771,11 @@ void PadDualshock2::SetAxisScale(float deadzone, float scale)
 {
 	this->axisDeadzone = deadzone;
 	this->axisScale = scale;
+}
+
+void PadDualshock2::SetAxisAntiDeadzone(float anti_deadzone)
+{
+	this->axisAntiDeadzone = std::clamp(anti_deadzone, 0.0f, 1.0f);
 }
 
 float PadDualshock2::GetVibrationScale(u32 motor) const

--- a/pcsx2/SIO/Pad/PadDualshock2.h
+++ b/pcsx2/SIO/Pad/PadDualshock2.h
@@ -72,6 +72,7 @@ private:
 	std::array<u8, VIBRATION_MOTORS> vibrationMotors = {};
 	float axisScale = 1.0f;
 	float axisDeadzone = 0.0f;
+	float axisAntiDeadzone = 0.0f;
 	std::array<float, 2> vibrationScale = {1.0f, 1.0f};
 	// When the pressure modifier binding is activated, this is multiplied against
 	// all values in pressures, to artificially reduce pressures and give players
@@ -140,6 +141,7 @@ public:
 	void SetRawAnalogs(const std::tuple<u8, u8> left, const std::tuple<u8, u8> right) override;
 	void SetRawPressureButton(u32 index, const std::tuple<bool, u8> value) override;
 	void SetAxisScale(float deadzone, float scale) override;
+	void SetAxisAntiDeadzone(float anti_deadzone) override;
 	float GetVibrationScale(u32 motor) const override;
 	void SetVibrationScale(u32 motor, float scale) override;
 	float GetPressureModifier() const override;

--- a/pcsx2/SIO/Pad/PadTypes.h
+++ b/pcsx2/SIO/Pad/PadTypes.h
@@ -100,6 +100,7 @@ namespace Pad
 
 	// Default stick deadzone/sensitivity.
 	static constexpr float DEFAULT_STICK_DEADZONE = 0.0f;
+	static constexpr float DEFAULT_STICK_ANTI_DEADZONE = 0.0f;
 	static constexpr float DEFAULT_STICK_SCALE = 1.33f;
 	static constexpr float DEFAULT_MOTOR_SCALE = 1.0f;
 	static constexpr float DEFAULT_PRESSURE_MODIFIER = 0.5f;


### PR DESCRIPTION
### Description of Changes

Adds an Analog Anti-Deadzone setting for DualShock 2 analog sticks.

Once stick movement exceeds the configured deadzone, the input magnitude is remapped so that the emulated stick output begins at the configured anti-deadzone value. The remapping preserves the input direction and full-scale diagonal input.

The setting defaults to 0%, so existing configurations retain their current behavior. The existing default analog sensitivity remains unchanged.

### Rationale behind Changes

Some games apply large internal analog deadzones, which can make small physical stick movements ineffective even when PCSX2's own deadzone is disabled.

An anti-deadzone allows users to configure a minimum emulated stick output after movement begins, improving responsiveness without requiring an overall sensitivity increase.

### Suggested Testing Steps

1. Set Analog Anti-Deadzone to 0% and verify that stick behavior matches the current implementation.
2. Test both left and right sticks with horizontal, vertical, and diagonal input.
3. Test a typical anti-deadzone value together with a non-zero analog deadzone.
4. Verify that movement below the configured deadzone remains centered.
5. Verify that movement immediately outside the deadzone begins at the configured minimum output.
6. Verify that full stick movement still reaches the full emulated range.
7. Test the 0% and 100% boundary values.
8. Confirm that the setting is saved and restored correctly.

The affected behavior was manually tested and no issues were observed.

### Did you use AI to help find, test, or implement this issue or feature?

Yes. Codex was used to review and to help draft the PR.