### PR TITLE
Flatpak: Update KDE runtime to 6.11

### DIFF
--- a/.github/workflows/linux_build_flatpak.yml
+++ b/.github/workflows/linux_build_flatpak.yml
@@ -45,7 +45,7 @@ jobs:
     name: ${{ inputs.jobName }}
     runs-on: ${{ inputs.os }}
     container:
-      image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.9
+      image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.10
       options: --privileged
     timeout-minutes: 60
 

--- a/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
+++ b/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
@@ -1,15 +1,15 @@
 {
   "app-id": "net.pcsx2.PCSX2",
   "runtime": "org.kde.Platform",
-  "runtime-version": "6.10",
+  "runtime-version": "6.11",
   "sdk": "org.kde.Sdk",
   "sdk-extensions": [
-    "org.freedesktop.Sdk.Extension.llvm20"
+    "org.freedesktop.Sdk.Extension.llvm22"
   ],
   "add-extensions": {
     "org.freedesktop.Platform.ffmpeg-full": {
       "directory": "lib/ffmpeg",
-      "version": "25.08",
+      "version": "26.08",
       "add-ld-path": ".",
       "autodownload": true
     }
@@ -52,8 +52,8 @@
           "-DCMAKE_PREFIX_PATH=\"${FLATPAK_DEST}\"",
           "-DCMAKE_BUILD_TYPE=Release",
           "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON",
-          "-DCMAKE_C_COMPILER=/usr/lib/sdk/llvm20/bin/clang",
-          "-DCMAKE_CXX_COMPILER=/usr/lib/sdk/llvm20/bin/clang++",
+          "-DCMAKE_C_COMPILER=/usr/lib/sdk/llvm22/bin/clang",
+          "-DCMAKE_CXX_COMPILER=/usr/lib/sdk/llvm22/bin/clang++",
           "-DCMAKE_EXE_LINKER_FLAGS_INIT=-fuse-ld=lld",
           "-DCMAKE_MODULE_LINKER_FLAGS_INIT=-fuse-ld=lld",
           "-DCMAKE_SHARED_LINKER_FLAGS_INIT=-fuse-ld=lld",

--- a/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
+++ b/.github/workflows/scripts/linux/flatpak/net.pcsx2.PCSX2.json
@@ -1,10 +1,10 @@
 {
   "app-id": "net.pcsx2.PCSX2",
   "runtime": "org.kde.Platform",
-  "runtime-version": "6.10",
+  "runtime-version": "6.11",
   "sdk": "org.kde.Sdk",
   "sdk-extensions": [
-    "org.freedesktop.Sdk.Extension.llvm20"
+    "org.freedesktop.Sdk.Extension.llvm22"
   ],
   "add-extensions": {
     "org.freedesktop.Platform.ffmpeg-full": {
@@ -52,8 +52,8 @@
           "-DCMAKE_PREFIX_PATH=\"${FLATPAK_DEST}\"",
           "-DCMAKE_BUILD_TYPE=Release",
           "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON",
-          "-DCMAKE_C_COMPILER=/usr/lib/sdk/llvm20/bin/clang",
-          "-DCMAKE_CXX_COMPILER=/usr/lib/sdk/llvm20/bin/clang++",
+          "-DCMAKE_C_COMPILER=/usr/lib/sdk/llvm22/bin/clang",
+          "-DCMAKE_CXX_COMPILER=/usr/lib/sdk/llvm22/bin/clang++",
           "-DCMAKE_EXE_LINKER_FLAGS_INIT=-fuse-ld=lld",
           "-DCMAKE_MODULE_LINKER_FLAGS_INIT=-fuse-ld=lld",
           "-DCMAKE_SHARED_LINKER_FLAGS_INIT=-fuse-ld=lld",

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -104,7 +104,7 @@ disable_compiler_warnings_for_target(speex)
 
 # Find the Qt components that we need.
 if(ENABLE_QT_UI)
-	find_package(Qt6 6.10.1 COMPONENTS CoreTools Core GuiTools Gui WidgetsTools Widgets LinguistTools REQUIRED)
+	find_package(Qt6 6.11.1 COMPONENTS CoreTools Core GuiTools Gui WidgetsTools Widgets LinguistTools REQUIRED)
 
 	if(NOT WIN32 AND NOT APPLE)
 		if (Qt6_VERSION VERSION_GREATER_EQUAL 6.10.0)

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -112,7 +112,7 @@ disable_compiler_warnings_for_target(speex)
 
 # Find the Qt components that we need.
 if(ENABLE_QT_UI)
-	find_package(Qt6 6.10.1 COMPONENTS CoreTools Core GuiTools Gui WidgetsTools Widgets LinguistTools REQUIRED)
+	find_package(Qt6 6.11.1 COMPONENTS CoreTools Core GuiTools Gui WidgetsTools Widgets LinguistTools REQUIRED)
 
 	if(NOT WIN32 AND NOT APPLE)
 		if (Qt6_VERSION VERSION_GREATER_EQUAL 6.10.0)


### PR DESCRIPTION
### Description of Changes
Updates the KDE runtime to 6.11 giving us Qt 6.11.0 on Flatpak.

### Rationale behind Changes
Having the latest Qt on Flatpak is nice.

### Suggested Testing Steps
Make sure Flatpak still builds and works as intended.

### Did you use AI to help find, test, or implement this issue or feature?
Beep Boo- I mean no.