### PR TITLE
Hotkeys: Add new default hotkey to mute audio using Ctrl + M

### DIFF
--- a/pcsx2/SIO/Pad/Pad.cpp
+++ b/pcsx2/SIO/Pad/Pad.cpp
@@ -239,6 +239,9 @@ void Pad::SetDefaultHotkeyConfig(SettingsInterface& si)
 	si.SetStringValue("Hotkeys", "ZoomOut", "Keyboard/Control & Keyboard/Minus");
 	// Missing hotkey for resetting zoom back to 100 with Keyboard/Control & Keyboard/Asterisk
 
+	// PCSX2 Controller Settings - Hotkeys - Graphics
+	si.SetStringValue("Hotkeys", "Mute", "Keyboard/Control & Keyboard/M");
+
 	// PCSX2 Controller Settings - Hotkeys - Input Recording
 	si.SetStringValue("Hotkeys", "InputRecToggleMode", "Keyboard/Shift & Keyboard/R");
 


### PR DESCRIPTION
### Description of Changes
This PR adds a hotkey for audio mute as requested in #14623

### Rationale behind Changes
Adds a more convenient way to mute audio.

### Suggested Testing Steps
Open pcsx2, go to Settings -> Hotkeys menu, click "restore default values", check audio mute is set to Ctrl + M.

### Did you use AI to help find, test, or implement this issue or feature?
Yes, I used it to help me find where the hotkeys were set.