### PR TITLE
GameDB: Fix network folders for burnout 3 pal / ntsc

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -20799,7 +20799,7 @@ SLES-52584:
   compat: 5
   memcardFilters: # Used for storage of network information on the memory card.
     - "SLES-52584"
-    - "PSCD-20001"
+    - "BEPSCD-20001sloginBE"
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
@@ -69913,7 +69913,7 @@ SLUS-21050:
   compat: 5
   memcardFilters: # Used for storage of network information on the memory card.
     - "SLUS-21050"
-    - "PSCD-10088"
+    - "PSCD10088slogin"
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:


### PR DESCRIPTION
### Description of Changes
use correct names to filter EA network account folders, pal / ntsc

### Rationale behind Changes
folder names are wrong, do not work

### Suggested Testing Steps
use memory card folder and log online using private server for burnout 3 and save settings. file paths are listed as seen in the attached picture. can also use the debugger to string search once logged online. 

### Did you use AI to help find, test, or implement this issue or feature?
no

confirmed: serial - folder name
SLUS-21050 - PSCD10088slogin
SLES-52584 - BEPSCD-20001sloginBE

unconfirmed:
BIPSCD-00004sloginBI
BKPSCD-30001sloginBK

<img width="655" height="753" alt="image" src="https://github.com/user-attachments/assets/cfe3f336-8dd4-47b2-9378-9f89e50d6dcb" />

<img width="1240" height="651" alt="image" src="https://github.com/user-attachments/assets/1c1df2c6-a820-4398-943b-79b94163b198" />
