### PR TITLE
ImGuiOverlays: Hide Debug and ROV status in SW

### DIFF
--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -441,12 +441,16 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 
 				// GPU
 				const char* gpu_suffix = "";
-				if (GSConfig.UseDebugDevice && GSConfig.HWROV)
-					gpu_suffix = " (Debug & ROV)";
-				else if (GSConfig.UseDebugDevice)
-					gpu_suffix = " (Debug)";
-				else if (GSConfig.HWROV)
-					gpu_suffix = " (ROV)";
+
+				if (GSConfig.Renderer != GSRendererType::SW)
+				{
+					if (GSConfig.UseDebugDevice && GSConfig.HWROV)
+						gpu_suffix = " (Debug & ROV)";
+					else if (GSConfig.UseDebugDevice)
+						gpu_suffix = " (Debug)";
+					else if (GSConfig.HWROV)
+						gpu_suffix = " (ROV)";
+				}
 
 				s_hardware_info_gpu_line.format(
 					"GPU: {}{}",


### PR DESCRIPTION
### Description of Changes
Hides the ROV and Debug status from the GPU load indicator when in Software Rendering.

### Rationale behind Changes
Both are redundant when using Software so don't display them.

### Suggested Testing Steps
Test that it still shows up correctly in Hardware rendering.

### Did you use AI to help find, test, or implement this issue or feature?
No.