### PR TITLE
GameDB: use correct names to filter EA network account folders, burnout 3 pal / ntsc

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -20814,6 +20814,9 @@ SLES-52584:
 SLES-52585:
   name: "Burnout 3 - Takedown"
   region: "PAL-F-G-I"
+  memcardFilters: # Used for storage of network information on the memory card.
+    - "SLES-52585"
+    - "BEPSCD-20001sloginBE"
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
@@ -32126,6 +32129,9 @@ SLKA-25206:
   name: "번아웃3 테이크다운"
   name-en: "Burnout 3 - Takedown"
   region: "NTSC-K"
+  memcardFilters: # Used for storage of network information on the memory card.
+    - "SLKA-25206"
+    - "BKPSCD-30001sloginBK"
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
@@ -45360,6 +45366,9 @@ SLPM-65719:
   name-sort: "ばーんあうと3 ていくだうん"
   name-en: "Burnout 3 - Takedown"
   region: "NTSC-J"
+  memcardFilters: # Used for storage of network information on the memory card.
+    - "SLPM-65719"
+    - "BIPSCD-00004sloginBI"
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -20799,7 +20799,7 @@ SLES-52584:
   compat: 5
   memcardFilters: # Used for storage of network information on the memory card.
     - "SLES-52584"
-    - "BEPSCD-20001sloginBE"
+    - "PSCD-20001"
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
@@ -20816,7 +20816,7 @@ SLES-52585:
   region: "PAL-F-G-I"
   memcardFilters: # Used for storage of network information on the memory card.
     - "SLES-52585"
-    - "BEPSCD-20001sloginBE"
+    - "PSCD-20001"
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
@@ -32131,7 +32131,7 @@ SLKA-25206:
   region: "NTSC-K"
   memcardFilters: # Used for storage of network information on the memory card.
     - "SLKA-25206"
-    - "BKPSCD-30001sloginBK"
+    - "PSCD-30001"
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
@@ -45368,7 +45368,7 @@ SLPM-65719:
   region: "NTSC-J"
   memcardFilters: # Used for storage of network information on the memory card.
     - "SLPM-65719"
-    - "BIPSCD-00004sloginBI"
+    - "PSCD-00004"
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
@@ -69922,7 +69922,7 @@ SLUS-21050:
   compat: 5
   memcardFilters: # Used for storage of network information on the memory card.
     - "SLUS-21050"
-    - "PSCD10088slogin"
+    - "PSCD10088"
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -20799,7 +20799,7 @@ SLES-52584:
   compat: 5
   memcardFilters: # Used for storage of network information on the memory card.
     - "SLES-52584"
-    - "PSCD-20001"
+    - "BEPSCD-20001sloginBE"
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
@@ -69913,7 +69913,7 @@ SLUS-21050:
   compat: 5
   memcardFilters: # Used for storage of network information on the memory card.
     - "SLUS-21050"
-    - "PSCD-10088"
+    - "PSCD10088slogin"
   clampModes:
     vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:


### PR DESCRIPTION
### Description of Changes
use correct names to filter EA network account folders, burnout 3 pal / ntsc.

### Rationale behind Changes
EA folder name for SLUS-21050 is wrong, does not work. add more while at it.

### Suggested Testing Steps
Using SLUS-21050, and primary dns set to 85.214.63.124

use memory card folder and log online with burnout 3, create EA account and save settings. file paths are listed as seen in the attached picture. can also use the debugger to string search once logged online. 

### Did you use AI to help find, test, or implement this issue or feature?
no

### confirmed: serial - folder name as seen on memory card after save
SLUS-21050 - PSCD10088slogin
SLES-52584 - BEPSCD-20001sloginBE
SLES-52585 - BEPSCD-20001sloginBE
SLKA-25206 - BKPSCD-30001sloginBK
SLPM-65719 - BIPSCD-00004sloginBI

<img width="655" height="753" alt="image" src="https://github.com/user-attachments/assets/cfe3f336-8dd4-47b2-9378-9f89e50d6dcb" />

<img width="1240" height="651" alt="image" src="https://github.com/user-attachments/assets/1c1df2c6-a820-4398-943b-79b94163b198" />

<img width="2381" height="2041" alt="Untitled" src="https://github.com/user-attachments/assets/04c62512-296b-4375-927f-4d15ea8f63db" />

