### PR TITLE
GS: Use current primitive mode for backing up spare vert buffers

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -2527,7 +2527,8 @@ void GSState::FlushPrim()
 
 		if (tail > head)
 		{
-			switch (PRIM->PRIM)
+			// NOTE: Do not use PRIM->PRIM as the previous environment may have been restored and it may have changed from strip to fan, which messes up the backup.
+			switch (m_env.PRIM.PRIM)
 			{
 				case GS_POINTLIST:
 					pxAssert(0);
@@ -2667,7 +2668,7 @@ void GSState::FlushPrim()
 
 			// If it's a Triangle fan the XY buffer needs to be updated to point to the correct head vert
 			// Jak 3 shadows get spikey (with autoflush) if you don't.
-			if (PRIM->PRIM == GS_TRIANGLEFAN)
+			if (m_env.PRIM.PRIM == GS_TRIANGLEFAN)
 			{
 				for (u32 i = 0; i < unused; i++)
 				{


### PR DESCRIPTION
### Description of Changes
Use the current environment primitive setting for backing up spare verts in the vert buffer

### Rationale behind Changes
We don't care if it changes between different types of triangle, we just realign the head/tail positions and continue adding new triangles to the buffer, since they are all triangles and we put them all in the same final format.  However when the flush happens it will back up depending on the primitive type, down to the type of triangle as Triangle Fan requires slightly different handling.

In Ratchet and Clank it switches between fan and strip, and because we don't reset the context, the backed up context can have a different type of triangle fan/strip setup, which is what was happening here. So we need to make sure we use the *current* triangle type when doing the backup to avoid issues.

### Suggested Testing Steps
Test the Ratchet & Clank games (1-3 + Gladiator known) and check the shadows are correct.

### Did you use AI to help find, test, or implement this issue or feature?
No

Fixes #14821

Example fix:

Ratchet - Gladiator:
Master:
<img width="682" height="512" alt="image" src="https://github.com/user-attachments/assets/c4b2cdce-c818-4211-9aa3-ca7c8a89fdeb" />

PR:
<img width="682" height="512" alt="image" src="https://github.com/user-attachments/assets/823e7ec2-11c0-431d-a404-2ec7d6e0ed23" />
