### PR TITLE
CI: Use separate job for building Windows deps

### DIFF
--- a/.github/workflows/release_cut_new.yml
+++ b/.github/workflows/release_cut_new.yml
@@ -120,10 +120,16 @@ jobs:
     secrets: inherit
 
   # Windows
+  build_windows_deps:
+    if: github.repository == 'PCSX2/pcsx2'
+    name: "Windows Dependencies"
+    uses: ./.github/workflows/windows_deps_build.yml
+
   build_windows_qt:
     if: github.repository == 'PCSX2/pcsx2'
     needs:
       - cut-release
+      - build_windows_deps
     name: "Windows"
     uses: ./.github/workflows/windows_build_qt.yml
     with:

--- a/.github/workflows/windows_build_matrix.yml
+++ b/.github/workflows/windows_build_matrix.yml
@@ -9,6 +9,10 @@ on:
       - master
 
 jobs:
+  build_qt_deps:
+    name: "Dependencies"
+    uses: ./.github/workflows/windows_deps_build.yml
+
   # MSBUILD
   lint_vs_proj_files:
     name: Lint VS Project Files
@@ -21,7 +25,7 @@ jobs:
         run: .github\workflows\scripts\windows\validate-vs-filters.ps1
 
   build_qt_sse4:
-    needs: lint_vs_proj_files
+    needs: [build_qt_deps, lint_vs_proj_files]
     name: "SSE4"
     if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
     uses: ./.github/workflows/windows_build_qt.yml
@@ -33,7 +37,7 @@ jobs:
     secrets: inherit
 
   build_qt_avx2:
-    needs: lint_vs_proj_files
+    needs: [build_qt_deps, lint_vs_proj_files]
     name: "AVX2"
     if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
     uses: ./.github/workflows/windows_build_qt.yml
@@ -44,6 +48,7 @@ jobs:
     secrets: inherit
 
   build_qt_cmake:
+    needs: build_qt_deps
     name: "CMake"
     if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
     uses: ./.github/workflows/windows_build_qt.yml
@@ -55,7 +60,7 @@ jobs:
     secrets: inherit
 
   build_qt_clang_sse4:
-    needs: lint_vs_proj_files
+    needs: [build_qt_deps, lint_vs_proj_files]
     name: "SSE4"
     if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
     uses: ./.github/workflows/windows_build_qt.yml
@@ -67,7 +72,7 @@ jobs:
     secrets: inherit
 
   build_qt_clang_avx2:
-    needs: lint_vs_proj_files
+    needs: [build_qt_deps, lint_vs_proj_files]
     name: "AVX2"
     if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
     uses: ./.github/workflows/windows_build_qt.yml
@@ -78,6 +83,7 @@ jobs:
     secrets: inherit
 
   build_qt_cmake_clang:
+    needs: build_qt_deps
     name: "CMake"
     if: github.repository != 'PCSX2/pcsx2' || github.event_name == 'pull_request'
     uses: ./.github/workflows/windows_build_qt.yml

--- a/.github/workflows/windows_build_qt.yml
+++ b/.github/workflows/windows_build_qt.yml
@@ -50,7 +50,7 @@ jobs:
     name: ${{ inputs.jobName }}
     runs-on: ${{ inputs.os }}
     # Set some sort of timeout in the event of run-away builds.  We are limited on concurrent jobs so, get rid of them.
-    timeout-minutes: 90
+    timeout-minutes: 30
     env:
       POWERSHELL_TELEMETRY_OPTOUT: 1
 
@@ -124,15 +124,10 @@ jobs:
         id: cache-deps
         uses: actions/cache@v6
         with:
+          fail-on-cache-miss: true
           path: deps
           key: ${{ inputs.os }} ${{ inputs.platform }} deps ${{ hashFiles('.github/workflows/scripts/windows/build-dependencies.bat', '.github/workflows/scripts/common/*.patch') }}
 
-      - name: Build Dependencies
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        env:
-          DEBUG: 0
-          BUILD_FFMPEG: 1
-        run: .github/workflows/scripts/windows/build-dependencies.bat
 
       - name: Generate CMake
         if: inputs.configuration == 'CMake'

--- a/.github/workflows/windows_deps_build.yml
+++ b/.github/workflows/windows_deps_build.yml
@@ -1,0 +1,41 @@
+name: Windows Build Steps - Deps
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: false
+        type: string
+        default: windows-2025-vs2026
+      platform:
+        required: false
+        type: string
+        default: x64
+
+jobs:
+  build_windows_deps:
+    name: "Cache Dependencies"
+    runs-on: ${{ inputs.os }}
+    # Set some sort of timeout in the event of run-away builds.  We are limited on concurrent jobs so, get rid of them.
+    timeout-minutes: 90
+    env:
+      POWERSHELL_TELEMETRY_OPTOUT: 1
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: Check Dependencies
+        id: cache-deps
+        uses: actions/cache@v6
+        with:
+          lookup-only: true
+          path: deps
+          key: ${{ inputs.os }} ${{ inputs.platform }} deps ${{ hashFiles('.github/workflows/scripts/windows/build-dependencies.bat', '.github/workflows/scripts/common/*.patch') }}
+
+      - name: Build Dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        env:
+          DEBUG: 0
+          BUILD_FFMPEG: 1
+        run: .github/workflows/scripts/windows/build-dependencies.bat


### PR DESCRIPTION
### Description of Changes
Splits building dependencies on windows to their own CI job

### Rationale behind Changes
The same deps are used across all 6 windows CI builds
This results in us sending 6 concurrent downloads to the same file on every deps update PR, as well as wasting resources building the same thing 6 times.
If one of those runs fails to downloads the deps, we have to wait until the other builds have finished before rerunning.

By using a separate job, we can avoid the above issues.

### Suggested Testing Steps
Test CI builds
Also test the cut-release action still works

### Did you use AI to help find, test, or implement this issue or feature?
No