### PR TITLE
EE:Rec: Fix recRAMCopy block compression

### DIFF
--- a/pcsx2/x86/ix86-32/iR5900.cpp
+++ b/pcsx2/x86/ix86-32/iR5900.cpp
@@ -2688,8 +2688,9 @@ StartRecomp:
 			if ((oldBlock->startpc + oldBlock->size * 4) <= HWADDR(startpc))
 				break;
 
-			if (memcmp(&recRAMCopy[oldBlock->startpc / 4], PSM(oldBlock->startpc),
-					oldBlock->size * 4))
+			if (memcmp(&recRAMCopy[oldBlock->startpc], PSM(oldBlock->startpc),
+					// clamp because delay slot might extend past the end of memory
+					std::min(oldBlock->size * 4, Ps2MemSize::ExposedRam - oldBlock->startpc)))
 			{
 				recClear(startpc, (pc - startpc) / 4);
 				s_pCurBlockEx = recBlocks.Get(HWADDR(startpc));
@@ -2698,7 +2699,7 @@ StartRecomp:
 			}
 		}
 
-		memcpy(&recRAMCopy[HWADDR(startpc) / 4], PSM(startpc), pc - startpc);
+		memcpy(&recRAMCopy[HWADDR(startpc)], PSM(startpc), pc - startpc);
 	}
 
 	s_pCurBlock->SetFnptr((uptr)recPtr);

--- a/pcsx2/x86/ix86-32/iR5900.cpp
+++ b/pcsx2/x86/ix86-32/iR5900.cpp
@@ -2689,8 +2689,7 @@ StartRecomp:
 				break;
 
 			if (memcmp(&recRAMCopy[oldBlock->startpc], PSM(oldBlock->startpc),
-					// clamp because delay slot might extend past the end of memory
-					std::min(oldBlock->size * 4, Ps2MemSize::ExposedRam - oldBlock->startpc)))
+					oldBlock->size * 4))
 			{
 				recClear(startpc, (pc - startpc) / 4);
 				s_pCurBlockEx = recBlocks.Get(HWADDR(startpc));


### PR DESCRIPTION
### Description of Changes
Change recRAMCopy to copy blocks to the full space of the ram copy buffer, not only compressed in the first quarter of it.

### Rationale behind Changes
Once upon a time recRAMCopy was an array of words and stored a copy of compiled blocks to verify if a new block overwrote the old blocks by straddling them. However it was changed to an array of u8 and the /4 was never fixed.
It still kinda works, copying blocks into a quarter-sized compressed space, it just thinks that blocks overlap way more than they do, causing recompilation storms in some situations.

### Suggested Testing Steps
Play games. I haven't reproduced any recompilation storms in x86 so I can't give you a game to verify it on, but this patch is still correct even if we can't find the issue in your architecture.  FFX may have an issue in the tech tree selector thingy.

### Did you use AI to help find, test, or implement this issue or feature?
Yes, I'm a contributor for a fork of PCSX2 that's being developed for the ARM architecture.  We use AI extensively for our development.  I've got a pretty good process now where after I fix stuff in our build I go type the code in myself for PCSX2, so you get to benefit from all my misspellings and shitty prose like this. Hi! Hope you're having an awesome day.