### PR TITLE
Qt: Silence warning when opening log window

### DIFF
--- a/pcsx2-qt/LogWindow.cpp
+++ b/pcsx2-qt/LogWindow.cpp
@@ -216,7 +216,7 @@ void LogWindow::createUi()
 		m_newline_on_enter = state == Qt::CheckState::Checked;
 	});
 
-	m_input_hbox = new QHBoxLayout(this);
+	m_input_hbox = new QHBoxLayout;
 	m_input_hbox->addWidget(m_line_input, 1);
 	m_input_hbox->addWidget(m_local_echo_checkbox);
 	m_input_hbox->addWidget(m_newline_on_enter_checkbox);


### PR DESCRIPTION
### Description of Changes
Don't try to set the QHBoxLayout for the input bar as the layout for the log window.

### Rationale behind Changes
Silence the following warning:
```
QLayout: Attempting to add QLayout "" to LogWindow "", which already has a layout
```

### Suggested Testing Steps
Open the log window, make sure the warning isn't printed.

### Did you use AI to help find, test, or implement this issue or feature?
No.