### PR TITLE
Qt: Fix logic for resetting the VM when changing discs

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -3732,8 +3732,6 @@ void MainWindow::doDiscChange(CDVD_SourceType source, const QString& path)
 		reset_system = (message.clickedButton() == reset_button);
 	}
 
-	switchToEmulationView();
-
 	g_emu_thread->changeDisc(source, path);
 	if (reset_system)
 	{
@@ -3743,6 +3741,11 @@ void MainWindow::doDiscChange(CDVD_SourceType source, const QString& path)
 		else
 			g_emu_thread->resetVM();
 	}
+
+	// We have to do this after resetting the VM, otherwise the reset would be
+	// deferred since the VM would be running, and then VMLock::~VMLock would
+	// trample the reset state with its unpause event.
+	switchToEmulationView();
 }
 
 MainWindow::VMLock MainWindow::pauseAndLockVM()


### PR DESCRIPTION
### Description of Changes
Make it so `MainWindow::switchToEmulationView` gets called after posting the reset event, so that the VM isn't running when we're trying to reset.

### Rationale behind Changes
Fixes #14250. The reset was being deferred, and then VMState::Resetting was being trampled by the unpause event posted by VMLock::~VMLock.

This could also be fixed by changing how the VM states are managed, but this seems sufficient for now.

### Suggested Testing Steps
Enable `Render To Separate Window` and try changing discs by clicking on items in the game list.

### Did you use AI to help find, test, or implement this issue or feature?
No.