### PR TITLE
AudioStream: Work around uninitialized read in cubeb

### DIFF
--- a/pcsx2/Host/CubebAudioStream.cpp
+++ b/pcsx2/Host/CubebAudioStream.cpp
@@ -205,7 +205,7 @@ bool CubebAudioStream::Initialize(const char* driver_name, const char* device_na
 	}
 
 	cubeb_devid selected_device = nullptr;
-	cubeb_device_collection devices;
+	cubeb_device_collection devices = {};
 	bool devices_valid = false;
 	if (device_name && *device_name)
 	{
@@ -350,7 +350,7 @@ std::vector<AudioStream::DeviceInfo> AudioStream::GetCubebOutputDevices(const ch
 
 	ScopedGuard context_cleanup([context]() { cubeb_destroy(context); });
 
-	cubeb_device_collection devices;
+	cubeb_device_collection devices = {};
 	rv = cubeb_enumerate_devices(context, CUBEB_DEVICE_TYPE_OUTPUT, &devices);
 	if (rv != CUBEB_OK)
 	{


### PR DESCRIPTION
### Description of Changes
Initialize the collection out parameter of cubeb_enumerate_devices before calling it.

### Rationale behind Changes
A number of months back I started getting crashes in cubeb_enumerate_devices after a system update that broke sound output. [I opened an upstream PR to fix the bug](https://github.com/mozilla/cubeb/pull/829), but it's not been merged, so lets work around it instead.

### Suggested Testing Steps
N/A

### Did you use AI to help find, test, or implement this issue or feature?
No.