### PR TITLE
Patch: Clean up PatchCommand struct

### DIFF
--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -903,7 +903,7 @@ void Patch::PatchFunc::patch(PatchGroup* group, const std::string_view cmd, cons
 	const std::optional<u32> addr = StringUtil::FromChars<u32>(pieces[2], 16, &addr_end);
 	const std::optional<patch_data_type> type = LookupEnumName<patch_data_type>(pieces[3], s_type_to_string);
 	std::optional<u64> data = StringUtil::FromChars<u64>(pieces[4], 16, &data_end);
-	u8* data_ptr = nullptr;
+	std::unique_ptr<u8[]> data_ptr;
 
 	if (!placetopatch.has_value())
 	{
@@ -944,8 +944,8 @@ void Patch::PatchFunc::patch(PatchGroup* group, const std::string_view cmd, cons
 		}
 
 		data = bytes->size();
-		data_ptr = static_cast<u8*>(std::malloc(bytes->size()));
-		std::memcpy(data_ptr, bytes->data(), bytes->size());
+		data_ptr = std::make_unique_for_overwrite<u8[]>(bytes->size());
+		std::memcpy(data_ptr.get(), bytes->data(), bytes->size());
 	}
 
 	PatchCommand iPatch;
@@ -954,7 +954,7 @@ void Patch::PatchFunc::patch(PatchGroup* group, const std::string_view cmd, cons
 	iPatch.addr = addr.value();
 	iPatch.type = type.value();
 	iPatch.data = data.value();
-	iPatch.data_ptr = data_ptr;
+	iPatch.data_ptr = std::move(data_ptr);
 	group->patches.push_back(std::move(iPatch));
 
 #undef PATCH_ERROR
@@ -1761,7 +1761,7 @@ void Patch::ApplyPatch(const PatchCommand* p, EEMemory& ee, IOPMemory& iop, Exte
 				case BYTES_T:
 				{
 					// We compare before writing so the rec doesn't get upset and invalidate when there's no change.
-					ee.IdempotentWriteBytes(p->addr, p->data_ptr, static_cast<u32>(p->data));
+					ee.IdempotentWriteBytes(p->addr, p->data_ptr.get(), static_cast<u32>(p->data));
 					break;
 				}
 				default:
@@ -1792,7 +1792,7 @@ void Patch::ApplyPatch(const PatchCommand* p, EEMemory& ee, IOPMemory& iop, Exte
 				}
 				case BYTES_T:
 				{
-					iop.IdempotentWriteBytes(p->addr, p->data_ptr, static_cast<u32>(p->data));
+					iop.IdempotentWriteBytes(p->addr, p->data_ptr.get(), static_cast<u32>(p->data));
 					break;
 				}
 				default:

--- a/pcsx2/Patch.h
+++ b/pcsx2/Patch.h
@@ -20,6 +20,7 @@
 #include "common/MemoryInterface.h"
 #include "common/SmallString.h"
 
+#include <memory>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -81,37 +82,12 @@ namespace Patch
 
 	struct PatchCommand
 	{
-		patch_place_type placetopatch;
-		patch_cpu_type cpu;
-		patch_data_type type;
-		u32 addr;
-		u64 data;
-		u8* data_ptr;
-
-		// needed because of the pointer
-		PatchCommand() { std::memset(static_cast<void*>(this), 0, sizeof(*this)); }
-		PatchCommand(const PatchCommand& p) = delete;
-		PatchCommand(PatchCommand&& p)
-		{
-			std::memcpy(static_cast<void*>(this), &p, sizeof(*this));
-			p.data_ptr = nullptr;
-		}
-		~PatchCommand()
-		{
-			if (data_ptr)
-				std::free(data_ptr);
-		}
-
-		PatchCommand& operator=(const PatchCommand& p) = delete;
-		PatchCommand& operator=(PatchCommand&& p)
-		{
-			std::memcpy(static_cast<void*>(this), &p, sizeof(*this));
-			p.data_ptr = nullptr;
-			return *this;
-		}
-
-		bool operator==(const PatchCommand& p) const { return std::memcmp(this, &p, sizeof(*this)) == 0; }
-		bool operator!=(const PatchCommand& p) const { return std::memcmp(this, &p, sizeof(*this)) != 0; }
+		patch_place_type placetopatch = PPT_ONCE_ON_LOAD;
+		patch_cpu_type cpu = CPU_EE;
+		patch_data_type type = BYTE_T;
+		u32 addr = 0;
+		u64 data = 0;
+		std::unique_ptr<u8[]> data_ptr;
 
 		SmallString ToString() const
 		{


### PR DESCRIPTION
### Description of Changes
Clean up the PatchCommand struct.

### Rationale behind Changes
The trick it was previously using where you memset/memcmp the whole struct isn't valid, since the compiler is allowed to overwrite padding when combining writes. In practice clang seems to be conservative about this, but we shouldn't be relying on it.

### Suggested Testing Steps
Make sure `bytes` patches still work as expected.

### Did you use AI to help find, test, or implement this issue or feature?
No.