### PR TITLE
Qt/Mac: Exit fullscreen on the display widget before destroying it

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -3016,6 +3016,7 @@ void MainWindow::destroyDisplayWidget(bool show_game_list)
 #else
 		m_display_container->setWindowState(m_display_container->windowState() & ~Qt::WindowFullScreen);
 #endif
+		QGuiApplication::sync();
 	}
 #endif
 

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -3012,9 +3012,9 @@ void MainWindow::destroyDisplayWidget(bool show_game_list)
 	if (m_display_surface->isFullScreen())
 	{
 #ifdef DISPLAY_SURFACE_WINDOW
-		m_display_surface->showNormal();
+		m_display_surface->setWindowStates(m_display_surface->windowStates() & ~Qt::WindowFullScreen);
 #else
-		m_display_container->showNormal();
+		m_display_container->setWindowState(m_display_container->windowState() & ~Qt::WindowFullScreen);
 #endif
 	}
 #endif

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -3006,6 +3006,19 @@ void MainWindow::destroyDisplayWidget(bool show_game_list)
 	if (!(m_display_surface->isFullScreen() || m_display_is_exclusive_fullscreen) && !isRenderingToMain())
 		saveDisplayWindowGeometryToConfig();
 
+#ifdef __APPLE__
+	// The fullscreen state affects the whole application on MacOS.
+	// Exit fullscreen before destroying the display widget.
+	if (m_display_surface->isFullScreen())
+	{
+#ifdef DISPLAY_SURFACE_WINDOW
+		m_display_surface->showNormal();
+#else
+		m_display_container->showNormal();
+#endif
+	}
+#endif
+
 	if (isRenderingToMain())
 	{
 		pxAssertRel(m_ui.mainContainer->indexOf(m_display_container) == 1, "Display widget in stack");


### PR DESCRIPTION
### Description of Changes
Exits fullscreen mode on the display widget before destroying it.

### Rationale behind Changes
We use a separate display window for fullscreen presentation.
Mac apparently shares the fullscreen state for all windows of an application, instead of just the display window.

Poir to v2.5.303, we would close the display window, however, that could full close the application in some situations (https://github.com/PCSX2/pcsx2/issues/12784)

Instead, I'm hoping that exiting fullscreen on the display widget will be enough to fix https://github.com/PCSX2/pcsx2/issues/14801.

### Suggested Testing Steps (Mac Only)
Test exiting fullscreen emulation on Mac.

### Did you use AI to help find, test, or implement this issue or feature?
No