### PR TITLE
EE/IOP: Fix loading elf's through relative path

### DIFF
--- a/pcsx2/IopBios.cpp
+++ b/pcsx2/IopBios.cpp
@@ -83,8 +83,9 @@ static std::string hostRoot;
 
 void Hle_SetHostRoot(const char* bootFilename)
 {
-	hostRoot = Path::ToNativePath(Path::GetDirectory(bootFilename));
-	Console.WriteLn("HLE Host: Set 'host:' root path to: %s\n", hostRoot.c_str());
+	std::string path = Path::RealPath(bootFilename);
+	hostRoot = Path::ToNativePath(Path::GetDirectory(path));
+	Console.WriteLn("HLE Host: Set 'host:' root path to: %s", hostRoot.c_str());
 }
 
 void Hle_ClearHostRoot()

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -3,6 +3,7 @@
 
 #include "Common.h"
 
+#include "common/Path.h"
 #include "common/StringUtil.h"
 #include "ps2/BiosTools.h"
 #include "R5900.h"
@@ -671,7 +672,8 @@ void eeloadHook()
 		const std::string& elf_override = VMManager::Internal::GetELFOverride();
 		if (!elf_override.empty())
 		{
-			elfname = fmt::format("host:{}", elf_override);
+			// The host: root should be directory containg the elf, so get only the filename part
+			elfname = fmt::format("host:{}", Path::GetFileName(elf_override));
 		}
 		else
 		{


### PR DESCRIPTION
### Description of Changes
Fixes loading elf files that are provided to pcsx2 using relative paths.

Previously the host root would end up empty and break any loads from "host:".

### Rationale behind Changes
It's really annoying and unintuitive to have to provide full absolute paths when launching homebrew with pcsx2.

### Suggested Testing Steps
Make sure loading elf files still works as expected.

### Did you use AI to help find, test, or implement this issue or feature?
No