### PR TITLE
GS: Fix status bar GPU % when OSD GPU usage is off

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -161,7 +161,7 @@ static bool OpenGSDevice(GSRendererType renderer, bool clear_state_on_fail, bool
 		return false;
 	}
 
-	if (GSConfig.OsdShowGPU && !g_gs_device->SetGPUTimingEnabled(true))
+	if (!g_gs_device->SetGPUTimingEnabled(true))
 		GSConfig.OsdShowGPU = false;
 	if (GSConfig.OsdShowGPUStats && !g_gs_device->SetGPUPipelineStatisticsEnabled(true))
 		GSConfig.OsdShowGPUStats = false;
@@ -881,9 +881,9 @@ void GSUpdateConfig(const Pcsx2Config::GSOptions& new_config)
 		g_gs_renderer->PurgeTextureCache(true, false, true);
 	}
 
-	if (GSConfig.OsdShowGPU != old_config.OsdShowGPU)
+	if (GSConfig.OsdShowGPU && !old_config.OsdShowGPU)
 	{
-		if (!g_gs_device->SetGPUTimingEnabled(GSConfig.OsdShowGPU))
+		if (!g_gs_device->SetGPUTimingEnabled(true))
 			GSConfig.OsdShowGPU = false;
 	}
 


### PR DESCRIPTION
### Description of Changes
#14792 only turned on GPU timing when the OSD GPU option was enabled, which left the Qt status bar stuck at 0%. Pretty sure that change was just a precaution and wasn't needed *(the original source of the crash was because of `GPUPipelineStatistics`)*.

### Rationale behind Changes
Fixes #14808 

### Suggested Testing Steps
Smoke test Windows GL Mesa and see if you can hit the same crash as #14792.

### Did you use AI to help find, test, or implement this issue or feature?
No