### PR TITLE
GS/VK: Workaround Nvidia issue when switching ROV targets

### DIFF
--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -5418,6 +5418,17 @@ void GSDeviceVK::PSSetROVs(GSTexture* rt, GSTexture* ds, bool write_rt, bool wri
 		PSSetShaderResource(TFX_TEXTURE_DEPTH_ROV, nullptr, false);
 	}
 
+	if (IsDeviceNVIDIA() && InRenderPass())
+	{
+		// Nvidia doesn't like switching ROV targets mid-render pass, doing so causes flickering or missing geometry.
+		// End the render pass to avoid such issues.
+		if (vkRt != oldVkRt || vkDs != oldVkDs)
+		{
+			GL_INS("VK: Ending render pass due to UAV switch");
+			EndRenderPass();
+		}
+	}
+
 	if (GSConfig.HWROVBarriersVK)
 	{
 		// This is to fix issues with some systems that seem to require barriers even with FSI.


### PR DESCRIPTION
### Description of Changes
Ends the current renderpass when switching ROV targets in the Vulkan backend when running on NVidia

### Rationale behind Changes
NVidia doesn't like switching ROV targets mid renderpass
Ending the renderpass fixes the flicking that can be seen in Burnout or Need for Speed: Hot Pursuit 2.
This should also be significantly faster then enabling ROV barriers.
fixes #14791 

### Suggested Testing Steps
Test Vulkan on Nvidia hardware, using the dump on #14791 (high blending) or https://github.com/PCSX2/pcsx2/pull/13754#issuecomment-3775601752 (max blending)

### Did you use AI to help find, test, or implement this issue or feature?
No