### PR TITLE
GS:HW: Only enable GPU timing/stats in backend if the option is enabled.

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -161,9 +161,9 @@ static bool OpenGSDevice(GSRendererType renderer, bool clear_state_on_fail, bool
 		return false;
 	}
 
-	if (!g_gs_device->SetGPUTimingEnabled(true))
+	if (GSConfig.OsdShowGPU && !g_gs_device->SetGPUTimingEnabled(true))
 		GSConfig.OsdShowGPU = false;
-	if (!g_gs_device->SetGPUPipelineStatisticsEnabled(true))
+	if (GSConfig.OsdShowGPUStats && !g_gs_device->SetGPUPipelineStatisticsEnabled(true))
 		GSConfig.OsdShowGPUStats = false;
 
 	Console.WriteLn(Color_StrongGreen, "%s Graphics Driver Info:", GSDevice::RenderAPIToString(new_api));
@@ -881,9 +881,9 @@ void GSUpdateConfig(const Pcsx2Config::GSOptions& new_config)
 		g_gs_renderer->PurgeTextureCache(true, false, true);
 	}
 
-	if (GSConfig.OsdShowGPU && !old_config.OsdShowGPU)
+	if (GSConfig.OsdShowGPU != old_config.OsdShowGPU)
 	{
-		if (!g_gs_device->SetGPUTimingEnabled(true))
+		if (!g_gs_device->SetGPUTimingEnabled(GSConfig.OsdShowGPU))
 			GSConfig.OsdShowGPU = false;
 	}
 

--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -1167,7 +1167,7 @@ void GSDevice11::DestroyTimestampQueries()
 	m_read_timestamp_query = 0;
 	m_write_timestamp_query = 0;
 	m_waiting_timestamp_queries = 0;
-	m_timestamp_query_started = 0;
+	m_timestamp_query_started = false;
 }
 
 void GSDevice11::PopTimestampQuery()
@@ -1286,13 +1286,13 @@ void GSDevice11::DestroyPipelineStatisticsQueries()
 		return;
 
 	if (m_pipeline_statistics_query_started)
-		m_ctx->End(m_pipeline_statistics_queries[m_write_timestamp_query].get());
+		m_ctx->End(m_pipeline_statistics_queries[m_write_pipeline_statistics_query].get());
 
-	m_timestamp_queries = {};
-	m_read_timestamp_query = 0;
-	m_write_timestamp_query = 0;
-	m_waiting_timestamp_queries = 0;
-	m_timestamp_query_started = 0;
+	m_pipeline_statistics_queries = {};
+	m_read_pipeline_statistics_query = 0;
+	m_write_pipeline_statistics_query = 0;
+	m_waiting_pipeline_statistics_queries = 0;
+	m_pipeline_statistics_query_started = false;
 }
 
 void GSDevice11::PopPipelineStatisticsQuery()

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -1292,7 +1292,7 @@ bool GSDeviceOGL::SetGPUPipelineStatisticsEnabled(bool enabled)
 	else
 		DestroyPipelineStatisticsQueries();
 
-	return true;
+	return (enabled == m_gpu_pipeline_statistics_enabled);
 }
 
 void GSDeviceOGL::DrawPrimitive()

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -1150,7 +1150,7 @@ GPUPipelineStatistics GSDeviceVK::GetAndResetAccumulatedGPUPipelineStatistics()
 bool GSDeviceVK::SetGPUPipelineStatisticsEnabled(bool enabled)
 {
 	m_gpu_pipeline_statistics_enabled = enabled && m_gpu_pipeline_statistics_supported;
-	return true;
+	return (enabled == m_gpu_pipeline_statistics_enabled);
 }
 
 void GSDeviceVK::ScanForCommandBufferCompletion()


### PR DESCRIPTION
### Description of Changes
Only enable GPU timing/stats in backend if the OsdShowGPU/OsdShowGPUStats setting is enabled.

### Rationale behind Changes
Helps prevent a crash in Mesa3D Windows drivers (https://github.com/pal1000/mesa-dist-win) on the OpenGL renderer.

### Suggested Testing Steps
- Install the above Mesa3D drivers (use "per-app" install and do it only for PCSX2).
- Select the OpenGL renderer. 
- Disable Settings > OSD (On-Screen Display) > Show GPU Pipeline Statistics.
- Run a game / GS dump.

There should not be a crash on PR when the setting is disabled (though it may crash when the setting is enabled).

On master it may crash both when the setting is enabled/disabled. 

### Did you use AI to help find, test, or implement this issue or feature?
No.