### PR TITLE
FSUI: Add gamelist hotkey to scan for new games

### DIFF
--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -410,9 +410,6 @@ void GameListWidget::setCustomBackground()
 			delete m_background_movie;
 			m_background_movie = nullptr;
 		}
-		// Cache all frames for small images so loops don't keep re-decoding
-		else if (const s64 file_size = FileSystem::GetPathFileSize(path.c_str()); file_size > 0 && file_size < 64 * 1024 * 1024)
-			m_background_movie->setCacheMode(QMovie::CacheAll);
 	}
 
 	// Invalidate frame cache so the next animated frame triggers full reprocessing
@@ -435,6 +432,10 @@ void GameListWidget::setCustomBackground()
 		m_table_view->setAlternatingRowColors(true);
 		return;
 	}
+
+	// Cache all frames for small images so loops don't keep re-decoding
+	if (const s64 file_size = FileSystem::GetPathFileSize(path.c_str()); file_size > 0 && file_size < 25 * 1024 * 1024)
+		m_background_movie->setCacheMode(QMovie::CacheAll);
 
 	// Retrieve scaling setting
 	m_background_scaling = QtUtils::ScalingMode::Fit;
@@ -792,7 +793,7 @@ void GameListWidget::setShowFullCoverTitles(bool enabled)
 	Host::SetBaseBoolSettingValue("UI", "GameListShowFullCoverTitles", enabled);
 	Host::CommitBaseSettingChanges();
 	m_model->setShowFullCoverTitles(enabled);
-	m_list_view->setWordWrap(enabled); 
+	m_list_view->setWordWrap(enabled);
 	if (isShowingGameGrid())
 		m_model->refresh();
 	updateToolbar();

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -1267,7 +1267,7 @@ void Host::RunOnGSThread(std::function<void()> function)
 
 void Host::RefreshGameListAsync(bool invalidate_cache)
 {
-	QMetaObject::invokeMethod(g_main_window, "refreshGameList", Qt::QueuedConnection, Q_ARG(bool, invalidate_cache));
+	QMetaObject::invokeMethod(g_main_window, "refreshGameList", Qt::QueuedConnection, Q_ARG(bool, invalidate_cache), Q_ARG(bool, true));
 }
 
 void Host::CancelGameListRefresh()

--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -1068,27 +1068,15 @@ void EmuThread::updatePerformanceMetrics(bool force)
 
 		if (gpu_usage != m_last_gpu_usage || force)
 		{
-			QString text;
-			if (gpu_usage == 0)
-				text = tr("GPU: N/A");
-			else
-				text = tr("GPU: %1%").arg(gpu_usage, 0, 'f', 0);
-
 			QMetaObject::invokeMethod(g_main_window, "setStatusGPUText", Qt::QueuedConnection,
-				Q_ARG(const QString&, text));
+				Q_ARG(const QString&, tr("GPU: %1%").arg(gpu_usage, 0, 'f', 0)));
 			m_last_gpu_usage = gpu_usage;
 		}
 
 		if (gfps != m_last_game_fps || force)
 		{
-			QString text;
-			if (gfps == 0)
-				text = tr("FPS: N/A");
-			else
-				text = tr("FPS: %1").arg(gfps, 0, 'f', 0);
-
 			QMetaObject::invokeMethod(g_main_window, "setStatusFPSText", Qt::QueuedConnection,
-				Q_ARG(const QString&, text));
+				Q_ARG(const QString&, gfps == 0 ? tr("FPS: N/A") : tr("FPS: %1").arg(gfps, 0, 'f', 0)));
 			m_last_game_fps = gfps;
 		}
 

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -2606,6 +2606,11 @@ void FullscreenUI::DrawGameListWindow()
 	{
 		OpenCoverDownloaderWindow();
 	}
+	else if (ImGui::IsKeyPressed(ImGuiKey_GamepadL2, false) || ImGui::IsKeyPressed(ImGuiKey_F5, false))
+	{
+		ShowToast(std::string(), FSUI_STR("Scanning for new games..."), 4.0f);
+		Host::RefreshGameListAsync(false);
+	}
 
 	switch (s_game_list_view)
 	{
@@ -2640,6 +2645,7 @@ void FullscreenUI::DrawGameListWindow()
 			std::make_pair(glyphs.dpad, FSUI_VSTR("Select Game")),
 			std::make_pair(glyphs.select, FSUI_VSTR("Cover Downloader")),
 			std::make_pair(glyphs.start, FSUI_VSTR("Settings")),
+			std::make_pair(ICON_PF_LEFT_TRIGGER_L2, FSUI_VSTR("Refresh List")),
 			std::make_pair(swapNorthWest ? glyphs.west : glyphs.north, FSUI_VSTR("Change View")),
 			std::make_pair(swapNorthWest ? glyphs.north : glyphs.west, FSUI_VSTR("Launch Options")),
 			std::make_pair(glyphs.confirm(circleOK), FSUI_VSTR("Start Game")),
@@ -2654,6 +2660,7 @@ void FullscreenUI::DrawGameListWindow()
 			std::make_pair(ICON_PF_F2, FSUI_VSTR("Settings")),
 			std::make_pair(ICON_PF_F3, FSUI_VSTR("Launch Options")),
 			std::make_pair(ICON_PF_F4, FSUI_VSTR("Cover Downloader")),
+			std::make_pair(ICON_PF_F5, FSUI_VSTR("Refresh List")),
 			std::make_pair(ICON_PF_ENTER, FSUI_VSTR("Start Game")),
 			std::make_pair(ICON_PF_ESC, FSUI_VSTR("Back")),
 		});

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -428,7 +428,7 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 					const CPUInfo& info = GetCPUInfo();
 					const bool has_small = info.num_small_cores > 0;
 					const bool has_smt = info.num_threads != info.num_big_cores + info.num_small_cores;
-					s_hardware_info_cpu_line.format("CPU: {}", info.name);
+					s_hardware_info_cpu_line.format("CPU: {}", !info.name.empty() ? info.name : "Unknown");
 					if (has_smt && has_small)
 						s_hardware_info_cpu_line.append_format(" ({}P/{}E/{}T)", info.num_big_cores, info.num_small_cores, info.num_threads);
 					else if (has_small)


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

This PR adds a new hotkey on the game list to scan for new games.
Its set to F5 for keyboards and L2 for controllers.

Preview:
<img width="2560" height="1440" alt="Screenshot_20260717_002847" src="https://github.com/user-attachments/assets/b58c89d4-fe9b-476d-8d1a-58ea8a277e42" />

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Useful if you pair PCSX2 and stores your game dumps on an external storage and wants to quickly rescan when you plug it in while PCSX2 is already running.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Check if the game list refreshes properly and that new games are correctly added, move a few dumps to a separate directory, do a scan, move it back in, then do another scan.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation as to how you used it. Please see the Large Language Model (LLM) Usage Policy for more information: https://pcsx2.net/docs/contributing/#large-language-model-llm-usage-policy -->
Nggak