### PR TITLE
FullscreenUI: Fix game list appearing empty after exiting and re-entering

### DIFF
--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -557,6 +557,7 @@ void FullscreenUI::Shutdown(bool clear_state)
 		CloseCoverDownloaderWindow();
 		s_cover_image_map.clear();
 		s_game_list_sorted_entries = {};
+		s_last_unsorted_entries = {};
 		s_game_list_directories_cache = {};
 		s_game_cheat_unlabelled_count = 0;
 		s_enabled_game_cheat_cache = {};
@@ -2467,7 +2468,6 @@ void FullscreenUI::PopulateGameListEntryList()
 	static int s_last_sort = -1;
 	static bool s_last_reverse = false;
 	static bool s_last_prefer_eng = false;
-	static std::vector<const GameList::Entry*> s_last_unsorted_entries;
 
 	// Sort can be expensive, try to avoid when possible
 	const u32 count = GameList::GetEntryCount();

--- a/pcsx2/ImGui/FullscreenUI_Internal.h
+++ b/pcsx2/ImGui/FullscreenUI_Internal.h
@@ -369,6 +369,9 @@ namespace FullscreenUI
 	inline std::vector<const GameList::Entry*> s_game_list_sorted_entries;
 	inline GameListView s_game_list_view = GameListView::Grid;
 
+	// Cached list of unsorted game list entries; used to detect changes and re-sort when needed
+	inline std::vector<const GameList::Entry*> s_last_unsorted_entries;
+
 	//////////////////////////////////////////////////////////////////////////
 	// Background
 	//////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Description of Changes
When FullscreenUI shuts down, the static variables in PopulateGameListEntryList() in FullscreenUI.cpp are not reset. So, if the user enters FSUI, looks at the game list, exits FSUI, re-enters FSUI within the same session, and checks the game list, the game list will be empty because no change is detected, so it skips repopulating/sorting the list.

I removed s_last_unsorted_entries as a local static variable and made it a global variable that gets reset when FSUI is shut down. So, if the user exits and re-enters FSUI, the game list will repopulate.

### Rationale behind Changes
Fixes a bug that requires the user to completely restart PCSX2 to repopulate the game list if they exit and re-enter FSUI within the same session.

### Suggested Testing Steps
- On master, enter FSUI, check the game list, exit FSUI, and re-enter FSUI, all within the same session. Note that the game list will be empty.
- Using this branch, do the same as above and check that the game list is repopulated.

### Did you use AI to help find, test, or implement this issue or feature?
No.