### PR TITLE
Misc/Windows: Use wide strings for formatting localisable date & time

### DIFF
--- a/pcsx2/GameList.cpp
+++ b/pcsx2/GameList.cpp
@@ -1215,9 +1215,15 @@ std::string GameList::FormatTimestamp(std::time_t timestamp)
 		}
 		else
 		{
+#ifdef _WIN32
+			wchar_t buf[128];
+			std::wcsftime(buf, std::size(buf), L"%x", &ttime);
+			ret = StringUtil::WideStringToUTF8String(buf);
+#else
 			char buf[128];
 			std::strftime(buf, std::size(buf), "%x", &ttime);
 			ret.assign(buf);
+#endif
 		}
 	}
 

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -58,8 +58,15 @@ TinyString FullscreenUI::TimeToPrintableString(time_t t)
 #endif
 
 	TinyString ret;
+#ifdef _WIN32
+	wchar_t buf[65];
+	pxAssert(std::size(buf) == ret.buffer_size());
+	std::wcsftime(buf, std::size(buf), L"%c", &lt);
+	ret.assign(StringUtil::WideStringToUTF8String(buf));
+#else
 	std::strftime(ret.data(), ret.buffer_size(), "%c", &lt);
 	ret.update_size();
+#endif
 	return ret;
 }
 
@@ -1309,9 +1316,16 @@ void FullscreenUI::DrawLandingTemplate(ImVec2* menu_pos, ImVec2* menu_size)
 #else
 			localtime_r(&utc_time_t, &tm_local);
 #endif
+
+#ifdef _WIN32
+			wchar_t buf[256];
+			std::wcsftime(buf, std::size(buf), L"%X", &tm_local);
+			heading_str.assign(StringUtil::WideStringToUTF8String(buf));
+#else
 			char buf[256];
-			std::strftime(buf, sizeof(buf), "%X", &tm_local);
+			std::strftime(buf, std::size(buf), "%X", &tm_local);
 			heading_str.assign(buf);
+#endif
 
 			const ImVec2 time_size = heading_font.first->CalcTextSizeA(heading_font.second, FLT_MAX, 0.0f, heading_str.c_str());
 			time_pos = ImVec2(heading_size.x - LayoutScale(LAYOUT_MENU_BUTTON_X_PADDING) - time_size.x,


### PR DESCRIPTION
### Description of Changes
Uses `wcsftime` instead of `strftime` on Windows to support Unicode characters.

### Rationale behind Changes
Localised date or time formats can include non-ascii characters, so we need to use the wide string apis

### Suggested Testing Steps
Test date/time formats that include non-ascii characters in the GameList or FSUI (closes https://github.com/PCSX2/pcsx2/issues/14815).

### Did you use AI to help find, test, or implement this issue or feature?
No