### PR TITLE
Qt: Fix wrong resolution on Gamescope

### DIFF
--- a/pcsx2-qt/DisplayWidget.cpp
+++ b/pcsx2-qt/DisplayWidget.cpp
@@ -284,7 +284,7 @@ void DisplaySurface::handleKeyInputEvent(QEvent* event)
 
 void DisplaySurface::onResizeDebounceTimer()
 {
-	emit windowResizedEvent(m_pending_window_width, m_pending_window_height, m_pending_window_scale);
+	emit windowResizedEvent(m_last_window_width, m_last_window_height, m_last_window_scale);
 }
 
 bool DisplaySurface::event(QEvent* event)
@@ -397,10 +397,6 @@ bool DisplaySurface::event(QEvent* event)
 			// avoid spamming resize events for paint events (sent on move on windows)
 			if (m_last_window_width != scaled_width || m_last_window_height != scaled_height || m_last_window_scale != dpr)
 			{
-				m_pending_window_width = scaled_width;
-				m_pending_window_height = scaled_height;
-				m_pending_window_scale = dpr;
-
 				m_last_window_width = scaled_width;
 				m_last_window_height = scaled_height;
 				m_last_window_scale = dpr;

--- a/pcsx2-qt/DisplayWidget.h
+++ b/pcsx2-qt/DisplayWidget.h
@@ -70,9 +70,5 @@ private:
 	float m_last_window_scale = 1.0f;
 
 	QTimer* m_resize_debounce_timer = nullptr;
-	u32 m_pending_window_width = 0;
-	u32 m_pending_window_height = 0;
-	float m_pending_window_scale = 1.0f;
-
 	QWidget* m_container = nullptr;
 };


### PR DESCRIPTION
### Description of Changes
Gamescope (Steam Deck UI) makes Qt open its window at 640x480, then resizes it to the actual screen resolution right afterwards.  This meant it was possible for the resize handler to start the resize debounce timer targeting 640x480, then have a call to `DisplaySurface::getWindowInfo` set `m_last_window_*` to 1280x800, and finally have the debounce timer fire and resize the viewport to 640x480.

### Rationale behind Changes
Not-broken UI on Steam Deck

### Suggested Testing Steps
On steam deck (or other device running the SteamOS gaming UI), repeatedly relaunch PCSX2 with `-bigpicture -fullscreen` and the OpenGL renderer selected, and make sure the UI doesn't end up taking up the 640x480 section in the bottom left corner.

### Did you use AI to help find, test, or implement this issue or feature?
No