### PR TITLE
GS/VK: Fix crash when no device is created and vk is the selected renderer.

### DIFF
--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -2254,8 +2254,11 @@ void GSDeviceVK::Destroy()
 
 	m_swap_chain.reset();
 
-	DestroySpinResources();
-	DestroyResources();
+	if (m_device != VK_NULL_HANDLE)
+	{
+		DestroySpinResources();
+		DestroyResources();
+	}
 
 	VKShaderCache::Destroy();
 


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/VK: Fix crash when no device is created and vk is the selected renderer.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
If the selected renderer is VK but the GPU doesn't support vulkan or the vk device fails to create then that will lead to a crash.
We shouldn't attempt to destroy resources if we don't have a valid device.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
To reproduce the crash on master boot using VK on a gpu that doesn't support it.
Smoke test VK, make sure it still works, booting/closing, switching between renderers.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation as to how you used it. Please see the Large Language Model (LLM) Usage Policy for more information: https://pcsx2.net/docs/contributing/#large-language-model-llm-usage-policy -->
No.