### PR TITLE
GS/HW: Fix some target detection and format issues

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -25662,6 +25662,7 @@ SLES-54138:
     preloadFrameData: 1 # Fixes menu graphics.
     autoFlush: 1 # Fixes motion blur.
     minimumBlendingLevel: 2 # Improves post effects.
+    limit24BitDepth: 2 # Fixes icon brightness.
 SLES-54139:
   name: "Earache - Extreme Metal Racing"
   region: "PAL-E"
@@ -26318,6 +26319,7 @@ SLES-54335:
     preloadFrameData: 1 # Fixes menu graphics.
     autoFlush: 1 # Fixes motion blur.
     minimumBlendingLevel: 2 # Improves post effects.
+    limit24BitDepth: 2 # Fixes icon brightness.
 SLES-54336:
   name: "Lumines Plus"
   region: "PAL-M5"
@@ -71845,6 +71847,7 @@ SLUS-21344:
     preloadFrameData: 1 # Fixes menu graphics.
     autoFlush: 1 # Fixes motion blur.
     minimumBlendingLevel: 2 # Improves post effects.
+    limit24BitDepth: 2 # Fixes icon brightness.
 SLUS-21345:
   name: "Grandia III [Disc 2 of 2]"
   region: "NTSC-U"
@@ -75403,6 +75406,7 @@ SLUS-28061:
     preloadFrameData: 1 # Fixes menu graphics.
     autoFlush: 1 # Fixes motion blur.
     minimumBlendingLevel: 2 # Improves post effects.
+    limit24BitDepth: 2 # Fixes icon brightness.
 SLUS-28062:
   name: "Dance Factory [Trade Demo]"
   region: "NTSC-U"
@@ -76189,6 +76193,7 @@ SLUS-29188:
     preloadFrameData: 1 # Fixes menu graphics.
     autoFlush: 1 # Fixes motion blur.
     minimumBlendingLevel: 2 # Improves post effects.
+    limit24BitDepth: 2 # Fixes icon brightness.
 SLUS-29189:
   name: "FIFA World Cup - Germany 2006 [Demo]"
   region: "NTSC-U"

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3939,7 +3939,8 @@ void GSRendererHW::Draw()
 
 			if (next_ctx.FRAME.Block() == FRAME_TEX0.TBP0 && next_ctx.FRAME.PSM != FRAME_TEX0.PSM)
 				FRAME_TEX0.PSM = next_ctx.FRAME.PSM;
-			else if (next_ctx.TEX0.TBP0 == FRAME_TEX0.TBP0 && next_ctx.TEX0.PSM != FRAME_TEX0.PSM)
+			// Be careful of the next draw being a channel shuffle!
+			else if (next_ctx.TEX0.TBP0 == FRAME_TEX0.TBP0 && next_ctx.TEX0.PSM != FRAME_TEX0.PSM && GSLocalMemory::m_psm[next_ctx.TEX0.PSM].trbpp >= 16)
 				FRAME_TEX0.PSM = next_ctx.TEX0.PSM;
 			else
 				FRAME_TEX0.PSM = PSMCT32; // Guess full color if no upcoming hint, it'll fix itself later.

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -2580,12 +2580,21 @@ GSTextureCache::Target* GSTextureCache::LookupDrawTarget(GIFRegTEX0 TEX0, const 
 			{
 				// Some games misuse the scissor so it ends up valid 1 pixel over, which causes hell for us. So check if it still overlaps without the extra pixel.
 				const GSVector4i adjusted_valid = GSVector4i(t->m_valid.x, t->m_valid.y, std::min(t->m_valid.z, static_cast<int>(t->m_TEX0.TBW) * 64), t->m_valid.w - 1);
-				const u32 adjusted_endblock = GSLocalMemory::GetEndBlockAddress(t->m_TEX0.TBP0, t->m_TEX0.TBW, t->m_TEX0.PSM, adjusted_valid);
+				u32 adjusted_endblock = GSLocalMemory::GetUnwrappedEndBlockAddress(t->m_TEX0.TBP0, t->m_TEX0.TBW, t->m_TEX0.PSM, adjusted_valid);
 				if (adjusted_endblock <= bp)
 				{
 					i++;
 					continue;
 				}
+				const GSVector4i adjusted_rect = GSVector4i(min_rect.x, min_rect.y, std::min(min_rect.z, static_cast<int>(t->m_TEX0.TBW) * 64), min_rect.w - 1);
+				// Also check the offset from the bp to the current request to see if it overlaps the begining of the selected target.
+				adjusted_endblock = GSLocalMemory::GetUnwrappedEndBlockAddress(TEX0.TBP0, TEX0.TBW, TEX0.PSM, adjusted_rect);
+				if (adjusted_endblock <= t->m_TEX0.TBP0)
+				{
+					i++;
+					continue;
+				}
+
 				const GSLocalMemory::psm_t& s_psm = GSLocalMemory::m_psm[TEX0.PSM];
 				const u32 widthpage_offset = (std::abs(static_cast<int>(bp - t->m_TEX0.TBP0)) >> 5) % std::max(t->m_TEX0.TBW, 1U);
 				const bool is_aligned_ok = widthpage_offset == 0 || ((min_rect.width() <= static_cast<int>((t->m_TEX0.TBW - widthpage_offset) * 64) && (t->m_TEX0.TBW == TEX0.TBW || TEX0.TBW == 1)) && bp >= t->m_TEX0.TBP0);


### PR DESCRIPTION
### Description of Changes
Fixes problems with target overlap of a single pixel and looking in to the future to get the correct frame format on shuffles.

### Rationale behind Changes
Single pixel overlap was happening on Steambot as it was drawing right on the edge of the target, then blending in the Z buffer, which is of course not good.

Also fixed an issue where when there is a texture shuffle it checks if the target is used in the next draw as a texture, but didn't consider if it was also a shuffle of a different type, so that is now corrected.

### Suggested Testing Steps
Test Steambot and just some random games (Hitman Contracts and Forbidden Siren 2 came up in the dump runs but no visible difference)

### Did you use AI to help find, test, or implement this issue or feature?
No

Fixes #14842

SteamBot Chronicles:
Master:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/e6bdae7e-3ad5-4f53-a29e-31af129c5a33" />
PR:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/fefba0b3-92cd-40c4-a597-ccb82ac7dd60" />

Master:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/b6a9d6e4-2a2c-4b6f-97dd-4483e06a706e" />
PR:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/18240b9e-50b3-4ab3-94cf-044974514ccf" />
