### PR TITLE
Low Latency Audio Sync

### DIFF
--- a/pcsx2-qt/Settings/AudioSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.cpp
@@ -52,6 +52,8 @@ AudioSettingsWidget::AudioSettingsWidget(SettingsWindow* settings_dialog, QWidge
 		Pcsx2Config::SPU2Options::DEFAULT_SYNC_MODE);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.bufferMS, "SPU2/Output", "BufferMS",
 		AudioStreamParameters::DEFAULT_BUFFER_MS);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.lowLatencyBufferMS, "SPU2/Output", "LowLatencyBufferMS",
+		AudioStreamParameters::DEFAULT_LOW_LATENCY_BUFFER_MS);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.outputLatencyMS, "SPU2/Output", "OutputLatencyMS",
 		AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MS);
 	connect(m_ui.audioBackend, &QComboBox::currentIndexChanged, this, &AudioSettingsWidget::updateDriverNames);
@@ -64,6 +66,7 @@ AudioSettingsWidget::AudioSettingsWidget(SettingsWindow* settings_dialog, QWidge
 	updateDriverNames();
 
 	connect(m_ui.bufferMS, &QSlider::valueChanged, this, &AudioSettingsWidget::updateLatencyLabel);
+	connect(m_ui.lowLatencyBufferMS, &QSlider::valueChanged, this, &AudioSettingsWidget::updateLatencyLabel);
 	connect(m_ui.outputLatencyMS, &QSlider::valueChanged, this, &AudioSettingsWidget::updateLatencyLabel);
 	updateLatencyLabel();
 
@@ -96,6 +99,9 @@ AudioSettingsWidget::AudioSettingsWidget(SettingsWindow* settings_dialog, QWidge
 		m_ui.bufferMS, tr("Buffer Size"), tr("%1 ms").arg(AudioStreamParameters::DEFAULT_BUFFER_MS),
 		tr("Determines the buffer size which the time stretcher will try to keep filled. It effectively selects the "
 		   "average latency, as audio will be stretched/shrunk to keep the buffer size within check."));
+	dialog()->registerWidgetHelp(m_ui.lowLatencyBufferMS, tr("Low-Latency Buffer"),
+		tr("%1 ms").arg(AudioStreamParameters::DEFAULT_LOW_LATENCY_BUFFER_MS),
+		tr("Larger buffers reduce underrun in exchange for latency."));
 	dialog()->registerWidgetHelp(
 		m_ui.outputLatencyMS, tr("Output Latency"), tr("%1 ms").arg(AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MS),
 		tr("Requests the host output latency. The backend may adjust or reject subminimum values."));
@@ -150,6 +156,15 @@ u32 AudioSettingsWidget::getEffectiveExpansionBlockSize() const
 	return std::has_single_bit(config_block_size) ? config_block_size : std::bit_ceil(config_block_size);
 }
 
+bool AudioSettingsWidget::isLowLatencyMode() const
+{
+	const std::string sync_mode_name = dialog()->getEffectiveStringValue("SPU2/Output", "SyncMode",
+		Pcsx2Config::SPU2Options::GetSyncModeName(Pcsx2Config::SPU2Options::DEFAULT_SYNC_MODE));
+	return Pcsx2Config::SPU2Options::ParseSyncMode(sync_mode_name.c_str())
+	           .value_or(Pcsx2Config::SPU2Options::DEFAULT_SYNC_MODE) ==
+	       Pcsx2Config::SPU2Options::SPU2SyncMode::LowLatency;
+}
+
 void AudioSettingsWidget::onExpansionModeChanged()
 {
 	const AudioExpansionMode expansion_mode = getEffectiveExpansionMode();
@@ -165,7 +180,14 @@ void AudioSettingsWidget::onSyncModeChanged()
 						Pcsx2Config::SPU2Options::GetSyncModeName(Pcsx2Config::SPU2Options::DEFAULT_SYNC_MODE))
 				.c_str())
 			.value_or(Pcsx2Config::SPU2Options::DEFAULT_SYNC_MODE);
-	m_ui.stretchSettings->setEnabled(sync_mode == Pcsx2Config::SPU2Options::SPU2SyncMode::TimeStretch);
+	const bool low_latency = (sync_mode == Pcsx2Config::SPU2Options::SPU2SyncMode::LowLatency);
+	m_ui.stretchSettings->setEnabled(
+		sync_mode == Pcsx2Config::SPU2Options::SPU2SyncMode::TimeStretch || low_latency);
+	m_ui.label_2->setText(low_latency ? tr("TimeStretch Fallback Buffer:") : tr("Buffer Size:"));
+	m_ui.lowLatencyBufferLabel->setVisible(low_latency);
+	m_ui.lowLatencyBufferMS->setVisible(low_latency);
+	m_ui.lowLatencyBufferMSLabel->setVisible(low_latency);
+	updateLatencyLabel();
 }
 
 AudioBackend AudioSettingsWidget::getEffectiveBackend() const
@@ -249,25 +271,29 @@ void AudioSettingsWidget::updateLatencyLabel()
 {
 	const u32 expand_buffer_ms = AudioStream::GetMSForFrames(SPU2::SAMPLE_RATE, getEffectiveExpansionBlockSize());
 	const u32 config_buffer_ms = dialog()->getEffectiveIntValue("SPU2/Output", "BufferMS", AudioStreamParameters::DEFAULT_BUFFER_MS);
+	const u32 config_low_latency_buffer_ms = dialog()->getEffectiveIntValue(
+		"SPU2/Output", "LowLatencyBufferMS", AudioStreamParameters::DEFAULT_LOW_LATENCY_BUFFER_MS);
 	const u32 config_output_latency_ms = dialog()->getEffectiveIntValue("SPU2/Output", "OutputLatencyMS", AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MS);
+	const u32 selected_buffer_ms = isLowLatencyMode() ? config_low_latency_buffer_ms : config_buffer_ms;
 
 	//: Preserve the %1 variable, adapt the latter ms (and/or any possible spaces in between) to your language's ruleset.
 	m_ui.outputLatencyLabel->setText(tr("%1 ms").arg(config_output_latency_ms));
 	m_ui.bufferMSLabel->setText(tr("%1 ms").arg(config_buffer_ms));
+	m_ui.lowLatencyBufferMSLabel->setText(tr("%1 ms").arg(config_low_latency_buffer_ms));
 
 	if (expand_buffer_ms > 0)
 	{
 		m_ui.bufferingLabel->setText(tr("Maximum Latency: %1 ms (%2 ms buffer + %3 ms expand + %4 ms output)")
-				.arg(config_buffer_ms + expand_buffer_ms + config_output_latency_ms)
-				.arg(config_buffer_ms)
+				.arg(selected_buffer_ms + expand_buffer_ms + config_output_latency_ms)
+				.arg(selected_buffer_ms)
 				.arg(expand_buffer_ms)
 				.arg(config_output_latency_ms));
 	}
 	else
 	{
 		m_ui.bufferingLabel->setText(tr("Maximum Latency: %1 ms (%2 ms buffer + %3 ms output)")
-				.arg(config_buffer_ms + config_output_latency_ms)
-				.arg(config_buffer_ms)
+				.arg(selected_buffer_ms + config_output_latency_ms)
+				.arg(selected_buffer_ms)
 				.arg(config_output_latency_ms));
 	}
 }

--- a/pcsx2-qt/Settings/AudioSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.cpp
@@ -54,7 +54,6 @@ AudioSettingsWidget::AudioSettingsWidget(SettingsWindow* settings_dialog, QWidge
 		AudioStreamParameters::DEFAULT_BUFFER_MS);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.outputLatencyMS, "SPU2/Output", "OutputLatencyMS",
 		AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MS);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.outputLatencyMinimal, "SPU2/Output", "OutputLatencyMinimal", false);
 	connect(m_ui.audioBackend, &QComboBox::currentIndexChanged, this, &AudioSettingsWidget::updateDriverNames);
 	connect(m_ui.expansionMode, &QComboBox::currentIndexChanged, this, &AudioSettingsWidget::onExpansionModeChanged);
 	connect(m_ui.expansionSettings, &QToolButton::clicked, this, &AudioSettingsWidget::onExpansionSettingsClicked);
@@ -66,8 +65,6 @@ AudioSettingsWidget::AudioSettingsWidget(SettingsWindow* settings_dialog, QWidge
 
 	connect(m_ui.bufferMS, &QSlider::valueChanged, this, &AudioSettingsWidget::updateLatencyLabel);
 	connect(m_ui.outputLatencyMS, &QSlider::valueChanged, this, &AudioSettingsWidget::updateLatencyLabel);
-	connect(m_ui.outputLatencyMinimal, &QCheckBox::checkStateChanged, this, &AudioSettingsWidget::onMinimalOutputLatencyChanged);
-	onMinimalOutputLatencyChanged();
 	updateLatencyLabel();
 
 	// for per-game, just use the normal path, since it needs to re-read/apply
@@ -101,11 +98,7 @@ AudioSettingsWidget::AudioSettingsWidget(SettingsWindow* settings_dialog, QWidge
 		   "average latency, as audio will be stretched/shrunk to keep the buffer size within check."));
 	dialog()->registerWidgetHelp(
 		m_ui.outputLatencyMS, tr("Output Latency"), tr("%1 ms").arg(AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MS),
-		tr("Determines the latency from the buffer to the host audio output. This can be set lower than the target latency "
-		   "to reduce audio delay."));
-	dialog()->registerWidgetHelp(
-		m_ui.outputLatencyMinimal, tr("Minimal Output Latency"), tr("Unchecked"),
-		tr("When enabled, the minimum supported output latency will be used for the host API."));
+		tr("Requests the host output latency. The backend may adjust or reject subminimum values."));
 	dialog()->registerWidgetHelp(
 		m_ui.driver, tr("Driver"), tr("Default"),
 		tr("Selects the host audio driver used by the audio backend."));
@@ -219,7 +212,6 @@ void AudioSettingsWidget::updateDeviceNames()
 
 	QObject::disconnect(m_ui.outputDevice, &QComboBox::currentIndexChanged, nullptr, nullptr);
 	m_ui.outputDevice->clear();
-	m_output_device_latency = 0;
 
 	if (devices.empty())
 	{
@@ -236,7 +228,6 @@ void AudioSettingsWidget::updateDeviceNames()
 			m_ui.outputDevice->addItem(QString::fromStdString(di.display_name), QString::fromStdString(di.name));
 			if (di.name == current_device)
 			{
-				m_output_device_latency = di.minimum_latency_frames;
 				is_known_device = true;
 			}
 		}
@@ -256,46 +247,28 @@ void AudioSettingsWidget::updateDeviceNames()
 
 void AudioSettingsWidget::updateLatencyLabel()
 {
-	const u32 expand_buffer_ms = AudioStream::GetMSForBufferSize(SPU2::SAMPLE_RATE, getEffectiveExpansionBlockSize());
+	const u32 expand_buffer_ms = AudioStream::GetMSForFrames(SPU2::SAMPLE_RATE, getEffectiveExpansionBlockSize());
 	const u32 config_buffer_ms = dialog()->getEffectiveIntValue("SPU2/Output", "BufferMS", AudioStreamParameters::DEFAULT_BUFFER_MS);
 	const u32 config_output_latency_ms = dialog()->getEffectiveIntValue("SPU2/Output", "OutputLatencyMS", AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MS);
-	const bool minimal_output = dialog()->getEffectiveBoolValue("SPU2/Output", "OutputLatencyMinimal", false);
 
 	//: Preserve the %1 variable, adapt the latter ms (and/or any possible spaces in between) to your language's ruleset.
-	m_ui.outputLatencyLabel->setText(minimal_output ? tr("N/A") : tr("%1 ms").arg(config_output_latency_ms));
+	m_ui.outputLatencyLabel->setText(tr("%1 ms").arg(config_output_latency_ms));
 	m_ui.bufferMSLabel->setText(tr("%1 ms").arg(config_buffer_ms));
 
-	const u32 output_latency_ms = minimal_output ? AudioStream::GetMSForBufferSize(SPU2::SAMPLE_RATE, m_output_device_latency) : config_output_latency_ms;
-	if (output_latency_ms > 0)
+	if (expand_buffer_ms > 0)
 	{
-		if (expand_buffer_ms > 0)
-		{
-			m_ui.bufferingLabel->setText(tr("Maximum Latency: %1 ms (%2 ms buffer + %3 ms expand + %4 ms output)")
-					.arg(config_buffer_ms + expand_buffer_ms + output_latency_ms)
-					.arg(config_buffer_ms)
-					.arg(expand_buffer_ms)
-					.arg(output_latency_ms));
-		}
-		else
-		{
-			m_ui.bufferingLabel->setText(tr("Maximum Latency: %1 ms (%2 ms buffer + %3 ms output)")
-					.arg(config_buffer_ms + output_latency_ms)
-					.arg(config_buffer_ms)
-					.arg(output_latency_ms));
-		}
+		m_ui.bufferingLabel->setText(tr("Maximum Latency: %1 ms (%2 ms buffer + %3 ms expand + %4 ms output)")
+				.arg(config_buffer_ms + expand_buffer_ms + config_output_latency_ms)
+				.arg(config_buffer_ms)
+				.arg(expand_buffer_ms)
+				.arg(config_output_latency_ms));
 	}
 	else
 	{
-		if (expand_buffer_ms > 0)
-		{
-			m_ui.bufferingLabel->setText(tr("Maximum Latency: %1 ms (%2 ms expand, minimum output latency unknown)")
-					.arg(expand_buffer_ms + config_buffer_ms)
-					.arg(expand_buffer_ms));
-		}
-		else
-		{
-			m_ui.bufferingLabel->setText(tr("Maximum Latency: %1 ms (minimum output latency unknown)").arg(config_buffer_ms));
-		}
+		m_ui.bufferingLabel->setText(tr("Maximum Latency: %1 ms (%2 ms buffer + %3 ms output)")
+				.arg(config_buffer_ms + config_output_latency_ms)
+				.arg(config_buffer_ms)
+				.arg(config_output_latency_ms));
 	}
 }
 
@@ -303,13 +276,6 @@ void AudioSettingsWidget::updateVolumeLabel()
 {
 	m_ui.standardVolumeLabel->setText(tr("%1%").arg(m_ui.standardVolume->value()));
 	m_ui.fastForwardVolumeLabel->setText(tr("%1%").arg(m_ui.fastForwardVolume->value()));
-}
-
-void AudioSettingsWidget::onMinimalOutputLatencyChanged()
-{
-	const bool minimal = dialog()->getEffectiveBoolValue("SPU2/Output", "OutputLatencyMinimal", false);
-	m_ui.outputLatencyMS->setEnabled(!minimal);
-	updateLatencyLabel();
 }
 
 void AudioSettingsWidget::onStandardVolumeChanged(const int new_value)

--- a/pcsx2-qt/Settings/AudioSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.cpp
@@ -18,6 +18,8 @@
 #include <algorithm>
 #include <bit>
 
+static constexpr int MINIMUM_LATENCY_FRAMES_ROLE = Qt::UserRole + 1;
+
 AudioSettingsWidget::AudioSettingsWidget(SettingsWindow* settings_dialog, QWidget* parent)
 	: SettingsWidget(settings_dialog, parent)
 {
@@ -156,13 +158,17 @@ u32 AudioSettingsWidget::getEffectiveExpansionBlockSize() const
 	return std::has_single_bit(config_block_size) ? config_block_size : std::bit_ceil(config_block_size);
 }
 
-bool AudioSettingsWidget::isLowLatencyMode() const
+AudioSynchronizationMode AudioSettingsWidget::getEffectiveSyncMode() const
 {
 	const std::string sync_mode_name = dialog()->getEffectiveStringValue("SPU2/Output", "SyncMode",
 		Pcsx2Config::SPU2Options::GetSyncModeName(Pcsx2Config::SPU2Options::DEFAULT_SYNC_MODE));
 	return Pcsx2Config::SPU2Options::ParseSyncMode(sync_mode_name.c_str())
-	           .value_or(Pcsx2Config::SPU2Options::DEFAULT_SYNC_MODE) ==
-	       Pcsx2Config::SPU2Options::SPU2SyncMode::LowLatency;
+		.value_or(Pcsx2Config::SPU2Options::DEFAULT_SYNC_MODE);
+}
+
+u32 AudioSettingsWidget::getMinimumOutputLatencyMS() const
+{
+	return AudioStream::GetMSForFramesCeil(SPU2::SAMPLE_RATE, m_minimum_output_latency_frames);
 }
 
 void AudioSettingsWidget::onExpansionModeChanged()
@@ -174,15 +180,9 @@ void AudioSettingsWidget::onExpansionModeChanged()
 
 void AudioSettingsWidget::onSyncModeChanged()
 {
-	const Pcsx2Config::SPU2Options::SPU2SyncMode sync_mode =
-		Pcsx2Config::SPU2Options::ParseSyncMode(
-			dialog()->getEffectiveStringValue("SPU2/Output", "SyncMode",
-						Pcsx2Config::SPU2Options::GetSyncModeName(Pcsx2Config::SPU2Options::DEFAULT_SYNC_MODE))
-				.c_str())
-			.value_or(Pcsx2Config::SPU2Options::DEFAULT_SYNC_MODE);
-	const bool low_latency = (sync_mode == Pcsx2Config::SPU2Options::SPU2SyncMode::LowLatency);
-	m_ui.stretchSettings->setEnabled(
-		sync_mode == Pcsx2Config::SPU2Options::SPU2SyncMode::TimeStretch || low_latency);
+	const AudioSynchronizationMode sync_mode = getEffectiveSyncMode();
+	const bool low_latency = (sync_mode == AudioSynchronizationMode::LowLatency);
+	m_ui.stretchSettings->setEnabled(sync_mode == AudioSynchronizationMode::TimeStretch || low_latency);
 	m_ui.label_2->setText(low_latency ? tr("TimeStretch Fallback Buffer:") : tr("Buffer Size:"));
 	m_ui.lowLatencyBufferLabel->setVisible(low_latency);
 	m_ui.lowLatencyBufferMS->setVisible(low_latency);
@@ -234,6 +234,7 @@ void AudioSettingsWidget::updateDeviceNames()
 
 	QObject::disconnect(m_ui.outputDevice, &QComboBox::currentIndexChanged, nullptr, nullptr);
 	m_ui.outputDevice->clear();
+	m_minimum_output_latency_frames = 0;
 
 	if (devices.empty())
 	{
@@ -248,8 +249,11 @@ void AudioSettingsWidget::updateDeviceNames()
 		for (const AudioStream::DeviceInfo& di : devices)
 		{
 			m_ui.outputDevice->addItem(QString::fromStdString(di.display_name), QString::fromStdString(di.name));
+			m_ui.outputDevice->setItemData(
+				m_ui.outputDevice->count() - 1, di.minimum_latency_frames, MINIMUM_LATENCY_FRAMES_ROLE);
 			if (di.name == current_device)
 			{
+				m_minimum_output_latency_frames = di.minimum_latency_frames;
 				is_known_device = true;
 			}
 		}
@@ -262,8 +266,15 @@ void AudioSettingsWidget::updateDeviceNames()
 
 		SettingWidgetBinder::BindWidgetToStringSetting(dialog()->getSettingsInterface(), m_ui.outputDevice, "SPU2/Output",
 			"DeviceName", std::move(devices.front().name));
+		connect(m_ui.outputDevice, &QComboBox::currentIndexChanged, this, &AudioSettingsWidget::onOutputDeviceChanged);
 	}
 
+	updateLatencyLabel();
+}
+
+void AudioSettingsWidget::onOutputDeviceChanged(int index)
+{
+	m_minimum_output_latency_frames = m_ui.outputDevice->itemData(index, MINIMUM_LATENCY_FRAMES_ROLE).toUInt();
 	updateLatencyLabel();
 }
 
@@ -274,13 +285,33 @@ void AudioSettingsWidget::updateLatencyLabel()
 	const u32 config_low_latency_buffer_ms = dialog()->getEffectiveIntValue(
 		"SPU2/Output", "LowLatencyBufferMS", AudioStreamParameters::DEFAULT_LOW_LATENCY_BUFFER_MS);
 	const u32 config_output_latency_ms = dialog()->getEffectiveIntValue("SPU2/Output", "OutputLatencyMS", AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MS);
-	const u32 selected_buffer_ms = isLowLatencyMode() ? config_low_latency_buffer_ms : config_buffer_ms;
+	const u32 selected_buffer_ms =
+		(getEffectiveSyncMode() == AudioSynchronizationMode::LowLatency) ? config_low_latency_buffer_ms : config_buffer_ms;
+	const u32 minimum_output_latency_ms = getMinimumOutputLatencyMS();
 
 	//: Preserve the %1 variable, adapt the latter ms (and/or any possible spaces in between) to your language's ruleset.
 	m_ui.outputLatencyLabel->setText(tr("%1 ms").arg(config_output_latency_ms));
 	m_ui.bufferMSLabel->setText(tr("%1 ms").arg(config_buffer_ms));
 	m_ui.lowLatencyBufferMSLabel->setText(tr("%1 ms").arg(config_low_latency_buffer_ms));
-
+	if (minimum_output_latency_ms > 0)
+	{
+		if (config_output_latency_ms < minimum_output_latency_ms)
+		{
+			m_ui.outputLatencyStatusLabel->setText(
+				tr("Reported minimum: %1 ms. Requested latency: %2 ms. If audio is poor, increase the requested latency.")
+					.arg(minimum_output_latency_ms)
+					.arg(config_output_latency_ms));
+		}
+		else
+		{
+			m_ui.outputLatencyStatusLabel->setText(tr("Backend minimum: %1 ms").arg(minimum_output_latency_ms));
+		}
+		m_ui.outputLatencyStatusLabel->show();
+	}
+	else
+	{
+		m_ui.outputLatencyStatusLabel->hide();
+	}
 	if (expand_buffer_ms > 0)
 	{
 		m_ui.bufferingLabel->setText(tr("Maximum Latency: %1 ms (%2 ms buffer + %3 ms expand + %4 ms output)")

--- a/pcsx2-qt/Settings/AudioSettingsWidget.h
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.h
@@ -9,6 +9,7 @@
 
 enum class AudioBackend : u8;
 enum class AudioExpansionMode : u8;
+enum class AudioSynchronizationMode : u8;
 
 class AudioSettingsWidget : public SettingsWidget
 {
@@ -24,6 +25,7 @@ private Q_SLOTS:
 
 	void updateDriverNames();
 	void updateDeviceNames();
+	void onOutputDeviceChanged(int index);
 	void updateLatencyLabel();
 	void updateVolumeLabel();
 	void onStandardVolumeChanged(const int new_value);
@@ -36,9 +38,11 @@ private Q_SLOTS:
 private:
 	AudioBackend getEffectiveBackend() const;
 	AudioExpansionMode getEffectiveExpansionMode() const;
+	AudioSynchronizationMode getEffectiveSyncMode() const;
 	u32 getEffectiveExpansionBlockSize() const;
-	bool isLowLatencyMode() const;
+	u32 getMinimumOutputLatencyMS() const;
 	void resetVolume(const bool fast_forward);
 
 	Ui::AudioSettingsWidget m_ui;
+	u32 m_minimum_output_latency_frames = 0;
 };

--- a/pcsx2-qt/Settings/AudioSettingsWidget.h
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.h
@@ -26,7 +26,6 @@ private Q_SLOTS:
 	void updateDeviceNames();
 	void updateLatencyLabel();
 	void updateVolumeLabel();
-	void onMinimalOutputLatencyChanged();
 	void onStandardVolumeChanged(const int new_value);
 	void onFastForwardVolumeChanged(const int new_value);
 	void onOutputMutedChanged(const int new_state);
@@ -41,5 +40,4 @@ private:
 	void resetVolume(const bool fast_forward);
 
 	Ui::AudioSettingsWidget m_ui;
-	u32 m_output_device_latency = 0;
 };

--- a/pcsx2-qt/Settings/AudioSettingsWidget.h
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.h
@@ -37,6 +37,7 @@ private:
 	AudioBackend getEffectiveBackend() const;
 	AudioExpansionMode getEffectiveExpansionMode() const;
 	u32 getEffectiveExpansionBlockSize() const;
+	bool isLowLatencyMode() const;
 	void resetVolume(const bool fast_forward);
 
 	Ui::AudioSettingsWidget m_ui;

--- a/pcsx2-qt/Settings/AudioSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.ui
@@ -125,7 +125,7 @@
         </property>
        </widget>
       </item>
-      <item row="7" column="0" colspan="2">
+      <item row="8" column="0" colspan="2">
        <widget class="QLabel" name="bufferingLabel">
         <property name="text">
          <string>Maximum latency: 0 frames (0.00ms)</string>
@@ -148,7 +148,7 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="1">
+      <item row="7" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout_3">
         <item>
          <widget class="QSlider" name="outputLatencyMS">
@@ -181,7 +181,7 @@
       <item row="0" column="1">
        <widget class="QComboBox" name="audioBackend"/>
       </item>
-      <item row="6" column="0">
+      <item row="7" column="0">
        <widget class="QLabel" name="label_5">
         <property name="text">
          <string>Output Latency:</string>
@@ -223,6 +223,55 @@
          <cstring>syncMode</cstring>
         </property>
        </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="lowLatencyBufferLabel">
+        <property name="text">
+         <string>Low-Latency Buffer:</string>
+        </property>
+        <property name="buddy">
+         <cstring>lowLatencyBufferMS</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <layout class="QHBoxLayout" name="lowLatencyBufferLayout" stretch="1,0">
+        <item>
+         <widget class="QSlider" name="lowLatencyBufferMS">
+          <property name="minimum">
+           <number>10</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="singleStep">
+           <number>1</number>
+          </property>
+          <property name="pageStep">
+           <number>5</number>
+          </property>
+          <property name="value">
+           <number>20</number>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Orientation::Horizontal</enum>
+          </property>
+          <property name="tickPosition">
+           <enum>QSlider::TickPosition::TicksBothSides</enum>
+          </property>
+          <property name="tickInterval">
+           <number>10</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="lowLatencyBufferMSLabel">
+          <property name="text">
+           <string>20 ms</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>
@@ -385,6 +434,7 @@
   <tabstop>syncMode</tabstop>
   <tabstop>stretchSettings</tabstop>
   <tabstop>bufferMS</tabstop>
+  <tabstop>lowLatencyBufferMS</tabstop>
   <tabstop>outputLatencyMS</tabstop>
   <tabstop>standardVolume</tabstop>
   <tabstop>resetStandardVolume</tabstop>

--- a/pcsx2-qt/Settings/AudioSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.ui
@@ -153,7 +153,7 @@
         <item>
          <widget class="QSlider" name="outputLatencyMS">
           <property name="minimum">
-           <number>15</number>
+           <number>1</number>
           </property>
           <property name="maximum">
            <number>200</number>
@@ -173,13 +173,6 @@
          <widget class="QLabel" name="outputLatencyLabel">
           <property name="text">
            <string>0 ms</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="outputLatencyMinimal">
-          <property name="text">
-           <string>Minimal</string>
           </property>
          </widget>
         </item>
@@ -393,7 +386,6 @@
   <tabstop>stretchSettings</tabstop>
   <tabstop>bufferMS</tabstop>
   <tabstop>outputLatencyMS</tabstop>
-  <tabstop>outputLatencyMinimal</tabstop>
   <tabstop>standardVolume</tabstop>
   <tabstop>resetStandardVolume</tabstop>
   <tabstop>fastForwardVolume</tabstop>

--- a/pcsx2-qt/Settings/AudioSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.ui
@@ -125,7 +125,7 @@
         </property>
        </widget>
       </item>
-      <item row="8" column="0" colspan="2">
+      <item row="9" column="0" colspan="2">
        <widget class="QLabel" name="bufferingLabel">
         <property name="text">
          <string>Maximum latency: 0 frames (0.00ms)</string>
@@ -177,6 +177,19 @@
          </widget>
         </item>
        </layout>
+      </item>
+      <item row="8" column="0" colspan="2">
+       <widget class="QLabel" name="outputLatencyStatusLabel">
+        <property name="text">
+         <string>Backend minimum: 0 ms</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
       </item>
       <item row="0" column="1">
        <widget class="QComboBox" name="audioBackend"/>

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -828,11 +828,15 @@ set(pcsx2DebugToolsHeaders
 	DebugTools/BiosDebugData.h)
 
 set(pcsx2HostSources
+	Host/AudioRateController.cpp
+	Host/AudioRateResampler.cpp
 	Host/AudioStream.cpp
 	Host/CubebAudioStream.cpp
 	Host/SDLAudioStream.cpp)
 
 set(pcsx2HostHeaders
+	Host/AudioRateController.h
+	Host/AudioRateResampler.h
 	Host/AudioStream.h
 	Host/AudioStreamTypes.h)
 

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -969,12 +969,7 @@ struct Pcsx2Config
 
 	struct SPU2Options
 	{
-		enum class SPU2SyncMode : u8
-		{
-			Disabled,
-			TimeStretch,
-			Count
-		};
+		using SPU2SyncMode = AudioSynchronizationMode;
 
 		static constexpr s32 MAX_VOLUME = 200;
 		static constexpr AudioBackend DEFAULT_BACKEND = AudioBackend::Cubeb;
@@ -1016,8 +1011,6 @@ struct Pcsx2Config
 		SPU2Options();
 
 		void LoadSave(SettingsWrapper& wrap);
-
-		bool IsTimeStretchEnabled() const { return (SyncMode == SPU2SyncMode::TimeStretch); }
 
 		bool operator==(const SPU2Options& right) const;
 		bool operator!=(const SPU2Options& right) const;

--- a/pcsx2/Host/AudioRateController.cpp
+++ b/pcsx2/Host/AudioRateController.cpp
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "Host/AudioRateController.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace
+{
+	constexpr float CORRECTION_LIMIT = 0.01f;
+	constexpr float FILTER_TIME_CONSTANT_SECONDS = 0.025f;
+	constexpr float PROPORTIONAL_GAIN = 0.012f;
+	constexpr float INTEGRAL_GAIN_PER_SECOND = 0.040f;
+	constexpr float CORRECTION_SLEW_PER_SECOND = 0.040f;
+	constexpr float INTEGRAL_DECAY_SECONDS = 0.75f;
+	constexpr float SATURATION_RELEASE_MARGIN = 0.0005f;
+} // namespace
+
+AudioRateController::AudioRateController(u32 sample_rate, u32 target_frames)
+	: m_sample_rate(std::max(sample_rate, 1u))
+	, m_target_frames(std::max(target_frames, 1u))
+{
+	Reset();
+}
+
+void AudioRateController::Reset()
+{
+	m_filtered_buffered_frames = static_cast<float>(m_target_frames);
+	m_integral = 0.0f;
+	m_correction = 1.0f;
+	m_saturation_direction = 0;
+}
+
+float AudioRateController::Update(
+	u32 buffered_frames, u32 callback_frames, u32 input_frames, float nominal_rate, bool discontinuity)
+{
+	const float target_frames = static_cast<float>(m_target_frames);
+	const float dt = static_cast<float>(std::max(input_frames, 1u)) / static_cast<float>(m_sample_rate);
+	if (discontinuity)
+	{
+		m_filtered_buffered_frames = static_cast<float>(buffered_frames);
+		m_integral = 0.0f;
+		m_saturation_direction = 0;
+	}
+
+	const float filter_alpha = 1.0f - std::exp(-dt / FILTER_TIME_CONSTANT_SECONDS);
+	m_filtered_buffered_frames +=
+		(static_cast<float>(buffered_frames) - m_filtered_buffered_frames) * filter_alpha;
+
+	float error_frames = m_filtered_buffered_frames - target_frames;
+	const float deadband_frames = std::max(static_cast<float>(m_sample_rate) * 0.001f,
+		static_cast<float>(callback_frames) * 0.20f);
+	if (std::abs(error_frames) <= deadband_frames)
+	{
+		error_frames = 0.0f;
+		m_integral *= std::exp(-dt / INTEGRAL_DECAY_SECONDS);
+	}
+	else
+	{
+		const float normalized_error = error_frames / target_frames;
+		const float proposed_integral = m_integral + normalized_error * INTEGRAL_GAIN_PER_SECOND * dt;
+		const float proposed_delta = PROPORTIONAL_GAIN * normalized_error + proposed_integral;
+		// Stop integrating while the error would push farther beyond a correction limit.
+		if (std::abs(proposed_delta) <= CORRECTION_LIMIT ||
+			(proposed_delta > CORRECTION_LIMIT && normalized_error < 0.0f) ||
+			(proposed_delta < -CORRECTION_LIMIT && normalized_error > 0.0f))
+		{
+			m_integral = proposed_integral;
+		}
+	}
+
+	const float normalized_error = error_frames / target_frames;
+	const float unclamped_correction = 1.0f + PROPORTIONAL_GAIN * normalized_error + m_integral;
+	const float lower_limit = 1.0f - CORRECTION_LIMIT;
+	const float upper_limit = 1.0f + CORRECTION_LIMIT;
+	if ((m_saturation_direction < 0 && unclamped_correction >= (lower_limit + SATURATION_RELEASE_MARGIN)) ||
+		(m_saturation_direction > 0 && unclamped_correction <= (upper_limit - SATURATION_RELEASE_MARGIN)))
+	{
+		m_saturation_direction = 0;
+	}
+	if (m_saturation_direction == 0)
+	{
+		if (unclamped_correction <= lower_limit)
+			m_saturation_direction = -1;
+		else if (unclamped_correction >= upper_limit)
+			m_saturation_direction = 1;
+	}
+
+	// Apply hysteresis at the correction limits to prevent callback jitter from repeatedly entering and leaving saturation.
+	const float requested_correction = (m_saturation_direction < 0) ? lower_limit :
+	                                   (m_saturation_direction > 0) ? upper_limit :
+	                                                                  unclamped_correction;
+	const float max_slew = CORRECTION_SLEW_PER_SECOND * dt;
+	m_correction += std::clamp(requested_correction - m_correction, -max_slew, max_slew);
+	m_correction = std::clamp(m_correction, lower_limit, upper_limit);
+
+	return std::max(nominal_rate, 0.0f) * m_correction;
+}

--- a/pcsx2/Host/AudioRateController.cpp
+++ b/pcsx2/Host/AudioRateController.cpp
@@ -6,16 +6,13 @@
 #include <algorithm>
 #include <cmath>
 
-namespace
-{
-	constexpr float CORRECTION_LIMIT = 0.01f;
-	constexpr float FILTER_TIME_CONSTANT_SECONDS = 0.025f;
-	constexpr float PROPORTIONAL_GAIN = 0.012f;
-	constexpr float INTEGRAL_GAIN_PER_SECOND = 0.040f;
-	constexpr float CORRECTION_SLEW_PER_SECOND = 0.040f;
-	constexpr float INTEGRAL_DECAY_SECONDS = 0.75f;
-	constexpr float SATURATION_RELEASE_MARGIN = 0.0005f;
-} // namespace
+constexpr float CORRECTION_LIMIT = 0.01f;
+constexpr float FILTER_TIME_CONSTANT_SECONDS = 0.025f;
+constexpr float PROPORTIONAL_GAIN = 0.012f;
+constexpr float INTEGRAL_GAIN_PER_SECOND = 0.040f;
+constexpr float CORRECTION_SLEW_PER_SECOND = 0.040f;
+constexpr float INTEGRAL_DECAY_SECONDS = 0.75f;
+constexpr float SATURATION_RELEASE_MARGIN = 0.0005f;
 
 AudioRateController::AudioRateController(u32 sample_rate, u32 target_frames)
 	: m_sample_rate(std::max(sample_rate, 1u))

--- a/pcsx2/Host/AudioRateController.h
+++ b/pcsx2/Host/AudioRateController.h
@@ -15,7 +15,7 @@ public:
 
 private:
 	u32 m_sample_rate;
-	u32 m_target_frames = 1;
+	u32 m_target_frames;
 	float m_filtered_buffered_frames = 0.0f;
 	float m_integral = 0.0f;
 	float m_correction = 1.0f;

--- a/pcsx2/Host/AudioRateController.h
+++ b/pcsx2/Host/AudioRateController.h
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#pragma once
+
+#include "common/Pcsx2Defs.h"
+
+class AudioRateController
+{
+public:
+	AudioRateController(u32 sample_rate, u32 target_frames);
+
+	void Reset();
+	float Update(u32 buffered_frames, u32 callback_frames, u32 input_frames, float nominal_rate, bool discontinuity);
+
+private:
+	u32 m_sample_rate;
+	u32 m_target_frames = 1;
+	float m_filtered_buffered_frames = 0.0f;
+	float m_integral = 0.0f;
+	float m_correction = 1.0f;
+	s8 m_saturation_direction = 0;
+};

--- a/pcsx2/Host/AudioRateResampler.cpp
+++ b/pcsx2/Host/AudioRateResampler.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "Host/AudioRateResampler.h"
+
+#include "../../3rdparty/soundtouch/source/SoundTouch/RateTransposer.h"
+
+#include <cmath>
+#include <vector>
+
+AudioRateResampler::AudioRateResampler(u32 channels)
+{
+	m_transposer = std::make_unique<soundtouch::RateTransposer>();
+	m_transposer->setChannels(static_cast<int>(channels));
+	m_transposer->enableAAFilter(false);
+	m_transposer->setRate(1.0);
+
+	// Preallocate SoundTouch's internal FIFOs before entering the real-time path.
+	static constexpr u32 PREWARM_FRAMES = 4096;
+	std::vector<float> silence(PREWARM_FRAMES * channels, 0.0f);
+	for (const double rate : {0.94, 1.07})
+	{
+		m_transposer->setRate(rate);
+		m_transposer->putSamples(silence.data(), PREWARM_FRAMES);
+		m_transposer->receiveSamples(m_transposer->numSamples());
+		m_transposer->clear();
+	}
+
+	m_transposer->setRate(1.0);
+	m_transposer->clear();
+}
+
+AudioRateResampler::~AudioRateResampler() = default;
+
+void AudioRateResampler::Reset()
+{
+	m_transposer->clear();
+}
+
+void AudioRateResampler::SetRate(float rate)
+{
+	if (!std::isfinite(rate) || rate <= 0.0f)
+		return;
+
+	m_transposer->setRate(static_cast<double>(rate));
+}
+
+void AudioRateResampler::PutFrames(const float* frames, u32 num_frames)
+{
+	m_transposer->putSamples(frames, num_frames);
+}
+
+u32 AudioRateResampler::ReceiveFrames(float* frames, u32 max_frames)
+{
+	return m_transposer->receiveSamples(frames, max_frames);
+}
+
+u32 AudioRateResampler::GetAvailableFrames() const
+{
+	return m_transposer->numSamples();
+}

--- a/pcsx2/Host/AudioRateResampler.h
+++ b/pcsx2/Host/AudioRateResampler.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#pragma once
+
+#include "common/Pcsx2Defs.h"
+
+#include <memory>
+
+namespace soundtouch
+{
+	class RateTransposer;
+}
+
+class AudioRateResampler
+{
+public:
+	explicit AudioRateResampler(u32 channels);
+	~AudioRateResampler();
+
+	AudioRateResampler(const AudioRateResampler&) = delete;
+	AudioRateResampler& operator=(const AudioRateResampler&) = delete;
+
+	void Reset();
+	void SetRate(float rate);
+	void PutFrames(const float* frames, u32 num_frames);
+	u32 ReceiveFrames(float* frames, u32 max_frames);
+
+	u32 GetAvailableFrames() const;
+
+private:
+	std::unique_ptr<soundtouch::RateTransposer> m_transposer;
+};

--- a/pcsx2/Host/AudioStream.cpp
+++ b/pcsx2/Host/AudioStream.cpp
@@ -834,9 +834,6 @@ void AudioStream::ResampleBlock(const float* block)
 
 void AudioStream::StretchAllocate()
 {
-	if (!IsStretchEnabled())
-		return;
-
 	m_soundtouch = std::make_unique<soundtouch::SoundTouch>();
 	m_soundtouch->setSampleRate(m_sample_rate);
 	m_soundtouch->setChannels(m_internal_channels);
@@ -1002,7 +999,6 @@ void AudioStream::StretchOverrun()
 {
 	// Produced more frames than can fit in the buffer.
 	m_stretch_reset++;
-	m_discontinuity_count.fetch_add(1, std::memory_order_relaxed);
 
 	// Drop two packets to give the time stretcher a bit more time to slow things down.
 	const u32 discard = CHUNK_SIZE * 2;

--- a/pcsx2/Host/AudioStream.cpp
+++ b/pcsx2/Host/AudioStream.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0+
 
 #include "Host/AudioStream.h"
+#include "Host/AudioRateController.h"
+#include "Host/AudioRateResampler.h"
 #include "FreeSurroundDecoder.h"
 #include "Host.h"
 #include "GS/GSVector.h"
@@ -67,7 +69,7 @@ std::unique_ptr<AudioStream> AudioStream::CreateNullStream(u32 sample_rate, u32 
 	params.buffer_ms = static_cast<u16>(buffer_ms);
 
 	std::unique_ptr<AudioStream> stream(new AudioStream(sample_rate, params));
-	stream->BaseInitialize(&StereoSampleReaderImpl, false);
+	stream->BaseInitialize(&StereoSampleReaderImpl, AudioSynchronizationMode::Disabled);
 	stream->SetOutputVolume(0);
 	return stream;
 }
@@ -105,19 +107,19 @@ std::vector<AudioStream::DeviceInfo> AudioStream::GetOutputDevices(AudioBackend 
 }
 
 std::unique_ptr<AudioStream> AudioStream::CreateStream(AudioBackend backend, u32 sample_rate, const AudioStreamParameters& parameters,
-	const char* driver_name, const char* device_name, bool stretch_enabled, Error* error)
+	const char* driver_name, const char* device_name, AudioSynchronizationMode sync_mode, Error* error)
 {
-	INFO_LOG("Creating {} audio stream, sample rate = {}, expansion = {}, buffer = {}, latency = {}, stretching {}, driver = {}, device = {}",
-		GetBackendName(backend), sample_rate, GetExpansionModeName(parameters.expansion_mode), parameters.buffer_ms, parameters.output_latency_ms,
-		stretch_enabled ? "enabled" : "disabled", driver_name, device_name);
+	INFO_LOG("Creating {} audio stream, sample rate = {}, expansion = {}, buffer = {}, low latency buffer = {}, latency = {}, sync mode {}, driver = {}, device = {}",
+		GetBackendName(backend), sample_rate, GetExpansionModeName(parameters.expansion_mode), parameters.buffer_ms,
+		parameters.low_latency_buffer_ms, parameters.output_latency_ms, static_cast<u32>(sync_mode), driver_name, device_name);
 
 	switch (backend)
 	{
 		case AudioBackend::Cubeb:
-			return CreateCubebAudioStream(sample_rate, parameters, driver_name, device_name, stretch_enabled, error);
+			return CreateCubebAudioStream(sample_rate, parameters, driver_name, device_name, sync_mode, error);
 
 		case AudioBackend::SDL:
-			return CreateSDLAudioStream(sample_rate, parameters, stretch_enabled, error);
+			return CreateSDLAudioStream(sample_rate, parameters, sync_mode, error);
 
 		case AudioBackend::Null:
 			return CreateNullStream(sample_rate, parameters.buffer_ms);
@@ -234,6 +236,7 @@ u32 AudioStream::GetBufferedFramesRelaxed() const
 
 void AudioStream::ReadFrames(SampleType* samples, u32 num_frames)
 {
+	m_callback_frames.store(num_frames, std::memory_order_relaxed);
 	const u32 available_frames = GetBufferedFramesRelaxed();
 	u32 frames_to_read = num_frames;
 	u32 silence_frames = 0;
@@ -260,6 +263,7 @@ void AudioStream::ReadFrames(SampleType* samples, u32 num_frames)
 		silence_frames = frames_to_read - available_frames;
 		frames_to_read = available_frames;
 		m_filling = true;
+		m_discontinuity_count.fetch_add(1, std::memory_order_relaxed);
 
 		if (IsStretchEnabled())
 			StretchUnderrun();
@@ -355,6 +359,7 @@ void AudioStream::InternalWriteFrames(const SampleType* data, u32 num_frames)
 		}
 		else
 		{
+			m_discontinuity_count.fetch_add(1, std::memory_order_relaxed);
 			LOG_UNDERRUN("Buffer overrun, chunk dropped");
 			return;
 		}
@@ -386,34 +391,72 @@ void AudioStream::InternalWriteFrames(const SampleType* data, u32 num_frames)
 	m_wpos.store(wpos, std::memory_order_release);
 }
 
-void AudioStream::BaseInitialize(SampleReader sample_reader, bool stretch_enabled)
+void AudioStream::BaseInitialize(SampleReader sample_reader, AudioSynchronizationMode sync_mode)
 {
-	m_stretch_enabled = stretch_enabled;
+	m_sync_mode = sync_mode;
+	switch (sync_mode)
+	{
+		case AudioSynchronizationMode::Disabled:
+			m_processing_mode = ProcessingMode::None;
+			break;
+
+		case AudioSynchronizationMode::TimeStretch:
+			m_processing_mode = ProcessingMode::TimeStretch;
+			break;
+
+		case AudioSynchronizationMode::LowLatency:
+			m_processing_mode = ProcessingMode::Resample;
+			break;
+
+		case AudioSynchronizationMode::Count:
+			break;
+	}
 	m_paused = false;
 	m_sample_reader = sample_reader;
 
 	AllocateBuffer();
 	ExpandAllocate();
-	StretchAllocate();
+	ProcessorAllocate();
+	if (m_processing_mode == ProcessingMode::Resample)
+		PrimeLowLatencyBuffer();
 }
 
 void AudioStream::AllocateBuffer()
 {
 	// use a larger buffer when time stretching, since we need more input
-	const u32 multiplier = IsStretchEnabled() ? 16 : 1;
-	m_buffer_size = GetAlignedBufferSize(((m_parameters.buffer_ms * multiplier) * m_sample_rate) / 1000);
-	m_target_buffer_size = GetAlignedBufferSize((m_sample_rate * m_parameters.buffer_ms) / 1000u);
+	u32 target_ms;
+	u32 multiplier;
+	switch (m_processing_mode)
+	{
+		case ProcessingMode::None:
+			target_ms = m_parameters.buffer_ms;
+			multiplier = 1;
+			break;
+
+		case ProcessingMode::Resample:
+			target_ms = m_parameters.low_latency_buffer_ms;
+			multiplier = 4;
+			break;
+
+		case ProcessingMode::TimeStretch:
+			target_ms = m_parameters.buffer_ms;
+			multiplier = 16;
+			break;
+	}
+	m_target_buffer_size = std::max(GetAlignedBufferSize((m_sample_rate * target_ms) / 1000u), CHUNK_SIZE);
+	m_buffer_size = GetAlignedBufferSize(((target_ms * multiplier) * m_sample_rate) / 1000u);
+	if (m_processing_mode == ProcessingMode::Resample)
+		m_buffer_size = std::max(m_buffer_size, m_target_buffer_size + CHUNK_SIZE);
 
 	m_buffer = std::make_unique<float[]>(m_buffer_size * m_internal_channels);
-	m_staging_buffer = std::make_unique<float[]>(CHUNK_SIZE * m_internal_channels);
+	m_staging_buffer = std::make_unique<float[]>(CHUNK_SIZE * 2 * m_internal_channels);
 
 	if (IsExpansionEnabled())
 		m_expand_buffer = std::make_unique<float[]>(m_parameters.expand_block_size * NUM_INPUT_CHANNELS);
 
-	DEV_LOG(
-		"Allocated buffer of {} frames for buffer of {} ms [expansion {} (block size {}), stretch {}, target size {}].",
-		m_buffer_size, m_parameters.buffer_ms, GetExpansionModeName(m_parameters.expansion_mode),
-		m_parameters.expand_block_size, m_stretch_enabled ? "enabled" : "disabled", m_target_buffer_size);
+	DEV_LOG("Allocated audio buffer: {} frames, {} ms, expansion {}, block size {}, mode {}, target {}.",
+		m_buffer_size, target_ms, GetExpansionModeName(m_parameters.expansion_mode), m_parameters.expand_block_size,
+		static_cast<u32>(m_processing_mode), m_target_buffer_size);
 }
 
 void AudioStream::DestroyBuffer()
@@ -435,6 +478,12 @@ void AudioStream::EmptyBuffer()
 		m_expand_buffer_pos = 0;
 	}
 
+	if (m_processing_mode == ProcessingMode::Resample)
+	{
+		ResetLowLatencyState(true);
+		return;
+	}
+
 	if (IsStretchEnabled())
 	{
 		m_soundtouch->clear();
@@ -445,9 +494,30 @@ void AudioStream::EmptyBuffer()
 	m_wpos.store(m_rpos.load(std::memory_order_acquire), std::memory_order_release);
 }
 
+void AudioStream::ResetForSavestateLoad()
+{
+	if (m_processing_mode == ProcessingMode::Resample)
+		ResetLowLatencyState(true);
+}
+
 void AudioStream::SetNominalRate(float tempo)
 {
 	m_nominal_rate = tempo;
+}
+
+AudioStream::ProcessingMode AudioStream::SelectProcessingMode(float speed) const
+{
+	// Hysteresis prevents mode changes near the fallback boundary.
+	const float minimum = (m_processing_mode == ProcessingMode::Resample) ? 0.95f : 0.97f;
+	const float maximum = (m_processing_mode == ProcessingMode::Resample) ? 1.05f : 1.03f;
+	return (speed >= minimum && speed <= maximum) ? ProcessingMode::Resample : ProcessingMode::TimeStretch;
+}
+
+void AudioStream::SetTargetSpeed(float speed)
+{
+	m_target_speed = speed;
+	if (m_sync_mode == AudioSynchronizationMode::LowLatency)
+		SetProcessingMode(SelectProcessingMode(speed));
 }
 
 void AudioStream::UpdateTargetTempo(float tempo)
@@ -469,22 +539,54 @@ void AudioStream::UpdateTargetTempo(float tempo)
 	m_dynamic_target_usage = static_cast<float>(m_target_buffer_size) * m_nominal_rate;
 }
 
-void AudioStream::SetStretchEnabled(bool enabled)
+void AudioStream::SetSynchronizationMode(AudioSynchronizationMode mode)
 {
-	if (m_stretch_enabled == enabled)
+	if (m_sync_mode == mode)
+		return;
+
+	m_sync_mode = mode;
+	switch (mode)
+	{
+		case AudioSynchronizationMode::Disabled:
+			SetProcessingMode(ProcessingMode::None);
+			break;
+
+		case AudioSynchronizationMode::TimeStretch:
+			SetProcessingMode(ProcessingMode::TimeStretch);
+			break;
+
+		case AudioSynchronizationMode::LowLatency:
+			SetProcessingMode(SelectProcessingMode(m_target_speed));
+			break;
+
+		case AudioSynchronizationMode::Count:
+			break;
+	}
+}
+
+void AudioStream::SetProcessingMode(ProcessingMode mode)
+{
+	if (m_processing_mode == mode)
 		return;
 
 	// can't resize the buffers while paused
 	const bool paused = m_paused;
 	if (!paused)
 		SetPaused(true);
+	if (IsExpansionEnabled())
+	{
+		m_expander->Flush();
+		m_expand_output_buffer = nullptr;
+		m_expand_buffer_pos = 0;
+	}
 
+	ProcessorDestroy();
 	DestroyBuffer();
-	StretchDestroy();
-	m_stretch_enabled = enabled;
-
+	m_processing_mode = mode;
 	AllocateBuffer();
-	StretchAllocate();
+	ProcessorAllocate();
+	if (mode == ProcessingMode::Resample)
+		ResetLowLatencyState(true);
 
 	if (!paused)
 		SetPaused(false);
@@ -492,7 +594,19 @@ void AudioStream::SetStretchEnabled(bool enabled)
 
 void AudioStream::SetPaused(bool paused)
 {
+	if (m_paused == paused)
+		return;
+
 	m_paused = paused;
+	if (m_processing_mode == ProcessingMode::Resample)
+	{
+		if (paused)
+			ResetLowLatencyState(false);
+		else if (GetBufferedFramesRelaxed() == 0)
+			ResetLowLatencyState(true);
+		else
+			m_rate_controller->Reset();
+	}
 }
 
 void AudioStream::SetOutputVolume(u32 volume)
@@ -562,7 +676,7 @@ void AudioStream::EndWrite(u32 num_frames)
 
 void AudioStream::WriteChunk(const SampleType* chunk)
 {
-	if (!IsExpansionEnabled() && !IsStretchEnabled())
+	if (!IsExpansionEnabled() && m_processing_mode == ProcessingMode::None)
 	{
 		InternalWriteFrames(chunk, CHUNK_SIZE);
 		return;
@@ -570,12 +684,12 @@ void AudioStream::WriteChunk(const SampleType* chunk)
 
 	if (IsExpansionEnabled())
 	{
-		// StretchWriteBlock() overwrites the staging buffer on output, so we need to copy into the expand buffer first.
+		// ProcessWriteBlock() overwrites the staging buffer on output, so we need to copy into the expand buffer first.
 		std::memcpy(m_expand_buffer.get() + m_expand_buffer_pos * NUM_INPUT_CHANNELS, chunk, CHUNK_SIZE * NUM_INPUT_CHANNELS * sizeof(SampleType));
 
 		// Output the corresponding block.
 		if (m_expand_output_buffer)
-			StretchWriteBlock(m_expand_output_buffer + m_expand_buffer_pos * m_internal_channels);
+			ProcessWriteBlock(m_expand_output_buffer + m_expand_buffer_pos * m_internal_channels);
 
 		// Decode the next block if we buffered enough.
 		m_expand_buffer_pos += CHUNK_SIZE;
@@ -587,7 +701,7 @@ void AudioStream::WriteChunk(const SampleType* chunk)
 	}
 	else
 	{
-		StretchWriteBlock(chunk);
+		ProcessWriteBlock(chunk);
 	}
 }
 
@@ -595,6 +709,127 @@ template <class T>
 __fi static bool IsInRange(const T& val, const T& min, const T& max)
 {
 	return (min <= val && val <= max);
+}
+
+void AudioStream::ProcessorAllocate()
+{
+	switch (m_processing_mode)
+	{
+		case ProcessingMode::None:
+			break;
+
+		case ProcessingMode::Resample:
+			ResampleAllocate();
+			break;
+
+		case ProcessingMode::TimeStretch:
+			StretchAllocate();
+			break;
+	}
+}
+
+void AudioStream::ProcessorDestroy()
+{
+	ResampleDestroy();
+	StretchDestroy();
+}
+
+void AudioStream::ProcessWriteBlock(const float* block)
+{
+	switch (m_processing_mode)
+	{
+		case ProcessingMode::None:
+			InternalWriteFrames(block, CHUNK_SIZE);
+			break;
+
+		case ProcessingMode::Resample:
+			ResampleBlock(block);
+			break;
+
+		case ProcessingMode::TimeStretch:
+			StretchWriteBlock(block);
+			break;
+	}
+}
+
+void AudioStream::ResampleAllocate()
+{
+	m_resampler = std::make_unique<AudioRateResampler>(m_internal_channels);
+	m_rate_controller = std::make_unique<AudioRateController>(m_sample_rate, m_target_buffer_size);
+	m_seen_discontinuity_count = m_discontinuity_count.load(std::memory_order_relaxed);
+	m_fade_in_frames_remaining = std::min(m_sample_rate / 200u, m_target_buffer_size);
+}
+
+void AudioStream::ResampleDestroy()
+{
+	m_rate_controller.reset();
+	m_resampler.reset();
+}
+
+void AudioStream::PrimeLowLatencyBuffer()
+{
+	pxAssert(m_processing_mode == ProcessingMode::Resample);
+	std::fill_n(m_staging_buffer.get(), CHUNK_SIZE * m_internal_channels, 0.0f);
+	for (u32 frames = 0; frames < m_target_buffer_size; frames += CHUNK_SIZE)
+		InternalWriteFrames(m_staging_buffer.get(), CHUNK_SIZE);
+}
+
+void AudioStream::ResetLowLatencyState(bool prime_buffer)
+{
+	if (!m_resampler || !m_rate_controller)
+		return;
+
+	m_wpos.store(m_rpos.load(std::memory_order_acquire), std::memory_order_release);
+	if (IsExpansionEnabled())
+	{
+		m_expander->Flush();
+		m_expand_output_buffer = nullptr;
+		m_expand_buffer_pos = 0;
+	}
+	m_staging_buffer_pos = 0;
+	m_resampler->Reset();
+	m_rate_controller->Reset();
+	m_seen_discontinuity_count = m_discontinuity_count.load(std::memory_order_relaxed);
+	m_fade_in_frames_remaining = std::min(m_sample_rate / 200u, m_target_buffer_size);
+	m_filling = false;
+	if (prime_buffer)
+		PrimeLowLatencyBuffer();
+}
+
+void AudioStream::ResampleBlock(const float* block)
+{
+	const float* input = block;
+	if (m_fade_in_frames_remaining > 0)
+	{
+		const u32 fade_total = std::max(m_sample_rate / 200u, 1u);
+		for (u32 frame = 0; frame < CHUNK_SIZE; frame++)
+		{
+			const float gain =
+				1.0f - (static_cast<float>(m_fade_in_frames_remaining) / static_cast<float>(fade_total));
+			for (u32 channel = 0; channel < m_internal_channels; channel++)
+				m_staging_buffer[frame * m_internal_channels + channel] =
+					block[frame * m_internal_channels + channel] * gain;
+			if (m_fade_in_frames_remaining > 0)
+				m_fade_in_frames_remaining--;
+		}
+		input = m_staging_buffer.get();
+	}
+
+	const u32 discontinuity_count = m_discontinuity_count.load(std::memory_order_relaxed);
+	const float rate = m_rate_controller->Update(
+		GetBufferedFramesRelaxed(), m_callback_frames.load(std::memory_order_relaxed), CHUNK_SIZE, m_target_speed,
+		discontinuity_count != m_seen_discontinuity_count);
+	m_seen_discontinuity_count = discontinuity_count;
+	m_resampler->SetRate(rate);
+	m_resampler->PutFrames(input, CHUNK_SIZE);
+
+	while (m_resampler->GetAvailableFrames() > 0)
+	{
+		const u32 output_frames = m_resampler->ReceiveFrames(m_staging_buffer.get(), CHUNK_SIZE * 2);
+		if (output_frames == 0)
+			break;
+		InternalWriteFrames(m_staging_buffer.get(), output_frames);
+	}
 }
 
 void AudioStream::StretchAllocate()
@@ -632,23 +867,15 @@ void AudioStream::StretchDestroy()
 
 void AudioStream::StretchWriteBlock(const float* block)
 {
-	if (IsStretchEnabled())
-	{
-		m_soundtouch->putSamples(block, CHUNK_SIZE);
+	m_soundtouch->putSamples(block, CHUNK_SIZE);
 
-		u32 tempProgress;
-		while (tempProgress = m_soundtouch->receiveSamples(m_staging_buffer.get(), CHUNK_SIZE), tempProgress != 0)
-		{
-			InternalWriteFrames(m_staging_buffer.get(), tempProgress);
-		}
-
-		if (IsStretchEnabled())
-			UpdateStretchTempo();
-	}
-	else
+	u32 tempProgress;
+	while (tempProgress = m_soundtouch->receiveSamples(m_staging_buffer.get(), CHUNK_SIZE), tempProgress != 0)
 	{
-		InternalWriteFrames(block, CHUNK_SIZE);
+		InternalWriteFrames(m_staging_buffer.get(), tempProgress);
 	}
+
+	UpdateStretchTempo();
 }
 
 float AudioStream::AddAndGetAverageTempo(float val)
@@ -775,6 +1002,7 @@ void AudioStream::StretchOverrun()
 {
 	// Produced more frames than can fit in the buffer.
 	m_stretch_reset++;
+	m_discontinuity_count.fetch_add(1, std::memory_order_relaxed);
 
 	// Drop two packets to give the time stretcher a bit more time to slow things down.
 	const u32 discard = CHUNK_SIZE * 2;
@@ -785,6 +1013,9 @@ void AudioStreamParameters::LoadSave(SettingsWrapper& wrap, const char* section)
 {
 	wrap.EnumEntry(section, "ExpansionMode", expansion_mode, &AudioStream::ParseExpansionMode, &AudioStream::GetExpansionModeName, DEFAULT_EXPANSION_MODE);
 	buffer_ms = static_cast<u16>(std::clamp<int>(wrap.EntryBitfield(section, "BufferMS", buffer_ms, DEFAULT_BUFFER_MS), 0, std::numeric_limits<u16>::max()));
+	low_latency_buffer_ms = static_cast<u16>(std::clamp<int>(wrap.EntryBitfield(section, "LowLatencyBufferMS",
+																 low_latency_buffer_ms, DEFAULT_LOW_LATENCY_BUFFER_MS),
+		10, 100));
 	output_latency_ms = static_cast<u16>(std::clamp<int>(wrap.EntryBitfield(section, "OutputLatencyMS",
 															 output_latency_ms, DEFAULT_OUTPUT_LATENCY_MS),
 		1, std::numeric_limits<u16>::max()));

--- a/pcsx2/Host/AudioStream.cpp
+++ b/pcsx2/Host/AudioStream.cpp
@@ -134,15 +134,20 @@ u32 AudioStream::GetAlignedBufferSize(u32 size)
 	return Common::AlignUpPow2(size, CHUNK_SIZE);
 }
 
-u32 AudioStream::GetBufferSizeForMS(u32 sample_rate, u32 ms)
+u32 AudioStream::GetFrameCountForMS(u32 sample_rate, u32 milliseconds)
 {
-	return GetAlignedBufferSize((ms * sample_rate) / 1000u);
+	const u64 frames = (static_cast<u64>(milliseconds) * sample_rate) / 1000u;
+	return static_cast<u32>(std::clamp<u64>(frames, 1, std::numeric_limits<u32>::max()));
 }
 
-u32 AudioStream::GetMSForBufferSize(u32 sample_rate, u32 buffer_size)
+u32 AudioStream::GetMSForFrames(u32 sample_rate, u32 frames)
 {
-	buffer_size = GetAlignedBufferSize(buffer_size);
-	return (buffer_size * 1000u) / sample_rate;
+	return static_cast<u32>((static_cast<u64>(frames) * 1000u) / sample_rate);
+}
+
+u32 AudioStream::GetMSForFramesCeil(u32 sample_rate, u32 frames)
+{
+	return static_cast<u32>((static_cast<u64>(frames) * 1000u + sample_rate - 1u) / sample_rate);
 }
 
 static constexpr const std::array s_backend_names = {
@@ -779,9 +784,10 @@ void AudioStream::StretchOverrun()
 void AudioStreamParameters::LoadSave(SettingsWrapper& wrap, const char* section)
 {
 	wrap.EnumEntry(section, "ExpansionMode", expansion_mode, &AudioStream::ParseExpansionMode, &AudioStream::GetExpansionModeName, DEFAULT_EXPANSION_MODE);
-	minimal_output_latency = wrap.EntryBitBool(section, "OutputLatencyMinimal", DEFAULT_OUTPUT_LATENCY_MINIMAL);
 	buffer_ms = static_cast<u16>(std::clamp<int>(wrap.EntryBitfield(section, "BufferMS", buffer_ms, DEFAULT_BUFFER_MS), 0, std::numeric_limits<u16>::max()));
-	output_latency_ms = static_cast<u16>(std::clamp<int>(wrap.EntryBitfield(section, "OutputLatencyMS", output_latency_ms, DEFAULT_OUTPUT_LATENCY_MS), 0, std::numeric_limits<u16>::max()));
+	output_latency_ms = static_cast<u16>(std::clamp<int>(wrap.EntryBitfield(section, "OutputLatencyMS",
+															 output_latency_ms, DEFAULT_OUTPUT_LATENCY_MS),
+		1, std::numeric_limits<u16>::max()));
 
 	stretch_sequence_length_ms = static_cast<u16>(std::clamp<int>(wrap.EntryBitfield(section, "StretchSequenceLengthMS", DEFAULT_STRETCH_SEQUENCE_LENGTH), 0, std::numeric_limits<u16>::max()));
 	stretch_seekwindow_ms = static_cast<u16>(std::clamp<int>(wrap.EntryBitfield(section, "StretchSeekWindowMS", DEFAULT_STRETCH_SEEKWINDOW), 0, std::numeric_limits<u16>::max()));

--- a/pcsx2/Host/AudioStream.h
+++ b/pcsx2/Host/AudioStream.h
@@ -13,6 +13,8 @@
 #include <string_view>
 #include <vector>
 
+class AudioRateController;
+class AudioRateResampler;
 class Error;
 
 class FreeSurroundDecoder;
@@ -23,6 +25,13 @@ namespace soundtouch
 
 class AudioStream
 {
+	enum class ProcessingMode : u8
+	{
+		None,
+		Resample,
+		TimeStretch,
+	};
+
 public:
 	using SampleType = float;
 
@@ -45,8 +54,6 @@ public:
 public:
 	virtual ~AudioStream();
 
-	static u32 GetAlignedBufferSize(u32 size);
-	static u32 GetFrameCountForMS(u32 sample_rate, u32 milliseconds);
 	static u32 GetMSForFrames(u32 sample_rate, u32 frames);
 	static u32 GetMSForFramesCeil(u32 sample_rate, u32 frames);
 
@@ -61,16 +68,12 @@ public:
 	__fi u32 GetSampleRate() const { return m_sample_rate; }
 	__fi u32 GetInternalChannels() const { return m_internal_channels; }
 	__fi u32 GetOutputChannels() const { return m_internal_channels; }
-	__fi u32 GetBufferSize() const { return m_buffer_size; }
-	__fi u32 GetTargetBufferSize() const { return m_target_buffer_size; }
 	__fi u32 GetOutputVolume() const { return m_volume; }
-	__fi float GetNominalTempo() const { return m_nominal_rate; }
 	__fi AudioExpansionMode GetExpansionMode() const { return m_parameters.expansion_mode; }
 	__fi bool IsExpansionEnabled() const { return m_parameters.expansion_mode != AudioExpansionMode::Disabled; }
-	__fi bool IsStretchEnabled() const { return m_stretch_enabled; }
+	__fi bool IsStretchEnabled() const { return m_processing_mode == ProcessingMode::TimeStretch; }
+	__fi AudioSynchronizationMode GetSynchronizationMode() const { return m_sync_mode; }
 	__fi bool IsPaused() const { return m_paused; }
-
-	u32 GetBufferedFramesRelaxed() const;
 
 	/// Temporarily pauses the stream, preventing it from requesting data.
 	virtual void SetPaused(bool paused);
@@ -83,18 +86,20 @@ public:
 	void WriteFrame(const SampleType* frame);
 	void EndWrite(u32 num_frames);
 	void EmptyBuffer();
+	void ResetForSavestateLoad();
 
 	/// Nominal rate is used for both resampling and timestretching, input samples are assumed to be this amount faster
 	/// than the sample rate.
 	void SetNominalRate(float tempo);
+	void SetTargetSpeed(float speed);
 	void UpdateTargetTempo(float tempo);
 
-	void SetStretchEnabled(bool enabled);
+	void SetSynchronizationMode(AudioSynchronizationMode mode);
 
 	static std::vector<std::pair<std::string, std::string>> GetDriverNames(AudioBackend backend);
 	static std::vector<DeviceInfo> GetOutputDevices(AudioBackend backend, const char* driver);
 	static std::unique_ptr<AudioStream> CreateStream(AudioBackend backend, u32 sample_rate, const AudioStreamParameters& parameters,
-		const char* driver_name, const char* device_name, bool stretch_enabled, Error* error = nullptr);
+		const char* driver_name, const char* device_name, AudioSynchronizationMode sync_mode, Error* error = nullptr);
 	static std::unique_ptr<AudioStream> CreateNullStream(u32 sample_rate, u32 buffer_ms);
 
 protected:
@@ -114,7 +119,8 @@ protected:
 	using SampleReader = void (*)(SampleType* dest, const SampleType* src, u32 num_frames);
 
 	AudioStream(u32 sample_rate, const AudioStreamParameters& parameters);
-	void BaseInitialize(SampleReader sample_reader, bool stretch_enabled);
+	void BaseInitialize(SampleReader sample_reader, AudioSynchronizationMode sync_mode);
+	static u32 GetFrameCountForMS(u32 sample_rate, u32 milliseconds);
 
 	void ReadFrames(SampleType* samples, u32 num_frames);
 
@@ -129,7 +135,8 @@ protected:
 	AudioStreamParameters m_parameters;
 	u8 m_internal_channels = 0;
 	u8 m_output_channels = 0;
-	bool m_stretch_enabled = false;
+	AudioSynchronizationMode m_sync_mode = AudioSynchronizationMode::Disabled;
+	ProcessingMode m_processing_mode = ProcessingMode::None;
 	bool m_stretch_inactive = false;
 	bool m_filling = false;
 	bool m_paused = false;
@@ -143,17 +150,30 @@ private:
 	static std::vector<std::pair<std::string, std::string>> GetCubebDriverNames();
 	static std::vector<DeviceInfo> GetCubebOutputDevices(const char* driver);
 	static std::unique_ptr<AudioStream> CreateCubebAudioStream(u32 sample_rate, const AudioStreamParameters& parameters,
-		const char* driver_name, const char* device_name, bool stretch_enabled, Error* error);
+		const char* driver_name, const char* device_name, AudioSynchronizationMode sync_mode, Error* error);
 
 	static std::unique_ptr<AudioStream> CreateSDLAudioStream(u32 sample_rate, const AudioStreamParameters& parameters,
-		bool stretch_enabled, Error* error);
+		AudioSynchronizationMode sync_mode, Error* error);
 
 	void AllocateBuffer();
 	void DestroyBuffer();
+	static u32 GetAlignedBufferSize(u32 size);
+	u32 GetBufferedFramesRelaxed() const;
 
 	void InternalWriteFrames(const SampleType* samples, u32 num_frames);
 
 	void ExpandAllocate();
+
+	void ProcessorAllocate();
+	void ProcessorDestroy();
+	void ProcessWriteBlock(const float* block);
+	void SetProcessingMode(ProcessingMode mode);
+	ProcessingMode SelectProcessingMode(float speed) const;
+	void PrimeLowLatencyBuffer();
+	void ResetLowLatencyState(bool prime_buffer);
+	void ResampleAllocate();
+	void ResampleDestroy();
+	void ResampleBlock(const float* block);
 
 	void StretchAllocate();
 	void StretchDestroy();
@@ -170,7 +190,11 @@ private:
 
 	std::atomic<u32> m_rpos{0};
 	std::atomic<u32> m_wpos{0};
+	std::atomic<u32> m_callback_frames{0};
+	std::atomic<u32> m_discontinuity_count{0};
 
+	std::unique_ptr<AudioRateResampler> m_resampler;
+	std::unique_ptr<AudioRateController> m_rate_controller;
 	std::unique_ptr<soundtouch::SoundTouch> m_soundtouch;
 
 	u32 m_target_buffer_size = 0;
@@ -178,7 +202,10 @@ private:
 
 	u32 m_stretch_ok_count = 0;
 	float m_nominal_rate = 1.0f;
+	float m_target_speed = 1.0f;
 	float m_dynamic_target_usage = 0.0f;
+	u32 m_fade_in_frames_remaining = 0;
+	u32 m_seen_discontinuity_count = 0;
 
 	u32 m_average_position = 0;
 	u32 m_average_available = 0;

--- a/pcsx2/Host/AudioStream.h
+++ b/pcsx2/Host/AudioStream.h
@@ -46,8 +46,9 @@ public:
 	virtual ~AudioStream();
 
 	static u32 GetAlignedBufferSize(u32 size);
-	static u32 GetBufferSizeForMS(u32 sample_rate, u32 ms);
-	static u32 GetMSForBufferSize(u32 sample_rate, u32 buffer_size);
+	static u32 GetFrameCountForMS(u32 sample_rate, u32 milliseconds);
+	static u32 GetMSForFrames(u32 sample_rate, u32 frames);
+	static u32 GetMSForFramesCeil(u32 sample_rate, u32 frames);
 
 	static std::optional<AudioBackend> ParseBackendName(const char* str);
 	static const char* GetBackendName(AudioBackend backend);

--- a/pcsx2/Host/AudioStreamTypes.h
+++ b/pcsx2/Host/AudioStreamTypes.h
@@ -28,10 +28,19 @@ enum class AudioExpansionMode : u8
 	Count
 };
 
+enum class AudioSynchronizationMode : u8
+{
+	Disabled,
+	TimeStretch,
+	LowLatency,
+	Count
+};
+
 struct AudioStreamParameters
 {
 	AudioExpansionMode expansion_mode = DEFAULT_EXPANSION_MODE;
 	u16 buffer_ms = DEFAULT_BUFFER_MS;
+	u16 low_latency_buffer_ms = DEFAULT_LOW_LATENCY_BUFFER_MS;
 	u16 output_latency_ms = DEFAULT_OUTPUT_LATENCY_MS;
 
 	u16 stretch_sequence_length_ms = DEFAULT_STRETCH_SEQUENCE_LENGTH;
@@ -53,6 +62,7 @@ struct AudioStreamParameters
 
 	static constexpr AudioExpansionMode DEFAULT_EXPANSION_MODE = AudioExpansionMode::Disabled;
 	static constexpr u16 DEFAULT_BUFFER_MS = 50;
+	static constexpr u16 DEFAULT_LOW_LATENCY_BUFFER_MS = 20;
 	static constexpr u16 DEFAULT_OUTPUT_LATENCY_MS = 20;
 
 	static constexpr u16 DEFAULT_EXPAND_BLOCK_SIZE = 2048;

--- a/pcsx2/Host/AudioStreamTypes.h
+++ b/pcsx2/Host/AudioStreamTypes.h
@@ -31,7 +31,6 @@ enum class AudioExpansionMode : u8
 struct AudioStreamParameters
 {
 	AudioExpansionMode expansion_mode = DEFAULT_EXPANSION_MODE;
-	bool minimal_output_latency = DEFAULT_OUTPUT_LATENCY_MINIMAL;
 	u16 buffer_ms = DEFAULT_BUFFER_MS;
 	u16 output_latency_ms = DEFAULT_OUTPUT_LATENCY_MS;
 
@@ -55,7 +54,6 @@ struct AudioStreamParameters
 	static constexpr AudioExpansionMode DEFAULT_EXPANSION_MODE = AudioExpansionMode::Disabled;
 	static constexpr u16 DEFAULT_BUFFER_MS = 50;
 	static constexpr u16 DEFAULT_OUTPUT_LATENCY_MS = 20;
-	static constexpr bool DEFAULT_OUTPUT_LATENCY_MINIMAL = false;
 
 	static constexpr u16 DEFAULT_EXPAND_BLOCK_SIZE = 2048;
 	static constexpr float DEFAULT_EXPAND_CIRCULAR_WRAP = 90.0f;

--- a/pcsx2/Host/CubebAudioStream.cpp
+++ b/pcsx2/Host/CubebAudioStream.cpp
@@ -171,14 +171,12 @@ bool CubebAudioStream::Initialize(const char* driver_name, const char* device_na
 	params.layout = channel_setups[static_cast<size_t>(m_parameters.expansion_mode)].first;
 	params.prefs = CUBEB_STREAM_PREF_NONE;
 
-	u32 latency_frames = GetBufferSizeForMS(
-		m_sample_rate, (m_parameters.minimal_output_latency) ? m_parameters.buffer_ms : m_parameters.output_latency_ms);
-	u32 min_latency_frames = 0;
-	rv = cubeb_get_min_latency(m_context, &params, &min_latency_frames);
+	u32 minimum_latency_frames = 0;
+	rv = cubeb_get_min_latency(m_context, &params, &minimum_latency_frames);
 	if (rv == CUBEB_ERROR_NOT_SUPPORTED)
 	{
-		DEV_LOG("Cubeb backend does not support latency queries, using latency of {} ms ({} frames).",
-			m_parameters.buffer_ms, latency_frames);
+		minimum_latency_frames = 0;
+		DEV_LOG("Cubeb backend does not support minimum latency queries.");
 	}
 	else
 	{
@@ -189,19 +187,20 @@ bool CubebAudioStream::Initialize(const char* driver_name, const char* device_na
 			return false;
 		}
 
-		const u32 minimum_latency_ms = GetMSForBufferSize(m_sample_rate, min_latency_frames);
-		DEV_LOG("Minimum latency: {} ms ({} audio frames)", minimum_latency_ms, min_latency_frames);
-		if (m_parameters.minimal_output_latency)
-		{
-			// use minimum
-			latency_frames = min_latency_frames;
-		}
-		else if (minimum_latency_ms > m_parameters.output_latency_ms)
-		{
-			WARNING_LOG("Minimum latency is above requested latency: {} vs {}, adjusting to compensate.",
-				min_latency_frames, latency_frames);
-			latency_frames = min_latency_frames;
-		}
+		const u32 minimum_latency_ms = GetMSForFramesCeil(m_sample_rate, minimum_latency_frames);
+		DEV_LOG("Minimum latency: {} ms ({} audio frames)", minimum_latency_ms, minimum_latency_frames);
+	}
+
+	u32 latency_frames = GetFrameCountForMS(m_sample_rate, m_parameters.output_latency_ms);
+	const bool below_minimum = minimum_latency_frames > 0 && latency_frames < minimum_latency_frames;
+	if (below_minimum)
+	{
+		WARNING_LOG("Configured output latency requests {} frames below Cubeb's guaranteed minimum of {} frames.",
+			latency_frames, minimum_latency_frames);
+	}
+	else
+	{
+		DEV_LOG("Requesting Cubeb latency of {} frames.", latency_frames);
 	}
 
 	cubeb_devid selected_device = nullptr;
@@ -245,6 +244,15 @@ bool CubebAudioStream::Initialize(const char* driver_name, const char* device_na
 
 	rv = cubeb_stream_init(m_context, &stream, stream_name, nullptr, nullptr, selected_device, &params, latency_frames,
 		&CubebAudioStream::DataCallback, StateCallback, this);
+	// Verified subminimum requests have an effect on cubeb backends
+	if (rv != CUBEB_OK && below_minimum && !stream)
+	{
+		WARNING_LOG("Subminimum Cubeb latency request failed with {}; retrying the guaranteed minimum of {} frames.",
+			GetCubebErrorString(rv), minimum_latency_frames);
+		latency_frames = minimum_latency_frames;
+		rv = cubeb_stream_init(m_context, &stream, stream_name, nullptr, nullptr, selected_device, &params,
+			latency_frames, &CubebAudioStream::DataCallback, StateCallback, this);
+	}
 
 	if (devices_valid)
 		cubeb_device_collection_destroy(m_context, &devices);

--- a/pcsx2/Host/CubebAudioStream.cpp
+++ b/pcsx2/Host/CubebAudioStream.cpp
@@ -32,7 +32,7 @@ namespace
 
 		void SetPaused(bool paused) override;
 
-		bool Initialize(const char* driver_name, const char* device_name, bool stretch_enabled, Error* error);
+		bool Initialize(const char* driver_name, const char* device_name, AudioSynchronizationMode sync_mode, Error* error);
 
 	private:
 		static void LogCallback(const char* fmt, ...);
@@ -117,7 +117,8 @@ void CubebAudioStream::DestroyContextAndStream()
 #endif
 }
 
-bool CubebAudioStream::Initialize(const char* driver_name, const char* device_name, bool stretch_enabled, Error* error)
+bool CubebAudioStream::Initialize(
+	const char* driver_name, const char* device_name, AudioSynchronizationMode sync_mode, Error* error)
 {
 	cubeb_set_log_callback(CUBEB_LOG_NORMAL, LogCallback);
 
@@ -237,13 +238,13 @@ bool CubebAudioStream::Initialize(const char* driver_name, const char* device_na
 		}
 	}
 
-	BaseInitialize(channel_setups[static_cast<size_t>(m_parameters.expansion_mode)].second, stretch_enabled);
+	BaseInitialize(channel_setups[static_cast<size_t>(m_parameters.expansion_mode)].second, sync_mode);
 
 	char stream_name[32];
 	std::snprintf(stream_name, sizeof(stream_name), "%p", this);
 
-	rv = cubeb_stream_init(m_context, &stream, stream_name, nullptr, nullptr, selected_device, &params, latency_frames,
-		&CubebAudioStream::DataCallback, StateCallback, this);
+	rv = cubeb_stream_init(m_context, &stream, stream_name, nullptr, nullptr, selected_device, &params,
+		latency_frames, &CubebAudioStream::DataCallback, StateCallback, this);
 	// Verified subminimum requests have an effect on cubeb backends
 	if (rv != CUBEB_OK && below_minimum && !stream)
 	{
@@ -295,21 +296,33 @@ void CubebAudioStream::SetPaused(bool paused)
 	if (paused == m_paused || !stream)
 		return;
 
-	const int rv = paused ? cubeb_stream_stop(stream) : cubeb_stream_start(stream);
-	if (rv != CUBEB_OK)
+	if (paused)
 	{
-		ERROR_LOG("Could not {} stream: {}", paused ? "pause" : "resume", GetCubebErrorString(rv));
+		const int rv = cubeb_stream_stop(stream);
+		if (rv != CUBEB_OK)
+		{
+			ERROR_LOG("Could not pause stream: {}", GetCubebErrorString(rv));
+			return;
+		}
+
+		AudioStream::SetPaused(true);
 		return;
 	}
 
-	m_paused = paused;
+	AudioStream::SetPaused(false);
+	const int rv = cubeb_stream_start(stream);
+	if (rv != CUBEB_OK)
+	{
+		AudioStream::SetPaused(true);
+		ERROR_LOG("Could not resume stream: {}", GetCubebErrorString(rv));
+	}
 }
 
 std::unique_ptr<AudioStream> AudioStream::CreateCubebAudioStream(u32 sample_rate, const AudioStreamParameters& parameters,
-	const char* driver_name, const char* device_name, bool stretch_enabled, Error* error)
+	const char* driver_name, const char* device_name, AudioSynchronizationMode sync_mode, Error* error)
 {
 	std::unique_ptr<CubebAudioStream> stream = std::make_unique<CubebAudioStream>(sample_rate, parameters);
-	if (!stream->Initialize(driver_name, device_name, stretch_enabled, error))
+	if (!stream->Initialize(driver_name, device_name, sync_mode, error))
 		stream.reset();
 	return stream;
 }

--- a/pcsx2/Host/SDLAudioStream.cpp
+++ b/pcsx2/Host/SDLAudioStream.cpp
@@ -19,7 +19,7 @@ namespace
 
 		void SetPaused(bool paused) override;
 
-		bool OpenDevice(bool stretch_enabled, Error* error);
+		bool OpenDevice(AudioSynchronizationMode sync_mode, Error* error);
 		void CloseDevice();
 
 	protected:
@@ -65,19 +65,19 @@ SDLAudioStream::~SDLAudioStream()
 }
 
 std::unique_ptr<AudioStream> AudioStream::CreateSDLAudioStream(u32 sample_rate, const AudioStreamParameters& parameters,
-	bool stretch_enabled, Error* error)
+	AudioSynchronizationMode sync_mode, Error* error)
 {
 	if (!InitializeSDLAudio(error))
 		return {};
 
 	std::unique_ptr<SDLAudioStream> stream = std::make_unique<SDLAudioStream>(sample_rate, parameters);
-	if (!stream->OpenDevice(stretch_enabled, error))
+	if (!stream->OpenDevice(sync_mode, error))
 		stream.reset();
 
 	return stream;
 }
 
-bool SDLAudioStream::OpenDevice(bool stretch_enabled, Error* error)
+bool SDLAudioStream::OpenDevice(AudioSynchronizationMode sync_mode, Error* error)
 {
 	pxAssert(!IsOpen());
 
@@ -117,7 +117,7 @@ bool SDLAudioStream::OpenDevice(bool stretch_enabled, Error* error)
 	else
 		DEV_LOG("SDL_GetAudioDeviceFormat() failed {}", SDL_GetError());
 
-	BaseInitialize(sample_readers[static_cast<size_t>(m_parameters.expansion_mode)], stretch_enabled);
+	BaseInitialize(sample_readers[static_cast<size_t>(m_parameters.expansion_mode)], sync_mode);
 	SDL_ResumeAudioDevice(SDL_GetAudioStreamDevice(m_stream));
 
 	return true;
@@ -129,11 +129,15 @@ void SDLAudioStream::SetPaused(bool paused)
 		return;
 
 	if (paused)
+	{
 		SDL_PauseAudioDevice(SDL_GetAudioStreamDevice(m_stream));
+		AudioStream::SetPaused(true);
+	}
 	else
+	{
+		AudioStream::SetPaused(false);
 		SDL_ResumeAudioDevice(SDL_GetAudioStreamDevice(m_stream));
-
-	m_paused = paused;
+	}
 }
 
 void SDLAudioStream::CloseDevice()

--- a/pcsx2/Host/SDLAudioStream.cpp
+++ b/pcsx2/Host/SDLAudioStream.cpp
@@ -102,8 +102,7 @@ bool SDLAudioStream::OpenDevice(bool stretch_enabled, Error* error)
 			READ_CHANNEL_REAR_LEFT, READ_CHANNEL_REAR_RIGHT>,
 	}};
 
-	uint samples = GetBufferSizeForMS(
-		m_sample_rate, (m_parameters.minimal_output_latency) ? m_parameters.buffer_ms : m_parameters.output_latency_ms);
+	uint samples = GetFrameCountForMS(m_sample_rate, m_parameters.output_latency_ms);
 
 	SDL_SetHint(SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES, fmt::format("{}", samples).c_str());
 

--- a/pcsx2/ImGui/FullscreenUI_Internal.h
+++ b/pcsx2/ImGui/FullscreenUI_Internal.h
@@ -480,6 +480,7 @@ namespace FullscreenUI
 		std::optional<DataType> (*from_string_function)(const char* str),
 		const char* (*to_string_function)(DataType value),
 		const char* (*to_display_string_function)(DataType value), SizeType option_count,
+		void (*change_callback)(SettingsInterface*) = nullptr,
 		bool enabled = true, float height = ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT,
 		std::pair<ImFont*, float> font = g_large_font, std::pair<ImFont*, float> summary_font = g_medium_font);
 	void DrawFolderSetting(SettingsInterface* bsi, const char* title, const char* section, const char* key,

--- a/pcsx2/ImGui/FullscreenUI_Settings.cpp
+++ b/pcsx2/ImGui/FullscreenUI_Settings.cpp
@@ -3610,6 +3610,10 @@ void FullscreenUI::DrawAudioSettingsPage()
 	DrawIntRangeSetting(bsi, FSUI_ICONSTR(ICON_FA_BUCKET, "Buffer Size"),
 		FSUI_CSTR("Determines the amount of audio buffered before being pulled by the host API."),
 		"SPU2/Output", "BufferMS", AudioStreamParameters::DEFAULT_BUFFER_MS, 10, 500, FSUI_CSTR("%d ms"));
+	DrawIntRangeSetting(bsi, FSUI_ICONSTR(ICON_FA_STOPWATCH, "Low-Latency Buffer"),
+		FSUI_CSTR("Larger buffers reduce underrun in exchange for latency."),
+		"SPU2/Output", "LowLatencyBufferMS", AudioStreamParameters::DEFAULT_LOW_LATENCY_BUFFER_MS, 10, 100,
+		FSUI_CSTR("%d ms"));
 	DrawIntRangeSetting(bsi, FSUI_ICONSTR(ICON_FA_STOPWATCH_20, "Output Latency"),
 		FSUI_CSTR("Requests the host output latency. The backend may adjust or reject subminimum values."),
 		"SPU2/Output", "OutputLatencyMS", AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MS, 1, 500, FSUI_CSTR("%d ms"));

--- a/pcsx2/ImGui/FullscreenUI_Settings.cpp
+++ b/pcsx2/ImGui/FullscreenUI_Settings.cpp
@@ -3610,17 +3610,9 @@ void FullscreenUI::DrawAudioSettingsPage()
 	DrawIntRangeSetting(bsi, FSUI_ICONSTR(ICON_FA_BUCKET, "Buffer Size"),
 		FSUI_CSTR("Determines the amount of audio buffered before being pulled by the host API."),
 		"SPU2/Output", "BufferMS", AudioStreamParameters::DEFAULT_BUFFER_MS, 10, 500, FSUI_CSTR("%d ms"));
-	if (!GetEffectiveBoolSetting(bsi, "Audio", "OutputLatencyMinimal", AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MINIMAL))
-	{
-		DrawIntRangeSetting(
-			bsi, FSUI_ICONSTR(ICON_FA_STOPWATCH_20, "Output Latency"),
-			FSUI_CSTR("Determines how much latency there is between the audio being picked up by the host API, and "
-					  "played through speakers."),
-			"SPU2/Output", "OutputLatencyMS", AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MS, 1, 500, FSUI_CSTR("%d ms"));
-	}
-	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_STOPWATCH, "Minimal Output Latency"),
-		FSUI_CSTR("When enabled, the minimum supported output latency will be used for the host API."),
-		"SPU2/Output", "OutputLatencyMinimal", AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MINIMAL);
+	DrawIntRangeSetting(bsi, FSUI_ICONSTR(ICON_FA_STOPWATCH_20, "Output Latency"),
+		FSUI_CSTR("Requests the host output latency. The backend may adjust or reject subminimum values."),
+		"SPU2/Output", "OutputLatencyMS", AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MS, 1, 500, FSUI_CSTR("%d ms"));
 
 	EndMenuButtons();
 }
@@ -6724,7 +6716,6 @@ TRANSLATE_NOOP("FullscreenUI", "Expansion Mode");
 TRANSLATE_NOOP("FullscreenUI", "Synchronization");
 TRANSLATE_NOOP("FullscreenUI", "Buffer Size");
 TRANSLATE_NOOP("FullscreenUI", "Output Latency");
-TRANSLATE_NOOP("FullscreenUI", "Minimal Output Latency");
 TRANSLATE_NOOP("FullscreenUI", "Create Memory Card");
 TRANSLATE_NOOP("FullscreenUI", "Memory Card Directory");
 TRANSLATE_NOOP("FullscreenUI", "Folder Memory Card Filter");

--- a/pcsx2/ImGui/FullscreenUI_Settings.cpp
+++ b/pcsx2/ImGui/FullscreenUI_Settings.cpp
@@ -15,6 +15,7 @@
 #include "Input/InputManager.h"
 #include "MTGS.h"
 #include "Patch.h"
+#include "SPU2/spu2.h"
 #include "USB/USB.h"
 #include "VMManager.h"
 #include "ps2/BiosTools.h"
@@ -49,6 +50,40 @@
 
 namespace FullscreenUI
 {
+	static u32 s_audio_output_minimum_latency_frames = 0;
+
+	static std::string GetEffectiveAudioStringSetting(
+		SettingsInterface* bsi, const char* key, const char* default_value)
+	{
+		if (IsEditingGameSettings(bsi))
+		{
+			std::optional<std::string> value = bsi->GetOptionalStringValue("SPU2/Output", key);
+			if (value.has_value())
+				return std::move(value.value());
+		}
+
+		return Host::Internal::GetBaseSettingsLayer()->GetStringValue("SPU2/Output", key, default_value);
+	}
+
+	static void RefreshAudioOutputMinimumLatency(SettingsInterface* bsi)
+	{
+		const AudioBackend backend = AudioStream::ParseBackendName(
+			GetEffectiveAudioStringSetting(
+				bsi, "Backend", AudioStream::GetBackendName(Pcsx2Config::SPU2Options::DEFAULT_BACKEND))
+				.c_str())
+			                                 .value_or(Pcsx2Config::SPU2Options::DEFAULT_BACKEND);
+		const std::string driver_name = GetEffectiveAudioStringSetting(bsi, "DriverName", "");
+		const std::string device_name = GetEffectiveAudioStringSetting(bsi, "DeviceName", "");
+
+		s_audio_output_minimum_latency_frames = 0;
+		const std::vector<AudioStream::DeviceInfo> devices = AudioStream::GetOutputDevices(backend, driver_name.c_str());
+		const auto device = std::find_if(devices.begin(), devices.end(), [&device_name](const AudioStream::DeviceInfo& info) {
+			return info.name == device_name;
+		});
+		if (device != devices.end())
+			s_audio_output_minimum_latency_frames = device->minimum_latency_frames;
+	}
+
 	class HddCreateInProgress : public HddCreate
 	{
 	private:
@@ -1353,7 +1388,8 @@ template <typename DataType, typename SizeType>
 void FullscreenUI::DrawEnumSetting(SettingsInterface* bsi, const char* title, const char* summary, const char* section,
 	const char* key, DataType default_value, std::optional<DataType> (*from_string_function)(const char* str),
 	const char* (*to_string_function)(DataType value), const char* (*to_display_string_function)(DataType value), SizeType option_count,
-	bool enabled, float height, std::pair<ImFont*, float> font, std::pair<ImFont*, float> summary_font)
+	void (*change_callback)(SettingsInterface*), bool enabled, float height, std::pair<ImFont*, float> font,
+	std::pair<ImFont*, float> summary_font)
 {
 	const bool game_settings = IsEditingGameSettings(bsi);
 	const std::optional<SmallString> value(bsi->GetOptionalSmallStringValue(
@@ -1375,7 +1411,7 @@ void FullscreenUI::DrawEnumSetting(SettingsInterface* bsi, const char* title, co
 				(typed_value.has_value() && i == static_cast<u32>(typed_value.value())));
 		OpenChoiceDialog(
 			title, false, std::move(cd_options),
-			[section, key, to_string_function, game_settings](s32 index, const std::string& title, bool checked) {
+			[section, key, to_string_function, change_callback, game_settings](s32 index, const std::string& title, bool checked) {
 				if (index >= 0)
 				{
 					auto lock = Host::GetSettingsLock();
@@ -1393,6 +1429,8 @@ void FullscreenUI::DrawEnumSetting(SettingsInterface* bsi, const char* title, co
 					}
 
 					SetSettingsChanged(bsi);
+					if (change_callback)
+						change_callback(bsi);
 				}
 
 				CloseChoiceDialog();
@@ -1761,6 +1799,7 @@ void FullscreenUI::DoClearGameSettings()
 
 void FullscreenUI::DrawSettingsWindow()
 {
+	const SettingsPage initial_settings_page = s_settings_page;
 	ImGuiIO& io = ImGui::GetIO();
 	const ImVec2 heading_size =
 		ImVec2(io.DisplaySize.x, LayoutScale(LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY) +
@@ -1940,6 +1979,8 @@ void FullscreenUI::DrawSettingsWindow()
 			ReturnToPreviousWindow();
 
 		auto lock = Host::GetSettingsLock();
+		if (s_settings_page == SettingsPage::Audio && initial_settings_page != SettingsPage::Audio)
+			RefreshAudioOutputMinimumLatency(bsi);
 
 		switch (s_settings_page)
 		{
@@ -3575,6 +3616,28 @@ void FullscreenUI::DrawOSDSettingsPage()
 void FullscreenUI::DrawAudioSettingsPage()
 {
 	SettingsInterface* bsi = GetEditingSettingsInterface();
+	const u32 minimum_latency_ms =
+		AudioStream::GetMSForFramesCeil(SPU2::SAMPLE_RATE, s_audio_output_minimum_latency_frames);
+	const int output_latency_ms = GetEffectiveIntSetting(
+		bsi, "SPU2/Output", "OutputLatencyMS", AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MS);
+	const bool has_minimum_latency = (minimum_latency_ms > 0);
+	SmallString output_latency_summary;
+	if (!has_minimum_latency)
+	{
+		output_latency_summary =
+			FSUI_CSTR("Requests the host output latency. The backend may adjust or reject subminimum values.");
+	}
+	else if (output_latency_ms < static_cast<int>(minimum_latency_ms))
+	{
+		output_latency_summary.format(FSUI_FSTR(
+			"Reported minimum: {} ms. Requested latency: {} ms. If audio is poor, increase the requested latency."),
+			minimum_latency_ms, output_latency_ms);
+	}
+	else
+	{
+		output_latency_summary.format(
+			FSUI_FSTR("Backend minimum: {} ms. The backend may adjust the requested latency."), minimum_latency_ms);
+	}
 
 	BeginMenuButtons();
 
@@ -3596,7 +3659,7 @@ void FullscreenUI::DrawAudioSettingsPage()
 		bsi, FSUI_ICONSTR(ICON_FA_VOLUME_OFF, "Backend"),
 		FSUI_CSTR("Determines how audio frames produced by the emulator are submitted to the host."), "SPU2/Output",
 		"Backend", Pcsx2Config::SPU2Options::DEFAULT_BACKEND, &AudioStream::ParseBackendName, &AudioStream::GetBackendName,
-		&AudioStream::GetBackendDisplayName, AudioBackend::Count);
+		&AudioStream::GetBackendDisplayName, AudioBackend::Count, &RefreshAudioOutputMinimumLatency);
 	DrawEnumSetting(bsi, FSUI_ICONSTR(ICON_PF_SPEAKER_ALT, "Expansion Mode"),
 		FSUI_CSTR("Determines how audio is expanded from stereo to surround for supported games."), "SPU2/Output",
 		"ExpansionMode", AudioStreamParameters::DEFAULT_EXPANSION_MODE, &AudioStream::ParseExpansionMode,
@@ -3614,9 +3677,10 @@ void FullscreenUI::DrawAudioSettingsPage()
 		FSUI_CSTR("Larger buffers reduce underrun in exchange for latency."),
 		"SPU2/Output", "LowLatencyBufferMS", AudioStreamParameters::DEFAULT_LOW_LATENCY_BUFFER_MS, 10, 100,
 		FSUI_CSTR("%d ms"));
-	DrawIntRangeSetting(bsi, FSUI_ICONSTR(ICON_FA_STOPWATCH_20, "Output Latency"),
-		FSUI_CSTR("Requests the host output latency. The backend may adjust or reject subminimum values."),
-		"SPU2/Output", "OutputLatencyMS", AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MS, 1, 500, FSUI_CSTR("%d ms"));
+	DrawIntRangeSetting(
+		bsi, FSUI_ICONSTR(ICON_FA_STOPWATCH_20, "Output Latency"),
+		output_latency_summary.c_str(), "SPU2/Output", "OutputLatencyMS", AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MS,
+		1, 500, FSUI_CSTR("%d ms"));
 
 	EndMenuButtons();
 }

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1203,10 +1203,12 @@ bool Pcsx2Config::GSOptions::ShouldDump(u64 draw, int frame) const
 static constexpr const std::array s_spu2_sync_mode_names = {
 	"Disabled",
 	"TimeStretch",
+	"LowLatency",
 };
 static constexpr const std::array s_spu2_sync_mode_display_names = {
 	TRANSLATE_NOOP("Pcsx2Config", "Disabled (Noisy)"),
 	TRANSLATE_NOOP("Pcsx2Config", "TimeStretch (Recommended)"),
+	TRANSLATE_NOOP("Pcsx2Config", "Low Latency (Resampling)"),
 };
 
 const char* Pcsx2Config::SPU2Options::GetSyncModeName(SPU2SyncMode mode)
@@ -1302,6 +1304,7 @@ bool Pcsx2Config::SPU2Options::operator==(const SPU2Options& right) const
 		   OpEqu(FastForwardVolume) &&
 		   OpEqu(OutputMuted) &&
 		   OpEqu(Backend) &&
+		   OpEqu(SyncMode) &&
 		   OpEqu(StreamParameters) &&
 		   OpEqu(DriverName) &&
 		   OpEqu(DeviceName);

--- a/pcsx2/SPU2/spu2.cpp
+++ b/pcsx2/SPU2/spu2.cpp
@@ -118,7 +118,7 @@ void SPU2::CreateOutputStream()
 
 	Error error;
 	s_output_stream = AudioStream::CreateStream(EmuConfig.SPU2.Backend, sample_rate, EmuConfig.SPU2.StreamParameters,
-		EmuConfig.SPU2.DriverName.c_str(), EmuConfig.SPU2.DeviceName.c_str(), EmuConfig.SPU2.IsTimeStretchEnabled(), &error);
+		EmuConfig.SPU2.DriverName.c_str(), EmuConfig.SPU2.DeviceName.c_str(), EmuConfig.SPU2.SyncMode, &error);
 	if (!s_output_stream)
 	{
 		Host::ReportErrorAsync("Error",
@@ -130,6 +130,7 @@ void SPU2::CreateOutputStream()
 
 	SPU2::UpdateOutputVolume();
 	s_output_stream->SetNominalRate(GetNominalRate());
+	s_output_stream->SetTargetSpeed(VMManager::GetTargetSpeed());
 	s_output_stream->SetPaused(VMManager::GetState() == VMState::Paused);
 }
 
@@ -261,13 +262,14 @@ void SPU2::OnTargetSpeedChanged()
 	if (!s_output_stream)
 		return;
 
-	if (!s_output_stream->IsStretchEnabled())
+	if (s_output_stream->GetSynchronizationMode() == AudioSynchronizationMode::Disabled)
 	{
 		s_output_stream->EmptyBuffer();
 		s_current_chunk_pos = 0;
 	}
 
 	s_output_stream->SetNominalRate(GetNominalRate());
+	s_output_stream->SetTargetSpeed(VMManager::GetTargetSpeed());
 
 	// Flipped save as speed has already changed.
 	if (!s_output_muted)
@@ -363,9 +365,9 @@ void SPU2::CheckForConfigChanges(const Pcsx2Config& old_config)
 	{
 		CreateOutputStream();
 	}
-	else if (opts.IsTimeStretchEnabled() != old_opts.IsTimeStretchEnabled())
+	else if (opts.SyncMode != old_opts.SyncMode)
 	{
-		s_output_stream->SetStretchEnabled(opts.IsTimeStretchEnabled());
+		s_output_stream->SetSynchronizationMode(opts.SyncMode);
 	}
 
 #ifdef PCSX2_DEVBUILD
@@ -484,7 +486,12 @@ s32 SPU2freeze(FreezeAction mode, freezeData* data)
 	switch (mode)
 	{
 		case FreezeAction::Load:
-			return SPU2Savestate::ThawIt(spud);
+		{
+			const s32 result = SPU2Savestate::ThawIt(spud);
+			if (result == 0 && s_output_stream)
+				s_output_stream->ResetForSavestateLoad();
+			return result;
+		}
 		case FreezeAction::Save:
 			return SPU2Savestate::FreezeIt(spud);
 

--- a/pcsx2/pcsx2.vcxproj
+++ b/pcsx2/pcsx2.vcxproj
@@ -248,6 +248,8 @@
     <ClCompile Include="GS\Renderers\Vulkan\vk_mem_alloc.cpp">
       <ExcludedFromBuild Condition="'$(Platform)'=='ARM64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="Host\AudioRateController.cpp" />
+    <ClCompile Include="Host\AudioRateResampler.cpp" />
     <ClCompile Include="Host\AudioStream.cpp" />
     <ClCompile Include="Host\CubebAudioStream.cpp" />
     <ClCompile Include="Host\SDLAudioStream.cpp" />
@@ -697,6 +699,8 @@
     <ClInclude Include="GS\Renderers\Vulkan\VKSwapChain.h">
       <ExcludedFromBuild Condition="'$(Platform)'=='ARM64'">true</ExcludedFromBuild>
     </ClInclude>
+    <ClInclude Include="Host\AudioRateController.h" />
+    <ClInclude Include="Host\AudioRateResampler.h" />
     <ClInclude Include="Host\AudioStream.h" />
     <ClInclude Include="Host\AudioStreamTypes.h" />
     <ClInclude Include="ImGui\FullscreenUI.h" />

--- a/pcsx2/pcsx2.vcxproj.filters
+++ b/pcsx2/pcsx2.vcxproj.filters
@@ -1416,6 +1416,12 @@
     <ClCompile Include="Host\AudioStream.cpp">
       <Filter>Misc\Host</Filter>
     </ClCompile>
+    <ClCompile Include="Host\AudioRateController.cpp">
+      <Filter>Misc\Host</Filter>
+    </ClCompile>
+    <ClCompile Include="Host\AudioRateResampler.cpp">
+      <Filter>Misc\Host</Filter>
+    </ClCompile>
     <ClCompile Include="Host\SDLAudioStream.cpp">
       <Filter>Misc\Host</Filter>
     </ClCompile>
@@ -2345,6 +2351,12 @@
       <Filter>System\Ps2\USB\usb-eyetoy</Filter>
     </ClInclude>
     <ClInclude Include="Host\AudioStream.h">
+      <Filter>Misc\Host</Filter>
+    </ClInclude>
+    <ClInclude Include="Host\AudioRateController.h">
+      <Filter>Misc\Host</Filter>
+    </ClInclude>
+    <ClInclude Include="Host\AudioRateResampler.h">
       <Filter>Misc\Host</Filter>
     </ClInclude>
     <ClInclude Include="Host\AudioStreamTypes.h">


### PR DESCRIPTION
### Description of Changes
Adds a new low-latency sync mode. Uses SoundTouch's `RateTransposer` in real-time mode to automatically resample based on a streaming feedback controller. Correction is capped to a +/-1% range so it requires full speed emulation to sound correct. Will sound incorrect outside this range. Small correction range clamp keeps the pitch variability inaudible and possible to bring minimum latency down to about 20ms end to end.

During fast-forward and slow-mo, the engine will switch to TimeStretch to not destroy the user's ears.

Also includes UI changes for the ability to reduce the slider past the minimum latency reported by cubeb. On my linux machine cubeb reports 25ms minimum with the pulse backend. That is way too conservative, and I was able use and measure a real latency of about 3ms. Cubeb was happy to be launched with values lower than the minimum and if requested latency was not possible it will clamp to the lower bound safely.

### Rationale behind Changes
TimeStretch keeps pitch accurate and helps to paper over slowdowns and jitter very well. The obvious trade off is latency, even without the pcsx2 buffers, the way TimeStretch configures SoundTouch https://github.com/PCSX2/pcsx2/blob/ca03806a4c86e8fbfc948fcb110f3961be10e5b2/pcsx2/Host/AudioStreamTypes.h#L71-L73 means the absolute latency floor is about 40ms. This configuration can be tuned somewhat, but impossible to be able to get it to the same latency as a simple rate transposer.

People interested in titles that rely on tight audio are willing to sacrifice audio consistency for latency, especially if sub-frame latency is possible which is the case with this new sync mode.

I have tested these changes on Windows and Linux machines. I've verified it works with cubeb and SDL, and have verified the WASAPI, Winmm, pulse, and jack backends. I do not have the hardware required to verify the mac backends but I doubt there will be any issues.

With settings configured with 10ms low-latency buffer, 3ms output latency on a usb 1.0 audio DAC, I was able to complete a 2hr session of amplitude with only 42 partial buffer underruns, no full underruns. 

The underruns were mostly at the beginning of emulation or around loading screens/transitions. They were not audible in my session, but obviously a larger buffer would help resolve that. I only bring this up to state that I believe the new sync method as tuned is quite reliable even with a 10ms latency goal.

Can confirm it fixes issues such as https://github.com/PCSX2/pcsx2/issues/9120

### Suggested Testing Steps
Test the various backends and drivers and identify any games that do not work well with the new sync mode. As there are no real SPU changes, I doubt there will be many issues here, but I won't rule out the possibility.

### Did you use AI to help find, test, or implement this issue or feature?
Yes, to help guide me through creating a test controller with gp2040-ce that would fire off inputs and a gpio bit so I can measure latency on the audio side accurately with a scope. Also used to help guide understanding and proper usage of cubeb and SoundTouch apis.