### PR TITLE
FullscreenUI: Close menus on resume, hide OSD while open

### DIFF
--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -447,6 +447,28 @@ void FullscreenUI::OnVMDestroyed()
 	});
 }
 
+void FullscreenUI::OnVMResumed()
+{
+	if (!IsInitialized())
+		return;
+
+	MTGS::RunOnGSThread([]() {
+		if (!IsInitialized())
+			return;
+
+		if (s_current_main_window == MainWindowType::PauseMenu ||
+			s_current_main_window == MainWindowType::Settings ||
+			s_current_main_window == MainWindowType::Achievements ||
+			s_current_main_window == MainWindowType::Leaderboards)
+		{
+			s_current_main_window = MainWindowType::None;
+			s_current_pause_submenu = PauseSubMenu::None;
+			s_pause_menu_was_open = false;
+			QueueResetFocus(FocusResetType::WindowChanged);
+		}
+	});
+}
+
 void FullscreenUI::GameChanged(std::string path, std::string serial, std::string title, u32 disc_crc, u32 crc)
 {
 	if (!IsInitialized())

--- a/pcsx2/ImGui/FullscreenUI.h
+++ b/pcsx2/ImGui/FullscreenUI.h
@@ -23,6 +23,7 @@ namespace FullscreenUI
 	void CheckForConfigChanges(const Pcsx2Config& old_config);
 	void OnVMStarted();
 	void OnVMDestroyed();
+	void OnVMResumed();
 	void GameChanged(std::string title, std::string path, std::string serial, u32 disc_crc, u32 crc);
 	void OpenPauseMenu();
 	bool OpenAchievementsWindow();

--- a/pcsx2/ImGui/ImGuiManager.cpp
+++ b/pcsx2/ImGui/ImGuiManager.cpp
@@ -1057,13 +1057,17 @@ void ImGuiManager::RenderOSD()
 	// acquire for IO.MousePos.
 	std::atomic_thread_fence(std::memory_order_acquire);
 
-	// Don't draw OSD when we're just running big picture.
-	if (VMManager::HasValidVM())
-		RenderOverlays();
-
 	const Common::Timer::Value current_time = Common::Timer::GetCurrentValue();
 	AcquirePendingOSDMessages(current_time);
-	DrawOSDMessages(current_time);
+
+	if (!FullscreenUI::HasActiveWindow())
+	{
+		// Don't draw OSD when we're just running big picture.
+		if (VMManager::HasValidVM())
+			RenderOverlays();
+
+		DrawOSDMessages(current_time);
+	}
 
 	// Cursors are always last.
 	DrawSoftwareCursors();

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -300,6 +300,7 @@ void VMManager::SetState(VMState state)
 		}
 		else
 		{
+			FullscreenUI::OnVMResumed();
 			Host::OnVMResumed();
 			ResetResumeTimestamp();
 		}


### PR DESCRIPTION
### Description of Changes
Closes FullscreenUI menus when the game resumes from outside them, and hides OSD while any FullscreenUI window is open.

### Rationale behind Changes
Menus could stay after an external unpause (ex: pressing unpause from the toolbar), and OSD was showing over Big Picture/menus.

### Suggested Testing Steps
- Resume from Qt (press the unpause toolbar button) with the settings/achievements open
- Check OSD doesn't show over FullscreenUI, still shows in game

### Did you use AI to help find, test, or implement this issue or feature?
No