### PR TITLE
MicroVU: Unjumble EATAN coefficients

### DIFF
--- a/pcsx2/x86/microVU_Misc.h
+++ b/pcsx2/x86/microVU_Misc.h
@@ -25,10 +25,10 @@ struct mVU_Globals
 	u32   one     [4] = __four(0x3f800000);
 	u32   Pi4     [4] = __four(0x3f490fdb);
 	u32   T1      [4] = __four(0x3f7ffff5);
-	u32   T5      [4] = __four(0xbeaaa61c);
-	u32   T2      [4] = __four(0x3e4c40a6);
-	u32   T3      [4] = __four(0xbe0e6c63);
-	u32   T4      [4] = __four(0x3dc577df);
+	u32   T2      [4] = __four(0xbeaaa61c);
+	u32   T3      [4] = __four(0x3e4c40a6);
+	u32   T4      [4] = __four(0xbe0e6c63);
+	u32   T5      [4] = __four(0x3dc577df);
 	u32   T6      [4] = __four(0xbd6501c4);
 	u32   T7      [4] = __four(0x3cb31652);
 	u32   T8      [4] = __four(0xbb84d7e7);


### PR DESCRIPTION
### Description of Changes
Fix the coefficients used by microVU for the EATAN instruction.

### Rationale behind Changes

After it was found that one of the coefficients used by the interpreter was wrong, I thought I would check the recompiler too. It turns out it was broken, but in a different way!

This fixes a regression from #12322, which changed how these coefficients were defined in the source code. Some existing comments in the file were wrong, which were used as the new variable names, resulting in the coefficients being jumbled up.

I've tested these changes using [efu.elf from ps2autotests](https://github.com/unknownbrackets/ps2autotests/blob/master/tests/vu/lower/efu.elf). You can also refer to the tables in the VU User's Manual.

v2.3.196:
```
-- TEST BEGIN
EATAN:
  EATAN CVF_ZERO: 34800000/+0.00
  EATAN CVF_NEGZERO: 34800000/+0.00
  EATAN CVF_MAX: 7fffffff/+NaN
  EATAN CVF_MIN: ffffffff/-NaN
  EATAN CVF_MAX_MANTISSA: 3f8db70b/+1.11
  EATAN CVF_MAX_EXP: 7fc00001/+NaN
  EATAN CVF_MIN_EXP: 34800000/+0.00
  EATAN CVF_ONE: 3f490fdb/+0.79
  EATAN CVF_NEGONE: ffc00000/-NaN
  EATAN CVF_GARBAGE1: 34800000/+0.00
  EATAN CVF_GARBAGE2: 3fc90fd9/+1.57
  EATAN CVF_INCREASING: 3f9fe0ba/+1.25
  EATAN CVF_DECREASING: 3f8db70b/+1.11
  EATAN CVF_PI_OVER2: 3f807f4c/+1.00
  EATAN CVF_PI: 3fa19dc5/+1.26
  EATAN CVF_3PI_OVER2: 3fae4be7/+1.36
EATANxy:
  EATANxy CVF_ZERO: ffc00000/-NaN
  EATANxy CVF_NEGZERO: ffc00000/-NaN
  EATANxy CVF_MAX: 7fffffff/+NaN
  EATANxy CVF_MIN: ffffffff/-NaN
  EATANxy CVF_MAX_MANTISSA: 3f490fdb/+0.79
  EATANxy CVF_MAX_EXP: 7fc00001/+NaN
  EATANxy CVF_MIN_EXP: ffc00000/-NaN
  EATANxy CVF_ONE: 3f490fdb/+0.79
  EATANxy CVF_NEGONE: 3f490fdb/+0.79
  EATANxy CVF_GARBAGE1: ffc00000/-NaN
  EATANxy CVF_GARBAGE2: 3f490fdb/+0.79
  EATANxy CVF_INCREASING: 3f8db70b/+1.11
  EATANxy CVF_DECREASING: 3f24bc7f/+0.64
  EATANxy CVF_PI_OVER2: 3f490fdb/+0.79
  EATANxy CVF_PI: 3f490fdb/+0.79
  EATANxy CVF_3PI_OVER2: 3f490fdb/+0.79
EATANxz:
  EATANxz CVF_ZERO: ffc00000/-NaN
  EATANxz CVF_NEGZERO: ffc00000/-NaN
  EATANxz CVF_MAX: 7fffffff/+NaN
  EATANxz CVF_MIN: ffffffff/-NaN
  EATANxz CVF_MAX_MANTISSA: 3f490fdb/+0.79
  EATANxz CVF_MAX_EXP: 7fc00001/+NaN
  EATANxz CVF_MIN_EXP: ffc00000/-NaN
  EATANxz CVF_ONE: 3f490fdb/+0.79
  EATANxz CVF_NEGONE: 3f490fdb/+0.79
  EATANxz CVF_GARBAGE1: ffc00000/-NaN
  EATANxz CVF_GARBAGE2: 3f490fdb/+0.79
  EATANxz CVF_INCREASING: 3f9fe0ba/+1.25
  EATANxz CVF_DECREASING: 3eed633d/+0.46
  EATANxz CVF_PI_OVER2: 3f490fdb/+0.79
  EATANxz CVF_PI: 3f490fdb/+0.79
  EATANxz CVF_3PI_OVER2: 3f490fdb/+0.79
```

Master:
```
-- TEST BEGIN
EATAN:
  EATAN CVF_ZERO: 34c00000/+0.00
  EATAN CVF_NEGZERO: 34c00000/+0.00
  EATAN CVF_MAX: 7fffffff/+NaN
  EATAN CVF_MIN: ffffffff/-NaN
  EATAN CVF_MAX_MANTISSA: 3f9012c8/+1.13
  EATAN CVF_MAX_EXP: 7fc00001/+NaN
  EATAN CVF_MIN_EXP: 34c00000/+0.00
  EATAN CVF_ONE: 3f490fdb/+0.79
  EATAN CVF_NEGONE: ffc00000/-NaN
  EATAN CVF_GARBAGE1: 34c00000/+0.00
  EATAN CVF_GARBAGE2: 3fc90fd8/+1.57
  EATAN CVF_INCREASING: 3fa72d09/+1.31
  EATAN CVF_DECREASING: 3f9012c8/+1.13
  EATAN CVF_PI_OVER2: 3f813895/+1.01
  EATAN CVF_PI: 3fa99875/+1.32
  EATAN CVF_3PI_OVER2: 3fbc5441/+1.47
EATANxy:
  EATANxy CVF_ZERO: ffc00000/-NaN
  EATANxy CVF_NEGZERO: ffc00000/-NaN
  EATANxy CVF_MAX: 7fffffff/+NaN
  EATANxy CVF_MIN: ffffffff/-NaN
  EATANxy CVF_MAX_MANTISSA: 3f490fdb/+0.79
  EATANxy CVF_MAX_EXP: 7fc00001/+NaN
  EATANxy CVF_MIN_EXP: ffc00000/-NaN
  EATANxy CVF_ONE: 3f490fdb/+0.79
  EATANxy CVF_NEGONE: 3f490fdb/+0.79
  EATANxy CVF_GARBAGE1: ffc00000/-NaN
  EATANxy CVF_GARBAGE2: 3f490fdb/+0.79
  EATANxy CVF_INCREASING: 3f9012c8/+1.13
  EATANxy CVF_DECREASING: 3f245801/+0.64
  EATANxy CVF_PI_OVER2: 3f490fdb/+0.79
  EATANxy CVF_PI: 3f490fdb/+0.79
  EATANxy CVF_3PI_OVER2: 3f490fdb/+0.79
EATANxz:
  EATANxz CVF_ZERO: ffc00000/-NaN
  EATANxz CVF_NEGZERO: ffc00000/-NaN
  EATANxz CVF_MAX: 7fffffff/+NaN
  EATANxz CVF_MIN: ffffffff/-NaN
  EATANxz CVF_MAX_MANTISSA: 3f490fdb/+0.79
  EATANxz CVF_MAX_EXP: 7fc00001/+NaN
  EATANxz CVF_MIN_EXP: ffc00000/-NaN
  EATANxz CVF_ONE: 3f490fdb/+0.79
  EATANxz CVF_NEGONE: 3f490fdb/+0.79
  EATANxz CVF_GARBAGE1: ffc00000/-NaN
  EATANxz CVF_GARBAGE2: 3f490fdb/+0.79
  EATANxz CVF_INCREASING: 3fa72d09/+1.31
  EATANxz CVF_DECREASING: 3ee3f44a/+0.45
  EATANxz CVF_PI_OVER2: 3f490fdb/+0.79
  EATANxz CVF_PI: 3f490fdb/+0.79
  EATANxz CVF_3PI_OVER2: 3f490fdb/+0.79
```

PR:
```
-- TEST BEGIN
EATAN:
  EATAN CVF_ZERO: 34800000/+0.00
  EATAN CVF_NEGZERO: 34800000/+0.00
  EATAN CVF_MAX: 7fffffff/+NaN
  EATAN CVF_MIN: ffffffff/-NaN
  EATAN CVF_MAX_MANTISSA: 3f8db70b/+1.11
  EATAN CVF_MAX_EXP: 7fc00001/+NaN
  EATAN CVF_MIN_EXP: 34800000/+0.00
  EATAN CVF_ONE: 3f490fdb/+0.79
  EATAN CVF_NEGONE: ffc00000/-NaN
  EATAN CVF_GARBAGE1: 34800000/+0.00
  EATAN CVF_GARBAGE2: 3fc90fd9/+1.57
  EATAN CVF_INCREASING: 3f9fe0ba/+1.25
  EATAN CVF_DECREASING: 3f8db70b/+1.11
  EATAN CVF_PI_OVER2: 3f807f4c/+1.00
  EATAN CVF_PI: 3fa19dc5/+1.26
  EATAN CVF_3PI_OVER2: 3fae4be7/+1.36
EATANxy:
  EATANxy CVF_ZERO: ffc00000/-NaN
  EATANxy CVF_NEGZERO: ffc00000/-NaN
  EATANxy CVF_MAX: 7fffffff/+NaN
  EATANxy CVF_MIN: ffffffff/-NaN
  EATANxy CVF_MAX_MANTISSA: 3f490fdb/+0.79
  EATANxy CVF_MAX_EXP: 7fc00001/+NaN
  EATANxy CVF_MIN_EXP: ffc00000/-NaN
  EATANxy CVF_ONE: 3f490fdb/+0.79
  EATANxy CVF_NEGONE: 3f490fdb/+0.79
  EATANxy CVF_GARBAGE1: ffc00000/-NaN
  EATANxy CVF_GARBAGE2: 3f490fdb/+0.79
  EATANxy CVF_INCREASING: 3f8db70b/+1.11
  EATANxy CVF_DECREASING: 3f24bc7f/+0.64
  EATANxy CVF_PI_OVER2: 3f490fdb/+0.79
  EATANxy CVF_PI: 3f490fdb/+0.79
  EATANxy CVF_3PI_OVER2: 3f490fdb/+0.79
EATANxz:
  EATANxz CVF_ZERO: ffc00000/-NaN
  EATANxz CVF_NEGZERO: ffc00000/-NaN
  EATANxz CVF_MAX: 7fffffff/+NaN
  EATANxz CVF_MIN: ffffffff/-NaN
  EATANxz CVF_MAX_MANTISSA: 3f490fdb/+0.79
  EATANxz CVF_MAX_EXP: 7fc00001/+NaN
  EATANxz CVF_MIN_EXP: ffc00000/-NaN
  EATANxz CVF_ONE: 3f490fdb/+0.79
  EATANxz CVF_NEGONE: 3f490fdb/+0.79
  EATANxz CVF_GARBAGE1: ffc00000/-NaN
  EATANxz CVF_GARBAGE2: 3f490fdb/+0.79
  EATANxz CVF_INCREASING: 3f9fe0ba/+1.25
  EATANxz CVF_DECREASING: 3eed633d/+0.46
  EATANxz CVF_PI_OVER2: 3f490fdb/+0.79
  EATANxz CVF_PI: 3f490fdb/+0.79
  EATANxz CVF_3PI_OVER2: 3f490fdb/+0.79
```

Real hardware (according to the `efu.expected` file from ps2autotests):
```
-- TEST BEGIN
EATAN:
  EATAN CVF_ZERO: 33e60000/+0.00
  EATAN CVF_NEGZERO: 33e60000/+0.00
  EATAN CVF_MAX: 3fc90fd9/+1.57
  EATAN CVF_MIN: 3fc90fd9/+1.57
  EATAN CVF_MAX_MANTISSA: 3f8db70b/+1.11
  EATAN CVF_MAX_EXP: 3fc90fd9/+1.57
  EATAN CVF_MIN_EXP: 33e60000/+0.00
  EATAN CVF_ONE: 3f490fda/+0.79
  EATAN CVF_NEGONE: ffc90fd7/-NaN
  EATAN CVF_GARBAGE1: 33e60000/+0.00
  EATAN CVF_GARBAGE2: 3fc90fd9/+1.57
  EATAN CVF_INCREASING: 3f9fe0ba/+1.25
  EATAN CVF_DECREASING: 3f8db70b/+1.11
  EATAN CVF_PI_OVER2: 3f807f4c/+1.00
  EATAN CVF_PI: 3fa19dc4/+1.26
  EATAN CVF_3PI_OVER2: 3fae4be7/+1.36
EATANxy:
  EATANxy CVF_ZERO: 7fc90fd7/+NaN
  EATANxy CVF_NEGZERO: ffc90fd7/-NaN
  EATANxy CVF_MAX: 3f490fda/+0.79
  EATANxy CVF_MIN: 3f490fda/+0.79
  EATANxy CVF_MAX_MANTISSA: 3f490fda/+0.79
  EATANxy CVF_MAX_EXP: 3f490fda/+0.79
  EATANxy CVF_MIN_EXP: 7fc90fd7/+NaN
  EATANxy CVF_ONE: 3f490fda/+0.79
  EATANxy CVF_NEGONE: 3f490fda/+0.79
  EATANxy CVF_GARBAGE1: 7fc90fd7/+NaN
  EATANxy CVF_GARBAGE2: 3f490fda/+0.79
  EATANxy CVF_INCREASING: 3f8db70b/+1.11
  EATANxy CVF_DECREASING: 3f24bc7d/+0.64
  EATANxy CVF_PI_OVER2: 3f490fda/+0.79
  EATANxy CVF_PI: 3f490fda/+0.79
  EATANxy CVF_3PI_OVER2: 3f490fda/+0.79
EATANxz:
  EATANxz CVF_ZERO: 7fc90fd7/+NaN
  EATANxz CVF_NEGZERO: ffc90fd7/-NaN
  EATANxz CVF_MAX: 3f490fda/+0.79
  EATANxz CVF_MIN: 3f490fda/+0.79
  EATANxz CVF_MAX_MANTISSA: 3f490fda/+0.79
  EATANxz CVF_MAX_EXP: 3f490fda/+0.79
  EATANxz CVF_MIN_EXP: 7fc90fd7/+NaN
  EATANxz CVF_ONE: 3f490fda/+0.79
  EATANxz CVF_NEGONE: 3f490fda/+0.79
  EATANxz CVF_GARBAGE1: 7fc90fd7/+NaN
  EATANxz CVF_GARBAGE2: 3f490fda/+0.79
  EATANxz CVF_INCREASING: 3f9fe0ba/+1.25
  EATANxz CVF_DECREASING: 3eed6339/+0.46
  EATANxz CVF_PI_OVER2: 3f490fda/+0.79
  EATANxz CVF_PI: 3f490fda/+0.79
  EATANxz CVF_3PI_OVER2: 3f490fda/+0.79
```

### Suggested Testing Steps
Try running [efu.elf from ps2autotests](https://github.com/unknownbrackets/ps2autotests/blob/master/tests/vu/lower/efu.elf).

Test games that make extensive use of VU1.

### Did you use AI to help find, test, or implement this issue or feature?
No.