### PR TITLE
GameDB: Patch The Gift to fix sound RPC

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -15134,6 +15134,14 @@ SLES-50276:
   name: "The Gift"
   name-sort: "Gift, The"
   region: "PAL-E"
+  patches:
+    CC76CD02:
+      content: |-
+        // Sound RPC races because of shared send/receive buffers with badly
+        // placed wait loop, fix by forcing all sound rpc to be synchronous.
+        // Ideal fix would be moving the rpc wait loop though.
+        author=Ziemas
+        patch=0,EE,002159e0,word,00000000
 SLES-50277:
   name: "Red Faction"
   region: "PAL-E"


### PR DESCRIPTION
### Description of Changes
Patches the game to force synchronous RPC calls for sound RPC.

Fixes #14640 

### Rationale behind Changes
There's a race where it writes to the send buffer before waiting for the previous RPC command to complete, causing a race where the return values overwrite the send values. Might also be saved by data cache on real console.

### Suggested Testing Steps
Check that the SFX work.

### Did you use AI to help find, test, or implement this issue or feature?
No.