### PR TITLE
3rdparty: Update LZMA/7zipSDK to 26.02

### DIFF
--- a/3rdparty/lzma/include/7zVersion.h
+++ b/3rdparty/lzma/include/7zVersion.h
@@ -1,7 +1,7 @@
 #define MY_VER_MAJOR 26
-#define MY_VER_MINOR 1
+#define MY_VER_MINOR 2
 #define MY_VER_BUILD 0
-#define MY_VERSION_NUMBERS "26.01"
+#define MY_VERSION_NUMBERS "26.02"
 #define MY_VERSION MY_VERSION_NUMBERS
 
 #ifdef MY_CPU_NAME
@@ -10,7 +10,7 @@
   #define MY_VERSION_CPU MY_VERSION
 #endif
 
-#define MY_DATE "2026-04-27"
+#define MY_DATE "2026-06-25"
 #undef MY_COPYRIGHT
 #undef MY_VERSION_COPYRIGHT_DATE
 #define MY_AUTHOR_NAME "Igor Pavlov"

--- a/3rdparty/lzma/include/Compiler.h
+++ b/3rdparty/lzma/include/Compiler.h
@@ -76,6 +76,11 @@
   #pragma GCC diagnostic ignored "-Wreserved-identifier"
 #endif
 
+#if __clang_major__ >= 22
+// for "StdAfx.h" and "Precomp.h"
+#pragma GCC diagnostic ignored "-Wshadow-header"
+#endif
+
 #endif // __clang__
 
 #if defined(__clang__) && __clang_major__ >= 16

--- a/3rdparty/lzma/lzma-history.txt
+++ b/3rdparty/lzma/lzma-history.txt
@@ -1,0 +1,680 @@
+ISTORY of the LZMA SDK
+-----------------------
+
+26.02          2026-06-25
+-------------------------
+- Some bugs and vulnerabilities were fixed.
+
+
+26.01          2026-04-27
+-------------------------
+- linux version of 7-Zip can use huge pages (2 MB pages). It can increase compression
+  speed for 10% for 7z/xz/LZMA/LZMA2 compression.
+- new -spo[d|c|r] switch specifies the path generation mode for the output directory
+  for archive extraction. The output directory path is generated from the path specified
+  in the -o{dir_path} switch and the name of the archive being unpacked.
+    -spod : for Linux/Posix/macOS: -o{dir_path} specifies the direct path to the output directory.
+            The asterisk (*) character in {dir_path} will not be replaced by the archive name.
+    -spoc : 7-Zip will concatenate the path specified in -o{dir_path} with the archive name
+            to form the final path to the output directory.
+    -spor : 7-Zip will replace asterisk (*) character in the path specified in the -o{dir_path}
+            with the archive name. This is the default option.
+- The 7zdec.exe program (a lightweight 7z archive decoder) has been modified for security purposes.
+  Now 7zdec.exe extracts files only to the current folder and its subfolders.
+- some bugs were fixed.
+
+
+
+26.00          2026-02-12
+-------------------------
+- some bugs were fixed.
+
+
+25.01          2025-08-03
+-------------------------
+- The code for handling symbolic links has been changed 
+  to provide greater security when extracting files from archives.
+  Command line switch -snld20 can be used to bypass default security 
+  checks when creating symbolic links.
+
+
+25.00          2025-07-05
+-------------------------
+- 7-Zip for Windows can now use more than 64 CPU threads for compression
+  to zip/7z/xz archives and for the 7-Zip benchmark.
+  If there are more than one processor group in Windows (on systems with more than
+  64 cpu threads), 7-Zip distributes running CPU threads across different processor groups.
+- fixed some bugs and vulnerabilities.
+
+
+24.09          2024-11-29
+-------------------------
+- The default dictionary size values for LZMA/LZMA2 compression methods were increased:
+         dictionary size   compression level
+  v24.08  v24.09  v24.09   
+          32-bit  64-bit    
+    8 MB   16 MB   16 MB   -mx4
+   16 MB   32 MB   32 MB   -mx5 : Normal
+   32 MB   64 MB   64 MB   -mx6
+   32 MB   64 MB  128 MB   -mx7 : Maximum
+   64 MB   64 MB  256 MB   -mx8
+   64 MB   64 MB  256 MB   -mx9 : Ultra
+  The default dictionary size values for 32-bit versions of LZMA/LZMA2 don't exceed 64 MB.
+- If an archive update operation uses a temporary archive folder and 
+  the archive is moved to the destination folder, 7-Zip shows the progress of moving 
+  the archive file, as this operation can take a long time if the archive is large.
+- Some bugs were fixed.
+
+
+24.07          2024-06-19
+-------------------------
+- Changes in files:
+    Asm/x86/Sha256Opt.asm
+  Now it uses "READONLY" flag for constant array segment.
+  It fixes an issue where ".rodata" section in 7-Zip for x86/x64 Linux had a "WRITE" attribute.
+
+
+24.05          2024-05-14
+-------------------------
+- New switch -myv={MMNN} to set decoder compatibility version for 7z archive creating.
+  {MMNN} is 4-digit number that represents the version of 7-Zip without a dot.
+  If -myv={MMNN} switch is specified, 7-Zip will only use compression methods that can 
+  be decoded by the specified version {MMNN} of 7-Zip and newer versions.
+  If -myv={MMNN} switch is not specified, -myv=2300 is used, and 7-Zip will only
+  use compression methods that can be decoded by 7-Zip 23.00 and newer versions.
+- New switch -myfa={FilterID} to    allow 7-Zip to use the specified filter method for 7z archive creating.
+- New switch -myfd={FilterID} to disallow 7-Zip to use the specified filter method for 7z archive creating.
+
+
+24.03          2024-03-23
+-------------------------
+- 7-Zip now can use new RISCV filter for compression to 7z and xz archives.
+  RISCV filter can increase compression ratio for data containing executable
+  files compiled for RISC-V architecture.
+- The speed for LZMA and LZMA2 decompression in ARM64 version for Windows
+  was increased by 20%-60%.
+  It uses arm64 assembler code, and clang-cl is required for arm64 assembler code compiling.
+- -slmu switch : to show timestamps as UTC instead of LOCAL TIME.
+- -slsl switch : in console 7-Zip for Windows : to show file paths with 
+  linux path separator slash '/' instead of backslash separator '\'.
+- 7-Zip supports .sha256 files that use backslash path separator '\'.
+- Some bugs were fixed.
+
+
+24.01          2024-01-31
+-------------------------
+- 7-Zip uses file C/Precomp.h that is included to all c and c++ files.
+  CPP/Common/Common.h also includes C/Precomp.h.
+  C/Precomp.h defines the following macros (if _WIN32 is defined):
+    Z7_LARGE_PAGES 1
+    Z7_LONG_PATH 1
+    Z7_WIN32_WINNT_MIN  0x0500 (or higher)
+    _WIN32_WINNT        0x0500 (or higher)
+    WINVER  _WIN32_WINNT
+    UNICODE 1
+    _UNICODE 1
+  if _WIN32_WINNT is defined already, C/Precomp.h doesn't redefine it.
+
+- Speed optimizations for hash caclulation: CRC-32, CRC-64.
+- The bug was fixed: 7-Zip for Linux could fail for multivolume creation in some cases.
+- 7zr.exe for arm64 is included to LZMA SDK package.
+- Some bugs were fixed.
+
+
+23.01          2023-06-20
+-------------------------
+- 7-Zip now can use new ARM64 filter for compression to 7z and xz archives.
+  ARM64 filter can increase compression ratio for data containing executable 
+  files compiled for ARM64 (AArch64) architecture.
+  Also 7-Zip now parses executable files (that have exe and dll filename extensions) 
+  before compressing, and it selects appropriate filter for each parsed file: 
+    - BCJ or BCJ2 filter for x86 executable files,
+    - ARM64 filter for ARM64 executable files.
+  Previous versions by default used x86 filter BCJ or BCJ2 for all exe/dll files.
+- Default section size for BCJ2 filter was changed from 64 MiB to 240 MiB.
+  It can increase compression ratio for executable files larger than 64 MiB.
+- Some optimizations in filters code: BCJ, BCJ2, Swap* and opthers.
+- If 7-Zip uses BCJ2 filter for big datasets compressing, it can use additional temp 
+  files in system's TEMP folder. 7-Zip uses temp file for additional compressed 
+  data stream, if size of such compressed stream is larger than predefined limit: 
+  16 MiB in 32-bit version, 4 GiB in 64-bit version.
+- When new 7-Zip creates multivolume archive, 7-Zip keeps in open state
+  only volumes that still can be changed. Previous versions kept all volumes 
+  in open state until the end of the archive creation.
+- 7-Zip for Linux and macOS now can reduce the number of simultaneously open files,
+  when 7-Zip opens, extracts or creates multivolume archive. It allows to avoid 
+  the failures for cases with big number of volumes, bacause there is a limitation 
+  for number of open files allowed for a single program in Linux and macOS.
+- Some bugs were fixed.
+- Source code changes:
+- All external macros for compiling C/C++ code of 7-Zip now have Z7_ prefix.
+- 7-Zip COM interfaces now use new macros that allow to declare and implement COM interface.
+- The code has been modified to compile with the maximum diagnostic warning level:
+    -Wall in MSVC and -Weverything in CLANG.
+  And some warning types are disabled in 2 files:
+    - C/Compiler.h for C/C++ code warnings.
+    - CPP/Common/Common.h for C++ code warnings.
+- Linux/macOS versions of 7-Zip: IUnknown interface in new code doesn't use 
+  virtual destructor that was used in previous 7-Zip and p7zip:
+     // virtual ~IUnknown() {}
+  So 7-Zip's dynamically linked shared libraries (codecs) are not compatible 
+  between new 7-Zip for Linux/macOS and old 7-Zip (and p7zip).
+
+
+21.07          2021-12-26
+-------------------------
+- New switches: -spm and -im!{file_path} to exclude directories from processing 
+    for specified paths that don't contain path separator character at the end of path.
+- The sorting order of files in archives was slightly changed to be more consistent
+  for cases where the name of some directory is the same as the prefix part of the name
+  of another directory or file.
+
+
+21.06          2021-11-24
+-------------------------
+- Bug in LZMA encoder in file LzmaEnc.c was fixed:
+  LzmaEnc_MemEncode(), LzmaEncode() and LzmaCompress() could work incorrectly, 
+    if size value for output buffer is smaller than size required for all compressed data.
+  LzmaEnc_Encode() could work incorrectly,
+    if callback ISeqOutStream::Write() doesn't write all compressed data.
+  NCompress::NLzma::CEncoder::Code() could work incorrectly,
+    if callback ISequentialOutStream::Write() returns error code.
+- Bug in versions 21.00-21.05 was fixed:
+  7-Zip didn't set attributes of directories during archive extracting.
+
+
+21.04 beta     2021-11-02
+-------------------------
+- 7-Zip now reduces the number of working CPU threads for compression,
+  if RAM size is not enough for compression with big LZMA2 dictionary.
+- 7-Zip now can create and check "file.sha256" text files that contain the list 
+  of file names and SHA-256 checksums in format compatible with sha256sum program.
+
+
+21.03 beta     2021-07-20
+-------------------------
+- The maximum dictionary size for LZMA/LZMA2 compressing was increased to 4 GB (3840 MiB).
+- Minor speed optimizations in LZMA/LZMA2 compressing.
+
+
+21.02 alpha    2021-05-06
+-------------------------
+- The command line version of 7-Zip for macOS was released.
+- The speed for LZMA and LZMA2 decompression in arm64 versions for macOS and Linux 
+  was increased by 20%-60%.
+
+
+21.01 alpha    2021-03-09
+-------------------------
+- The command line version of 7-Zip for Linux was released.
+- The improvements for speed of ARM64 version using hardware CPU instructions 
+  for AES, CRC-32, SHA-1 and SHA-256.
+- Some bugs were fixed.
+
+
+20.02 alpha    2020-08-08
+-------------------------
+- The default number of LZMA2 chunks per solid block in 7z archive was increased to 64.
+  It allows to increase the compression speed for big 7z archives, if there is a big number 
+  of CPU cores and threads.
+- The speed of PPMd compressing/decompressing was increased for 7z archives.
+- The new -ssp switch. If the switch -ssp is specified, 7-Zip doesn't allow the system 
+  to modify "Last Access Time" property of source files for archiving and hashing operations. 
+- Some bugs were fixed.
+
+
+20.00 alpha    2020-02-06
+-------------------------
+- 7-Zip now supports new optional match finders for LZMA/LZMA2 compression: bt5 and hc5, 
+  that can work faster than bt4 and hc4 match finders for the data with big redundancy.
+- The compression ratio was improved for Fast and Fastest compression levels with the 
+  following default settings:
+   - Fastest level (-mx1) : hc5 match finder with 256 KB dictionary.
+   - Fast    level (-mx3) : hc5 match finder with 4 MB dictionary.
+- Minor speed optimizations in multithreaded LZMA/LZMA2 compression for Normal/Maximum/Ultra 
+  compression levels.
+
+
+19.00          2019-02-21
+-------------------------
+- Encryption strength for 7z archives was increased:
+  the size of random initialization vector was increased from 64-bit to 128-bit,
+  and the pseudo-random number generator was improved.
+- The bug in 7zIn.c code was fixed.
+
+
+18.06          2018-12-30
+-------------------------
+- The speed for LZMA/LZMA2 compressing was increased by 3-10%,
+  and there are minor changes in compression ratio.
+- Some bugs were fixed.
+- The bug in 7-Zip 18.02-18.05 was fixed:
+  There was memory leak in multithreading xz decoder - XzDecMt_Decode(),
+  if xz stream contains only one block.
+- The changes for MSVS compiler makefiles: 
+   - the makefiles now use "PLATFORM" macroname with values (x64, x86, arm64)
+     instead of "CPU" macroname with values (AMD64, ARM64).
+   - the makefiles by default now use static version of the run-time library.
+
+
+18.05          2018-04-30
+-------------------------
+- The speed for LZMA/LZMA2 compressing was increased 
+    by 8% for fastest/fast compression levels and 
+    by 3% for normal/maximum compression levels.
+- Previous versions of 7-Zip could work incorrectly in "Large memory pages" mode in
+  Windows 10 because of some BUG with "Large Pages" in Windows 10. 
+  Now 7-Zip doesn't use "Large Pages" on Windows 10 up to revision 1709 (16299).
+- The BUG was fixed in Lzma2Enc.c
+    Lzma2Enc_Encode2() function worked incorretly,
+      if (inStream == NULL) and the number of block threads is more than 1.
+
+
+18.03 beta     2018-03-04
+-------------------------
+- Asm\x86\LzmaDecOpt.asm: new optimized LZMA decoder written in asm 
+  for x64 with about 30% higher speed than main version of LZMA decoder written in C.
+- The speed for single-thread LZMA/LZMA2 decoder written in C was increased by 3%.
+- 7-Zip now can use multi-threading for 7z/LZMA2 decoding,
+  if there are multiple independent data chunks in LZMA2 stream.
+- 7-Zip now can use multi-threading for xz decoding,
+  if there are multiple blocks in xz stream.
+
+
+18.01          2019-01-28
+-------------------------
+- The BUG in 17.01 - 18.00 beta was fixed:
+  XzDec.c : random block unpacking and XzUnpacker_IsBlockFinished()
+  didn't work correctly for xz archives without checksum (CRC).
+
+
+18.00 beta     2019-01-10
+-------------------------
+- The BUG in xz encoder was fixed:
+  There was memory leak of 16 KB for each file compressed with 
+  xz compression method, if additional filter was used.
+
+
+17.01 beta     2017-08-28
+-------------------------
+- Minor speed optimization for LZMA2 (xz and 7z) multi-threading compression.
+  7-Zip now uses additional memory buffers for multi-block LZMA2 compression.
+  CPU utilization was slightly improved.
+- 7-zip now creates multi-block xz archives by default. Block size can be 
+  specified with -ms[Size]{m|g} switch.
+- xz decoder now can unpack random block from multi-block xz archives.
+- 7-Zip command line: @listfile now doesn't work after -- switch.
+  Use -i@listfile before -- switch instead.
+- The BUGs were fixed:
+  7-Zip 17.00 beta crashed for commands that write anti-item to 7z archive.
+
+
+17.00 beta     2017-04-29
+-------------------------
+- NewHandler.h / NewHandler.cpp: 
+    now it redefines operator new() only for old MSVC compilers (_MSC_VER < 1900).
+- C/7zTypes.h : the names of variables in interface structures were changed (vt).
+- Some bugs were fixed. 7-Zip could crash in some cases.
+- Some internal changes in code.
+
+
+16.04          2016-10-04
+-------------------------
+- The bug was fixed in DllSecur.c.
+
+
+16.03          2016-09-28
+-------------------------
+- SFX modules now use some protection against DLL preloading attack.
+- Some bugs in 7z code were fixed.
+
+
+16.02          2016-05-21
+-------------------------
+- The BUG in 16.00 - 16.01 was fixed:
+  Split Handler (SplitHandler.cpp) returned incorrect 
+  total size value (kpidSize) for split archives.
+
+
+16.01          2016-05-19
+-------------------------	
+- Some internal changes to reduce the number of compiler warnings.
+
+
+16.00          2016-05-10
+-------------------------	
+- Some bugs were fixed.
+
+
+15.12          2015-11-19
+-------------------------	
+- The BUG in C version of 7z decoder was fixed:
+  7zDec.c : SzDecodeLzma2()
+  7z decoder could mistakenly report about decoding error for some 7z archives
+  that use LZMA2 compression method.
+  The probability to get that mistaken decoding error report was about 
+  one error per 16384 solid blocks for solid blocks larger than 16 KB (compressed size). 
+- The BUG (in 9.26-15.11) in C version of 7z decoder was fixed:
+  7zArcIn.c : SzReadHeader2()
+  7z decoder worked incorrectly for 7z archives that contain 
+  empty solid blocks, that can be placed to 7z archive, if some file is 
+  unavailable for reading during archive creation.
+
+
+15.09 beta     2015-10-16
+-------------------------	
+- The BUG in LZMA / LZMA2 encoding code was fixed.
+  The BUG in LzFind.c::MatchFinder_ReadBlock() function.
+  If input data size is larger than (4 GiB - dictionary_size),
+  the following code worked incorrectly:
+  -  LZMA : LzmaEnc_MemEncode(), LzmaEncode() : LZMA encoding functions 
+     for compressing from memory to memory. 
+     That BUG is not related to LZMA encoder version that works via streams.
+  -  LZMA2 : multi-threaded version of LZMA2 encoder worked incorrectly, if 
+     default value of chunk size (CLzma2EncProps::blockSize) is changed 
+     to value larger than (4 GiB - dictionary_size).
+
+
+9.38 beta      2015-01-03
+-------------------------	
+- The BUG in 9.31-9.37 was fixed:
+  IArchiveGetRawProps interface was disabled for 7z archives.
+- The BUG in 9.26-9.36 was fixed:
+  Some code in CPP\7zip\Archive\7z\ worked correctly only under Windows.
+
+
+9.36 beta      2014-12-26
+-------------------------	
+- The BUG in command line version was fixed:
+  7-Zip created temporary archive in current folder during update archive
+  operation, if -w{Path} switch was not specified. 
+  The fixed 7-Zip creates temporary archive in folder that contains updated archive.
+- The BUG in 9.33-9.35 was fixed:
+  7-Zip silently ignored file reading errors during 7z or gz archive creation,
+  and the created archive contained only part of file that was read before error.
+  The fixed 7-Zip stops archive creation and it reports about error.
+
+
+9.35 beta      2014-12-07
+-------------------------	
+- 7zr.exe now support AES encryption.
+- SFX mudules were added to LZMA SDK
+- Some bugs were fixed.
+
+
+9.21 beta      2011-04-11
+-------------------------	
+- New class FString for file names at file systems.
+- Speed optimization in CRC code for big-endian CPUs.
+- The BUG in Lzma2Dec.c was fixed:
+    Lzma2Decode function didn't work.
+
+
+9.18 beta      2010-11-02
+-------------------------	
+- New small SFX module for installers (SfxSetup).
+
+
+9.12 beta      2010-03-24
+-------------------------
+- The BUG in LZMA SDK 9.* was fixed: LZMA2 codec didn't work,
+  if more than 10 threads were used (or more than 20 threads in some modes).
+
+
+9.11 beta      2010-03-15
+-------------------------
+- PPMd compression method support
+   
+
+9.09           2009-12-12
+-------------------------
+- The bug was fixed:
+   Utf16_To_Utf8 funstions in UTFConvert.cpp and 7zMain.c
+   incorrectly converted surrogate characters (the code >= 0x10000) to UTF-8.
+- Some bugs were fixed
+
+
+9.06           2009-08-17
+-------------------------
+- Some changes in ANSI-C 7z Decoder interfaces.
+
+
+9.04           2009-05-30
+-------------------------
+- LZMA2 compression method support
+- xz format support
+
+
+4.65           2009-02-03
+-------------------------
+- Some minor fixes
+
+
+4.63           2008-12-31
+-------------------------
+- Some minor fixes
+
+
+4.61 beta      2008-11-23
+-------------------------
+- The bug in ANSI-C LZMA Decoder was fixed:
+    If encoded stream was corrupted, decoder could access memory 
+    outside of allocated range.
+- Some changes in ANSI-C 7z Decoder interfaces.
+- LZMA SDK is placed in the public domain.
+
+
+4.60 beta      2008-08-19
+-------------------------
+- Some minor fixes.
+
+
+4.59 beta      2008-08-13
+-------------------------
+- The bug was fixed:
+    LZMA Encoder in fast compression mode could access memory outside of 
+    allocated range in some rare cases.
+
+
+4.58 beta      2008-05-05
+-------------------------
+- ANSI-C LZMA Decoder was rewritten for speed optimizations.
+- ANSI-C LZMA Encoder was included to LZMA SDK.
+- C++ LZMA code now is just wrapper over ANSI-C code.
+
+
+4.57           2007-12-12
+-------------------------
+- Speed optimizations in Ñ++ LZMA Decoder. 
+- Small changes for more compatibility with some C/C++ compilers.
+
+
+4.49 beta      2007-07-05
+-------------------------
+- .7z ANSI-C Decoder:
+     - now it supports BCJ and BCJ2 filters
+     - now it supports files larger than 4 GB.
+     - now it supports "Last Write Time" field for files.
+- C++ code for .7z archives compressing/decompressing from 7-zip 
+  was included to LZMA SDK.
+  
+
+4.43           2006-06-04
+-------------------------
+- Small changes for more compatibility with some C/C++ compilers.
+  
+
+4.42           2006-05-15
+-------------------------
+- Small changes in .h files in ANSI-C version.
+  
+
+4.39 beta      2006-04-14
+-------------------------
+- The bug in versions 4.33b:4.38b was fixed:
+  C++ version of LZMA encoder could not correctly compress 
+  files larger than 2 GB with HC4 match finder (-mfhc4).
+  
+
+4.37 beta      2005-04-06
+-------------------------
+- Fixes in C++ code: code could no be compiled if _NO_EXCEPTIONS was defined. 
+
+
+4.35 beta      2005-03-02
+-------------------------
+- The bug was fixed in C++ version of LZMA Decoder:
+    If encoded stream was corrupted, decoder could access memory 
+    outside of allocated range.
+
+
+4.34 beta      2006-02-27
+-------------------------
+- Compressing speed and memory requirements for compressing were increased
+- LZMA now can use only these match finders: HC4, BT2, BT3, BT4
+
+
+4.32           2005-12-09
+-------------------------
+- Java version of LZMA SDK was included
+
+
+4.30           2005-11-20
+-------------------------
+- Compression ratio was improved in -a2 mode
+- Speed optimizations for compressing in -a2 mode
+- -fb switch now supports values up to 273
+- The bug in 7z_C (7zIn.c) was fixed:
+  It used Alloc/Free functions from different memory pools.
+  So if program used two memory pools, it worked incorrectly.
+- 7z_C: .7z format supporting was improved
+- LZMA# SDK (C#.NET version) was included
+
+
+4.27 (Updated) 2005-09-21
+-------------------------
+- Some GUIDs/interfaces in C++ were changed.
+ IStream.h:
+   ISequentialInStream::Read now works as old ReadPart
+   ISequentialOutStream::Write now works as old WritePart
+
+
+4.27           2005-08-07
+-------------------------
+- The bug in LzmaDecodeSize.c was fixed:
+   if _LZMA_IN_CB and _LZMA_OUT_READ were defined,
+   decompressing worked incorrectly.
+
+
+4.26           2005-08-05
+-------------------------
+- Fixes in 7z_C code and LzmaTest.c:
+  previous versions could work incorrectly,
+  if malloc(0) returns 0
+
+
+4.23           2005-06-29
+-------------------------
+- Small fixes in C++ code
+
+
+4.22           2005-06-10
+-------------------------
+- Small fixes
+
+
+4.21           2005-06-08
+-------------------------
+- Interfaces for ANSI-C LZMA Decoder (LzmaDecode.c) were changed
+- New additional version of ANSI-C LZMA Decoder with zlib-like interface:
+    - LzmaStateDecode.h
+    - LzmaStateDecode.c
+    - LzmaStateTest.c
+- ANSI-C LZMA Decoder now can decompress files larger than 4 GB
+
+
+4.17           2005-04-18
+-------------------------
+- New example for RAM->RAM compressing/decompressing: 
+  LZMA + BCJ (filter for x86 code):
+    - LzmaRam.h
+    - LzmaRam.cpp
+    - LzmaRamDecode.h
+    - LzmaRamDecode.c
+    - -f86 switch for lzma.exe
+
+
+4.16           2005-03-29
+-------------------------
+- The bug was fixed in LzmaDecode.c (ANSI-C LZMA Decoder): 
+   If _LZMA_OUT_READ was defined, and if encoded stream was corrupted,
+   decoder could access memory outside of allocated range.
+- Speed optimization of ANSI-C LZMA Decoder (now it's about 20% faster).
+  Old version of LZMA Decoder now is in file LzmaDecodeSize.c. 
+  LzmaDecodeSize.c can provide slightly smaller code than LzmaDecode.c
+- Small speed optimization in LZMA C++ code
+- filter for SPARC's code was added
+- Simplified version of .7z ANSI-C Decoder was included
+
+
+4.06           2004-09-05
+-------------------------
+- The bug in v4.05 was fixed:
+    LZMA-Encoder didn't release output stream in some cases.
+
+
+4.05           2004-08-25
+-------------------------
+- Source code of filters for x86, IA-64, ARM, ARM-Thumb 
+  and PowerPC code was included to SDK
+- Some internal minor changes
+
+
+4.04           2004-07-28
+-------------------------
+- More compatibility with some C++ compilers
+
+
+4.03           2004-06-18
+-------------------------
+- "Benchmark" command was added. It measures compressing 
+  and decompressing speed and shows rating values. 
+  Also it checks hardware errors.
+
+
+4.02           2004-06-10
+-------------------------
+- C++ LZMA Encoder/Decoder code now is more portable
+  and it can be compiled by GCC on Linux.
+
+
+4.01           2004-02-15
+-------------------------
+- Some detection of data corruption was enabled.
+    LzmaDecode.c / RangeDecoderReadByte
+    .....
+    {
+      rd->ExtraBytes = 1;
+      return 0xFF;
+    }
+
+
+4.00           2004-02-13
+-------------------------
+- Original version of LZMA SDK
+
+
+
+HISTORY of the LZMA
+-------------------
+  2001-2008:  Improvements to LZMA compressing/decompressing code, 
+              keeping compatibility with original LZMA format
+  1996-2001:  Development of LZMA compression format
+
+  Some milestones:
+
+  2001-08-30: LZMA compression was added to 7-Zip
+  1999-01-02: First version of 7-Zip was released
+  
+
+End of document

--- a/3rdparty/lzma/src/7zArcIn.c
+++ b/3rdparty/lzma/src/7zArcIn.c
@@ -11,7 +11,7 @@
 #include "CpuArch.h"
 
 #define MY_ALLOC(T, p, size, alloc) \
-  { if ((p = (T *)ISzAlloc_Alloc(alloc, (size) * sizeof(T))) == NULL) return SZ_ERROR_MEM; }
+  { if ((p = (T *)ISzAlloc_Alloc(alloc, (size_t)(size) * sizeof(T))) == NULL) return SZ_ERROR_MEM; }
 
 #define MY_ALLOC_ZE(T, p, size, alloc) \
   { if ((size) == 0) p = NULL; else MY_ALLOC(T, p, size, alloc) }
@@ -21,8 +21,6 @@
 
 #define MY_ALLOC_ZE_AND_CPY(to, size, from, alloc) \
   { if ((size) == 0) to = NULL; else { MY_ALLOC_AND_CPY(to, size, from, alloc) } }
-
-#define k7zMajorVersion 0
 
 enum EIdEnum
 {
@@ -52,15 +50,13 @@ enum EIdEnum
   k7zIdEncodedHeader,
   k7zIdStartPos,
   k7zIdDummy
-  // k7zNtSecure,
-  // k7zParent,
-  // k7zIsReal
 };
 
 const Byte k7zSignature[k7zSignatureSize] = {'7', 'z', 0xBC, 0xAF, 0x27, 0x1C};
 
 #define SzBitUi32s_INIT(p) { (p)->Defs = NULL; (p)->Vals = NULL; }
 
+Z7_FORCE_INLINE
 static SRes SzBitUi32s_Alloc(CSzBitUi32s *p, size_t num, ISzAllocPtr alloc)
 {
   if (num == 0)
@@ -76,6 +72,7 @@ static SRes SzBitUi32s_Alloc(CSzBitUi32s *p, size_t num, ISzAllocPtr alloc)
   return SZ_OK;
 }
 
+Z7_FORCE_INLINE
 static void SzBitUi32s_Free(CSzBitUi32s *p, ISzAllocPtr alloc)
 {
   ISzAlloc_Free(alloc, p->Defs); p->Defs = NULL;
@@ -84,13 +81,14 @@ static void SzBitUi32s_Free(CSzBitUi32s *p, ISzAllocPtr alloc)
 
 #define SzBitUi64s_INIT(p) { (p)->Defs = NULL; (p)->Vals = NULL; }
 
+Z7_FORCE_INLINE
 static void SzBitUi64s_Free(CSzBitUi64s *p, ISzAllocPtr alloc)
 {
   ISzAlloc_Free(alloc, p->Defs); p->Defs = NULL;
   ISzAlloc_Free(alloc, p->Vals); p->Vals = NULL;
 }
 
-
+Z7_NO_INLINE
 static void SzAr_Init(CSzAr *p)
 {
   p->NumPackStreams = 0;
@@ -110,23 +108,22 @@ static void SzAr_Init(CSzAr *p)
   p->RangeLimit = 0;
 }
 
+Z7_NO_INLINE
 static void SzAr_Free(CSzAr *p, ISzAllocPtr alloc)
 {
   ISzAlloc_Free(alloc, p->PackPositions);
   SzBitUi32s_Free(&p->FolderCRCs, alloc);
- 
   ISzAlloc_Free(alloc, p->FoCodersOffsets);
   ISzAlloc_Free(alloc, p->FoStartPackStreamIndex);
   ISzAlloc_Free(alloc, p->FoToCoderUnpackSizes);
   ISzAlloc_Free(alloc, p->FoToMainUnpackSizeIndex);
   ISzAlloc_Free(alloc, p->CoderUnpackSizes);
-  
   ISzAlloc_Free(alloc, p->CodersData);
 
   SzAr_Init(p);
 }
 
-
+Z7_NO_INLINE
 void SzArEx_Init(CSzArEx *p)
 {
   SzAr_Init(&p->db);
@@ -150,6 +147,7 @@ void SzArEx_Init(CSzArEx *p)
   SzBitUi64s_INIT(&p->CTime)
 }
 
+Z7_NO_INLINE
 void SzArEx_Free(CSzArEx *p, ISzAllocPtr alloc)
 {
   ISzAlloc_Free(alloc, p->UnpackPositions);
@@ -172,15 +170,6 @@ void SzArEx_Free(CSzArEx *p, ISzAllocPtr alloc)
 }
 
 
-static int TestSignatureCandidate(const Byte *testBytes)
-{
-  unsigned i;
-  for (i = 0; i < k7zSignatureSize; i++)
-    if (testBytes[i] != k7zSignature[i])
-      return 0;
-  return 1;
-}
-
 #define SzData_CLEAR(p) { (p)->Data = NULL; (p)->Size = 0; }
 
 #define SZ_READ_BYTE_SD_NOCHECK(_sd_, dest) \
@@ -199,14 +188,9 @@ static int TestSignatureCandidate(const Byte *testBytes)
 #define SKIP_DATA(sd, size) { sd->Size -= (size_t)(size); sd->Data += (size_t)(size); }
 #define SKIP_DATA2(sd, size) { sd.Size -= (size_t)(size); sd.Data += (size_t)(size); }
 
-#define SZ_READ_32(dest) if (sd.Size < 4) return SZ_ERROR_ARCHIVE; \
-   dest = GetUi32(sd.Data); SKIP_DATA2(sd, 4);
-
 static Z7_NO_INLINE SRes ReadNumber(CSzData *sd, UInt64 *value)
 {
-  Byte firstByte, mask;
-  unsigned i;
-  UInt32 v;
+  unsigned firstByte, mask, i, v;
 
   SZ_READ_BYTE(firstByte)
   if ((firstByte & 0x80) == 0)
@@ -223,18 +207,18 @@ static Z7_NO_INLINE SRes ReadNumber(CSzData *sd, UInt64 *value)
   SZ_READ_BYTE(mask)
   *value = v | ((UInt32)mask << 8);
   mask = 0x20;
-  for (i = 2; i < 8; i++)
+  for (i = 2 * 8; i < 8 * 8; i += 8)
   {
-    Byte b;
+    unsigned b;
     if ((firstByte & mask) == 0)
     {
       const UInt64 highPart = (unsigned)firstByte & (unsigned)(mask - 1);
-      *value |= (highPart << (8 * i));
+      *value |= (highPart << i);
       return SZ_OK;
     }
-    SZ_READ_BYTE(b)
-    *value |= ((UInt64)b << (8 * i));
     mask >>= 1;
+    SZ_READ_BYTE(b)
+    *value |= ((UInt64)b << i);
   }
   return SZ_OK;
 }
@@ -242,7 +226,7 @@ static Z7_NO_INLINE SRes ReadNumber(CSzData *sd, UInt64 *value)
 
 static Z7_NO_INLINE SRes SzReadNumber32(CSzData *sd, UInt32 *value)
 {
-  Byte firstByte;
+  unsigned firstByte;
   UInt64 value64;
   if (sd->Size == 0)
     return SZ_ERROR_ARCHIVE;
@@ -265,6 +249,7 @@ static Z7_NO_INLINE SRes SzReadNumber32(CSzData *sd, UInt32 *value)
 
 #define ReadID(sd, value) ReadNumber(sd, value)
 
+Z7_NO_INLINE
 static SRes SkipData(CSzData *sd)
 {
   UInt64 size;
@@ -275,6 +260,7 @@ static SRes SkipData(CSzData *sd)
   return SZ_OK;
 }
 
+Z7_NO_INLINE
 static SRes WaitId(CSzData *sd, UInt32 id)
 {
   for (;;)
@@ -289,16 +275,8 @@ static SRes WaitId(CSzData *sd, UInt32 id)
   }
 }
 
-static SRes RememberBitVector(CSzData *sd, size_t numItems, const Byte **v)
-{
-  const size_t numBytes = (numItems + 7) >> 3;
-  if (numBytes > sd->Size)
-    return SZ_ERROR_ARCHIVE;
-  *v = sd->Data;
-  SKIP_DATA(sd, numBytes)
-  return SZ_OK;
-}
 
+Z7_NO_INLINE
 static UInt32 CountDefinedBits(const Byte *bits, UInt32 numItems)
 {
   unsigned b = 0;
@@ -339,8 +317,8 @@ static Z7_NO_INLINE SRes ReadBitVector(CSzData *sd, size_t numItems, Byte **v, I
   memset(v2, 0xFF, (size_t)numBytes);
   {
     const unsigned numBits = (unsigned)numItems & 7;
-    if (numBits != 0)
-      v2[(size_t)numBytes - 1] = (Byte)((((UInt32)1 << numBits) - 1) << (8 - numBits));
+    if (numBits)
+      v2[(size_t)numBytes - 1] = (Byte)(0xff00u >> numBits);
   }
   return SZ_OK;
 }
@@ -348,31 +326,40 @@ static Z7_NO_INLINE SRes ReadBitVector(CSzData *sd, size_t numItems, Byte **v, I
 static Z7_NO_INLINE SRes ReadUi32s(CSzData *sd2, size_t numItems, CSzBitUi32s *crcs, ISzAllocPtr alloc)
 {
   size_t i;
-  CSzData sd;
+  const Byte *data;
+  size_t size;
   UInt32 *vals;
   const Byte *defs;
-  MY_ALLOC_ZE(UInt32, crcs->Vals, numItems, alloc)
-  sd = *sd2;
+  MY_ALLOC_ZE(UInt32, vals, numItems, alloc)
+  crcs->Vals = vals;
   defs = crcs->Defs;
-  vals = crcs->Vals;
+  data = sd2->Data;
+  size = sd2->Size;
   for (i = 0; i < numItems; i++)
     if (SzBitArray_Check(defs, i))
     {
-      SZ_READ_32(vals[i])
+      if (size < 4)
+        return SZ_ERROR_ARCHIVE;
+      size -= 4;
+      vals[i] = GetUi32(data);
+      data += 4;
     }
     else
       vals[i] = 0;
-  *sd2 = sd;
+  sd2->Data = data;
+  sd2->Size = size;
   return SZ_OK;
 }
 
 static SRes ReadBitUi32s(CSzData *sd, size_t numItems, CSzBitUi32s *crcs, ISzAllocPtr alloc)
 {
-  SzBitUi32s_Free(crcs, alloc);
+  if (crcs->Defs)
+    return SZ_ERROR_ARCHIVE;
   RINOK(ReadBitVector(sd, numItems, &crcs->Defs, alloc))
   return ReadUi32s(sd, numItems, crcs, alloc);
 }
 
+Z7_NO_INLINE
 static SRes SkipBitUi32s(CSzData *sd, UInt32 numItems)
 {
   Byte allAreDefined;
@@ -395,25 +382,26 @@ static SRes SkipBitUi32s(CSzData *sd, UInt32 numItems)
 static SRes ReadPackInfo(CSzAr *p, CSzData *sd, ISzAllocPtr alloc)
 {
   RINOK(SzReadNumber32(sd, &p->NumPackStreams))
-
   RINOK(WaitId(sd, k7zIdSize))
-  MY_ALLOC(UInt64, p->PackPositions, (size_t)p->NumPackStreams + 1, alloc)
   {
-    UInt64 sum = 0;
-    UInt32 i;
-    const UInt32 numPackStreams = p->NumPackStreams;
-    for (i = 0; i < numPackStreams; i++)
+    UInt64 *packPositions;
+    UInt64 sum;
+    size_t num = (size_t)p->NumPackStreams + 1;
+    MY_ALLOC(UInt64, packPositions, num, alloc)
+    p->PackPositions = packPositions;
+    sum = 0;
+    for (;;)
     {
       UInt64 packSize;
-      p->PackPositions[i] = sum;
+      *packPositions++ = sum;
+      if (--num == 0)
+        break;
       RINOK(ReadNumber(sd, &packSize))
       sum += packSize;
       if (sum < packSize)
         return SZ_ERROR_ARCHIVE;
     }
-    p->PackPositions[i] = sum;
   }
-
   for (;;)
   {
     UInt64 type;
@@ -430,85 +418,79 @@ static SRes ReadPackInfo(CSzAr *p, CSzData *sd, ISzAllocPtr alloc)
   }
 }
 
-/*
-static SRes SzReadSwitch(CSzData *sd)
-{
-  Byte external;
-  RINOK(SzReadByte(sd, &external));
-  return (external == 0) ? SZ_OK: SZ_ERROR_UNSUPPORTED;
-}
-*/
 
 #define k_NumCodersStreams_in_Folder_MAX (SZ_NUM_BONDS_IN_FOLDER_MAX + SZ_NUM_PACK_STREAMS_IN_FOLDER_MAX)
 
 SRes SzGetNextFolderItem(CSzFolder *f, CSzData *sd)
 {
-  UInt32 numCoders, i;
-  UInt32 numInStreams = 0;
-  const Byte *dataStart = sd->Data;
+  UInt32 numCoders, i, numInStreams = 0;
+  const Byte * const dataStart = sd->Data;
 
-  f->NumCoders = 0;
-  f->NumBonds = 0;
-  f->NumPackStreams = 0;
+  // f->NumCoders = 0;
+  // f->NumBonds = 0;
+  // f->NumPackStreams = 0;
   f->UnpackStream = 0;
   
   RINOK(SzReadNumber32(sd, &numCoders))
   if (numCoders == 0 || numCoders > SZ_NUM_CODERS_IN_FOLDER_MAX)
     return SZ_ERROR_UNSUPPORTED;
+  f->NumCoders = numCoders;
   
   for (i = 0; i < numCoders; i++)
   {
     Byte mainByte;
-    CSzCoderInfo *coder = f->Coders + i;
-    unsigned idSize, j;
-    UInt64 id;
-    
-    SZ_READ_BYTE(mainByte)
-    if ((mainByte & 0xC0) != 0)
-      return SZ_ERROR_UNSUPPORTED;
-    
-    idSize = (unsigned)(mainByte & 0xF);
-    if (idSize > sizeof(id))
-      return SZ_ERROR_UNSUPPORTED;
-    if (idSize > sd->Size)
-      return SZ_ERROR_ARCHIVE;
-    id = 0;
-    for (j = 0; j < idSize; j++)
+    CSzCoderInfo *coder;
     {
-      id = ((id << 8) | *sd->Data);
-      sd->Data++;
+      unsigned idSize, j;
+      UInt64 id;
+      const Byte *data;
+      
+      if (!sd->Size)
+        return SZ_ERROR_ARCHIVE;
       sd->Size--;
+      data = sd->Data;
+      mainByte = *data++;
+      if (mainByte & 0xC0)
+        return SZ_ERROR_UNSUPPORTED;
+      idSize = mainByte & 0xF;
+      if (idSize > sizeof(id))
+        return SZ_ERROR_UNSUPPORTED;
+      if (idSize > sd->Size)
+        return SZ_ERROR_ARCHIVE;
+      sd->Size -= idSize;
+      id = 0;
+      for (j = 0; j < idSize; j++)
+        id = (id << 8) | *data++;
+      sd->Data = data;
+      if (id > (UInt32)0xFFFFFFFF)
+        return SZ_ERROR_UNSUPPORTED;
+      coder = f->Coders + i;
+      coder->MethodID = (UInt32)id;
     }
-    if (id > (UInt32)0xFFFFFFFF)
-      return SZ_ERROR_UNSUPPORTED;
-    coder->MethodID = (UInt32)id;
     
     coder->NumStreams = 1;
     coder->PropsOffset = 0;
     coder->PropsSize = 0;
     
-    if ((mainByte & 0x10) != 0)
+    if (mainByte & 0x10)
     {
       UInt32 numStreams;
-      
       RINOK(SzReadNumber32(sd, &numStreams))
       if (numStreams > k_NumCodersStreams_in_Folder_MAX)
         return SZ_ERROR_UNSUPPORTED;
       coder->NumStreams = (Byte)numStreams;
-
       RINOK(SzReadNumber32(sd, &numStreams))
       if (numStreams != 1)
         return SZ_ERROR_UNSUPPORTED;
     }
 
     numInStreams += coder->NumStreams;
-
     if (numInStreams > k_NumCodersStreams_in_Folder_MAX)
       return SZ_ERROR_UNSUPPORTED;
 
-    if ((mainByte & 0x20) != 0)
+    if (mainByte & 0x20)
     {
-      UInt32 propsSize = 0;
+      UInt32 propsSize;
       RINOK(SzReadNumber32(sd, &propsSize))
       if (propsSize > sd->Size)
         return SZ_ERROR_ARCHIVE;
@@ -521,14 +503,6 @@ SRes SzGetNextFolderItem(CSzFolder *f, CSzData *sd)
     }
   }
 
-  /*
-  if (numInStreams == 1 && numCoders == 1)
-  {
-    f->NumPackStreams = 1;
-    f->PackStreams[0] = 0;
-  }
-  else
-  */
   {
     Byte streamUsed[k_NumCodersStreams_in_Folder_MAX];
     UInt32 numBonds, numPackStreams;
@@ -545,14 +519,13 @@ SRes SzGetNextFolderItem(CSzFolder *f, CSzData *sd)
       return SZ_ERROR_UNSUPPORTED;
     f->NumPackStreams = numPackStreams;
   
-    for (i = 0; i < numInStreams; i++)
+    for (i = 0; i < Z7_ARRAY_SIZE(streamUsed); i++) // numInStreams
       streamUsed[i] = False;
     
-    if (numBonds != 0)
+    if (numBonds)
     {
       Byte coderUsed[SZ_NUM_CODERS_IN_FOLDER_MAX];
-
-      for (i = 0; i < numCoders; i++)
+      for (i = 0; i < Z7_ARRAY_SIZE(coderUsed); i++) // numCoders
         coderUsed[i] = False;
       
       for (i = 0; i < numBonds; i++)
@@ -570,24 +543,25 @@ SRes SzGetNextFolderItem(CSzFolder *f, CSzData *sd)
         coderUsed[bp->OutIndex] = True;
       }
       
-      for (i = 0; i < numCoders; i++)
+      for (i = 0;;)
+      {
         if (!coderUsed[i])
-        {
-          f->UnpackStream = i;
           break;
-        }
-      
-      if (i == numCoders)
-        return SZ_ERROR_ARCHIVE;
+        if (++i == numCoders)
+          return SZ_ERROR_ARCHIVE;
+      }
+      f->UnpackStream = i;
     }
     
     if (numPackStreams == 1)
     {
-      for (i = 0; i < numInStreams; i++)
+      for (i = 0;; i++)
+      {
+        if (i == numInStreams)
+          return SZ_ERROR_ARCHIVE;
         if (!streamUsed[i])
           break;
-      if (i == numInStreams)
-        return SZ_ERROR_ARCHIVE;
+      }
       f->PackStreams[0] = i;
     }
     else
@@ -601,40 +575,30 @@ SRes SzGetNextFolderItem(CSzFolder *f, CSzData *sd)
         f->PackStreams[i] = index;
       }
   }
-
-  f->NumCoders = numCoders;
-
   return SZ_OK;
 }
 
 
-static Z7_NO_INLINE SRes SkipNumbers(CSzData *sd2, UInt32 num)
+static SRes SkipNumbers(CSzData *sd2, UInt32 num)
 {
-  CSzData sd;
-  sd = *sd2;
+  const Byte *data = sd2->Data;
+  size_t size = sd2->Size;
   for (; num != 0; num--)
   {
-    Byte firstByte, mask;
+    unsigned firstByte;
     unsigned i;
-    SZ_READ_BYTE_2(firstByte)
-    if ((firstByte & 0x80) == 0)
-      continue;
-    if ((firstByte & 0x40) == 0)
-    {
-      if (sd.Size == 0)
-        return SZ_ERROR_ARCHIVE;
-      sd.Size--;
-      sd.Data++;
-      continue;
-    }
-    mask = 0x20;
-    for (i = 2; i < 8 && (firstByte & mask) != 0; i++)
-      mask >>= 1;
-    if (i > sd.Size)
+    if (size == 0)
       return SZ_ERROR_ARCHIVE;
-    SKIP_DATA2(sd, i)
+    firstByte = *data;
+    for (i = 1; firstByte & 0x80; i++)
+      firstByte <<= 1;
+    if (size < i)
+      return SZ_ERROR_ARCHIVE;
+    size -= i;
+    data += i;
   }
-  *sd2 = sd;
+  sd2->Data = data;
+  sd2->Size = size;
   return SZ_OK;
 }
 
@@ -642,15 +606,10 @@ static Z7_NO_INLINE SRes SkipNumbers(CSzData *sd2, UInt32 num)
 #define k_Scan_NumCoders_MAX 64
 #define k_Scan_NumCodersStreams_in_Folder_MAX 64
 
-
-static SRes ReadUnpackInfo(CSzAr *p,
-    CSzData *sd2,
-    UInt32 numFoldersMax,
-    const CBuf *tempBufs, UInt32 numTempBufs,
-    ISzAllocPtr alloc)
+static SRes ReadUnpackInfo(CSzAr *p, CSzData *sd2, const UInt32 numFoldersMax,
+    const CBuf *tempBufs, UInt32 numTempBufs, ISzAllocPtr alloc)
 {
   CSzData sd;
-  
   UInt32 fo, numFolders, numCodersOutStreams, packStreamIndex;
   const Byte *startBufPtr;
   Byte external;
@@ -742,15 +701,12 @@ static SRes ReadUnpackInfo(CSzAr *p,
       {
         Byte streamUsed[k_Scan_NumCodersStreams_in_Folder_MAX];
         Byte coderUsed[k_Scan_NumCoders_MAX];
-    
         UInt32 i;
         const UInt32 numBonds = numCoders - 1;
         if (numInStreams < numBonds)
           return SZ_ERROR_ARCHIVE;
-        
         if (numInStreams > k_Scan_NumCodersStreams_in_Folder_MAX)
           return SZ_ERROR_UNSUPPORTED;
-        
         for (i = 0; i < numInStreams; i++)
           streamUsed[i] = False;
         for (i = 0; i < numCoders; i++)
@@ -782,16 +738,15 @@ static SRes ReadUnpackInfo(CSzAr *p,
               return SZ_ERROR_ARCHIVE;
             streamUsed[index] = True;
           }
-          
-        for (i = 0; i < numCoders; i++)
+
+        for (i = 0;;)
+        {
           if (!coderUsed[i])
-          {
-            indexOfMainStream = i;
             break;
-          }
- 
-        if (i == numCoders)
-          return SZ_ERROR_ARCHIVE;
+          if (++i == numCoders)
+            return SZ_ERROR_ARCHIVE;
+        }
+        indexOfMainStream = i;
       }
       
       p->FoStartPackStreamIndex[fo] = packStreamIndex;
@@ -806,31 +761,38 @@ static SRes ReadUnpackInfo(CSzAr *p,
     }
   }
 
+  {
+    const size_t k_numCodersOutStreams_Limit = (size_t)1 << (sizeof(size_t) * 8 - 4);
+    if (numCodersOutStreams >= k_numCodersOutStreams_Limit)
+      return SZ_ERROR_UNSUPPORTED;
+  }
   p->FoToCoderUnpackSizes[fo] = numCodersOutStreams;
-  
+  p->FoStartPackStreamIndex[fo] = packStreamIndex;
   {
     const size_t dataSize = (size_t)(sd.Data - startBufPtr);
-    p->FoStartPackStreamIndex[fo] = packStreamIndex;
     p->FoCodersOffsets[fo] = dataSize;
     MY_ALLOC_ZE_AND_CPY(p->CodersData, dataSize, startBufPtr, alloc)
   }
   
-  if (external != 0)
+  if (external)
   {
-    if (sd.Size != 0)
+    if (sd.Size)
       return SZ_ERROR_ARCHIVE;
     sd = *sd2;
   }
   
   RINOK(WaitId(&sd, k7zIdCodersUnpackSize))
-  
-  MY_ALLOC_ZE(UInt64, p->CoderUnpackSizes, (size_t)numCodersOutStreams, alloc)
   {
-    UInt32 i;
-    for (i = 0; i < numCodersOutStreams; i++)
-    {
-      RINOK(ReadNumber(&sd, p->CoderUnpackSizes + i))
-    }
+    UInt64 *sizes;
+    MY_ALLOC_ZE(UInt64, sizes, (size_t)numCodersOutStreams, alloc)
+    p->CoderUnpackSizes = sizes;
+    if (numCodersOutStreams)
+      do
+      {
+        RINOK(ReadNumber(&sd, sizes))
+        sizes++;
+      }
+      while (--numCodersOutStreams);
   }
 
   for (;;)
@@ -838,10 +800,7 @@ static SRes ReadUnpackInfo(CSzAr *p,
     UInt64 type;
     RINOK(ReadID(&sd, &type))
     if (type == k7zIdEnd)
-    {
-      *sd2 = sd;
-      return SZ_OK;
-    }
+      break;
     if (type == k7zIdCRC)
     {
       RINOK(ReadBitUi32s(&sd, numFolders, &p->FolderCRCs, alloc))
@@ -849,6 +808,8 @@ static SRes ReadUnpackInfo(CSzAr *p,
     }
     RINOK(SkipData(&sd))
   }
+  *sd2 = sd;
+  return SZ_OK;
 }
 
 
@@ -868,12 +829,12 @@ typedef struct
 } CSubStreamInfo;
 
 
-static SRes ReadSubStreamsInfo(CSzAr *p, CSzData *sd, CSubStreamInfo *ssi)
+static SRes ReadSubStreamsInfo(const CSzAr *p, CSzData *sd, CSubStreamInfo *ssi)
 {
   UInt64 type = 0;
-  UInt32 numSubDigests = 0;
   const UInt32 numFolders = p->NumFolders;
   UInt32 numUnpackStreams = numFolders;
+  UInt32 numSubDigests = numFolders;
   UInt32 numUnpackSizesInData = 0;
 
   for (;;)
@@ -882,6 +843,8 @@ static SRes ReadSubStreamsInfo(CSzAr *p, CSzData *sd, CSubStreamInfo *ssi)
     if (type == k7zIdNumUnpackStream)
     {
       UInt32 i;
+      if (ssi->sdNumSubStreams.Data)
+        return SZ_ERROR_UNSUPPORTED;
       ssi->sdNumSubStreams.Data = sd->Data;
       numUnpackStreams = 0;
       numSubDigests = 0;
@@ -889,10 +852,10 @@ static SRes ReadSubStreamsInfo(CSzAr *p, CSzData *sd, CSubStreamInfo *ssi)
       {
         UInt32 numStreams;
         RINOK(SzReadNumber32(sd, &numStreams))
-        if (numUnpackStreams > numUnpackStreams + numStreams)
-          return SZ_ERROR_UNSUPPORTED;
         numUnpackStreams += numStreams;
-        if (numStreams != 0)
+        if (numUnpackStreams < numStreams)
+          return SZ_ERROR_UNSUPPORTED;
+        if (numStreams)
           numUnpackSizesInData += (numStreams - 1);
         if (numStreams != 1 || !SzBitWithVals_Check(&p->FolderCRCs, i))
           numSubDigests += numStreams;
@@ -905,12 +868,8 @@ static SRes ReadSubStreamsInfo(CSzAr *p, CSzData *sd, CSubStreamInfo *ssi)
     RINOK(SkipData(sd))
   }
 
-  if (!ssi->sdNumSubStreams.Data)
-  {
-    numSubDigests = numFolders;
-    if (p->FolderCRCs.Defs)
-      numSubDigests = numFolders - CountDefinedBits(p->FolderCRCs.Defs, numFolders);
-  }
+  if (!ssi->sdNumSubStreams.Data && p->FolderCRCs.Defs)
+    numSubDigests = numFolders - CountDefinedBits(p->FolderCRCs.Defs, numFolders);
   
   ssi->NumTotalSubStreams = numUnpackStreams;
   ssi->NumSubDigests = numSubDigests;
@@ -929,6 +888,8 @@ static SRes ReadSubStreamsInfo(CSzAr *p, CSzData *sd, CSubStreamInfo *ssi)
       return SZ_OK;
     if (type == k7zIdCRC)
     {
+      if (ssi->sdCRCs.Data)
+        return SZ_ERROR_UNSUPPORTED;
       ssi->sdCRCs.Data = sd->Data;
       RINOK(SkipBitUi32s(sd, numSubDigests))
       ssi->sdCRCs.Size = (size_t)(sd->Data - ssi->sdCRCs.Data);
@@ -941,9 +902,11 @@ static SRes ReadSubStreamsInfo(CSzAr *p, CSzData *sd, CSubStreamInfo *ssi)
   }
 }
 
+
 static SRes SzReadStreamsInfo(CSzAr *p,
     CSzData *sd,
-    UInt32 numFoldersMax, const CBuf *tempBufs, UInt32 numTempBufs,
+    const UInt32 numFoldersMax,
+    const CBuf * const tempBufs, const UInt32 numTempBufs,
     UInt64 *dataOffset,
     CSubStreamInfo *ssi,
     ISzAllocPtr alloc)
@@ -985,12 +948,13 @@ static SRes SzReadStreamsInfo(CSzAr *p,
   return (type == k7zIdEnd ? SZ_OK : SZ_ERROR_UNSUPPORTED);
 }
 
+
 static SRes SzReadAndDecodePackedStreams(
     ILookInStreamPtr inStream,
     CSzData *sd,
-    CBuf *tempBufs,
-    UInt32 numFoldersMax,
-    UInt64 baseOffset,
+    CBuf * const tempBufs,
+    const UInt32 numFoldersMax,
+    const UInt64 baseOffset,
     CSzAr *p,
     ISzAllocPtr allocTemp)
 {
@@ -1027,6 +991,7 @@ static SRes SzReadAndDecodePackedStreams(
   return SZ_OK;
 }
 
+
 // (size & 1) == 0
 // (data) is aligned for 2-bytes
 static SRes SzReadFileNames(const Byte *data, size_t size, UInt32 numFiles, size_t *offsets)
@@ -1053,30 +1018,35 @@ static SRes SzReadFileNames(const Byte *data, size_t size, UInt32 numFiles, size
   return (p == lim) ? SZ_OK : SZ_ERROR_ARCHIVE;
 }
 
-static Z7_NO_INLINE SRes ReadTime(CSzBitUi64s *p, size_t num,
-    CSzData *sd2,
-    const CBuf *tempBufs, UInt32 numTempBufs,
-    ISzAllocPtr alloc)
+
+static SRes ReadTime(CSzBitUi64s *p, size_t num, CSzData *sd2,
+    const CBuf *tempBufs, UInt32 numTempBufs, ISzAllocPtr alloc)
 {
-  CSzData sd;
+  const Byte *data;
+  size_t size;
   size_t i;
   CNtfsFileTime *vals;
   Byte *defs;
   Byte external;
   
+  if (p->Defs)
+    return SZ_ERROR_ARCHIVE;
   RINOK(ReadBitVector(sd2, num, &p->Defs, alloc))
   
   SZ_READ_BYTE_SD(sd2, external)
   if (external == 0)
-    sd = *sd2;
+  {
+    data = sd2->Data;
+    size = sd2->Size;
+  }
   else
   {
     UInt32 index;
     RINOK(SzReadNumber32(sd2, &index))
-    if (index >= numTempBufs)
+    if (index >= numTempBufs || sd2->Size)
       return SZ_ERROR_ARCHIVE;
-    sd.Data = tempBufs[index].data;
-    sd.Size = tempBufs[index].size;
+    data = tempBufs[index].data;
+    size = tempBufs[index].size;
   }
   
   MY_ALLOC_ZE(CNtfsFileTime, p->Vals, num, alloc)
@@ -1085,18 +1055,18 @@ static Z7_NO_INLINE SRes ReadTime(CSzBitUi64s *p, size_t num,
   for (i = 0; i < num; i++)
     if (SzBitArray_Check(defs, i))
     {
-      if (sd.Size < 8)
+      if (size < 8)
         return SZ_ERROR_ARCHIVE;
-      vals[i].Low = GetUi32(sd.Data);
-      vals[i].High = GetUi32(sd.Data + 4);
-      SKIP_DATA2(sd, 8)
+      size -= 8;
+      vals[i].Low = GetUi32(data);
+      vals[i].High = GetUi32(data + 4);
+      data += 8;
     }
     else
       vals[i].High = vals[i].Low = 0;
   
-  if (external == 0)
-    *sd2 = sd;
-  
+  if (size)
+    return SZ_ERROR_ARCHIVE;
   return SZ_OK;
 }
 
@@ -1104,16 +1074,11 @@ static Z7_NO_INLINE SRes ReadTime(CSzBitUi64s *p, size_t num,
 #define NUM_ADDITIONAL_STREAMS_MAX 8
 
 
-static SRes SzReadHeader2(
-    CSzArEx *p,   /* allocMain */
-    CSzData *sd,
-    ILookInStreamPtr inStream,
-    CBuf *tempBufs, UInt32 *numTempBufs,
-    ISzAllocPtr allocMain,
-    ISzAllocPtr allocTemp
-    )
+static SRes SzReadHeader2(CSzArEx *p, CSzData *sd, ILookInStreamPtr inStream,
+    CBuf * const tempBufs, ISzAllocPtr allocMain, ISzAllocPtr allocTemp)
 {
   CSubStreamInfo ssi;
+  UInt32 numTempBufs = 0;
 
 {
   UInt64 type;
@@ -1150,7 +1115,7 @@ static SRes SzReadHeader2(
 
     res = SzReadAndDecodePackedStreams(inStream, sd, tempBufs, NUM_ADDITIONAL_STREAMS_MAX,
         p->startPosAfterHeader, &tempAr, allocTemp);
-    *numTempBufs = tempAr.NumFolders;
+    numTempBufs = tempAr.NumFolders;
     SzAr_Free(&tempAr, allocTemp);
     
     if (res != SZ_OK)
@@ -1160,24 +1125,21 @@ static SRes SzReadHeader2(
 
   if (type == k7zIdMainStreamsInfo)
   {
-    RINOK(SzReadStreamsInfo(&p->db, sd, (UInt32)1 << 30, tempBufs, *numTempBufs,
+    static const UInt32 k_numFoldersMax = (UInt32)1 << 30;
+    RINOK(SzReadStreamsInfo(&p->db, sd, k_numFoldersMax, tempBufs, numTempBufs,
         &p->dataPos, &ssi, allocMain))
     p->dataPos += p->startPosAfterHeader;
     RINOK(ReadID(sd, &type))
   }
 
   if (type == k7zIdEnd)
-  {
     return SZ_OK;
-  }
-
   if (type != k7zIdFilesInfo)
     return SZ_ERROR_ARCHIVE;
 }
 
 {
-  UInt32 numFiles = 0;
-  UInt32 numEmptyStreams = 0;
+  UInt32 numFiles, numEmptyStreams = 0;
   const Byte *emptyStreams = NULL;
   const Byte *emptyFiles = NULL;
   
@@ -1186,44 +1148,68 @@ static SRes SzReadHeader2(
 
   for (;;)
   {
+    CSzData sdSwitch;
     UInt64 type;
-    UInt64 size;
     RINOK(ReadID(sd, &type))
     if (type == k7zIdEnd)
       break;
-    RINOK(ReadNumber(sd, &size))
-    if (size > sd->Size)
-      return SZ_ERROR_ARCHIVE;
-    
-    if (type >= ((UInt32)1 << 8))
     {
+      UInt64 size;
+      RINOK(ReadNumber(sd, &size))
+      if (size > sd->Size)
+        return SZ_ERROR_ARCHIVE;
+      sdSwitch.Data = sd->Data;
+      sdSwitch.Size = (size_t)size;
       SKIP_DATA(sd, size)
     }
-    else switch ((unsigned)type)
+    if (type >= 64)
+      continue;
+    
+    switch ((unsigned)type)
     {
+      case k7zIdEmptyStream:
+      {
+        if (emptyStreams || emptyFiles)
+          return SZ_ERROR_ARCHIVE;
+        if ((numFiles + 7) >> 3 != sdSwitch.Size)
+          return SZ_ERROR_ARCHIVE;
+        emptyStreams = sdSwitch.Data;
+        numEmptyStreams = CountDefinedBits(emptyStreams, numFiles);
+        break;
+      }
+      
+      case k7zIdEmptyFile:
+      {
+        if (emptyFiles)
+          return SZ_ERROR_ARCHIVE;
+        if ((numEmptyStreams + 7) >> 3 != sdSwitch.Size)
+          return SZ_ERROR_ARCHIVE;
+        emptyFiles = sdSwitch.Data;
+        break;
+      }
+      
       case k7zIdName:
       {
         size_t namesSize;
         const Byte *namesData;
         Byte external;
-
-        SZ_READ_BYTE(external)
+        if (p->FileNameOffsets)
+          return SZ_ERROR_ARCHIVE;
+        SZ_READ_BYTE_SD(&sdSwitch, external)
         if (external == 0)
         {
-          namesSize = (size_t)size - 1;
-          namesData = sd->Data;
-          SKIP_DATA(sd, namesSize)
+          namesData = sdSwitch.Data;
+          namesSize = sdSwitch.Size;
         }
         else
         {
           UInt32 index;
-          RINOK(SzReadNumber32(sd, &index))
-          if (index >= *numTempBufs)
+          RINOK(SzReadNumber32(&sdSwitch, &index))
+          if (index >= numTempBufs || sdSwitch.Size)
             return SZ_ERROR_ARCHIVE;
-          namesData = (tempBufs)[index].data;
-          namesSize = (tempBufs)[index].size;
+          namesData = tempBufs[index].data;
+          namesSize = tempBufs[index].size;
         }
-
         if (namesSize & 1)
           return SZ_ERROR_ARCHIVE;
         MY_ALLOC(size_t, p->FileNameOffsets, numFiles + 1, allocMain)
@@ -1231,58 +1217,38 @@ static SRes SzReadHeader2(
         RINOK(SzReadFileNames(p->FileNames, namesSize, numFiles, p->FileNameOffsets))
         break;
       }
-      case k7zIdEmptyStream:
-      {
-        RINOK(RememberBitVector(sd, numFiles, &emptyStreams))
-        numEmptyStreams = CountDefinedBits(emptyStreams, numFiles);
-        emptyFiles = NULL;
-        break;
-      }
-      case k7zIdEmptyFile:
-      {
-        RINOK(RememberBitVector(sd, numEmptyStreams, &emptyFiles))
-        break;
-      }
+      
       case k7zIdWinAttrib:
       {
         Byte external;
-        CSzData sdSwitch;
-        CSzData *sdPtr;
-        SzBitUi32s_Free(&p->Attribs, allocMain);
-        RINOK(ReadBitVector(sd, numFiles, &p->Attribs.Defs, allocMain))
-
-        SZ_READ_BYTE(external)
-        if (external == 0)
-          sdPtr = sd;
-        else
+        if (p->Attribs.Defs)
+          return SZ_ERROR_ARCHIVE;
+        RINOK(ReadBitVector(&sdSwitch, numFiles, &p->Attribs.Defs, allocMain))
+        SZ_READ_BYTE_SD(&sdSwitch, external)
+        if (external)
         {
           UInt32 index;
-          RINOK(SzReadNumber32(sd, &index))
-          if (index >= *numTempBufs)
+          RINOK(SzReadNumber32(&sdSwitch, &index))
+          if (index >= numTempBufs || sdSwitch.Size)
             return SZ_ERROR_ARCHIVE;
-          sdSwitch.Data = (tempBufs)[index].data;
-          sdSwitch.Size = (tempBufs)[index].size;
-          sdPtr = &sdSwitch;
+          sdSwitch.Data = tempBufs[index].data;
+          sdSwitch.Size = tempBufs[index].size;
         }
-        RINOK(ReadUi32s(sdPtr, numFiles, &p->Attribs, allocMain))
+        RINOK(ReadUi32s(&sdSwitch, numFiles, &p->Attribs, allocMain))
+        if (sdSwitch.Size)
+          return SZ_ERROR_ARCHIVE;
         break;
       }
-      /*
-      case k7zParent:
+      
+      case k7zIdMTime:
+      case k7zIdCTime:
       {
-        SzBitUi32s_Free(&p->Parents, allocMain);
-        RINOK(ReadBitVector(sd, numFiles, &p->Parents.Defs, allocMain));
-        RINOK(SzReadSwitch(sd));
-        RINOK(ReadUi32s(sd, numFiles, &p->Parents, allocMain));
+        RINOK(ReadTime((unsigned)type == k7zIdMTime ? &p->MTime: &p->CTime,
+            numFiles, &sdSwitch, tempBufs, numTempBufs, allocMain))
         break;
       }
-      */
-      case k7zIdMTime: RINOK(ReadTime(&p->MTime, numFiles, sd, tempBufs, *numTempBufs, allocMain)) break;
-      case k7zIdCTime: RINOK(ReadTime(&p->CTime, numFiles, sd, tempBufs, *numTempBufs, allocMain)) break;
-      default:
-      {
-        SKIP_DATA(sd, size)
-      }
+      
+      default: break;
     }
   }
 
@@ -1481,25 +1447,19 @@ static SRes SzReadHeader(
     ISzAllocPtr allocTemp)
 {
   UInt32 i;
-  UInt32 numTempBufs = 0;
   SRes res;
   CBuf tempBufs[NUM_ADDITIONAL_STREAMS_MAX];
 
   for (i = 0; i < NUM_ADDITIONAL_STREAMS_MAX; i++)
     Buf_Init(tempBufs + i);
   
-  res = SzReadHeader2(p, sd, inStream,
-      tempBufs, &numTempBufs,
-      allocMain, allocTemp);
+  res = SzReadHeader2(p, sd, inStream, tempBufs, allocMain, allocTemp);
   
   for (i = 0; i < NUM_ADDITIONAL_STREAMS_MAX; i++)
     Buf_Free(tempBufs + i, allocTemp);
 
-  RINOK(res)
-
-  if (sd->Size != 0)
-    return SZ_ERROR_FAIL;
-
+  if (res == SZ_OK && sd->Size != 0)
+    return SZ_ERROR_ARCHIVE;
   return res;
 }
 
@@ -1510,53 +1470,52 @@ static SRes SzArEx_Open2(
     ISzAllocPtr allocTemp)
 {
   Byte header[k7zStartHeaderSize];
-  Int64 startArcPos;
+  Int64 startPosAfterHeader;
   UInt64 nextHeaderOffset, nextHeaderSize;
   size_t nextHeaderSizeT;
   UInt32 nextHeaderCRC;
   CBuf buf;
   SRes res;
 
-  startArcPos = 0;
-  RINOK(ILookInStream_Seek(inStream, &startArcPos, SZ_SEEK_CUR))
-
   RINOK(LookInStream_Read2(inStream, header, k7zStartHeaderSize, SZ_ERROR_NO_ARCHIVE))
-
-  if (!TestSignatureCandidate(header))
-    return SZ_ERROR_NO_ARCHIVE;
-  if (header[6] != k7zMajorVersion)
-    return SZ_ERROR_UNSUPPORTED;
+  startPosAfterHeader = 0; // k7zStartHeaderSize
+  RINOK(ILookInStream_Seek(inStream, &startPosAfterHeader, SZ_SEEK_CUR))
+  p->startPosAfterHeader = (UInt64)startPosAfterHeader;
+  {
+    unsigned i;
+    for (i = 0; i < k7zSignatureSize; i++)
+      if (header[i] != k7zSignature[i])
+        return SZ_ERROR_NO_ARCHIVE;
+    if (header[6] != 0) // k7zMajorVersion
+      return SZ_ERROR_UNSUPPORTED;
+  }
+  if (CrcCalc(header + 12, 20) != GetUi32(header + 8))
+    return SZ_ERROR_CRC;
 
   nextHeaderOffset = GetUi64(header + 12);
   nextHeaderSize = GetUi64(header + 20);
   nextHeaderCRC = GetUi32(header + 28);
 
-  p->startPosAfterHeader = (UInt64)startArcPos + k7zStartHeaderSize;
-  
-  if (CrcCalc(header + 12, 20) != GetUi32(header + 8))
-    return SZ_ERROR_CRC;
-
   p->db.RangeLimit = nextHeaderOffset;
-
+  if (nextHeaderOffset >= (UInt64)1 << 62 ||
+      nextHeaderSize >= (UInt64)1 << 48)
+    return SZ_ERROR_NO_ARCHIVE;
   nextHeaderSizeT = (size_t)nextHeaderSize;
   if (nextHeaderSizeT != nextHeaderSize)
     return SZ_ERROR_MEM;
   if (nextHeaderSizeT == 0)
+  {
+    if (nextHeaderOffset != 0 || nextHeaderCRC != 0)
+      return SZ_ERROR_NO_ARCHIVE;
     return SZ_OK;
-  if (nextHeaderOffset > nextHeaderOffset + nextHeaderSize ||
-      nextHeaderOffset > nextHeaderOffset + nextHeaderSize + k7zStartHeaderSize)
-    return SZ_ERROR_NO_ARCHIVE;
-
+  }
   {
     Int64 pos = 0;
     RINOK(ILookInStream_Seek(inStream, &pos, SZ_SEEK_END))
-    if ((UInt64)pos < (UInt64)startArcPos + nextHeaderOffset ||
-        (UInt64)pos < (UInt64)startArcPos + k7zStartHeaderSize + nextHeaderOffset ||
-        (UInt64)pos < (UInt64)startArcPos + k7zStartHeaderSize + nextHeaderOffset + nextHeaderSize)
+    if ((UInt64)(pos - startPosAfterHeader) < nextHeaderOffset + nextHeaderSize)
       return SZ_ERROR_INPUT_EOF;
   }
-
-  RINOK(LookInStream_SeekTo(inStream, (UInt64)startArcPos + k7zStartHeaderSize + nextHeaderOffset))
+  RINOK(LookInStream_SeekTo(inStream, (UInt64)startPosAfterHeader + nextHeaderOffset))
 
   if (!Buf_Create(&buf, nextHeaderSizeT, allocTemp))
     return SZ_ERROR_MEM;
@@ -1720,61 +1679,23 @@ SRes SzArEx_Extract(
 
 size_t SzArEx_GetFileNameUtf16(const CSzArEx *p, size_t fileIndex, UInt16 *dest)
 {
-  const size_t offs = p->FileNameOffsets[fileIndex];
-  const size_t len = p->FileNameOffsets[fileIndex + 1] - offs;
-  if (dest != 0)
+  const size_t * const offsets = p->FileNameOffsets;
+  if (!offsets)
   {
-    size_t i;
-    const Byte *src = p->FileNames + offs * 2;
-    for (i = 0; i < len; i++)
-      dest[i] = GetUi16(src + i * 2);
-  }
-  return len;
-}
-
-/*
-size_t SzArEx_GetFullNameLen(const CSzArEx *p, size_t fileIndex)
-{
-  size_t len;
-  if (!p->FileNameOffsets)
+    if (dest)
+      *dest = 0;
     return 1;
-  len = 0;
-  for (;;)
+  }
   {
-    UInt32 parent = (UInt32)(Int32)-1;
-    len += p->FileNameOffsets[fileIndex + 1] - p->FileNameOffsets[fileIndex];
-    if SzBitWithVals_Check(&p->Parents, fileIndex)
-      parent = p->Parents.Vals[fileIndex];
-    if (parent == (UInt32)(Int32)-1)
-      return len;
-    fileIndex = parent;
+    const size_t offs = offsets[fileIndex];
+    const size_t len = offsets[fileIndex + 1] - offs;
+    if (dest)
+    {
+      size_t i;
+      const Byte *src = p->FileNames + offs * 2;
+      for (i = 0; i < len; i++)
+        dest[i] = GetUi16a(src + i * 2);
+    }
+    return len;
   }
 }
-
-UInt16 *SzArEx_GetFullNameUtf16_Back(const CSzArEx *p, size_t fileIndex, UInt16 *dest)
-{
-  BoolInt needSlash;
-  if (!p->FileNameOffsets)
-  {
-    *(--dest) = 0;
-    return dest;
-  }
-  needSlash = False;
-  for (;;)
-  {
-    UInt32 parent = (UInt32)(Int32)-1;
-    size_t curLen = p->FileNameOffsets[fileIndex + 1] - p->FileNameOffsets[fileIndex];
-    SzArEx_GetFileNameUtf16(p, fileIndex, dest - curLen);
-    if (needSlash)
-      *(dest - 1) = '/';
-    needSlash = True;
-    dest -= curLen;
-
-    if SzBitWithVals_Check(&p->Parents, fileIndex)
-      parent = p->Parents.Vals[fileIndex];
-    if (parent == (UInt32)(Int32)-1)
-      return dest;
-    fileIndex = parent;
-  }
-}
-*/

--- a/3rdparty/lzma/src/DllSecur.c
+++ b/3rdparty/lzma/src/DllSecur.c
@@ -1,5 +1,5 @@
 /* DllSecur.c -- DLL loading security
-2023-12-03 : Igor Pavlov : Public domain */
+: Igor Pavlov : Public domain */
 
 #include "Precomp.h"
 
@@ -67,7 +67,7 @@ void LoadSecurityDlls(void)
   // at Vista (ver 6.0) : CoCreateInstance(CLSID_ShellLink, ...) doesn't work after SetDefaultDllDirectories() : Check it ???
   IF_NON_VISTA_SET_DLL_DIRS_AND_RETURN
   {
-    wchar_t buf[MAX_PATH + 100];
+    WCHAR buf[MAX_PATH + 100];
     const char *dll;
     unsigned pos = GetSystemDirectoryW(buf, MAX_PATH + 2);
     if (pos == 0 || pos > MAX_PATH)
@@ -76,7 +76,7 @@ void LoadSecurityDlls(void)
       buf[pos++] = '\\';
     for (dll = g_Dlls; *dll != 0;)
     {
-      wchar_t *dest = &buf[pos];
+      WCHAR *dest = &buf[pos];
       for (;;)
       {
         const char c = *dll++;

--- a/3rdparty/lzma/src/MtDec.c
+++ b/3rdparty/lzma/src/MtDec.c
@@ -1,5 +1,5 @@
 /* MtDec.c -- Multi-thread Decoder
-2024-02-20 : Igor Pavlov : Public domain */
+: Igor Pavlov : Public domain */
 
 #include "Precomp.h"
 
@@ -22,7 +22,7 @@
 #define PRF(x)
 #endif
 
-#define PRF_STR_INT(s, d) PRF(printf("\n" s " %d\n", (unsigned)d))
+#define PRF_STR_INT(s, d) PRF(printf("\n" s " %d\n", (unsigned)d);)
 
 void MtProgress_Init(CMtProgress *p, ICompressProgressPtr progress)
 {

--- a/3rdparty/lzma/src/XzDec.c
+++ b/3rdparty/lzma/src/XzDec.c
@@ -25,8 +25,8 @@
 #define PRF(x)
 #endif
 
-#define PRF_STR(s) PRF(printf("\n" s "\n"))
-#define PRF_STR_INT(s, d) PRF(printf("\n" s " %d\n", (unsigned)d))
+#define PRF_STR(s) PRF(printf("\n" s "\n");)
+#define PRF_STR_INT(s, d) PRF(printf("\n" s " %d\n", (unsigned)d);)
 
 #include <stdlib.h>
 #include <string.h>
@@ -574,7 +574,7 @@ static SRes MixCoder_ResetFromMethod(CMixCoder *p, unsigned coderIndex, UInt64 m
 output (status) can be :
   CODER_STATUS_NOT_FINISHED
   CODER_STATUS_FINISHED_WITH_MARK
-  CODER_STATUS_NEEDS_MORE_INPUT - not implemented still
+  CODER_STATUS_NEEDS_MORE_INPUT
 */
 
 static SRes MixCoder_Code(CMixCoder *p,
@@ -582,8 +582,8 @@ static SRes MixCoder_Code(CMixCoder *p,
     const Byte *src, SizeT *srcLen, int srcWasFinished,
     ECoderFinishMode finishMode)
 {
-  SizeT destLenOrig = *destLen;
-  SizeT srcLenOrig = *srcLen;
+  const SizeT destLenOrig = *destLen;
+  const SizeT srcLenOrig = *srcLen;
 
   *destLen = 0;
   *srcLen = 0;
@@ -597,39 +597,26 @@ static SRes MixCoder_Code(CMixCoder *p,
   if (p->outBuf)
   {
     SRes res;
-    SizeT destLen2, srcLen2;
+    SizeT destLen2;
     int wasFinished;
     
     PRF_STR("------- MixCoder Single ----------")
       
-    srcLen2 = srcLenOrig;
     destLen2 = destLenOrig;
-    
+    if (p->numCoders != 1)
+    {
+      if (destLen2 < p->outWritten)
+        return SZ_ERROR_FAIL;
+      destLen2 -= p->outWritten;
+    }
+    *srcLen = srcLenOrig;
     {
       IStateCoder *coder = &p->coders[0];
-      res = coder->Code2(coder->p, NULL, &destLen2, src, &srcLen2, srcWasFinished, finishMode,
-          // &wasFinished,
-          &p->status);
-      wasFinished = (p->status == CODER_STATUS_FINISHED_WITH_MARK);
+      res = coder->Code2(coder->p, NULL, &destLen2, src, srcLen, srcWasFinished, finishMode, &p->status);
     }
-    
     p->res = res;
-    
-    /*
-    if (wasFinished)
-      p->status = CODER_STATUS_FINISHED_WITH_MARK;
-    else
-    {
-      if (res == SZ_OK)
-        if (destLen2 != destLenOrig)
-          p->status = CODER_STATUS_NEEDS_MORE_INPUT;
-    }
-    */
-
-    
-    *srcLen = srcLen2;
-    src += srcLen2;
     p->outWritten += destLen2;
+    wasFinished = (p->status == CODER_STATUS_FINISHED_WITH_MARK);
     
     if (res != SZ_OK || srcWasFinished || wasFinished)
       p->wasFinished = True;
@@ -1016,8 +1003,8 @@ SRes XzUnpacker_Code(CXzUnpacker *p, Byte *dest, SizeT *destLen,
     const Byte *src, SizeT *srcLen, int srcFinished,
     ECoderFinishMode finishMode, ECoderStatus *status)
 {
-  SizeT destLenOrig = *destLen;
-  SizeT srcLenOrig = *srcLen;
+  const SizeT destLenOrig = *destLen;
+  const SizeT srcLenOrig = *srcLen;
   *destLen = 0;
   *srcLen = 0;
   *status = CODER_STATUS_NOT_SPECIFIED;


### PR DESCRIPTION
### Description of Changes
Updates the LZMA/7zipSDK from 26.01 to 26.02.

### Rationale behind Changes
CVE bad fix good.

### Suggested Testing Steps
Make sure it builds dumps play back and games load correctly.

### Did you use AI to help find, test, or implement this issue or feature?
No.