### PR TITLE
SW: Fix C rasterizor IIP vector pack (signed->unsigned)

### DIFF
--- a/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
+++ b/pcsx2/GS/Renderers/SW/GSDrawScanline.cpp
@@ -339,8 +339,8 @@ void GSDrawScanline::CSetupPrim(const GSVertexSW* vertex, const u16* index, cons
 
 			for (int i = 0; i < vlen; i++)
 			{
-				VectorI r = (VectorI(dr * load_shift(i)) & mask16).ps32();
-				VectorI b = (VectorI(db * load_shift(i)) & mask16).ps32();
+				VectorI r = (VectorI(dr * load_shift(i)) & mask16).pu32();
+				VectorI b = (VectorI(db * load_shift(i)) & mask16).pu32();
 
 				local.d[i].rb = r.upl16(b);
 			}
@@ -350,8 +350,8 @@ void GSDrawScanline::CSetupPrim(const GSVertexSW* vertex, const u16* index, cons
 
 			for (int i = 0; i < vlen; i++)
 			{
-				VectorI g = (VectorI(dg * load_shift(i)) & mask16).ps32();
-				VectorI a = (VectorI(da * load_shift(i)) & mask16).ps32();
+				VectorI g = (VectorI(dg * load_shift(i)) & mask16).pu32();
+				VectorI a = (VectorI(da * load_shift(i)) & mask16).pu32();
 
 				local.d[i].ga = g.upl16(a);
 			}


### PR DESCRIPTION
### Description of Changes
The SW C rasterizer (compile time option, default disabled) was improperly using a signed function when it should've been unsigned.

### Rationale behind Changes
This caused games to have broken drawing whenever they used gouraud shading.
<img width="961" height="710" alt="image" src="https://github.com/user-attachments/assets/05ebc52b-6041-4c2f-bdbe-303133f87309" />

### Suggested Testing Steps
Compile PCSX2 to use the C rasterizer, try out a game.

### Did you use AI to help find, test, or implement this issue or feature?
Yes.
I have been working on some other stuff that requires no SW JIT. This was bugging me, and I know I didn't want to debug it.
As a shot in the dark, I asked an AI to try and find the difference between the C and JIT implementations, and it found this issue.

I can independently verify that this is correct based on the JIT implementation.

Matter of fact, the JIT has the reference implementation commented:

```c
			// VectorI r = (VectorI(dr * shift[1 + i]) & mask16).pu32();

			if (i < 4 || many_regs)
				THREEARG(mulps, xym0, XYm(4 + i), xym2);
			else
				vmulps(ymm0, ymm2, ptr[&g_const_256b.m_shift[8 - i]]);
			cvttps2dq(xym0, xym0);
			pand(xym0, mask16);
			packusdw(xym0, xym0);
```