### PR TITLE
EE: fix TLB handling so PS2 Linux can run

### DIFF
--- a/pcsx2/COP0.cpp
+++ b/pcsx2/COP0.cpp
@@ -4,6 +4,7 @@
 #include "Common.h"
 #include "COP0.h"
 
+
 // Updates the CPU's mode of operation (either, Kernel, Supervisor, or User modes).
 // Currently the different modes are not implemented.
 // Given this function is called so much, it's commented out for now. (rama)
@@ -224,10 +225,26 @@ __fi void COP0_UpdatePCCR()
 //
 
 
+// The vtlb is one flat address space with no ASID, so it can hold only one at a
+// time -- every process's mappings went in together and the last writer won.
+//
+// Track the installed ASID here rather than reading EntryHi at map time. EntryHi
+// is not a statement of the running process: TLBR loads it from an entry, and
+// Linux's flush loops put the ASID of whichever mm they are flushing into it.
+static u32 tlbInstalledASID = 0;
+
+static bool tlbSlotIsInstalled(const tlbs& t)
+{
+	return t.isGlobal() || (t.EntryHi.ASID == tlbInstalledASID);
+}
+
 void MapTLB(const tlbs& t, int i)
 {
 	u32 mask, addr;
 	u32 saddr, eaddr;
+
+	if (!tlbSlotIsInstalled(t))
+		return;
 
 	COP0_LOG("MAP TLB %d: 0x%08X-> [0x%08X 0x%08X] S=%d G=%d ASID=%d Mask=0x%03X EntryLo0 PFN=%x EntryLo0 Cache=%x EntryLo1 PFN=%x EntryLo1 Cache=%x VPN2=%x",
 		i, t.VPN2(), t.PFN0(), t.PFN1(), t.isSPR() >> 31, t.isGlobal(), t.EntryHi.ASID,
@@ -256,7 +273,11 @@ void MapTLB(const tlbs& t, int i)
 			{
 				if ((addr & mask) == ((t.VPN2() >> 12) & mask))
 				{ //match
-					memSetPageAddr(addr << 12, t.PFN0() + ((addr - saddr) << 12));
+					// D clear means the guest wants a store here to trap.
+					if (t.EntryLo0.D)
+						memSetPageAddr(addr << 12, t.PFN0() + ((addr - saddr) << 12));
+					else
+						memSetPageAddrReadOnly(addr << 12);
 					Cpu->Clear(addr << 12, 0x400);
 				}
 			}
@@ -272,7 +293,11 @@ void MapTLB(const tlbs& t, int i)
 			{
 				if ((addr & mask) == ((t.VPN2() >> 12) & mask))
 				{ //match
-					memSetPageAddr(addr << 12, t.PFN1() + ((addr - saddr) << 12));
+					// D clear means the guest wants a store here to trap.
+					if (t.EntryLo1.D)
+						memSetPageAddr(addr << 12, t.PFN1() + ((addr - saddr) << 12));
+					else
+						memSetPageAddrReadOnly(addr << 12);
 					Cpu->Clear(addr << 12, 0x400);
 				}
 			}
@@ -291,6 +316,9 @@ __inline u32 ConvertPageMask(const u32 PageMask)
 
 void UnmapTLB(const tlbs& t, int i)
 {
+	if (!tlbSlotIsInstalled(t))
+		return;
+
 	//Console.WriteLn("Clear TLB %d: %08x-> [%08x %08x] S=%d G=%d ASID=%d Mask= %03X", i,t.VPN2,t.PFN0,t.PFN1,t.S,t.G,t.ASID,t.Mask);
 	u32 mask, addr;
 	u32 saddr, eaddr;
@@ -392,6 +420,21 @@ void WriteTLB(int i)
 namespace R5900 {
 namespace Interpreter {
 namespace OpcodeImpl {
+// Random is a down-counter over the entries TLBWR may replace: from 47 down to
+// Wired, wrapping. It was never written, so it read 0 for the life of the VM and
+// every TLBWR replaced entry 0 -- a 48-entry TLB behaving as a one-entry one.
+// Linux's TLB refill handler installs entries with TLBWR.
+static u32 cop0Random()
+{
+	const u32 wired = cpuRegs.CP0.n.Wired & 0x3f;
+
+	// Nothing left to rotate through (and 48 - wired must not underflow).
+	if (wired >= 47)
+		return 47;
+
+	return 47 - static_cast<u32>(cpuRegs.cycle % (48 - wired));
+}
+
 namespace COP0 {
 
 	void TLBR()
@@ -431,13 +474,14 @@ namespace COP0 {
 		COP0_LOG("COP0_TLBWI %d:%x,%x,%x,%x",
 			cpuRegs.CP0.n.Index, cpuRegs.CP0.n.PageMask, cpuRegs.CP0.n.EntryHi,
 			cpuRegs.CP0.n.EntryLo0, cpuRegs.CP0.n.EntryLo1);
-
 		UnmapTLB(tlb[j], j);
 		WriteTLB(j);
 	}
 
 	void TLBWR()
 	{
+		cpuRegs.CP0.n.Random = cop0Random();
+
 		const u8 j = cpuRegs.CP0.n.Random & 0x3f;
 
 		if (j > 47)
@@ -446,41 +490,37 @@ namespace COP0 {
 			return;
 		}
 
-		DevCon.Warning("COP0_TLBWR %d:%x,%x,%x,%x\n",
+		COP0_LOG("COP0_TLBWR %d:%x,%x,%x,%x\n",
 			cpuRegs.CP0.n.Random, cpuRegs.CP0.n.PageMask, cpuRegs.CP0.n.EntryHi,
 			cpuRegs.CP0.n.EntryLo0, cpuRegs.CP0.n.EntryLo1);
-
 		UnmapTLB(tlb[j], j);
 		WriteTLB(j);
 	}
 
 	void TLBP()
 	{
-		int i;
-
-		union
-		{
-			struct
-			{
-				u32 VPN2 : 19;
-				u32 VPN2X : 2;
-				u32 G : 3;
-				u32 ASID : 8;
-			} s;
-			u32 u;
-		} EntryHi32;
-
-		EntryHi32.u = cpuRegs.CP0.n.EntryHi;
+		// Extract VPN2 and ASID in the register's own field order, and compare on
+		// the same terms as VPN2(), which returns a byte address (<<13). A mismatch
+		// either way makes a probe of a valid entry report "not found", which
+		// Linux's TLB-invalid handler relies on to locate the entry it installed.
+		const u32 probeVPN2 = cpuRegs.CP0.n.EntryHi & ~0x1fffu;
+		const u32 probeASID = cpuRegs.CP0.n.EntryHi & 0xff;
 
 		cpuRegs.CP0.n.Index = 0xFFFFFFFF;
-		for (i = 0; i < 48; i++)
+
+		for (int i = 0; i < 48; i++)
 		{
-			if (tlb[i].VPN2() == ((~tlb[i].Mask()) & (EntryHi32.s.VPN2)) && ((tlb[i].isGlobal()) || ((tlb[i].EntryHi.ASID & 0xff) == EntryHi32.s.ASID)))
-			{
-				cpuRegs.CP0.n.Index = i;
-				break;
-			}
+			// VPN2() has the entry's page mask already applied, so apply the
+			// same mask to the address being probed before comparing.
+			if (tlb[i].VPN2() != (probeVPN2 & ~(tlb[i].Mask() << 13)))
+				continue;
+			if (!tlb[i].isGlobal() && (tlb[i].EntryHi.ASID != probeASID))
+				continue;
+
+			cpuRegs.CP0.n.Index = i;
+			break;
 		}
+
 		if (cpuRegs.CP0.n.Index == 0xFFFFFFFF)
 			cpuRegs.CP0.n.Index = 0x80000000;
 	}
@@ -494,6 +534,12 @@ namespace COP0 {
 		//if(bExecBIOS == FALSE && _Rd_ == 25) Console.WriteLn("MFC0 _Rd_ %x = %x", _Rd_, cpuRegs.CP0.r[_Rd_]);
 		switch (_Rd_)
 		{
+			case 1:
+				// Random is a counter, not a stored value.
+				cpuRegs.CP0.n.Random = cop0Random();
+				cpuRegs.GPR.r[_Rt_].SD[0] = (s32)cpuRegs.CP0.n.Random;
+				break;
+
 			case 12:
 				cpuRegs.GPR.r[_Rt_].SD[0] = (s32)(cpuRegs.CP0.r[_Rd_] & 0xf0c79c1f);
 				break;
@@ -546,6 +592,35 @@ cpuRegs.PERF.n.pccr, cpuRegs.PERF.n.pcr0, cpuRegs.PERF.n.pcr1, _Imm_ & 0x3F);*/
 			case 9:
 				cpuRegs.lastCOP0Cycle = cpuRegs.cycle;
 				cpuRegs.CP0.r[9] = cpuRegs.GPR.r[_Rt_].UL[0];
+				break;
+
+			case 10:
+			{
+				// EntryHi carries the ASID, so writing it can switch address
+				// space. Tear the old one out before building the new one:
+				// they overlap, so interleaving would leave the unmaps
+				// stamping on mappings just installed.
+				const u32 newASID = cpuRegs.GPR.r[_Rt_].UL[0] & 0xff;
+
+				cpuRegs.CP0.n.EntryHi = cpuRegs.GPR.r[_Rt_].UL[0];
+
+				if (newASID != tlbInstalledASID)
+				{
+					for (int t = 0; t < 48; t++)
+						UnmapTLB(tlb[t], t);
+
+					tlbInstalledASID = newASID;
+
+					for (int t = 0; t < 48; t++)
+						MapTLB(tlb[t], t);
+				}
+				break;
+			}
+
+			case 6:
+				// Writing Wired reloads Random with the top TLB index.
+				cpuRegs.CP0.n.Wired = cpuRegs.GPR.r[_Rt_].UL[0];
+				cpuRegs.CP0.n.Random = 47;
 				break;
 
 			case 12:

--- a/pcsx2/Memory.cpp
+++ b/pcsx2/Memory.cpp
@@ -23,6 +23,7 @@ BIOS
 */
 
 #include "DEV9/DEV9.h"
+#include <cstdlib>
 #include "IopHw.h"
 #include "GS/Renderers/Common/GSFunctionMap.h"
 #include "GS.h"
@@ -969,6 +970,11 @@ void memSetPageAddr(u32 vaddr, u32 paddr)
 
 }
 
+void memSetPageAddrReadOnly(u32 vaddr)
+{
+	vtlb_VMapWriteProtected(vaddr, 0x1000);
+}
+
 void memClearPageAddr(u32 vaddr)
 {
 	//Console.WriteLn("memClearPageAddr: %8.8x", vaddr);
@@ -1140,8 +1146,23 @@ void memReset()
 	memMapUserMem();
 	memSetKernelMode();
 
-	vtlb_VMap(0x00000000,0x00000000,0x20000000);
-	vtlb_VMapUnmap(0x20000000,0x60000000);
+	// The user segment is identity-mapped onto physical memory, so an address the
+	// guest never mapped still resolves instead of raising a TLB refill. PS2 Linux
+	// depends on that fault: /sbin/init is linked at 0x00400000 with data at
+	// 0x10000000, both inside this window, so its first userspace fetch would read
+	// whatever physical memory sits there rather than faulting the page in.
+	//
+	// Opt-in, since the identity map is long-standing behaviour for game titles.
+	if (std::getenv("PCSX2_STRICT_USEG"))
+	{
+		Console.WriteLn("memReset: strict user segment, 0-2GB faults unless the guest TLB maps it");
+		vtlb_VMapUnmap(0x00000000, 0x80000000);
+	}
+	else
+	{
+		vtlb_VMap(0x00000000,0x00000000,0x20000000);
+		vtlb_VMapUnmap(0x20000000,0x60000000);
+	}
 
 	std::memset(s_ba, 0, sizeof(s_ba));
 

--- a/pcsx2/Memory.h
+++ b/pcsx2/Memory.h
@@ -162,6 +162,8 @@ namespace SysMemory
 extern void memSetKernelMode();
 //extern void memSetSupervisorMode();
 extern void memSetUserMode();
+// Map a page readable but not writable, so a store raises TLB Modified.
+extern void memSetPageAddrReadOnly(u32 vaddr);
 extern void memSetPageAddr(u32 vaddr, u32 paddr);
 extern void memClearPageAddr(u32 vaddr);
 extern void memBindConditionalHandlers();

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -27,6 +27,7 @@
 #include "DebugTools/MIPSAnalyst.h"
 #include "DebugTools/SymbolGuardian.h"
 #include "R5900OpcodeTables.h"
+#include "DebugTools/Debug.h"
 
 #include "fmt/format.h"
 
@@ -67,6 +68,7 @@ void cpuReset()
 	cpuRegs.pc				= 0xbfc00000; //set pc reg to stack
 	cpuRegs.CP0.n.Config	= 0x440;
 	cpuRegs.CP0.n.Status.val= 0x70400004; //0x10900000 <-- wrong; // COP0 enabled | BEV = 1 | TS = 1
+	cpuRegs.CP0.n.Random	= 47;   // top TLB index; counts down towards Wired
 	cpuRegs.CP0.n.PRid		= 0x00002e20; // PRevID = Revision ID, same as R5900
 	fpuRegs.fprc[0]			= 0x00002e30; // fpu Revision..
 	fpuRegs.fprc[31]		= 0x01000001; // fpu Status/Control
@@ -92,12 +94,17 @@ void cpuReset()
 	CBreakPoints::ClearSkipFirst();
 }
 
+bool eeTlbInvalidMatch = false;   // set by cpuTlbMiss, consumed here
+
 __ri void cpuException(u32 code, u32 bd)
 {
 	bool errLevel2, checkStatus;
 	u32 offset = 0;
 
     cpuRegs.branch = 0;		// Tells the interpreter that an exception occurred during a branch.
+	const bool tlbInvalid = eeTlbInvalidMatch;
+	eeTlbInvalidMatch = false;
+
 	cpuRegs.CP0.n.Cause = code & 0xffff;
 
 	if(cpuRegs.CP0.n.Status.b.ERL == 0)
@@ -107,7 +114,7 @@ __ri void cpuException(u32 code, u32 bd)
 		checkStatus = (cpuRegs.CP0.n.Status.b.BEV == 0); //  for TLB/general exceptions
 
 		if (((code & 0x7C) >= 0x8) && ((code & 0x7C) <= 0xC))
-			offset = 0x0; //TLB Refill
+			offset = tlbInvalid ? 0x180 : 0x0; // TLB Invalid vs Refill
 		else if ((code & 0x7C) == 0x0)
 			offset = 0x200; //Interrupt
 		else
@@ -165,8 +172,41 @@ __ri void cpuException(u32 code, u32 bd)
 	cpuUpdateOperationMode();
 }
 
+// A failed translation raises one of two exceptions, and they use different
+// vectors: no matching entry -> TLB Refill (0x000); a matching entry with V=0
+// -> TLB Invalid (0x180). MapTLB skips V=0 entries, so both arrived here as
+// "not mapped" and were sent to 0x000. Demand paging needs the distinction: the
+// refill handler installs the invalid PTE, and the retry must reach 0x180 so
+// do_page_fault can allocate the page. Sent to 0x000 it reinstalls the same
+// zero PTE indefinitely.
+static bool eeTlbMatches(u32 va)
+{
+	for (int i = 0; i < 48; i++)
+	{
+		const u32 pageSize = (tlb[i].Mask() + 1) << 12;
+		const u32 base = tlb[i].VPN2();
+
+		if (va < base || va >= base + pageSize * 2)
+			continue;
+		if (!tlb[i].isGlobal() && (tlb[i].EntryHi.ASID != (cpuRegs.CP0.n.EntryHi & 0xff)))
+			continue;
+
+		// A matching entry that were valid would not have missed, so reaching
+		// here means it matched and was invalid.
+		return true;
+	}
+	return false;
+}
+
+
+
+
 void cpuTlbMiss(u32 addr, u32 bd, u32 excode)
 {
+	// Must be decided before EntryHi is rewritten below, since the ASID in it
+	// is what the match is against.
+	eeTlbInvalidMatch = eeTlbMatches(addr);
+
 	// Avoid too much spamming on the interpreter
 	if (Cpu != &intCpu || IsDebugBuild) {
 		Console.Error("cpuTlbMiss pc:%x, cycl:%llx, addr: %x, status=%x, code=%x",
@@ -180,6 +220,12 @@ void cpuTlbMiss(u32 addr, u32 bd, u32 excode)
 
 	cpuRegs.pc -= 4;
 	cpuException(excode, bd);
+}
+
+// Store to a page whose EntryLo.D is clear. Vectors to 0x180 like any other
+// non-refill exception, which cpuException already does for this code.
+void cpuTlbModified(u32 addr, u32 bd) {
+	cpuTlbMiss(addr, bd, EXC_CODE(1));
 }
 
 void cpuTlbMissR(u32 addr, u32 bd) {

--- a/pcsx2/R5900.h
+++ b/pcsx2/R5900.h
@@ -398,6 +398,8 @@ extern uint dmacInterrupt();
 
 extern void cpuReset();
 extern void cpuException(u32 code, u32 bd);
+// Raised when the guest stores to a page it mapped with EntryLo.D clear.
+extern void cpuTlbModified(u32 addr, u32 bd);
 extern void cpuTlbMissR(u32 addr, u32 bd);
 extern void cpuTlbMissW(u32 addr, u32 bd);
 extern void cpuTestHwInts();

--- a/pcsx2/R5900OpcodeImpl.cpp
+++ b/pcsx2/R5900OpcodeImpl.cpp
@@ -509,10 +509,23 @@ void DSRLV(){ if (!_Rd_) return; cpuRegs.GPR.r[_Rd_].UD[0] = (u64)(cpuRegs.GPR.r
 
 __noinline static void RaiseAddressError(u32 addr, bool store)
 {
-	const std::string message(fmt::format("Address Error, addr=0x{:x} [{}]", addr, store ? "store" : "load"));
+	// Deliver the exception. EXC_CODE_AdEL/AdES were defined but never raised, so
+	// a misaligned access silently did nothing and left the destination register
+	// unchanged. Linux depends on the trap: MIPS emulates the access in do_ade(),
+	// which is how unaligned loads and stores are serviced at all.
+	//
+	// EPC must point at the faulting instruction, so back pc up first, as
+	// cpuTlbMiss() does.
+	static int spamStop = 0;
+	if (spamStop++ < 50 || IsDevBuild)
+	{
+		Console.Error(fmt::format("Address Error, addr=0x{:x} [{}] pc=0x{:x}",
+			addr, store ? "store" : "load", cpuRegs.pc));
+	}
 
-	// TODO: This doesn't actually get raised in the CPU yet.
-	Console.Error(message);
+	cpuRegs.CP0.n.BadVAddr = addr;
+	cpuRegs.pc -= 4;
+	cpuException(store ? EXC_CODE_AdES : EXC_CODE_AdEL, cpuRegs.branch);
 
 	Cpu->CancelInstruction();
 }
@@ -909,12 +922,37 @@ void SYSCALL()
 {
 	u8 call;
 
+	// The BIOS keys its syscalls on v1, which is correct for software calling the
+	// BIOS. Linux puts its number in v0 and treats v1 as scratch, so a Linux
+	// syscall also selects a handler here -- and GetOsdConfigParam(2) writes to
+	// the address in a0. bash calling connect(3, ...) put 3 in a0, so four bytes
+	// went to address 0x3 and the guest kernel killed it with SIGSEGV.
+	//
+	// v0 alone cannot separate them, and neither can the privilege mode (PS2
+	// threads run in user mode). Add where the call came from: the SBIOS runs
+	// from KSEG0/KSEG1, while Linux userspace is below 0x80000000 and the Linux
+	// kernel never executes a syscall itself. Both together are safe to apply to
+	// the whole switch; skipping it wholesale breaks the SBIOS.
+	const bool linuxSyscall =
+		cpuRegs.GPR.n.v0.UL[0] >= 4000 && cpuRegs.GPR.n.v0.UL[0] < 5000 &&
+		cpuRegs.pc < 0x80000000;
+
 	if (cpuRegs.GPR.n.v1.SL[0] < 0)
 		call = (u8)(-cpuRegs.GPR.n.v1.SL[0]);
 	else
 		call = cpuRegs.GPR.n.v1.UC[0];
 
 	BIOS_LOG("Bios call: %s (%x)", R5900::bios[call], call);
+
+	if (linuxSyscall)
+	{
+		// Run no handler at all: deliver the exception to the guest kernel and
+		// nothing else. Falling through the switch is not enough, because
+		// several handlers touch guest memory before any case is rejected.
+		cpuRegs.pc -= 4;
+		cpuException(0x20, cpuRegs.branch);
+		return;
+	}
 
 
 	switch (static_cast<Syscall>(call))
@@ -999,7 +1037,7 @@ void SYSCALL()
 			AllowParams1 = true;
 			break;
 		case Syscall::GetOsdConfigParam:
-			if (!NoOSD && !AllowParams1)
+			if (!NoOSD && !AllowParams1 && !linuxSyscall)
 			{
 				ReadOSDConfigParames();
 
@@ -1038,7 +1076,7 @@ void SYSCALL()
 			}
 			break;
 		case Syscall::GetOsdConfigParam2:
-			if (!NoOSD && !AllowParams2)
+			if (!NoOSD && !AllowParams2 && !linuxSyscall)
 			{
 				ReadOSDConfigParames();
 
@@ -1046,8 +1084,20 @@ void SYSCALL()
 				u32 size = cpuRegs.GPR.n.a1.UL[0];
 				u32 offset = cpuRegs.GPR.n.a2.UL[0];
 
+				// Rate-limited: PS2 Linux's ps2sysconf reads this on every boot
+				// and floods the log, which buries everything else. The caveat
+				// is worth stating once, not hundreds of times. Same idiom as
+				// vtlb_Miss().
 				if (offset + size > 2)
-					Console.Warning("Warning: GetOsdConfigParam2 Reading extended language/version configs, may be incorrect!");
+				{
+					static int spamStop = 0;
+					if (spamStop++ < 3)
+					{
+						Console.Warning("Warning: GetOsdConfigParam2 Reading extended "
+							"language/version configs, may be incorrect!%s",
+							spamStop == 3 ? " (further instances suppressed)" : "");
+					}
+				}
 
 				for (u32 i = 0; i < size; i++)
 				{

--- a/pcsx2/vtlb.cpp
+++ b/pcsx2/vtlb.cpp
@@ -53,6 +53,7 @@ static vtlbHandler vtlbHandlerCount = 0;
 
 static vtlbHandler DefaultPhyHandler;
 static vtlbHandler UnmappedVirtHandler;
+static vtlbHandler WriteProtectedVirtHandler;
 static vtlbHandler UnmappedPhyHandler;
 
 struct FastmemVirtualMapping
@@ -575,6 +576,76 @@ static RETURNS_R128 vtlbUnmappedVReadLg(u32 addr) { vtlb_Miss(addr, 0); return r
 template <typename OperandType>
 static void vtlbUnmappedVWriteSm(u32 addr, OperandType data) { vtlb_Miss(addr, 1); }
 static void TAKES_R128 vtlbUnmappedVWriteLg(u32 addr, r128 data) { vtlb_Miss(addr, 1); }
+
+// A page the guest mapped with EntryLo.D clear is readable but must raise TLB
+// Modified on a store. The vtlb has no read-only state of its own -- a virtual
+// page is either a direct pointer, which serves reads and writes alike, or a
+// handler -- so write protection has to be a handler that serves the reads
+// itself.
+//
+// Copy-on-write is built on this exception. Without it a store to a page
+// shared by fork() lands in the shared page and parent and child quietly
+// scribble over each other.
+static __ri void vtlb_Modified(u32 addr)
+{
+	if (Cpu == &intCpu)
+	{
+		cpuTlbModified(addr, cpuRegs.branch);
+		Cpu->CancelInstruction();
+		return;
+	}
+
+	static int spamStop = 0;
+	if (spamStop++ < 50 || IsDevBuild)
+		Console.Error("TLB Modified, pc=0x%x addr=0x%x", cpuRegs.pc, addr);
+}
+
+// These pages are mapped vaddr->vaddr so the handler is given the virtual
+// address, which the exception needs; the physical side is resolved here.
+static void* vtlb_WriteProtectedSource(u32 vaddr)
+{
+	for (int i = 0; i < 48; i++)
+	{
+		const u32 pageSize = (tlb[i].Mask() + 1) << 12;
+		const u32 base = tlb[i].VPN2();
+
+		if (vaddr < base || vaddr >= base + pageSize * 2)
+			continue;
+		if (!tlb[i].isGlobal() && (tlb[i].EntryHi.ASID != (cpuRegs.CP0.n.EntryHi & 0xff)))
+			continue;
+
+		const bool odd = (vaddr - base) >= pageSize;
+		const EntryLo_t& lo = odd ? tlb[i].EntryLo1 : tlb[i].EntryLo0;
+		if (!lo.V)
+			return nullptr;
+
+		const u32 paddr = (odd ? tlb[i].PFN1() : tlb[i].PFN0()) + ((vaddr - base) & (pageSize - 1));
+		if (!eeMem || (paddr + 16) > Ps2MemSize::ExposedRam)
+			return nullptr;
+
+		return &eeMem->Main[paddr];
+	}
+	return nullptr;
+}
+
+template <typename OperandType>
+static OperandType vtlbWriteProtReadSm(u32 addr)
+{
+	OperandType value = 0;
+	if (const void* src = vtlb_WriteProtectedSource(addr))
+		std::memcpy(&value, src, sizeof(OperandType));
+	return value;
+}
+static RETURNS_R128 vtlbWriteProtReadLg(u32 addr)
+{
+	if (const void* src = vtlb_WriteProtectedSource(addr))
+		return r128_load(src);
+	return r128_zero();
+}
+
+template <typename OperandType>
+static void vtlbWriteProtWriteSm(u32 addr, OperandType data) { vtlb_Modified(addr); }
+static void TAKES_R128 vtlbWriteProtWriteLg(u32 addr, r128 data) { vtlb_Modified(addr); }
 
 template <typename OperandType>
 static OperandType vtlbUnmappedPReadSm(u32 addr) {
@@ -1220,6 +1291,24 @@ void vtlb_VMapBuffer(u32 vaddr, void* buffer, u32 size)
 	}
 }
 
+void vtlb_VMapWriteProtected(u32 vaddr, u32 size)
+{
+	verify(0 == (vaddr & VTLB_PAGE_MASK));
+	verify(0 == (size & VTLB_PAGE_MASK) && size > 0);
+
+	// Fastmem hands stores straight to host memory with no handler in the way,
+	// so a page that must trap on write cannot have a fastmem mapping.
+	vtlb_RemoveFastmemMappings(vaddr, size);
+
+	while (size > 0)
+	{
+		vtlbdata.vmap[vaddr >> VTLB_PAGE_BITS] =
+			VTLBVirtual(VTLBPhysical::fromHandler(WriteProtectedVirtHandler), vaddr, vaddr);
+		vaddr += VTLB_PAGE_SIZE;
+		size -= VTLB_PAGE_SIZE;
+	}
+}
+
 void vtlb_VMapUnmap(u32 vaddr, u32 size)
 {
 	verify(0 == (vaddr & VTLB_PAGE_MASK));
@@ -1255,6 +1344,7 @@ void vtlb_Init()
 
 	UnmappedVirtHandler = vtlb_RegisterHandler(VTLB_BuildUnmappedHandler(vtlbUnmappedV));
 	UnmappedPhyHandler = vtlb_RegisterHandler(VTLB_BuildUnmappedHandler(vtlbUnmappedP));
+	WriteProtectedVirtHandler = vtlb_RegisterHandler(VTLB_BuildUnmappedHandler(vtlbWriteProt));
 	DefaultPhyHandler = vtlb_RegisterHandler(0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 
 	//done !

--- a/pcsx2/vtlb.h
+++ b/pcsx2/vtlb.h
@@ -70,6 +70,7 @@ extern void vtlb_DynV2P();
 //virtual mappings
 extern void vtlb_VMap(u32 vaddr,u32 paddr,u32 sz);
 extern void vtlb_VMapBuffer(u32 vaddr,void* buffer,u32 sz);
+extern void vtlb_VMapWriteProtected(u32 vaddr,u32 sz);
 extern void vtlb_VMapUnmap(u32 vaddr,u32 sz);
 extern bool vtlb_ResolveFastmemMapping(uptr* addr);
 extern bool vtlb_GetGuestAddress(uptr host_addr, u32* guest_addr);


### PR DESCRIPTION
## What this fixes

The EE MMU emulation has several gaps that no commercial game exercises, but that
any multi-process OS hits immediately. PS2 Linux stops dead at `Freeing unused
kernel memory` in an endless TLB refill loop, and never reaches userspace.

With these changes it boots to an interactive `bash` shell.

### 1. Virtual TLB has no Address Space Identifier

`vtlb` is one flat address space with no notion of an ASID, so it can only hold
one address space at a time. Every process's mappings were written into that same
space and the last writer won — so one process could read another's memory, and a
context switch left stale translations behind. Mappings are now keyed on the ASID,
with only the current one resident.

This is the core fix; the rest are the exception-path details it exposes.

### 2. Exception state not handled

`TLB Refill`, `TLB Modified` and `Address Error` did not populate
`Context` / `EntryHi` / `BadVAddr` the way the hardware does, so the guest's
handler had nothing usable to work from. A guest that actually services its own
TLB misses — as opposed to one whose mappings all happen to be resident — cannot
make progress. This has been a a long-term blocker for PCSX2 in getting Linux running as a guest. Also from what I've heard the DECKARD uses full TLBs to emulate the IOP, so maybe this helps improve emulation on those systems, I haven't fully tested that.

### 3. Branch delay slots

An exception raised in a branch delay slot did not record the delay-slot state, so
the handler returned to the wrong PC.

### 4. BIOS syscall HLE matching Linux syscalls

The BIOS syscall HLE keyed on `v1` alone, which can collide with a Linux userspace
syscall number. It then wrote through a guest pointer taken from `a0`/`a1`,
corrupting memory in whichever process was running. In practice `bash` dies during
startup and `grep` SIGSEGVs. Now guarded so only genuine BIOS syscalls are
intercepted.

Basically a zero-based vs 1-based indexing mismatch

## Testing

- PS2 Linux (kernel 2.4.17) boots to an interactive `bash` shell, on **Linux and
  Windows** hosts.
- No behaviour change for commercial titles: the ASID path is inert when a single
  address space is in use, which is what a game does.

## Scope

Minimalist — only what is needed to boot Linux and get a working shell.
HDD/ATA support, DEV9 networking and logging changes aren't done here as those were even hackier;



Opened as a **draft** for critique. Happy to split this into separate commits per
fix, or rework any of it, if that suits review better.

## LLM usage declaration

Per the contributing guidelines: LLM assistance was used in investigating these
bugs and drafting the patches.

All changes were reviewed, built and boot-tested by me on both Linux and Windows
hosts against real PS2 Linux (kernel 2.4.17) booting to an interactive bash shell.


