### PR TITLE
VMManger: State Save Slot Expansion

### DIFF
--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -69,7 +69,9 @@ using VMBootDoneCallback = std::function<void(VMBootResult result, const Error& 
 namespace VMManager
 {
 	/// The number of usable save state slots.
-	static constexpr s32 NUM_SAVE_STATE_SLOTS = 10;
+	//// TODO: Check available space.
+	static constexpr s32 NUM_SAVE_STATE_SLOTS = 100;
+	
 
 	/// The stack size to use for threads running recompilers
 	static constexpr std::size_t EMU_THREAD_STACK_SIZE = 2 * 1024 * 1024; // µVU likes recursion


### PR DESCRIPTION
- Increase number of available save slots.

### Description of Changes
 A minor quality-of-life improvement that gives users more headroom and bandwidth to 
1. Quickly iterate on challenging play sequences.
2. Explore and map games without having to sacrifice previous saves.


### Rationale behind Changes
10 save states are better than none, but they're prohibitively few when conventional wisdom like "git gud" isn't quite working.
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

### Did you use AI to help find, test, or implement this issue or feature?
No
<!-- Answer yes or no. If you answer yes, please provide a brief explanation as to how you used it. Please see the Large Language Model (LLM) Usage Policy for more information: https://pcsx2.net/docs/contributing/#large-language-model-llm-usage-policy -->