### PR TITLE
USB: Follow the PCRTC video mode for GunCon2 aim

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -662,21 +662,6 @@ void GSgetInternalResolution(int* width, int* height)
 	*height = res.y;
 }
 
-void GSgetDisplayResolution(int* width, int* height)
-{
-	GSRenderer* gs = g_gs_renderer.get();
-	if (!gs)
-	{
-		*width = 0;
-		*height = 0;
-		return;
-	}
-
-	const GSVector2i res(gs->PCRTCDisplays.GetResolution());
-	*width = res.x;
-	*height = res.y;
-}
-
 void GSgetStats(SmallStringBase& info)
 {
 	GSPerfMon& pm = g_perfmon;

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -662,6 +662,21 @@ void GSgetInternalResolution(int* width, int* height)
 	*height = res.y;
 }
 
+void GSgetDisplayResolution(int* width, int* height)
+{
+	GSRenderer* gs = g_gs_renderer.get();
+	if (!gs)
+	{
+		*width = 0;
+		*height = 0;
+		return;
+	}
+
+	const GSVector2i res(gs->PCRTCDisplays.GetResolution());
+	*width = res.x;
+	*height = res.y;
+}
+
 void GSgetStats(SmallStringBase& info)
 {
 	GSPerfMon& pm = g_perfmon;

--- a/pcsx2/GS/GS.h
+++ b/pcsx2/GS/GS.h
@@ -96,6 +96,7 @@ std::vector<GSAdapterInfo> GSGetAdapterInfo(GSRendererType renderer);
 u32 GSGetMaxUpscaleMultiplier(u32 max_texture_size);
 GSVideoMode GSgetDisplayMode();
 void GSgetInternalResolution(int* width, int* height);
+void GSgetDisplayResolution(int* width, int* height);
 void GSgetStats(SmallStringBase& info);
 void GSgetMemoryStats(SmallStringBase& info);
 void GSgetTitleStats(std::string& info);

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -26,6 +26,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <deque>
 #include <thread>
 #include <mutex>
@@ -46,6 +47,10 @@ std::unique_ptr<GSRenderer> g_gs_renderer;
 // Since we read this on the EE thread, we can't put it in the renderer, because
 // we might be switching while the other thread reads it.
 static GSVector4 s_last_draw_rect;
+// Relaxed is enough: nothing else is ordered against it, and both components
+// must come from the same frame, hence one atomic rather than two.
+static std::atomic<GSVector2i> s_last_display_resolution;
+static_assert(std::atomic<GSVector2i>::is_always_lock_free);
 
 // Last time we reset the renderer due to a GPU crash, if any.
 static Common::Timer::Value s_last_gpu_reset_time;
@@ -57,6 +62,7 @@ GSRenderer::GSRenderer()
 	: m_shader_time_start(Common::Timer::GetCurrentValue())
 {
 	s_last_draw_rect = GSVector4::zero();
+	s_last_display_resolution.store(GSVector2i(0, 0), std::memory_order_relaxed);
 }
 
 GSRenderer::~GSRenderer() = default;
@@ -221,6 +227,7 @@ bool GSRenderer::Merge(int field)
 	}
 
 	const GSVector2i resolution = PCRTCDisplays.GetResolution();
+	s_last_display_resolution.store(resolution, std::memory_order_relaxed);
 	fs = GSVector2i(static_cast<int>(static_cast<float>(resolution.x) * GetUpscaleMultiplier()),
 		static_cast<int>(static_cast<float>(resolution.y) * GetUpscaleMultiplier()));
 
@@ -995,6 +1002,13 @@ void GSTranslateWindowToDisplayCoordinates(float window_x, float window_y, float
 
 	*display_x = rel_x / draw_width;
 	*display_y = rel_y / draw_height;
+}
+
+void GSgetDisplayResolution(int* width, int* height)
+{
+	const GSVector2i res = s_last_display_resolution.load(std::memory_order_relaxed);
+	*width = res.x;
+	*height = res.y;
 }
 
 void GSSetDisplayAlignment(GSDisplayAlignment alignment)

--- a/pcsx2/USB/usb-lightgun/guncon2.cpp
+++ b/pcsx2/USB/usb-lightgun/guncon2.cpp
@@ -149,6 +149,12 @@ namespace usb_lightgun
 		u32 cursor_color = 0xFFFFFFFF;
 		float relative_pos[4] = {};
 
+		bool follow_video_mode = false;
+		s32 ref_width = 0;
+		s32 ref_height = 0;
+		s32 last_width = 0;
+		s32 last_height = 0;
+
 		//////////////////////////////////////////////////////////////////////////
 		// Device State (Saved)
 		//////////////////////////////////////////////////////////////////////////
@@ -362,6 +368,7 @@ namespace usb_lightgun
 			center_y = static_cast<float>(gc.center_y);
 			screen_width = gc.screen_width;
 			screen_height = gc.screen_height;
+			follow_video_mode = true;
 			return;
 		}
 
@@ -391,6 +398,33 @@ namespace usb_lightgun
 			// apply curvature scale
 			fx *= scale_x;
 			fy *= scale_y;
+
+			if (follow_video_mode)
+			{
+				int cur_width, cur_height;
+				GSgetDisplayResolution(&cur_width, &cur_height);
+				if (cur_height > 0)
+				{
+					if (ref_height == 0)
+					{
+						ref_width = cur_width;
+						ref_height = cur_height;
+					}
+
+					const float mode_scale =
+						std::min(1.0f, static_cast<float>(cur_height) / static_cast<float>(ref_height));
+
+					if (cur_width != last_width || cur_height != last_height)
+					{
+						last_width = cur_width;
+						last_height = cur_height;
+						Console.WriteLn(fmt::format("(GunCon2) Display {}x{} (reference {}x{}), scaling vertical aim by {:.3f}",
+							cur_width, cur_height, ref_width, ref_height, mode_scale));
+					}
+
+					fy *= mode_scale;
+				}
+			}
 
 			// and re-center based on game center
 			s32 x = static_cast<s32>(std::round(fx + center_x));


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
The per-serial calibration table is applied once by AutoConfigure() and never revisited, but its values are video mode dependent -- the table carries commented-out 480i/480p twins for three discs to prove it.

Time Crisis 2 and 3 halve the vertical mode when entering split-screen co-op (640x448 -> 640x224). The range of positions the gun can report halves with it while the frozen scale keeps sending the full range, so aim travels twice as far as it should.

Scale the vertical deflection by the ratio between the live PCRTC resolution and the one latched on first use. The ratio is exactly 1.0 for a game that never changes mode, so output is unchanged everywhere else, and the correction is only armed when a table row actually matched -- manually configured guns and unlisted games are untouched.

Only the vertical is corrected. The horizontal reading also moves when one of the two display circuits is disabled (Time Crisis 3 reports 320x224 for several frames while transitioning), which is a change in what is being composited rather than in video timing.

The ratio is clamped so it can only reduce the deflection. The reference is not saved to the state, so a state made in split-screen latches the reduced height on load; the clamp keeps that inert rather than letting it overshoot by 2x when the game returns to full height.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Fixes split-screen aim scaling with Guncon2 in Time Crisis 2 and Time Crisis 3

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
- Launch Time Crisis 2 or Time Crisis 3 in split-screen
- Check log for scaling ratio
- Quit to main menu, aim returns to normal
- Start single player, aim returns to normal
- Launch non-TC2/TC3 game (I tested with Vampire Night), scaling ratio remains at 1.0 and aim is correct.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation as to how you used it. Please see the Large Language Model (LLM) Usage Policy for more information: https://pcsx2.net/docs/contributing/#large-language-model-llm-usage-policy -->
Claude Opus 5 used to implement, fix suggested by stenzek in a thread about the issue. Tested manually.