### PR TITLE
GameDB: Crazy Frog Racer fixes

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -24972,6 +24972,10 @@ SLES-53869:
   name: "Crazy Frog Racer"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    deinterlace: 9 # Game requires AdaptiveBFF de-interlacing.
+    halfPixelOffset: 5 # Aligns shadows.
+    nativeScaling: 1 # Aligns post-processing.
 SLES-53870:
   name: "Devil Kings"
   region: "PAL-M5"


### PR DESCRIPTION
### Description of Changes
Adds Adaptive BFF Align to Native With Texture Offset and Native Scaling Normal to fix issues with deinterlacing post alignment and shadow alignment.

### Rationale behind Changes
Makes the game slightly less abysmal for the masochists that play it.

### Suggested Testing Steps
Watch the CI to see if it explodes.

### Did you use AI to help find, test, or implement this issue or feature?
No.