### PR TITLE
Add Support to load texture replacement via zip file

### DIFF
--- a/common/ZipHelpers.h
+++ b/common/ZipHelpers.h
@@ -2,40 +2,113 @@
 // SPDX-License-Identifier: GPL-3.0+
 
 #pragma once
+#include <algorithm>
 #include <memory>
 #include <optional>
 #include <string>
 #include <vector>
+
 #include "zip.h"
 
+#include "common/Path.h"
+#include "common/StringUtil.h"
 #include "Console.h"
+
+static inline std::unique_ptr<zip_t, void (*)(zip_t*)> zip_open_managed(const char* filename, int flags, zip_error_t* ze);
+static inline std::unique_ptr<zip_file_t, int (*)(zip_file_t*)> zip_fopen_managed(zip_t* zip, const char* filename, zip_flags_t flags);
+static inline std::unique_ptr<zip_file_t, int (*)(zip_file_t*)> zip_fopen_index_managed(zip_t* zip, zip_uint64_t index, zip_flags_t flags);
+static inline std::optional<std::vector<u8>> ReadZipEntryBytes(const std::string& archive_path, const std::string& entry_name);
+static inline std::optional<std::vector<u8>> ReadBinaryFileInZip(zip_t* zip, const char* name);
+static inline std::optional<std::vector<u8>> ReadBinaryFileInZip(zip_file_t* file, u32 chunk_size = 4096);
+
+static inline bool ArchiveEntryMatches(const std::string_view archive_entry_name, const std::string_view wanted_name)
+{
+	const std::string archive_name(Path::GetFileName(archive_entry_name));
+	const std::string normalized_wanted_name(Path::GetFileName(wanted_name));
+
+	if (archive_name.size() == normalized_wanted_name.size() &&
+		StringUtil::Strncasecmp(archive_name.c_str(), normalized_wanted_name.c_str(), archive_name.size()) == 0)
+	{
+		return true;
+	}
+
+	return (StringUtil::Strncasecmp(std::string(archive_entry_name).c_str(), std::string(wanted_name).c_str(), std::min(archive_entry_name.size(), wanted_name.size())) == 0) &&
+	       (archive_entry_name.size() == wanted_name.size());
+}
+
+static inline std::vector<std::string> ListArchiveEntryNames(const std::string& archive_path)
+{
+	std::vector<std::string> entries;
+
+	zip_error_t zip_error = {};
+	auto archive = zip_open_managed(archive_path.c_str(), ZIP_RDONLY, &zip_error);
+	if (!archive)
+		return entries;
+
+	const zip_uint64_t total_entries = static_cast<zip_uint64_t>(zip_get_num_entries(archive.get(), 0));
+	for (zip_uint64_t i = 0; i < total_entries; ++i)
+	{
+		const char* name = zip_get_name(archive.get(), i, 0);
+		if (name)
+			entries.emplace_back(name);
+	}
+	return entries;
+}
+
+static inline std::optional<std::vector<u8>> ReadArchiveEntryBytes(const std::string& archive_path, const std::string& entry_name)
+{
+	return ReadZipEntryBytes(archive_path, entry_name);
+}
+
+static inline std::optional<std::vector<u8>> ReadZipEntryBytes(const std::string& archive_path, const std::string& entry_name)
+{
+	zip_error_t zip_error = {};
+	auto archive = zip_open_managed(archive_path.c_str(), ZIP_RDONLY, &zip_error);
+	if (!archive)
+		return std::nullopt;
+
+	zip_int64_t index = zip_name_locate(archive.get(), entry_name.c_str(), ZIP_FL_NOCASE);
+	if (index < 0)
+	{
+		const std::string_view wanted_name = Path::GetFileName(entry_name);
+		const zip_uint64_t total_entries = static_cast<zip_uint64_t>(zip_get_num_entries(archive.get(), 0));
+		for (zip_uint64_t i = 0; i < total_entries; ++i)
+		{
+			const char* name = zip_get_name(archive.get(), i, 0);
+			if (!name)
+				continue;
+
+			const std::string_view archive_name = Path::GetFileName(name);
+			if (archive_name.size() == wanted_name.size() &&
+				StringUtil::Strncasecmp(archive_name.data(), wanted_name.data(), archive_name.size()) == 0)
+			{
+				index = static_cast<zip_int64_t>(i);
+				break;
+			}
+		}
+	}
+
+	if (index < 0)
+		return std::nullopt;
+
+	zip_stat_t stat = {};
+	if (zip_stat_index(archive.get(), index, ZIP_FL_NOCASE, &stat) != 0)
+		return std::nullopt;
+
+	auto file = zip_fopen_index_managed(archive.get(), static_cast<zip_uint64_t>(index), ZIP_FL_NOCASE);
+	if (!file)
+		return std::nullopt;
+
+	auto data = ReadBinaryFileInZip(file.get());
+	if (!data.has_value())
+		return std::nullopt;
+
+	return data;
+}
 
 static inline std::unique_ptr<zip_t, void (*)(zip_t*)> zip_open_managed(const char* filename, int flags, zip_error_t* ze)
 {
 	zip_source_t* zs = zip_source_file_create(filename, 0, 0, ze);
-	zip_t* zip = nullptr;
-	if (zs && !(zip = zip_open_from_source(zs, flags, ze)))
-	{
-		// have to clean up source
-		zip_source_free(zs);
-	}
-
-	return std::unique_ptr<zip_t, void (*)(zip_t*)>(zip, [](zip_t* zf) {
-		if (!zf)
-			return;
-
-		int err = zip_close(zf);
-		if (err != 0)
-		{
-			Console.Error("Failed to close zip file: %d", err);
-			zip_discard(zf);
-		}
-	});
-}
-
-static inline std::unique_ptr<zip_t, void (*)(zip_t*)> zip_open_buffer_managed(const void* buffer, size_t size, int flags, int freep, zip_error_t* ze)
-{
-	zip_source_t* zs = zip_source_buffer_create(buffer, size, freep, ze);
 	zip_t* zip = nullptr;
 	if (zs && !(zip = zip_open_from_source(zs, flags, ze)))
 	{
@@ -136,7 +209,7 @@ static inline std::optional<std::vector<u8>> ReadBinaryFileInZip(zip_t* zip, con
 	return ReadFileInZipToContainer<std::vector<u8>>(zip, name);
 }
 
-static inline std::optional<std::vector<u8>> ReadBinaryFileInZip(zip_file_t* file, u32 chunk_size = 4096)
+static inline std::optional<std::vector<u8>> ReadBinaryFileInZip(zip_file_t* file, u32 chunk_size)
 {
 	return ReadFileInZipToContainer<std::vector<u8>>(file, chunk_size);
 }

--- a/pcsx2/GS/Renderers/HW/GSTextureReplacementLoaders.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureReplacementLoaders.cpp
@@ -7,9 +7,11 @@
 #include "common/Path.h"
 #include "common/StringUtil.h"
 #include "common/ScopedGuard.h"
+#include "common/ZipHelpers.h"
 
 #include "GS/Renderers/HW/GSTextureReplacements.h"
 
+#include <cstdio>
 #include <csetjmp>
 #include <png.h>
 
@@ -146,7 +148,8 @@ static void ConvertTexture_R8G8B8(u32 width, u32 height, std::vector<u8>& data, 
 // PNG Handlers
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-bool PNGLoader(const std::string& filename, GSTextureReplacements::ReplacementTexture* tex, bool only_base_image)
+template <typename InitIoFunc>
+static bool PNGLoaderInternal(InitIoFunc&& init_io, GSTextureReplacements::ReplacementTexture* tex)
 {
 	png_structp png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
 	if (!png_ptr)
@@ -163,14 +166,11 @@ bool PNGLoader(const std::string& filename, GSTextureReplacements::ReplacementTe
 		png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
 	});
 
-	auto fp = FileSystem::OpenManagedCFile(filename.c_str(), "rb");
-	if (!fp)
-		return false;
-
 	if (setjmp(png_jmpbuf(png_ptr)))
 		return false;
 
-	png_init_io(png_ptr, fp.get());
+	init_io(png_ptr);
+
 	png_read_info(png_ptr, info_ptr);
 
 	png_uint_32 width = 0;
@@ -206,7 +206,7 @@ bool PNGLoader(const std::string& filename, GSTextureReplacements::ReplacementTe
 				u32 pixel = static_cast<u32>(*(row_ptr)++);
 				pixel |= static_cast<u32>(*(row_ptr)++) << 8;
 				pixel |= static_cast<u32>(*(row_ptr)++) << 16;
-				pixel |= 0x80000000u; // make opaque
+				pixel |= 0x80000000u;
 				std::memcpy(out_ptr, &pixel, sizeof(pixel));
 				out_ptr += sizeof(pixel);
 			}
@@ -218,6 +218,48 @@ bool PNGLoader(const std::string& filename, GSTextureReplacements::ReplacementTe
 	}
 
 	return true;
+}
+
+static bool PNGLoaderFromFile(FILE* fp, const std::string& filename, GSTextureReplacements::ReplacementTexture* tex, bool only_base_image)
+{
+	return PNGLoaderInternal([fp](png_structp png_ptr) {
+		png_init_io(png_ptr, fp);
+	},
+		tex);
+}
+
+bool PNGLoader(const std::string& filename, GSTextureReplacements::ReplacementTexture* tex, bool only_base_image)
+{
+	auto fp = FileSystem::OpenManagedCFile(filename.c_str(), "rb");
+	if (!fp)
+		return false;
+
+	return PNGLoaderFromFile(fp.get(), filename, tex, only_base_image);
+}
+
+static void PNGReadFromMemory(png_structp png_ptr, png_bytep out, png_size_t count)
+{
+	auto* src = static_cast<std::vector<u8>*>(png_get_io_ptr(png_ptr));
+	if (src->empty())
+	{
+		png_error(png_ptr, "unexpected end of PNG data");
+		return;
+	}
+
+	const size_t available = std::min<size_t>(count, src->size());
+	std::memcpy(out, src->data(), available);
+	src->erase(src->begin(), src->begin() + static_cast<std::ptrdiff_t>(available));
+	if (available < count)
+		png_error(png_ptr, "unexpected end of PNG data");
+}
+
+static bool PNGLoaderFromBuffer(const std::vector<u8>& data, const std::string& filename, GSTextureReplacements::ReplacementTexture* tex, bool only_base_image)
+{
+	std::vector<u8> buffer = data;
+	return PNGLoaderInternal([&buffer](png_structp png_ptr) {
+		png_set_read_fn(png_ptr, &buffer, PNGReadFromMemory);
+	},
+		tex);
 }
 
 bool GSTextureReplacements::SavePNGImage(const std::string& filename, u32 width, u32 height, const u8* buffer, u32 pitch)
@@ -392,12 +434,16 @@ struct DDSLoadInfo
 	u32 height = 0;
 	u32 mip_count = 0;
 	GSTexture::Format format = GSTexture::Format::Color;
-	s64 base_image_offset = 0;
+	size_t base_image_offset = 0;
 	u32 base_image_size = 0;
 	u32 base_image_pitch = 0;
 
 	std::function<void(u32 width, u32 height, std::vector<u8>& data, u32& pitch)> conversion_function;
 };
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Functions for reading from a file
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 static bool ParseDDSHeader(std::FILE* fp, DDSLoadInfo* info)
 {
@@ -410,25 +456,20 @@ static bool ParseDDSHeader(std::FILE* fp, DDSLoadInfo* info)
 	if (std::fread(&header, header_size, 1, fp) != 1 || header.dwSize < header_size)
 		return false;
 
-	// We should check for DDS_HEADER_FLAGS_TEXTURE here, but some tools don't seem
-	// to set it (e.g. compressonator). But we can still validate the size.
 	if (header.dwWidth == 0 || header.dwWidth >= DDS_MAX_TEXTURE_SIZE ||
 		header.dwHeight == 0 || header.dwHeight >= DDS_MAX_TEXTURE_SIZE)
 	{
 		return false;
 	}
 
-	// Image should be 2D.
 	if (header.dwFlags & DDS_HEADER_FLAGS_VOLUME)
 		return false;
 
-	// Presence of width/height fields is already tested by DDS_HEADER_FLAGS_TEXTURE.
 	info->width = header.dwWidth;
 	info->height = header.dwHeight;
 	if (info->width == 0 || info->height == 0)
 		return false;
 
-	// Check for mip levels.
 	if (header.dwFlags & DDS_HEADER_FLAGS_MIPMAP)
 	{
 		info->mip_count = header.dwMipMapCount;
@@ -442,11 +483,9 @@ static bool ParseDDSHeader(std::FILE* fp, DDSLoadInfo* info)
 		info->mip_count = 1;
 	}
 
-	// Handle fourcc formats vs uncompressed formats.
 	const bool has_fourcc = (header.ddspf.dwFlags & DDS_FOURCC) != 0;
 	if (has_fourcc)
 	{
-		// Handle DX10 extension header.
 		u32 dxt10_format = 0;
 		if (header.ddspf.dwFourCC == MAKEFOURCC('D', 'X', '1', '0'))
 		{
@@ -454,7 +493,6 @@ static bool ParseDDSHeader(std::FILE* fp, DDSLoadInfo* info)
 			if (std::fread(&dxt10_header, sizeof(dxt10_header), 1, fp) != 1)
 				return false;
 
-			// Can't handle array textures here. Doesn't make sense to use them, anyway.
 			if (dxt10_header.resourceDimension != DDS_DIMENSION_TEXTURE2D || dxt10_header.arraySize != 1)
 				return false;
 
@@ -463,7 +501,7 @@ static bool ParseDDSHeader(std::FILE* fp, DDSLoadInfo* info)
 		}
 
 		const GSDevice::FeatureSupport features(g_gs_device->Features());
-		if (header.ddspf.dwFourCC == MAKEFOURCC('D', 'X', 'T', '1') || dxt10_format == 71 /*DXGI_FORMAT_BC1_UNORM*/)
+		if (header.ddspf.dwFourCC == MAKEFOURCC('D', 'X', 'T', '1') || dxt10_format == 71)
 		{
 			info->format = GSTexture::Format::BC1;
 			info->block_size = 4;
@@ -471,7 +509,7 @@ static bool ParseDDSHeader(std::FILE* fp, DDSLoadInfo* info)
 			if (!features.dxt_textures)
 				return false;
 		}
-		else if (header.ddspf.dwFourCC == MAKEFOURCC('D', 'X', 'T', '2') || header.ddspf.dwFourCC == MAKEFOURCC('D', 'X', 'T', '3') || dxt10_format == 74 /*DXGI_FORMAT_BC2_UNORM*/)
+		else if (header.ddspf.dwFourCC == MAKEFOURCC('D', 'X', 'T', '2') || header.ddspf.dwFourCC == MAKEFOURCC('D', 'X', 'T', '3') || dxt10_format == 74)
 		{
 			info->format = GSTexture::Format::BC2;
 			info->block_size = 4;
@@ -479,7 +517,7 @@ static bool ParseDDSHeader(std::FILE* fp, DDSLoadInfo* info)
 			if (!features.dxt_textures)
 				return false;
 		}
-		else if (header.ddspf.dwFourCC == MAKEFOURCC('D', 'X', 'T', '4') || header.ddspf.dwFourCC == MAKEFOURCC('D', 'X', 'T', '5') || dxt10_format == 77 /*DXGI_FORMAT_BC3_UNORM*/)
+		else if (header.ddspf.dwFourCC == MAKEFOURCC('D', 'X', 'T', '4') || header.ddspf.dwFourCC == MAKEFOURCC('D', 'X', 'T', '5') || dxt10_format == 77)
 		{
 			info->format = GSTexture::Format::BC3;
 			info->block_size = 4;
@@ -487,7 +525,7 @@ static bool ParseDDSHeader(std::FILE* fp, DDSLoadInfo* info)
 			if (!features.dxt_textures)
 				return false;
 		}
-		else if (dxt10_format == 98 /*DXGI_FORMAT_BC7_UNORM*/)
+		else if (dxt10_format == 98)
 		{
 			info->format = GSTexture::Format::BC7;
 			info->block_size = 4;
@@ -497,70 +535,44 @@ static bool ParseDDSHeader(std::FILE* fp, DDSLoadInfo* info)
 		}
 		else
 		{
-			// Leave all remaining formats to SOIL.
 			return false;
 		}
 	}
 	else
 	{
 		if (DDSPixelFormatMatches(header.ddspf, DDSPF_A8R8G8B8))
-		{
 			info->conversion_function = ConvertTexture_A8R8G8B8;
-		}
 		else if (DDSPixelFormatMatches(header.ddspf, DDSPF_X8R8G8B8))
-		{
 			info->conversion_function = ConvertTexture_X8R8G8B8;
-		}
 		else if (DDSPixelFormatMatches(header.ddspf, DDSPF_X8B8G8R8))
-		{
 			info->conversion_function = ConvertTexture_X8B8G8R8;
-		}
 		else if (DDSPixelFormatMatches(header.ddspf, DDSPF_R8G8B8))
-		{
 			info->conversion_function = ConvertTexture_R8G8B8;
-		}
-		else if (DDSPixelFormatMatches(header.ddspf, DDSPF_A8B8G8R8))
-		{
-			// This format is already in RGBA order, so no conversion necessary.
-		}
-		else
-		{
+		else if (!DDSPixelFormatMatches(header.ddspf, DDSPF_A8B8G8R8))
 			return false;
-		}
 
-		// All these formats are RGBA, just with byte swapping.
 		info->format = GSTexture::Format::Color;
 		info->block_size = 1;
 		info->bytes_per_block = header.ddspf.dwRGBBitCount / 8;
 	}
 
-	// Mip levels smaller than the block size are padded to multiples of the block size.
 	const u32 blocks_wide = GetBlockCount(info->width, info->block_size);
 	const u32 blocks_high = GetBlockCount(info->height, info->block_size);
 
-	// Pitch can be specified in the header, otherwise we can derive it from the dimensions. For
-	// compressed formats, both DDS_HEADER_FLAGS_LINEARSIZE and DDS_HEADER_FLAGS_PITCH should be
-	// set. See https://msdn.microsoft.com/en-us/library/windows/desktop/bb943982(v=vs.85).aspx
 	if (header.dwFlags & DDS_HEADER_FLAGS_PITCH && header.dwFlags & DDS_HEADER_FLAGS_LINEARSIZE)
 	{
-		// Convert pitch (in bytes) to texels/row length.
 		if (header.dwPitchOrLinearSize < info->bytes_per_block)
-		{
-			// Likely a corrupted or invalid file.
 			return false;
-		}
 
 		info->base_image_pitch = header.dwPitchOrLinearSize;
 		info->base_image_size = info->base_image_pitch * blocks_high;
 	}
 	else
 	{
-		// Assume no padding between rows of blocks.
 		info->base_image_pitch = blocks_wide * info->bytes_per_block;
 		info->base_image_size = info->base_image_pitch * blocks_high;
 	}
 
-	// Check for truncated or corrupted files.
 	info->base_image_offset = sizeof(magic) + header_size;
 	if (info->base_image_offset >= FileSystem::FSize64(fp))
 		return false;
@@ -570,8 +582,6 @@ static bool ParseDDSHeader(std::FILE* fp, DDSLoadInfo* info)
 
 static bool ReadDDSMipLevel(std::FILE* fp, const std::string& filename, u32 mip_level, const DDSLoadInfo& info, u32 width, u32 height, std::vector<u8>& data, u32& pitch, u32 size)
 {
-	// D3D11 cannot handle block compressed textures where the first mip level is
-	// not a multiple of the block size.
 	if (mip_level == 0 && info.block_size > 1 &&
 		((width % info.block_size) != 0 || (height % info.block_size) != 0))
 	{
@@ -586,9 +596,244 @@ static bool ReadDDSMipLevel(std::FILE* fp, const std::string& filename, u32 mip_
 	if (std::fread(data.data(), size, 1, fp) != 1)
 		return false;
 
-	// Apply conversion function for uncompressed textures.
 	if (info.conversion_function)
 		info.conversion_function(width, height, data, pitch);
+
+	return true;
+}
+
+static bool DDSLoaderFromFile(FILE* fp, const std::string& filename, GSTextureReplacements::ReplacementTexture* tex, bool only_base_image)
+{
+	DDSLoadInfo info;
+	if (!ParseDDSHeader(fp, &info))
+		return false;
+
+	if (FileSystem::FSeek64(fp, info.base_image_offset, SEEK_SET) != 0)
+		return false;
+
+	tex->format = info.format;
+	tex->width = info.width;
+	tex->height = info.height;
+	tex->pitch = info.base_image_pitch;
+	if (!ReadDDSMipLevel(fp, filename, 0, info, tex->width, tex->height, tex->data, tex->pitch, info.base_image_size))
+		return false;
+
+	if (!only_base_image)
+	{
+		for (u32 level = 1; level <= info.mip_count; level++)
+		{
+			GSTextureReplacements::ReplacementTexture::MipData md;
+			u32 mip_size;
+			CalcBlockMipmapSize(info.block_size, info.bytes_per_block, info.width, info.height, level, md.width, md.height, md.pitch, mip_size);
+			if (!ReadDDSMipLevel(fp, filename, level, info, md.width, md.height, md.data, md.pitch, mip_size))
+				break;
+
+			tex->mips.push_back(std::move(md));
+		}
+	}
+
+	return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Functions for reading from a memory buffer (e.g., from a zip file)
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+static bool ParseDDSHeaderFromBuffer(const u8* buffer_data, size_t buffer_size, DDSLoadInfo* info)
+{
+	size_t offset = 0;
+
+	if (buffer_size < sizeof(u32) + sizeof(DDS_HEADER))
+		return false;
+
+	u32 magic;
+	std::memcpy(&magic, buffer_data + offset, sizeof(magic));
+	offset += sizeof(magic);
+
+	if (magic != DDS_MAGIC)
+		return false;
+
+	DDS_HEADER header;
+	u32 header_size = sizeof(header);
+	std::memcpy(&header, buffer_data + offset, header_size);
+	offset += header_size;
+
+	if (header.dwSize < sizeof(DDS_HEADER))
+		return false;
+
+	if (header.dwWidth == 0 || header.dwWidth >= DDS_MAX_TEXTURE_SIZE ||
+		header.dwHeight == 0 || header.dwHeight >= DDS_MAX_TEXTURE_SIZE)
+	{
+		return false;
+	}
+
+	if (header.dwFlags & DDS_HEADER_FLAGS_VOLUME)
+		return false;
+
+	info->width = header.dwWidth;
+	info->height = header.dwHeight;
+
+	if (header.dwFlags & DDS_HEADER_FLAGS_MIPMAP)
+	{
+		info->mip_count = (header.dwMipMapCount != 0) ?
+		                      header.dwMipMapCount :
+		                      GSTextureReplacements::CalcMipmapLevelsForReplacement(info->width, info->height);
+	}
+	else
+	{
+		info->mip_count = 1;
+	}
+
+	const bool has_fourcc = (header.ddspf.dwFlags & DDS_FOURCC) != 0;
+	if (has_fourcc)
+	{
+		u32 dxt10_format = 0;
+		if (header.ddspf.dwFourCC == MAKEFOURCC('D', 'X', '1', '0'))
+		{
+			if (buffer_size < offset + sizeof(DDS_HEADER_DXT10))
+				return false;
+
+			DDS_HEADER_DXT10 dxt10_header;
+			std::memcpy(&dxt10_header, buffer_data + offset, sizeof(dxt10_header));
+			offset += sizeof(dxt10_header);
+
+			if (dxt10_header.resourceDimension != DDS_DIMENSION_TEXTURE2D || dxt10_header.arraySize != 1)
+				return false;
+
+			dxt10_format = dxt10_header.dxgiFormat;
+		}
+
+		const GSDevice::FeatureSupport features(g_gs_device->Features());
+		if (header.ddspf.dwFourCC == MAKEFOURCC('D', 'X', 'T', '1') || dxt10_format == 71)
+		{
+			info->format = GSTexture::Format::BC1;
+			info->block_size = 4;
+			info->bytes_per_block = 8;
+			if (!features.dxt_textures)
+				return false;
+		}
+		else if (header.ddspf.dwFourCC == MAKEFOURCC('D', 'X', 'T', '2') || header.ddspf.dwFourCC == MAKEFOURCC('D', 'X', 'T', '3') || dxt10_format == 74)
+		{
+			info->format = GSTexture::Format::BC2;
+			info->block_size = 4;
+			info->bytes_per_block = 16;
+			if (!features.dxt_textures)
+				return false;
+		}
+		else if (header.ddspf.dwFourCC == MAKEFOURCC('D', 'X', 'T', '4') || header.ddspf.dwFourCC == MAKEFOURCC('D', 'X', 'T', '5') || dxt10_format == 77)
+		{
+			info->format = GSTexture::Format::BC3;
+			info->block_size = 4;
+			info->bytes_per_block = 16;
+			if (!features.dxt_textures)
+				return false;
+		}
+		else if (dxt10_format == 98)
+		{
+			info->format = GSTexture::Format::BC7;
+			info->block_size = 4;
+			info->bytes_per_block = 16;
+			if (!features.bptc_textures)
+				return false;
+		}
+		else
+		{
+			return false;
+		}
+	}
+	else
+	{
+		if (DDSPixelFormatMatches(header.ddspf, DDSPF_A8R8G8B8))
+			info->conversion_function = ConvertTexture_A8R8G8B8;
+		else if (DDSPixelFormatMatches(header.ddspf, DDSPF_X8R8G8B8))
+			info->conversion_function = ConvertTexture_X8R8G8B8;
+		else if (DDSPixelFormatMatches(header.ddspf, DDSPF_X8B8G8R8))
+			info->conversion_function = ConvertTexture_X8B8G8R8;
+		else if (DDSPixelFormatMatches(header.ddspf, DDSPF_R8G8B8))
+			info->conversion_function = ConvertTexture_R8G8B8;
+		else if (!DDSPixelFormatMatches(header.ddspf, DDSPF_A8B8G8R8))
+			return false;
+
+		info->format = GSTexture::Format::Color;
+		info->block_size = 1;
+		info->bytes_per_block = header.ddspf.dwRGBBitCount / 8;
+	}
+
+	const u32 blocks_wide = GetBlockCount(info->width, info->block_size);
+	const u32 blocks_high = GetBlockCount(info->height, info->block_size);
+
+	if (header.dwFlags & DDS_HEADER_FLAGS_PITCH && header.dwFlags & DDS_HEADER_FLAGS_LINEARSIZE)
+	{
+		if (header.dwPitchOrLinearSize < info->bytes_per_block)
+			return false;
+
+		info->base_image_pitch = header.dwPitchOrLinearSize;
+		info->base_image_size = info->base_image_pitch * blocks_high;
+	}
+	else
+	{
+		info->base_image_pitch = blocks_wide * info->bytes_per_block;
+		info->base_image_size = info->base_image_pitch * blocks_high;
+	}
+
+	info->base_image_offset = offset;
+	if (info->base_image_offset >= buffer_size)
+		return false;
+
+	return true;
+}
+
+static bool ReadDDSMipLevelFromBuffer(const u8* buffer_data, size_t buffer_size, size_t& offset, u32 mip_level, const DDSLoadInfo& info, u32 width, u32 height, std::vector<u8>& data, u32& pitch, u32 size)
+{
+	if (mip_level == 0 && info.block_size > 1 &&
+		((width % info.block_size) != 0 || (height % info.block_size) != 0))
+	{
+		return false;
+	}
+
+	if (offset + size > buffer_size)
+		return false;
+
+	data.resize(size);
+	std::memcpy(data.data(), buffer_data + offset, size);
+	offset += size;
+
+	if (info.conversion_function)
+		info.conversion_function(width, height, data, pitch);
+
+	return true;
+}
+
+static bool DDSLoaderFromBuffer(const std::vector<u8>& data, const std::string& filename, GSTextureReplacements::ReplacementTexture* tex, bool only_base_image)
+{
+	DDSLoadInfo info;
+	if (!ParseDDSHeaderFromBuffer(data.data(), data.size(), &info))
+		return false;
+
+	size_t current_offset = info.base_image_offset;
+
+	tex->format = info.format;
+	tex->width = info.width;
+	tex->height = info.height;
+	tex->pitch = info.base_image_pitch;
+
+	if (!ReadDDSMipLevelFromBuffer(data.data(), data.size(), current_offset, 0, info, tex->width, tex->height, tex->data, tex->pitch, info.base_image_size))
+		return false;
+
+	if (!only_base_image)
+	{
+		for (u32 level = 1; level <= info.mip_count; level++)
+		{
+			GSTextureReplacements::ReplacementTexture::MipData md;
+			u32 mip_size;
+			CalcBlockMipmapSize(info.block_size, info.bytes_per_block, info.width, info.height, level, md.width, md.height, md.pitch, mip_size);
+
+			if (!ReadDDSMipLevelFromBuffer(data.data(), data.size(), current_offset, level, info, md.width, md.height, md.data, md.pitch, mip_size))
+				break;
+
+			tex->mips.push_back(std::move(md));
+		}
+	}
 
 	return true;
 }
@@ -599,35 +844,23 @@ bool DDSLoader(const std::string& filename, GSTextureReplacements::ReplacementTe
 	if (!fp)
 		return false;
 
-	DDSLoadInfo info;
-	if (!ParseDDSHeader(fp.get(), &info))
+	return DDSLoaderFromFile(fp.get(), filename, tex, only_base_image);
+}
+
+bool GSTextureReplacements::LoadImageFromArchiveEntry(const std::string& archive_path,
+	const std::string& normalized_name,
+	GSTextureReplacements::ReplacementTexture* tex,
+	bool only_base_image)
+{
+	const auto data = ReadArchiveEntryBytes(archive_path, normalized_name);
+	if (!data.has_value())
 		return false;
 
-	// always load the base image
-	if (FileSystem::FSeek64(fp.get(), info.base_image_offset, SEEK_SET) != 0)
-		return false;
+	const std::string_view ext = Path::GetExtension(normalized_name);
+	if (StringUtil::Strncasecmp(ext.data(), "png", ext.size()) == 0)
+		return PNGLoaderFromBuffer(*data, normalized_name, tex, only_base_image);
+	if (StringUtil::Strncasecmp(ext.data(), "dds", ext.size()) == 0)
+		return DDSLoaderFromBuffer(*data, normalized_name, tex, only_base_image);
 
-	tex->format = info.format;
-	tex->width = info.width;
-	tex->height = info.height;
-	tex->pitch = info.base_image_pitch;
-	if (!ReadDDSMipLevel(fp.get(), filename, 0, info, tex->width, tex->height, tex->data, tex->pitch, info.base_image_size))
-		return false;
-
-	// Read in any remaining mip levels in the file.
-	if (!only_base_image)
-	{
-		for (u32 level = 1; level <= info.mip_count; level++)
-		{
-			GSTextureReplacements::ReplacementTexture::MipData md;
-			u32 mip_size;
-			CalcBlockMipmapSize(info.block_size, info.bytes_per_block, info.width, info.height, level, md.width, md.height, md.pitch, mip_size);
-			if (!ReadDDSMipLevel(fp.get(), filename, level, info, md.width, md.height, md.data, md.pitch, mip_size))
-				break;
-
-			tex->mips.push_back(std::move(md));
-		}
-	}
-
-	return true;
+	return false;
 }

--- a/pcsx2/GS/Renderers/HW/GSTextureReplacements.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureReplacements.cpp
@@ -9,6 +9,7 @@
 #include "common/StringUtil.h"
 #include "common/ScopedGuard.h"
 #include "common/TextureDecompress.h"
+#include "common/ZipHelpers.h"
 
 #include "Config.h"
 #include "Host.h"
@@ -187,6 +188,30 @@ GSTextureCache::HashCacheKey GSTextureReplacements::HashCacheKeyFromTextureName(
 	key.region_width = tn.region_width;
 	key.region_height = tn.region_height;
 	return key;
+}
+
+static std::string NormalizeReplacementEntryName(std::string path_or_name)
+{
+	std::replace(path_or_name.begin(), path_or_name.end(), '\\', '/');
+
+	const std::size_t archive_sep = path_or_name.find("!");
+	if (archive_sep != std::string::npos)
+		path_or_name = path_or_name.substr(archive_sep + 1);
+
+	const std::size_t slash = path_or_name.find_last_of('/');
+	if (slash != std::string::npos)
+		path_or_name = path_or_name.substr(slash + 1);
+
+	return path_or_name;
+}
+
+static std::pair<std::string, std::string> SplitArchiveReference(const std::string& value)
+{
+	const std::size_t archive_sep = value.find('!');
+	if (archive_sep == std::string::npos)
+		return {value, {}};
+
+	return {value.substr(0, archive_sep), value.substr(archive_sep + 1)};
 }
 
 std::optional<TextureName> GSTextureReplacements::ParseReplacementName(const std::string& filename)
@@ -408,33 +433,64 @@ void GSTextureReplacements::ReloadReplacementMap()
 	{
 		Host::AddKeyedOSDMessage("TextureReplacementDirCaseMismatch",
 			fmt::format(TRANSLATE_FS("TextureReplacement", "Texture replacement directory {} will not work on case sensitive filesystems.\n"
-			                                               "Rename it to {} to remove this warning."),
-			            wrong_case_path, *right_case_path),
+														   "Rename it to {} to remove this warning."),
+				wrong_case_path, *right_case_path),
 			Host::OSD_WARNING_DURATION);
 	}
 
-	if (!FileSystem::FindFiles(replacement_dir.c_str(), "*", FILESYSTEM_FIND_FILES | FILESYSTEM_FIND_HIDDEN_FILES | FILESYSTEM_FIND_RECURSIVE, &files))
-		return;
+	auto process_file = [&](const std::string& path) {
+		const auto entries = ListArchiveEntryNames(path);
+		if (!entries.empty())
+		{
+			for (const std::string& entry : entries)
+			{
+				const std::string entry_name = NormalizeReplacementEntryName(entry);
+				if (!GetLoader(entry_name))
+					continue;
 
-	std::string filename;
-	for (FILESYSTEM_FIND_DATA& fd : files)
-	{
-		// file format we can handle?
-		filename = Path::GetFileName(fd.FileName);
+				auto name = ParseReplacementName(entry_name);
+				if (!name.has_value())
+					continue;
+
+				s_replacement_texture_filenames.emplace(name.value(), path + "!" + entry);
+				name->CLUTHash = 0;
+				s_replacement_textures_without_clut_hash.insert(name.value());
+			}
+			return;
+		}
+
+		const std::string filename(std::string(Path::GetFileName(path)));
 		if (!GetLoader(filename))
-			continue;
+			return;
 
-		// parse the name if it's valid
 		std::optional<TextureName> name = ParseReplacementName(filename);
 		if (!name.has_value())
-			continue;
+			return;
 
-		DbgCon.WriteLn("Found %ux%u replacement '%.*s'", name->Width(), name->Height(), static_cast<int>(filename.size()), filename.data());
-		s_replacement_texture_filenames.emplace(name.value(), std::move(fd.FileName));
+		s_replacement_texture_filenames.emplace(name.value(), path);
 
-		// zero out the CLUT hash, because we need this for checking if there's any replacements with this hash when using paltex
 		name->CLUTHash = 0;
 		s_replacement_textures_without_clut_hash.insert(name.value());
+	};
+
+	const std::string texture_zip = texture_dir + ".zip";
+
+	if (FileSystem::FileExists(texture_zip.c_str()))
+	{
+		process_file(texture_zip);
+	}
+	else if (FileSystem::FindFiles(texture_dir.c_str(), "*", FILESYSTEM_FIND_FILES | FILESYSTEM_FIND_HIDDEN_FILES | FILESYSTEM_FIND_RECURSIVE, &files))
+	{
+		const std::string dump_dir = Path::Combine(texture_dir, TEXTURE_DUMP_SUBDIRECTORY_NAME);
+
+		for (const FILESYSTEM_FIND_DATA& fd : files)
+		{
+
+			if (fd.FileName.rfind(dump_dir, 0) == 0)
+				continue;
+
+			process_file(fd.FileName);
+		}
 	}
 
 	if (!s_replacement_texture_filenames.empty())
@@ -629,21 +685,34 @@ void GSTextureReplacements::SetReplacementTextureAlphaMinMax(ReplacementTexture&
 	}
 }
 
-std::optional<GSTextureReplacements::ReplacementTexture> GSTextureReplacements::LoadReplacementTexture(const TextureName& name, const std::string& filename, bool only_base_image)
+std::optional<GSTextureReplacements::ReplacementTexture> GSTextureReplacements::LoadReplacementTexture(
+	const TextureName& name, const std::string& filename, bool only_base_image)
 {
-	ReplacementTextureLoader loader = GetLoader(filename);
+	std::string archive_path;
+	std::string entry_name;
+	std::tie(archive_path, entry_name) = SplitArchiveReference(filename);
+
+	const std::string normalized = entry_name.empty() ? NormalizeReplacementEntryName(filename) : NormalizeReplacementEntryName(entry_name);
+	ReplacementTextureLoader loader = GetLoader(normalized);
 	if (!loader)
 		return std::nullopt;
 
 	ReplacementTexture rtex;
-	if (!loader(filename.c_str(), &rtex, only_base_image))
+	if (!entry_name.empty())
+	{
+		if (!LoadImageFromArchiveEntry(archive_path, entry_name, &rtex, only_base_image))
+		{
+			Console.Warning("Failed to load replacement texture %s", entry_name.c_str());
+			return std::nullopt;
+		}
+	}
+	else if (!loader(filename, &rtex, only_base_image))
 	{
 		Console.Warning("Failed to load replacement texture %s", filename.c_str());
 		return std::nullopt;
 	}
 
 	SetReplacementTextureAlphaMinMax(rtex);
-
 	return rtex;
 }
 

--- a/pcsx2/GS/Renderers/HW/GSTextureReplacements.h
+++ b/pcsx2/GS/Renderers/HW/GSTextureReplacements.h
@@ -56,6 +56,7 @@ namespace GSTextureReplacements
 	/// Loader will take a filename and interpret the format (e.g. DDS, PNG, etc).
 	using ReplacementTextureLoader = bool (*)(const std::string& filename, GSTextureReplacements::ReplacementTexture* tex, bool only_base_image);
 	ReplacementTextureLoader GetLoader(const std::string_view filename);
+	bool LoadImageFromArchiveEntry(const std::string& archive_path, const std::string& entry_name, GSTextureReplacements::ReplacementTexture* tex, bool only_base_image);
 
 	/// Saves an image buffer to a PNG file (for dumping).
 	bool SavePNGImage(const std::string& filename, u32 width, u32 height, const u8* buffer, u32 pitch);


### PR DESCRIPTION
ISSUE: #14838



## Description of Changes

Added support for loading replacement files from ZIP archives using the following directory structure:

```text
SLES-54255.zip
└── replacement
```

This implementation currently supports ZIP archives only. I attempted to support .7z archives as well, but ran into issues, so that support is not included in this PR.

## Rationale behind Changes

The goal of these changes is to allow replacement files to be loaded directly from ZIP archives without requiring them to be extracted beforehand. This provides a more convenient way to distribute and use replacement files while preserving the expected directory structure.

## Suggested Testing Steps

- Create a ZIP archive named after the game serial (for example, SLES-54255.zip).
- Inside the archive, create a replacement directory containing the replacement files.
- Launch the game and verify that the replacement files are detected and loaded correctly.
- Confirm that the same files continue to work when using the existing extracted directory structure.

## Did you use AI to help find, test, or implement this issue or feature?

Yes. I used AI primarily as a development aid to look up implementation examples, assist with the build process, and help diagnose and resolve compilation errors. The implementation itself was written and integrated by me.

<img width="1585" height="852" alt="260816_01h19m07s_screenshot" src="https://github.com/user-attachments/assets/6fef2b25-19c1-48b4-aae7-6a52b76bb90e" />

