### PR TITLE
3rdparty: Configure D3D12MemAlloc to use DirectX-Headers under CMake

### DIFF
--- a/3rdparty/d3d12memalloc/CMakeLists.txt
+++ b/3rdparty/d3d12memalloc/CMakeLists.txt
@@ -6,4 +6,5 @@ add_library(D3D12MemAlloc
 target_link_libraries(D3D12MemAlloc PRIVATE Microsoft::DirectX-Headers)
 
 target_include_directories(D3D12MemAlloc PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_compile_definitions(D3D12MemAlloc PRIVATE "D3D12MA_USING_DIRECTX_HEADERS")
 disable_compiler_warnings_for_target(D3D12MemAlloc)


### PR DESCRIPTION
### Description of Changes
Configure D3D12MemAlloc to use DirectX-Headers under CMake

### Rationale behind Changes
Allows D3D12MemAlloc to use the newer DirectX headers, enabling D3D12MemAlloc to use tight allocations when built using CMake

### Suggested Testing Steps
Test that Tight alignment is enabled using CMake builds.

### Did you use AI to help find, test, or implement this issue or feature?
No