### PR TITLE
Core: Init video mode based on disc or BIOS first

### DIFF
--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -468,7 +468,7 @@ u32 cdvdGetElfCRC(const std::string& path)
 	return elfo.GetCRC();
 }
 
-static CDVDDiscType GetPS2ElfName(IsoReader& isor, std::string* name, std::string* version, Error* error)
+static CDVDDiscType GetPS2ElfName(IsoReader& isor, std::string* name, std::string* version, std::string* vmode, Error* error)
 {
 	CDVDDiscType retype = CDVDDiscType::Other;
 	name->clear();
@@ -510,6 +510,7 @@ static CDVDDiscType GetPS2ElfName(IsoReader& isor, std::string* name, std::strin
 		else if (key == "VMODE")
 		{
 			DevCon.WriteLn(Color_Blue, fmt::format("(SYSTEM.CNF) Disc region type = {}", value));
+			*vmode = value;
 		}
 		else if (key == "VER")
 		{
@@ -574,15 +575,15 @@ static std::string ExecutablePathToSerial(const std::string& path)
 	return serial;
 }
 
-void cdvdGetDiscInfo(std::string* out_serial, std::string* out_elf_path, std::string* out_version, u32* out_crc,
+void cdvdGetDiscInfo(std::string* out_serial, std::string* out_elf_path, std::string* out_version, std::string* out_region, u32* out_crc,
 	CDVDDiscType* out_disc_type)
 {
 	Error error;
 	IsoReader isor;
 
-	std::string elfpath, version;
+	std::string elfpath, version, vmode;
 	CDVDDiscType disc_type = CDVDDiscType::Other;
-	if (!isor.Open(&error) || (disc_type = GetPS2ElfName(isor, &elfpath, &version, &error)) == CDVDDiscType::Other)
+	if (!isor.Open(&error) || (disc_type = GetPS2ElfName(isor, &elfpath, &version, &vmode, &error)) == CDVDDiscType::Other)
 		Console.Error(fmt::format("Failed to get ELF name: {}", error.GetDescription()));
 
 	// Don't bother parsing it if we don't need the CRC.
@@ -616,6 +617,8 @@ void cdvdGetDiscInfo(std::string* out_serial, std::string* out_elf_path, std::st
 		*out_version = std::move(version);
 	if (out_disc_type)
 		*out_disc_type = disc_type;
+	if (out_region)
+		*out_region = vmode;
 }
 
 void cdvdReadKey(u8, u16, u32 arg2, u8* key)

--- a/pcsx2/CDVD/CDVD.h
+++ b/pcsx2/CDVD/CDVD.h
@@ -179,7 +179,7 @@ extern void cdvdNewDiskCB();
 extern u8 cdvdRead(u8 key);
 extern void cdvdWrite(u8 key, u8 rt);
 
-extern void cdvdGetDiscInfo(std::string* out_serial, std::string* out_elf_path, std::string* out_version, u32* out_crc,
+extern void cdvdGetDiscInfo(std::string* out_serial, std::string* out_elf_path, std::string* out_version, std::string* out_region, u32* out_crc,
 	CDVDDiscType* out_disc_type);
 extern u32 cdvdGetElfCRC(const std::string& path);
 extern bool cdvdLoadElf(ElfObject* elfo, const std::string_view elfpath, bool isPSXElf, Error* error);

--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -215,7 +215,7 @@ static void vSyncInfoCalc(vSyncTimingInfo* info, double framesPerSecond, u32 sca
 	// Dynasty Warriors 3 Xtreme Legends - fake save corruption when loading save
 	// Jak II - random speedups
 	// Shadow of Rome - FMV audio issues
-	const bool ntsc_hblank = gsVideoMode != GS_VideoMode::PAL && gsVideoMode != GS_VideoMode::DVD_PAL;
+	const bool ntsc_hblank = gsVideoMode != GS_VideoMode::PAL && gsVideoMode != GS_VideoMode::DVD_PAL && (gsVideoMode != GS_VideoMode::Uninitialized || framesPerSecond != 25.00);
 	const u64 HalfFrame = Frame / 2;
 	const float extra_scanlines = static_cast<float>(IsProgressiveVideoMode()) * (ntsc_hblank ? 0.5f : 1.5f);
 	const u64 Blank = Scanline * ((ntsc_hblank ? 22.5f : 24.5f) + extra_scanlines);

--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -215,7 +215,7 @@ static void vSyncInfoCalc(vSyncTimingInfo* info, double framesPerSecond, u32 sca
 	// Dynasty Warriors 3 Xtreme Legends - fake save corruption when loading save
 	// Jak II - random speedups
 	// Shadow of Rome - FMV audio issues
-	const bool ntsc_hblank = gsVideoMode != GS_VideoMode::PAL && gsVideoMode != GS_VideoMode::DVD_PAL && (gsVideoMode != GS_VideoMode::Uninitialized || framesPerSecond != 25.00);
+	const bool ntsc_hblank = gsVideoMode != GS_VideoMode::PAL && gsVideoMode != GS_VideoMode::DVD_PAL && (gsVideoMode != GS_VideoMode::Uninitialized || framesPerSecond != (Pcsx2Config::GSOptions::DEFAULT_FRAME_RATE_PAL / 2));
 	const u64 HalfFrame = Frame / 2;
 	const float extra_scanlines = static_cast<float>(IsProgressiveVideoMode()) * (ntsc_hblank ? 0.5f : 1.5f);
 	const u64 Blank = Scanline * ((ntsc_hblank ? 22.5f : 24.5f) + extra_scanlines);
@@ -312,7 +312,7 @@ double GetVerticalFrequency()
 	switch (gsVideoMode)
 	{
 		case GS_VideoMode::Uninitialized: // SetGsCrt hasn't executed yet, give some temporary values.
-			return (cur_region == "PAL") ? 50.00 : 60.00;
+			return (cur_region == "PAL") ? Pcsx2Config::GSOptions::DEFAULT_FRAME_RATE_PAL : Pcsx2Config::GSOptions::DEFAULT_FRAME_RATE_NTSC;
 		case GS_VideoMode::PAL:
 		case GS_VideoMode::DVD_PAL:
 			return (IsProgressiveVideoMode() == false) ? EmuConfig.GS.FrameratePAL : EmuConfig.GS.FrameratePAL - 0.24f;
@@ -354,9 +354,9 @@ void UpdateVSyncRate(bool force)
 		{
 			case GS_VideoMode::Uninitialized: // SYSCALL instruction hasn't executed yet, give some temporary values.
 				if (gsIsInterlaced)
-					total_scanlines = (vertical_frequency == 50.00) ? SCANLINES_TOTAL_PAL_I : SCANLINES_TOTAL_NTSC_I;
+					total_scanlines = (vertical_frequency == Pcsx2Config::GSOptions::DEFAULT_FRAME_RATE_PAL) ? SCANLINES_TOTAL_PAL_I : SCANLINES_TOTAL_NTSC_I;
 				else
-					total_scanlines = (vertical_frequency == 50.00) ? SCANLINES_TOTAL_PAL_NI : SCANLINES_TOTAL_NTSC_NI;
+					total_scanlines = (vertical_frequency == Pcsx2Config::GSOptions::DEFAULT_FRAME_RATE_PAL) ? SCANLINES_TOTAL_PAL_NI : SCANLINES_TOTAL_NTSC_NI;
 				break;
 			case GS_VideoMode::PAL:
 			case GS_VideoMode::DVD_PAL:

--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -307,10 +307,12 @@ double GetVerticalFrequency()
 	// https://web.archive.org/web/20120629231826fw_/http://ntsc-tv.com/index.html
 	// https://web.archive.org/web/20200831051302/https://www.hdretrovision.com/240p/
 
+	std::string cur_region = VMManager::Internal::GetCurrentRegion();
+
 	switch (gsVideoMode)
 	{
 		case GS_VideoMode::Uninitialized: // SetGsCrt hasn't executed yet, give some temporary values.
-			return 60.00;
+			return (cur_region == "PAL") ? 50.00 : 60.00;
 		case GS_VideoMode::PAL:
 		case GS_VideoMode::DVD_PAL:
 			return (IsProgressiveVideoMode() == false) ? EmuConfig.GS.FrameratePAL : EmuConfig.GS.FrameratePAL - 0.24f;
@@ -352,9 +354,9 @@ void UpdateVSyncRate(bool force)
 		{
 			case GS_VideoMode::Uninitialized: // SYSCALL instruction hasn't executed yet, give some temporary values.
 				if (gsIsInterlaced)
-					total_scanlines = SCANLINES_TOTAL_NTSC_I;
+					total_scanlines = (vertical_frequency == 50.00) ? SCANLINES_TOTAL_PAL_I : SCANLINES_TOTAL_NTSC_I;
 				else
-					total_scanlines = SCANLINES_TOTAL_NTSC_NI;
+					total_scanlines = (vertical_frequency == 50.00) ? SCANLINES_TOTAL_PAL_NI : SCANLINES_TOTAL_NTSC_NI;
 				break;
 			case GS_VideoMode::PAL:
 			case GS_VideoMode::DVD_PAL:

--- a/pcsx2/GameList.cpp
+++ b/pcsx2/GameList.cpp
@@ -267,7 +267,7 @@ bool GameList::GetIsoSerialAndCRC(const std::string& path, s32* disc_type, std::
 
 	// TODO: we could include the version in the game list?
 	*disc_type = DoCDVDdetectDiskType();
-	cdvdGetDiscInfo(serial, nullptr, nullptr, crc, nullptr);
+	cdvdGetDiscInfo(serial, nullptr, nullptr, nullptr, crc, nullptr);
 	DoCDVDclose();
 	return true;
 }

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -679,7 +679,7 @@ void eeloadHook()
 		{
 			CDVDDiscType disc_type;
 			std::string disc_elf;
-			cdvdGetDiscInfo(nullptr, &disc_elf, nullptr, nullptr, &disc_type);
+			cdvdGetDiscInfo(nullptr, &disc_elf, nullptr, nullptr, nullptr, &disc_type);
 			if (disc_type == CDVDDiscType::PS2Disc)
 			{
 				// only allow fast boot for PS2 games

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -171,6 +171,7 @@ static std::string s_disc_version;
 static std::string s_title;
 static std::string s_title_en_search;
 static std::string s_title_en_replace;
+static std::string s_cur_region;
 static u32 s_disc_crc;
 static u32 s_current_crc;
 static u32 s_elf_entry_point = 0xFFFFFFFFu;
@@ -1051,11 +1052,12 @@ void VMManager::UpdateDiscDetails(bool booting)
 			s_disc_crc = GSDumpReplayer::GetDumpCRC();
 			s_disc_elf = {};
 			s_disc_version = {};
+			s_cur_region = "NTSC";
 			serial_is_valid = !s_disc_serial.empty();
 		}
 		else if (CDVDsys_GetSourceType() != CDVD_SourceType::NoDisc)
 		{
-			cdvdGetDiscInfo(&s_disc_serial, &s_disc_elf, &s_disc_version, &s_disc_crc, nullptr);
+			cdvdGetDiscInfo(&s_disc_serial, &s_disc_elf, &s_disc_version, &s_cur_region, &s_disc_crc, nullptr);
 			serial_is_valid = !s_disc_serial.empty();
 		}
 		else if (!s_elf_override.empty())
@@ -1063,12 +1065,14 @@ void VMManager::UpdateDiscDetails(bool booting)
 			s_disc_serial = Path::GetFileTitle(s_elf_override);
 			s_disc_version = {};
 			s_disc_crc = 0; // set below
+			s_cur_region = "NTSC";
 		}
 		else
 		{
 			s_disc_serial = BiosSerial;
 			s_disc_version = {};
 			s_disc_crc = 0;
+			s_cur_region = (BiosZone == "Europe") ? "PAL" : "NTSC";
 			title = fmt::format(TRANSLATE_FS("VMManager", "PS2 BIOS ({})"), BiosZone);
 		}
 
@@ -2816,6 +2820,11 @@ bool VMManager::Internal::WasFastBooted()
 bool VMManager::Internal::IsFastBootInProgress()
 {
 	return s_fast_boot_requested && !HasBootedELF();
+}
+
+std::string VMManager::Internal::GetCurrentRegion()
+{
+	return s_cur_region;
 }
 
 void VMManager::Internal::DisableFastBoot()

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -306,6 +306,9 @@ namespace VMManager
 		/// Returns true if fast booting is active (requested but ELF not started).
 		bool IsFastBootInProgress();
 
+		// Returns the current disc/BIOS region, if set.
+		std::string GetCurrentRegion();
+
 		/// Disables fast boot if it was requested, and found to be incompatible.
 		void DisableFastBoot();
 


### PR DESCRIPTION
### Description of Changes
Sets the video mode on boot more appropriately to the current disc or bios (whichever is available in that order) by default, instead of always NTSC.

### Rationale behind Changes
When fast booting, the initialisation normally done by the BIOS gets skipped, so any game which calculates cycles based on the framerate (which it expects the BIOS to have done) before setting its own video mode, will calculate bad cycles and cause sync issues.  This will resolve that, with no (known) side effects, since the only thing which *should* care, is the BIOS, which won't because it immediately inits the video.

### Suggested Testing Steps
Test the EU (and US I guess) versions of Spyro - Enter the Dragonfly with fast boot. Full booting the EU game on an NTSC BIOS will still result in bad timing, just like would happen on a real console.

### Did you use AI to help find, test, or implement this issue or feature?
No

Fixes #8286

Thanks goes out to Ziemas and Goatman13 for diagnosing this one.