### PR TITLE
Input/FullscreenUI: Fix shared-binding navigation bug; fix and expand controller icon/glyph support

### DIFF
--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -170,24 +170,12 @@ void FullscreenUI::ApplyLayoutSettings(const SettingsInterface* bsi)
 			return InputLayout::Playstation;
 		if (mode == "nintendo")
 			return InputLayout::Nintendo;
+		if (mode == "generic")
+			return InputLayout::Generic;
 		return InputLayout::Unknown;
 	};
 
-	switch (parse_glyph_layout(glyph_mode))
-	{
-		case InputLayout::Xbox:
-			InputManager::SetGamepadIconPreference(InputLayout::Xbox);
-			break;
-		case InputLayout::Playstation:
-			InputManager::SetGamepadIconPreference(InputLayout::Playstation);
-			break;
-		case InputLayout::Nintendo:
-			InputManager::SetGamepadIconPreference(InputLayout::Nintendo);
-			break;
-		default:
-			InputManager::SetGamepadIconPreference(InputLayout::Unknown);
-			break;
-	}
+	InputManager::SetGamepadIconPreference(parse_glyph_layout(glyph_mode));
 
 	const InputLayout layout = ImGuiFullscreen::GetGamepadLayout();
 

--- a/pcsx2/ImGui/FullscreenUI_Settings.cpp
+++ b/pcsx2/ImGui/FullscreenUI_Settings.cpp
@@ -2296,12 +2296,14 @@ void FullscreenUI::DrawInterfaceSettingsPage()
 		FSUI_NSTR("Xbox"),
 		FSUI_NSTR("PlayStation"),
 		FSUI_NSTR("Nintendo"),
+		FSUI_NSTR("Generic"),
 	};
 	static constexpr const char* glyph_values[] = {
 		"auto",
 		"xbox",
 		"playstation",
 		"nintendo",
+		"generic",
 	};
 	size_t glyph_index = std::size(glyph_values);
 	for (size_t i = 0; i < std::size(glyph_values); i++)

--- a/pcsx2/ImGui/ImGuiFullscreen.cpp
+++ b/pcsx2/ImGui/ImGuiFullscreen.cpp
@@ -971,7 +971,7 @@ InputLayout ImGuiFullscreen::GetGamepadLayout()
 static InputLayout GetEffectiveGlyphLayout()
 {
 	const InputLayout preferred_layout = InputManager::GetGamepadIconPreference();
-	if (preferred_layout == InputLayout::Xbox || preferred_layout == InputLayout::Playstation || preferred_layout == InputLayout::Nintendo)
+	if (preferred_layout != InputLayout::Unknown)
 		return preferred_layout;
 
 	return ImGuiFullscreen::GetGamepadLayout();
@@ -982,7 +982,7 @@ ImGuiFullscreen::GamepadGlyphs ImGuiFullscreen::GetGamepadGlyphs()
 	const InputLayout layout = GetEffectiveGlyphLayout();
 	const bool xbox = (layout == InputLayout::Xbox);
 	const bool nintendo = (layout == InputLayout::Nintendo);
-	const bool unknown = (layout == InputLayout::Unknown);
+	const bool unknown = (layout == InputLayout::Unknown || layout == InputLayout::Generic);
 	return {
 		unknown ? ICON_PF_BUTTON_DOWN_A : (nintendo ? ICON_PF_BUTTON_B : (xbox ? ICON_PF_BUTTON_A : ICON_PF_BUTTON_CROSS)),
 		unknown ? ICON_PF_BUTTON_RIGHT_B : (nintendo ? ICON_PF_BUTTON_A : (xbox ? ICON_PF_BUTTON_B : ICON_PF_BUTTON_CIRCLE)),

--- a/pcsx2/ImGui/ImGuiFullscreen.cpp
+++ b/pcsx2/ImGui/ImGuiFullscreen.cpp
@@ -974,19 +974,7 @@ static InputLayout GetEffectiveGlyphLayout()
 	if (preferred_layout == InputLayout::Xbox || preferred_layout == InputLayout::Playstation || preferred_layout == InputLayout::Nintendo)
 		return preferred_layout;
 
-	const InputLayout detected_layout = ImGuiFullscreen::GetGamepadLayout();
-	switch (detected_layout)
-	{
-		case InputLayout::Playstation:
-			return InputLayout::Playstation;
-		case InputLayout::Xbox:
-			return InputLayout::Xbox;
-		case InputLayout::Nintendo:
-			return InputLayout::Nintendo;
-		case InputLayout::Unknown:
-		default:
-			return InputLayout::Playstation;
-	}
+	return ImGuiFullscreen::GetGamepadLayout();
 }
 
 ImGuiFullscreen::GamepadGlyphs ImGuiFullscreen::GetGamepadGlyphs()
@@ -994,16 +982,17 @@ ImGuiFullscreen::GamepadGlyphs ImGuiFullscreen::GetGamepadGlyphs()
 	const InputLayout layout = GetEffectiveGlyphLayout();
 	const bool xbox = (layout == InputLayout::Xbox);
 	const bool nintendo = (layout == InputLayout::Nintendo);
+	const bool unknown = (layout == InputLayout::Unknown);
 	return {
-		nintendo ? ICON_PF_BUTTON_B : (xbox ? ICON_PF_BUTTON_A : ICON_PF_BUTTON_CROSS),
-		nintendo ? ICON_PF_BUTTON_A : (xbox ? ICON_PF_BUTTON_B : ICON_PF_BUTTON_CIRCLE),
-		nintendo ? ICON_PF_BUTTON_Y : (xbox ? ICON_PF_BUTTON_X : ICON_PF_BUTTON_SQUARE),
-		nintendo ? ICON_PF_BUTTON_X : (xbox ? ICON_PF_BUTTON_Y : ICON_PF_BUTTON_TRIANGLE),
+		unknown ? ICON_PF_BUTTON_DOWN_A : (nintendo ? ICON_PF_BUTTON_B : (xbox ? ICON_PF_BUTTON_A : ICON_PF_BUTTON_CROSS)),
+		unknown ? ICON_PF_BUTTON_RIGHT_B : (nintendo ? ICON_PF_BUTTON_A : (xbox ? ICON_PF_BUTTON_B : ICON_PF_BUTTON_CIRCLE)),
+		unknown ? ICON_PF_BUTTON_LEFT_X : (nintendo ? ICON_PF_BUTTON_Y : (xbox ? ICON_PF_BUTTON_X : ICON_PF_BUTTON_SQUARE)),
+		unknown ? ICON_PF_BUTTON_UP_Y : (nintendo ? ICON_PF_BUTTON_X : (xbox ? ICON_PF_BUTTON_Y : ICON_PF_BUTTON_TRIANGLE)),
 		xbox ? ICON_PF_XBOX_DPAD : ICON_PF_DPAD,
 		xbox ? ICON_PF_XBOX_DPAD_LEFT_RIGHT : ICON_PF_DPAD_LEFT_RIGHT,
 		xbox ? ICON_PF_XBOX_DPAD_UP_DOWN : ICON_PF_DPAD_UP_DOWN,
-		nintendo ? ICON_PF_MINUS : (xbox ? ICON_PF_SHARE_CAPTURE : ICON_PF_SELECT_SHARE),
-		nintendo ? ICON_PF_PLUS : (xbox ? ICON_PF_BURGER_MENU : ICON_PF_START),
+		nintendo ? ICON_PF_MINUS : ((xbox || unknown) ? ICON_PF_SHARE_CAPTURE : ICON_PF_SELECT_SHARE),
+		nintendo ? ICON_PF_PLUS : ((xbox || unknown) ? ICON_PF_BURGER_MENU : ICON_PF_START),
 	};
 }
 

--- a/pcsx2/Input/InputManager.cpp
+++ b/pcsx2/Input/InputManager.cpp
@@ -108,7 +108,7 @@ namespace InputManager
 	static float ApplySingleBindingScale(float sensitivity, float deadzone, float value);
 
 	static void AddHotkeyBindings(SettingsInterface& si, bool is_profile);
-	static void AddPadBindings(SettingsInterface& si, u32 pad, bool is_profile);
+	static void AddPadBindings(SettingsInterface& si, u32 pad, bool is_profile, SettingsInterface* nav_si);
 	static void AddUSBBindings(SettingsInterface& si, u32 port, bool is_profile);
 	static void UpdateContinuedVibration();
 	static void GenerateRelativeMouseEvents();
@@ -874,7 +874,7 @@ void InputManager::AddHotkeyBindings(SettingsInterface& si, bool is_profile)
 	}
 }
 
-void InputManager::AddPadBindings(SettingsInterface& si, u32 pad_index, bool is_profile)
+void InputManager::AddPadBindings(SettingsInterface& si, u32 pad_index, bool is_profile, SettingsInterface* nav_si)
 {
 	const Pad::ControllerType type = EmuConfig.Pad.Ports[pad_index].Type;
 
@@ -913,30 +913,30 @@ void InputManager::AddPadBindings(SettingsInterface& si, u32 pad_index, bool is_
 							Pad::SetControllerState(pad_index, bind_index, ApplySingleBindingScale(sensitivity, deadzone, value));
 						}},
 						bi.bind_type, si, section.c_str(), bi.name, is_profile);
+				}
 
-					// Build reverse maps for controller navigation; user bindings take priority over static defaults.
-					if (bi.generic_mapping != GenericInputBinding::Unknown)
+				// So per-game bindings never affect FullscreenUI navigation.
+				if (nav_si && bi.generic_mapping != GenericInputBinding::Unknown)
+				{
+					for (const std::string& binding_str : nav_si->GetStringList(section.c_str(), bi.name))
 					{
-						for (const std::string& binding_str : bindings)
-						{
-							InputBindingKey bkey;
-							InputSource* bsrc;
-							if (!ParseBindingAndGetSource(binding_str, &bkey, &bsrc))
-								continue;
+						InputBindingKey bkey;
+						InputSource* bsrc;
+						if (!ParseBindingAndGetSource(binding_str, &bkey, &bsrc))
+							continue;
 
-							if (bkey.source_subtype == InputSubclass::ControllerButton)
-							{
-								s_controller_button_generic_map.emplace(bkey.MaskDirection(), bi.generic_mapping);
-							}
-							else if (bkey.source_subtype == InputSubclass::ControllerAxis)
-							{
-								auto& entry = s_controller_axis_generic_map[bkey.MaskDirection()];
-								// Negate modifier = negative half of axis (e.g. "-Axis0" → LeftStickLeft)
-								if (bkey.modifier == InputModifier::Negate)
-									entry[0] = bi.generic_mapping;
-								else
-									entry[1] = bi.generic_mapping;
-							}
+						if (bkey.source_subtype == InputSubclass::ControllerButton)
+						{
+							s_controller_button_generic_map.emplace(bkey.MaskDirection(), bi.generic_mapping);
+						}
+						else if (bkey.source_subtype == InputSubclass::ControllerAxis)
+						{
+							auto& entry = s_controller_axis_generic_map[bkey.MaskDirection()];
+							// Negate modifier = negative half of axis (e.g. "-Axis0" → LeftStickLeft)
+							if (bkey.modifier == InputModifier::Negate)
+								entry[0] = bi.generic_mapping;
+							else
+								entry[1] = bi.generic_mapping;
 						}
 					}
 				}
@@ -1312,9 +1312,14 @@ bool InputManager::PreprocessEvent(InputBindingKey key, float value, GenericInpu
 	}
 	else if (key.source_subtype == InputSubclass::ControllerButton)
 	{
-		// User binding takes priority; fall back to the generic_key passed by the source (static table).
-		const auto it = s_controller_button_generic_map.find(key.MaskDirection());
-		const GenericInputBinding resolved = (it != s_controller_button_generic_map.end()) ? it->second : generic_key;
+		// Static table takes priority; falls back to the Shared/global map only if the source has none (e.g. DInput).
+		GenericInputBinding resolved = generic_key;
+		if (resolved == GenericInputBinding::Unknown)
+		{
+			const auto it = s_controller_button_generic_map.find(key.MaskDirection());
+			if (it != s_controller_button_generic_map.end())
+				resolved = it->second;
+		}
 		if (resolved != GenericInputBinding::Unknown)
 		{
 			const u32 controller_id = (static_cast<u32>(key.source_type) << 8) | key.source_index;
@@ -1325,10 +1330,20 @@ bool InputManager::PreprocessEvent(InputBindingKey key, float value, GenericInpu
 	}
 	else if (key.source_subtype == InputSubclass::ControllerAxis)
 	{
-		// User binding takes priority; fall back to the neg/pos keys passed by the source (static table).
-		const auto it = s_controller_axis_generic_map.find(key.MaskDirection());
-		const GenericInputBinding neg = (it != s_controller_axis_generic_map.end()) ? it->second[0] : axis_neg_key;
-		const GenericInputBinding pos = (it != s_controller_axis_generic_map.end()) ? it->second[1] : axis_pos_key;
+		// Same priority as above; map only fills in directions the source couldn't resolve.
+		GenericInputBinding neg = axis_neg_key;
+		GenericInputBinding pos = axis_pos_key;
+		if (neg == GenericInputBinding::Unknown || pos == GenericInputBinding::Unknown)
+		{
+			const auto it = s_controller_axis_generic_map.find(key.MaskDirection());
+			if (it != s_controller_axis_generic_map.end())
+			{
+				if (neg == GenericInputBinding::Unknown)
+					neg = it->second[0];
+				if (pos == GenericInputBinding::Unknown)
+					pos = it->second[1];
+			}
+		}
 		if (neg != GenericInputBinding::Unknown || pos != GenericInputBinding::Unknown)
 		{
 			const u32 controller_id = (static_cast<u32>(key.source_type) << 8) | key.source_index;
@@ -1619,10 +1634,11 @@ void InputManager::ReloadBindings(SettingsInterface& si, SettingsInterface& bind
 	// Hotkeys use the base configuration, except if the custom hotkeys option is enabled.
 	AddHotkeyBindings(hotkey_binding_si, is_hotkey_profile);
 
-	// If there's an input profile, we load pad bindings from it alone, rather than
-	// falling back to the base configuration.
+	// nav_si is always the base config, so per-game profiles can't affect UI navigation.
+	const LayeredSettingsInterface& lsi = static_cast<LayeredSettingsInterface&>(si);
+	SettingsInterface* base_si = lsi.GetLayer(LayeredSettingsInterface::LAYER_BASE);
 	for (u32 pad = 0; pad < Pad::NUM_CONTROLLER_PORTS; pad++)
-		AddPadBindings(binding_si, pad, is_binding_profile);
+		AddPadBindings(binding_si, pad, is_binding_profile, base_si);
 
 	constexpr float ui_ctrl_range = 100.0f;
 	constexpr float pointer_sensitivity = 0.05f;

--- a/pcsx2/Input/InputManager.cpp
+++ b/pcsx2/Input/InputManager.cpp
@@ -1323,7 +1323,7 @@ bool InputManager::PreprocessEvent(InputBindingKey key, float value, GenericInpu
 		if (resolved != GenericInputBinding::Unknown)
 		{
 			const u32 controller_id = (static_cast<u32>(key.source_type) << 8) | key.source_index;
-			const InputLayout layout = s_input_sources[static_cast<u32>(InputSourceType::SDL)]->GetControllerLayout(key.source_index);
+			const InputLayout layout = s_input_sources[static_cast<u32>(key.source_type)]->GetControllerLayout(key.source_index);
 			if (ImGuiManager::ProcessGenericInputEvent(resolved, layout, value, controller_id) && value != 0.0f)
 				return true;
 		}
@@ -1347,7 +1347,7 @@ bool InputManager::PreprocessEvent(InputBindingKey key, float value, GenericInpu
 		if (neg != GenericInputBinding::Unknown || pos != GenericInputBinding::Unknown)
 		{
 			const u32 controller_id = (static_cast<u32>(key.source_type) << 8) | key.source_index;
-			const InputLayout layout = s_input_sources[static_cast<u32>(InputSourceType::SDL)]->GetControllerLayout(key.source_index);
+			const InputLayout layout = s_input_sources[static_cast<u32>(key.source_type)]->GetControllerLayout(key.source_index);
 			ImGuiManager::ProcessGenericAxisEvent(neg, pos, layout, value, controller_id);
 		}
 	}

--- a/pcsx2/Input/InputManager.h
+++ b/pcsx2/Input/InputManager.h
@@ -52,7 +52,8 @@ enum class InputLayout : u8
 	Unknown,
 	Xbox,
 	Playstation,
-	Nintendo
+	Nintendo,
+	Generic
 };
 
 enum class InputModifier : u32

--- a/pcsx2/Input/SDLInputSource.cpp
+++ b/pcsx2/Input/SDLInputSource.cpp
@@ -319,6 +319,23 @@ static constexpr const char* s_sdl_button_icons[] = {
 	ICON_PF_XBOX_DPAD_LEFT, // SDL_GAMEPAD_BUTTON_DPAD_LEFT
 	ICON_PF_XBOX_DPAD_RIGHT, // SDL_GAMEPAD_BUTTON_DPAD_RIGHT
 };
+static constexpr const char* s_sdl_button_xbox_icons[] = {
+	ICON_PF_BUTTON_A, // SDL_GAMEPAD_BUTTON_SOUTH
+	ICON_PF_BUTTON_B, // SDL_GAMEPAD_BUTTON_EAST
+	ICON_PF_BUTTON_X, // SDL_GAMEPAD_BUTTON_WEST
+	ICON_PF_BUTTON_Y, // SDL_GAMEPAD_BUTTON_NORTH
+	ICON_PF_SHARE_CAPTURE, // SDL_GAMEPAD_BUTTON_BACK
+	ICON_PF_XBOX, // SDL_GAMEPAD_BUTTON_GUIDE
+	ICON_PF_BURGER_MENU, // SDL_GAMEPAD_BUTTON_START
+	ICON_PF_LEFT_ANALOG_CLICK, // SDL_GAMEPAD_BUTTON_LEFT_STICK
+	ICON_PF_RIGHT_ANALOG_CLICK, // SDL_GAMEPAD_BUTTON_RIGHT_STICK
+	ICON_PF_LEFT_SHOULDER_LB, // SDL_GAMEPAD_BUTTON_LEFT_SHOULDER
+	ICON_PF_RIGHT_SHOULDER_RB, // SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER
+	ICON_PF_XBOX_DPAD_UP, // SDL_GAMEPAD_BUTTON_DPAD_UP
+	ICON_PF_XBOX_DPAD_DOWN, // SDL_GAMEPAD_BUTTON_DPAD_DOWN
+	ICON_PF_XBOX_DPAD_LEFT, // SDL_GAMEPAD_BUTTON_DPAD_LEFT
+	ICON_PF_XBOX_DPAD_RIGHT, // SDL_GAMEPAD_BUTTON_DPAD_RIGHT
+};
 static constexpr const char* s_sdl_button_ps3_icons[] = {
 	ICON_PF_BUTTON_CROSS, // SDL_GAMEPAD_BUTTON_SOUTH
 	ICON_PF_BUTTON_CIRCLE, // SDL_GAMEPAD_BUTTON_EAST
@@ -403,8 +420,8 @@ static constexpr const char* s_sdl_button_nintendo_icons[] = {
 static constexpr const char* const* s_sdl_button_icons_list[] = {
 	s_sdl_button_icons, // SDL_GAMEPAD_TYPE_UNKNOWN
 	s_sdl_button_icons, // SDL_GAMEPAD_TYPE_STANDARD
-	s_sdl_button_icons, // SDL_GAMEPAD_TYPE_XBOX360
-	s_sdl_button_icons, // SDL_GAMEPAD_TYPE_XBOXONE
+	s_sdl_button_xbox_icons, // SDL_GAMEPAD_TYPE_XBOX360
+	s_sdl_button_xbox_icons, // SDL_GAMEPAD_TYPE_XBOXONE
 	s_sdl_button_ps3_icons, // SDL_GAMEPAD_TYPE_PS3
 	s_sdl_button_ps4_icons, // SDL_GAMEPAD_TYPE_PS4
 	s_sdl_button_ps5_icons, // SDL_GAMEPAD_TYPE_PS5
@@ -413,8 +430,8 @@ static constexpr const char* const* s_sdl_button_icons_list[] = {
 static constexpr size_t s_sdl_button_iconsize_list[] = {
 	std::size(s_sdl_button_icons), // SDL_GAMEPAD_TYPE_UNKNOWN
 	std::size(s_sdl_button_icons), // SDL_GAMEPAD_TYPE_STANDARD
-	std::size(s_sdl_button_icons), // SDL_GAMEPAD_TYPE_XBOX360
-	std::size(s_sdl_button_icons), // SDL_GAMEPAD_TYPE_XBOXONE
+	std::size(s_sdl_button_xbox_icons), // SDL_GAMEPAD_TYPE_XBOX360
+	std::size(s_sdl_button_xbox_icons), // SDL_GAMEPAD_TYPE_XBOXONE
 	std::size(s_sdl_button_ps3_icons), // SDL_GAMEPAD_TYPE_PS3
 	std::size(s_sdl_button_ps4_icons), // SDL_GAMEPAD_TYPE_PS4
 	std::size(s_sdl_button_ps5_icons), // SDL_GAMEPAD_TYPE_PS5

--- a/pcsx2/Input/SDLInputSource.cpp
+++ b/pcsx2/Input/SDLInputSource.cpp
@@ -225,6 +225,38 @@ static constexpr const char* s_sdl_button_names[] = {
 	"Misc 5", // SDL_GAMEPAD_BUTTON_MISC5
 	"Misc 6", // SDL_GAMEPAD_BUTTON_MISC6
 };
+static constexpr const char* s_sdl_button_standard_names[] = {
+	"A", // SDL_GAMEPAD_BUTTON_SOUTH
+	"B", // SDL_GAMEPAD_BUTTON_EAST
+	"X", // SDL_GAMEPAD_BUTTON_WEST
+	"Y", // SDL_GAMEPAD_BUTTON_NORTH
+};
+static constexpr const char* s_sdl_button_xbox360_names[] = {
+	nullptr, // SDL_GAMEPAD_BUTTON_SOUTH
+	nullptr, // SDL_GAMEPAD_BUTTON_EAST
+	nullptr, // SDL_GAMEPAD_BUTTON_WEST
+	nullptr, // SDL_GAMEPAD_BUTTON_NORTH
+	nullptr, // SDL_GAMEPAD_BUTTON_BACK
+	nullptr, // SDL_GAMEPAD_BUTTON_GUIDE
+	nullptr, // SDL_GAMEPAD_BUTTON_START
+	nullptr, // SDL_GAMEPAD_BUTTON_LEFT_STICK
+	nullptr, // SDL_GAMEPAD_BUTTON_RIGHT_STICK
+	"LB", // SDL_GAMEPAD_BUTTON_LEFT_SHOULDER
+	"RB", // SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER
+};
+static constexpr const char* s_sdl_button_xboxone_names[] = {
+	nullptr, // SDL_GAMEPAD_BUTTON_SOUTH
+	nullptr, // SDL_GAMEPAD_BUTTON_EAST
+	nullptr, // SDL_GAMEPAD_BUTTON_WEST
+	nullptr, // SDL_GAMEPAD_BUTTON_NORTH
+	"View", // SDL_GAMEPAD_BUTTON_BACK
+	"Xbox", // SDL_GAMEPAD_BUTTON_GUIDE
+	"Menu", // SDL_GAMEPAD_BUTTON_START
+	nullptr, // SDL_GAMEPAD_BUTTON_LEFT_STICK
+	nullptr, // SDL_GAMEPAD_BUTTON_RIGHT_STICK
+	"LB", // SDL_GAMEPAD_BUTTON_LEFT_SHOULDER
+	"RB", // SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER
+};
 static constexpr const char* s_sdl_button_ps3_names[] = {
 	"Cross", // SDL_GAMEPAD_BUTTON_SOUTH
 	"Circle", // SDL_GAMEPAD_BUTTON_EAST
@@ -269,26 +301,39 @@ static constexpr const char* s_sdl_button_ps5_names[] = {
 	nullptr, // SDL_GAMEPAD_BUTTON_DPAD_RIGHT
 	"Mute", // SDL_GAMEPAD_BUTTON_MISC1
 };
+static constexpr const char* s_sdl_button_nintendo_names[] = {
+	"B", // SDL_GAMEPAD_BUTTON_SOUTH
+	"A", // SDL_GAMEPAD_BUTTON_EAST
+	"Y", // SDL_GAMEPAD_BUTTON_WEST
+	"X", // SDL_GAMEPAD_BUTTON_NORTH
+	"Minus", // SDL_GAMEPAD_BUTTON_BACK
+	"Home", // SDL_GAMEPAD_BUTTON_GUIDE
+	"Plus", // SDL_GAMEPAD_BUTTON_START
+	"Left Stick", // SDL_GAMEPAD_BUTTON_LEFT_STICK
+	"Right Stick", // SDL_GAMEPAD_BUTTON_RIGHT_STICK
+	"L", // SDL_GAMEPAD_BUTTON_LEFT_SHOULDER
+	"R", // SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER
+};
 
 static constexpr const char* const* s_sdl_button_names_list[] = {
 	s_sdl_button_names, // SDL_GAMEPAD_TYPE_UNKNOWN
-	s_sdl_button_names, // SDL_GAMEPAD_TYPE_STANDARD
-	s_sdl_button_names, // SDL_GAMEPAD_TYPE_XBOX360
-	s_sdl_button_names, // SDL_GAMEPAD_TYPE_XBOXONE
+	s_sdl_button_standard_names, // SDL_GAMEPAD_TYPE_STANDARD
+	s_sdl_button_xbox360_names, // SDL_GAMEPAD_TYPE_XBOX360
+	s_sdl_button_xboxone_names, // SDL_GAMEPAD_TYPE_XBOXONE
 	s_sdl_button_ps3_names, // SDL_GAMEPAD_TYPE_PS3
 	s_sdl_button_ps4_names, // SDL_GAMEPAD_TYPE_PS4
 	s_sdl_button_ps5_names, // SDL_GAMEPAD_TYPE_PS5
-	// Switch
+	s_sdl_button_nintendo_names, // SDL_GAMEPAD_TYPE_NINTENDO_SWITCH_PRO
 };
 static constexpr size_t s_sdl_button_namesize_list[] = {
 	std::size(s_sdl_button_names), // SDL_GAMEPAD_TYPE_UNKNOWN
-	std::size(s_sdl_button_names), // SDL_GAMEPAD_TYPE_STANDARD
-	std::size(s_sdl_button_names), // SDL_GAMEPAD_TYPE_XBOX360
-	std::size(s_sdl_button_names), // SDL_GAMEPAD_TYPE_XBOXONE
+	std::size(s_sdl_button_standard_names), // SDL_GAMEPAD_TYPE_STANDARD
+	std::size(s_sdl_button_xbox360_names), // SDL_GAMEPAD_TYPE_XBOX360
+	std::size(s_sdl_button_xboxone_names), // SDL_GAMEPAD_TYPE_XBOXONE
 	std::size(s_sdl_button_ps3_names), // SDL_GAMEPAD_TYPE_PS3
 	std::size(s_sdl_button_ps4_names), // SDL_GAMEPAD_TYPE_PS4
 	std::size(s_sdl_button_ps5_names), // SDL_GAMEPAD_TYPE_PS5
-	// Switch
+	std::size(s_sdl_button_nintendo_names), // SDL_GAMEPAD_TYPE_NINTENDO_SWITCH_PRO
 };
 
 static constexpr const char* s_sdl_face_button_icons[] = {
@@ -308,29 +353,52 @@ static constexpr const char* s_sdl_button_icons[] = {
 	ICON_PF_BUTTON_LEFT_X, // SDL_GAMEPAD_BUTTON_WEST
 	ICON_PF_BUTTON_UP_Y, // SDL_GAMEPAD_BUTTON_NORTH
 	ICON_PF_SHARE_CAPTURE, // SDL_GAMEPAD_BUTTON_BACK
-	ICON_PF_XBOX, // SDL_GAMEPAD_BUTTON_GUIDE
+	ICON_PF_HOME_MENU, // SDL_GAMEPAD_BUTTON_GUIDE
 	ICON_PF_BURGER_MENU, // SDL_GAMEPAD_BUTTON_START
 	ICON_PF_LEFT_ANALOG_CLICK, // SDL_GAMEPAD_BUTTON_LEFT_STICK
 	ICON_PF_RIGHT_ANALOG_CLICK, // SDL_GAMEPAD_BUTTON_RIGHT_STICK
 	ICON_PF_LEFT_SHOULDER_LB, // SDL_GAMEPAD_BUTTON_LEFT_SHOULDER
 	ICON_PF_RIGHT_SHOULDER_RB, // SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER
+	ICON_PF_DPAD_UP, // SDL_GAMEPAD_BUTTON_DPAD_UP
+	ICON_PF_DPAD_DOWN, // SDL_GAMEPAD_BUTTON_DPAD_DOWN
+	ICON_PF_DPAD_LEFT, // SDL_GAMEPAD_BUTTON_DPAD_LEFT
+	ICON_PF_DPAD_RIGHT, // SDL_GAMEPAD_BUTTON_DPAD_RIGHT
+};
+static constexpr const char* s_sdl_button_standard_icons[] = {
+	ICON_PF_BUTTON_A, // SDL_GAMEPAD_BUTTON_SOUTH
+	ICON_PF_BUTTON_B, // SDL_GAMEPAD_BUTTON_EAST
+	ICON_PF_BUTTON_X, // SDL_GAMEPAD_BUTTON_WEST
+	ICON_PF_BUTTON_Y, // SDL_GAMEPAD_BUTTON_NORTH
+};
+static constexpr const char* s_sdl_button_xbox360_icons[] = {
+	ICON_PF_BUTTON_A, // SDL_GAMEPAD_BUTTON_SOUTH
+	ICON_PF_BUTTON_B, // SDL_GAMEPAD_BUTTON_EAST
+	ICON_PF_BUTTON_X, // SDL_GAMEPAD_BUTTON_WEST
+	ICON_PF_BUTTON_Y, // SDL_GAMEPAD_BUTTON_NORTH
+	ICON_PF_JOYCON_DPAD_LEFT, // SDL_GAMEPAD_BUTTON_BACK
+	ICON_PF_XBOX, // SDL_GAMEPAD_BUTTON_GUIDE
+	ICON_PF_JOYCON_DPAD_RIGHT, // SDL_GAMEPAD_BUTTON_START
+	nullptr, // SDL_GAMEPAD_BUTTON_LEFT_STICK
+	nullptr, // SDL_GAMEPAD_BUTTON_RIGHT_STICK
+	nullptr, // SDL_GAMEPAD_BUTTON_LEFT_SHOULDER
+	nullptr, // SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER
 	ICON_PF_XBOX_DPAD_UP, // SDL_GAMEPAD_BUTTON_DPAD_UP
 	ICON_PF_XBOX_DPAD_DOWN, // SDL_GAMEPAD_BUTTON_DPAD_DOWN
 	ICON_PF_XBOX_DPAD_LEFT, // SDL_GAMEPAD_BUTTON_DPAD_LEFT
 	ICON_PF_XBOX_DPAD_RIGHT, // SDL_GAMEPAD_BUTTON_DPAD_RIGHT
 };
-static constexpr const char* s_sdl_button_xbox_icons[] = {
+static constexpr const char* s_sdl_button_xboxone_icons[] = {
 	ICON_PF_BUTTON_A, // SDL_GAMEPAD_BUTTON_SOUTH
 	ICON_PF_BUTTON_B, // SDL_GAMEPAD_BUTTON_EAST
 	ICON_PF_BUTTON_X, // SDL_GAMEPAD_BUTTON_WEST
 	ICON_PF_BUTTON_Y, // SDL_GAMEPAD_BUTTON_NORTH
-	ICON_PF_SHARE_CAPTURE, // SDL_GAMEPAD_BUTTON_BACK
+	nullptr, // SDL_GAMEPAD_BUTTON_BACK
 	ICON_PF_XBOX, // SDL_GAMEPAD_BUTTON_GUIDE
-	ICON_PF_BURGER_MENU, // SDL_GAMEPAD_BUTTON_START
-	ICON_PF_LEFT_ANALOG_CLICK, // SDL_GAMEPAD_BUTTON_LEFT_STICK
-	ICON_PF_RIGHT_ANALOG_CLICK, // SDL_GAMEPAD_BUTTON_RIGHT_STICK
-	ICON_PF_LEFT_SHOULDER_LB, // SDL_GAMEPAD_BUTTON_LEFT_SHOULDER
-	ICON_PF_RIGHT_SHOULDER_RB, // SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER
+	nullptr, // SDL_GAMEPAD_BUTTON_START
+	nullptr, // SDL_GAMEPAD_BUTTON_LEFT_STICK
+	nullptr, // SDL_GAMEPAD_BUTTON_RIGHT_STICK
+	nullptr, // SDL_GAMEPAD_BUTTON_LEFT_SHOULDER
+	nullptr, // SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER
 	ICON_PF_XBOX_DPAD_UP, // SDL_GAMEPAD_BUTTON_DPAD_UP
 	ICON_PF_XBOX_DPAD_DOWN, // SDL_GAMEPAD_BUTTON_DPAD_DOWN
 	ICON_PF_XBOX_DPAD_LEFT, // SDL_GAMEPAD_BUTTON_DPAD_LEFT
@@ -419,9 +487,9 @@ static constexpr const char* s_sdl_button_nintendo_icons[] = {
 };
 static constexpr const char* const* s_sdl_button_icons_list[] = {
 	s_sdl_button_icons, // SDL_GAMEPAD_TYPE_UNKNOWN
-	s_sdl_button_icons, // SDL_GAMEPAD_TYPE_STANDARD
-	s_sdl_button_xbox_icons, // SDL_GAMEPAD_TYPE_XBOX360
-	s_sdl_button_xbox_icons, // SDL_GAMEPAD_TYPE_XBOXONE
+	s_sdl_button_standard_icons, // SDL_GAMEPAD_TYPE_STANDARD
+	s_sdl_button_xbox360_icons, // SDL_GAMEPAD_TYPE_XBOX360
+	s_sdl_button_xboxone_icons, // SDL_GAMEPAD_TYPE_XBOXONE
 	s_sdl_button_ps3_icons, // SDL_GAMEPAD_TYPE_PS3
 	s_sdl_button_ps4_icons, // SDL_GAMEPAD_TYPE_PS4
 	s_sdl_button_ps5_icons, // SDL_GAMEPAD_TYPE_PS5
@@ -429,9 +497,9 @@ static constexpr const char* const* s_sdl_button_icons_list[] = {
 };
 static constexpr size_t s_sdl_button_iconsize_list[] = {
 	std::size(s_sdl_button_icons), // SDL_GAMEPAD_TYPE_UNKNOWN
-	std::size(s_sdl_button_icons), // SDL_GAMEPAD_TYPE_STANDARD
-	std::size(s_sdl_button_xbox_icons), // SDL_GAMEPAD_TYPE_XBOX360
-	std::size(s_sdl_button_xbox_icons), // SDL_GAMEPAD_TYPE_XBOXONE
+	std::size(s_sdl_button_standard_icons), // SDL_GAMEPAD_TYPE_STANDARD
+	std::size(s_sdl_button_xbox360_icons), // SDL_GAMEPAD_TYPE_XBOX360
+	std::size(s_sdl_button_xboxone_icons), // SDL_GAMEPAD_TYPE_XBOXONE
 	std::size(s_sdl_button_ps3_icons), // SDL_GAMEPAD_TYPE_PS3
 	std::size(s_sdl_button_ps4_icons), // SDL_GAMEPAD_TYPE_PS4
 	std::size(s_sdl_button_ps5_icons), // SDL_GAMEPAD_TYPE_PS5
@@ -1051,7 +1119,7 @@ TinyString SDLInputSource::ConvertKeyToString(InputBindingKey key, bool display,
 				if (it != m_controllers.end())
 					type = SDL_GetRealGamepadType(it->gamepad);
 
-				if (type > SDL_GAMEPAD_TYPE_STANDARD && type < std::size(s_sdl_button_names_list) &&
+				if (type > SDL_GAMEPAD_TYPE_UNKNOWN && type < std::size(s_sdl_button_names_list) &&
 					key.data < s_sdl_button_namesize_list[type] && s_sdl_button_names_list[type][key.data] != nullptr)
 				{
 					ret.format("SDL-{} {}", static_cast<u32>(key.source_index), s_sdl_button_names_list[type][key.data]);
@@ -1158,7 +1226,7 @@ TinyString SDLInputSource::ConvertKeyToIcon(InputBindingKey key)
 		}
 		else if (key.source_subtype == InputSubclass::ControllerButton)
 		{
-			if (type > SDL_GAMEPAD_TYPE_STANDARD && type < std::size(s_sdl_button_icons_list) &&
+			if (type > SDL_GAMEPAD_TYPE_UNKNOWN && type < std::size(s_sdl_button_icons_list) &&
 				key.data < s_sdl_button_iconsize_list[type] && s_sdl_button_icons_list[type][key.data] != nullptr)
 			{
 				ret.format("SDL-{}  {}", static_cast<u32>(key.source_index), s_sdl_button_icons_list[type][key.data]);

--- a/pcsx2/Input/SDLInputSource.cpp
+++ b/pcsx2/Input/SDLInputSource.cpp
@@ -1196,6 +1196,8 @@ TinyString SDLInputSource::ConvertKeyToIcon(InputBindingKey key)
 			type = SDL_GAMEPAD_TYPE_PS5;
 		else if (glyph_preference == InputLayout::Nintendo)
 			type = SDL_GAMEPAD_TYPE_NINTENDO_SWITCH_PRO;
+		else if (glyph_preference == InputLayout::Generic)
+			type = SDL_GAMEPAD_TYPE_UNKNOWN;
 
 		if (key.source_subtype == InputSubclass::ControllerAxis)
 		{
@@ -1234,7 +1236,7 @@ TinyString SDLInputSource::ConvertKeyToIcon(InputBindingKey key)
 			else if (key.data < 4)
 			{
 				SDL_GamepadButtonLabel label = SDL_GAMEPAD_BUTTON_LABEL_UNKNOWN;
-				if (it != m_controllers.end() && it->gamepad)
+				if (glyph_preference != InputLayout::Generic && it != m_controllers.end() && it->gamepad)
 					label = SDL_GetGamepadButtonLabel(it->gamepad, static_cast<SDL_GamepadButton>(key.data));
 
 				if (label > SDL_GAMEPAD_BUTTON_LABEL_UNKNOWN && label < std::size(s_sdl_face_button_icons))

--- a/pcsx2/Input/XInputSource.cpp
+++ b/pcsx2/Input/XInputSource.cpp
@@ -387,7 +387,7 @@ TinyString XInputSource::ConvertKeyToIcon(InputBindingKey key)
 {
 	TinyString ret;
 
-	if (key.source_type == InputSourceType::SDL)
+	if (key.source_type == InputSourceType::XInput)
 	{
 		if (key.source_subtype == InputSubclass::ControllerAxis)
 		{

--- a/pcsx2/Input/XInputSource.cpp
+++ b/pcsx2/Input/XInputSource.cpp
@@ -79,7 +79,7 @@ static const char* s_button_names[XInputSource::NUM_BUTTONS] = {
 	"B", // XINPUT_GAMEPAD_B
 	"X", // XINPUT_GAMEPAD_X
 	"Y", // XINPUT_GAMEPAD_Y
-	"Guide", // XINPUT_GAMEPAD_GUIDE
+	"Xbox", // XINPUT_GAMEPAD_GUIDE
 };
 
 static const u16 s_button_masks[XInputSource::NUM_BUTTONS] = {


### PR DESCRIPTION
### Description of Changes

This PR is sort of a two-parter, and I can split it if I'm asked to. The first part fixes #14722. Part of what I added in PR #14228 was using the current active controller bindings for FullscreenUI / ImGui menu navigation. The problem with this approach is that ImGui's controller glyphs don't dynamically change, so a user can have a per-game profile on, enter an ImGui menu, and the buttons don't match, so it can be a bit confusing. I changed ImGui navigation to ignore the active per-game profile.

I did explore having dynamic glyphs. I had it mostly working. Swapping face buttons between each other was fine, but it becomes harder to choose which glyph to use if a user rebinds the navigation or uses combo bindings. So I stopped pursuing dynamic glyphs and just do what Steam does for its Big Picture Mode, which doesn't allow rebinding for menu navigation. So now menu navigation uses a static table. The exception is DInput. DInput has no standardized layout, so I still look up the Shared/global bindings for DInput.

For the second part, while working in the InputManager, I noticed missing SDL name/icon arrays. I added an array for Nintendo. Xbox was using the same arrays as SDL, so I split those and corrected some of the SDL entries.

There were a couple of bugs with XInput glyphs. When SDL is turned off and XInput is on, it would just default to PlayStation glyphs. The if statement in XInput's ConvertKeyToIcon function would always fail because it was checking the input source type for SDL instead of XInput.

Finally, I added a "Generic" option to the controller preference, so instead of A / B / X / Y (or the PlayStation equivalents), users see generic glyphs like the following:

<img width="1558" height="105" alt="image"
src="https://github.com/user-attachments/assets/ea67fc2e-3161-4f32-b4cc-b33b986db998" />

If SDL recognizes a controller as UNKNOWN, these generic glyphs will also be used (unless a preference overrides them).

### Rationale behind Changes

Consistent and accurate glyphs and names for the ImGui menus and Qt's controller bindings menu.

### Suggested Testing Steps

- Check that SDL/XInput no longer use the active bindings profile and instead use static bindings.
- DInput still uses the Shared/global bindings.
- Using SDL with an Xbox controller, check that the correct button names, such as "Menu" and "View" for the Start and Select buttons, are shown in the Qt / ImGui controller binding settings. ImGui should also show the correct glyphs.
- Same with Nintendo, but with "Plus" and "Minus".
- Using XInput instead of SDL shows the correct glyphs and names in the same menus above.
- Choose "Generic" in either the Qt / ImGui controller preference setting in the Interface menu. Check that the correct glyphs and names are used.
- Connect a controller SDL can't identify and confirm it falls back to generic glyphs instead of defaulting to PlayStation.

### Did you use AI to help find, test, or implement this issue or feature?

Yes, I used AI to ask questions about how the InputManager works, to find things in the codebase, and to show me where else I needed to update in case I missed anything. I also used it to generate those tedious SDL arrays but had to fix those anyways because you don't need to write every entry. A nullptr or an empty entry defaults to the SDL standard.