### PR TITLE
GS:MTL: Fix PipelineSelectorMTL padding

### DIFF
--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.h
@@ -74,7 +74,7 @@ struct PipelineSelectorMTL
 	GSHWDrawConfig::PSSelector ps;
 	PipelineSelectorExtrasMTL extras;
 	GSHWDrawConfig::VSSelector vs;
-	u8 pad[7];
+	u8 pad[3];
 	PipelineSelectorMTL()
 	{
 		memset(this, 0, sizeof(*this));
@@ -101,7 +101,7 @@ struct PipelineSelectorMTL
 	}
 };
 
-static_assert(sizeof(PipelineSelectorMTL) == 28);
+static_assert(sizeof(PipelineSelectorMTL) == 24);
 
 template <>
 struct std::hash<PipelineSelectorMTL>


### PR DESCRIPTION
### Description of Changes
We seem to have included too much padding in PipelineSelectorMTL during #14503, fix that.

### Rationale behind Changes
Avoid over-padding

### Suggested Testing Steps
Test Metal and make sure we aren't making infinite pipelines and using up tons of memory

### Did you use AI to help find, test, or implement this issue or feature?
No