### PR TITLE
SPU2: Pass IOP cycle count at 64bit

### DIFF
--- a/pcsx2/SPU2/spu2.h
+++ b/pcsx2/SPU2/spu2.h
@@ -81,6 +81,6 @@ void SPU2writeDMA7Mem(u16* pMem, u32 size);
 extern u64 lClocks;
 
 extern void CounterUpdate(u32 DMAICounter);
-extern void TimeUpdate(u32 cClocks);
+extern void TimeUpdate(u64 cClocks);
 extern void SPU2_FastWrite(u32 rmem, u16 value);
 

--- a/pcsx2/SPU2/spu2sys.cpp
+++ b/pcsx2/SPU2/spu2sys.cpp
@@ -314,7 +314,7 @@ __forceinline void CheckDMAProgress(int cid)
 static constexpr uint TickInterval = 768;
 static constexpr int SanityInterval = 4800;
 
-__forceinline void TimeUpdate(u32 cClocks)
+__forceinline void TimeUpdate(u64 cClocks)
 {
 	u32 dClocks = cClocks - lClocks;
 


### PR DESCRIPTION
### Description of Changes
Updates the TimeUpdate function of SPU2 to take a 64bit cycle number instead of 32.

### Rationale behind Changes
Probably got missed during the move to 64bit cycle counters, but could have caused problems if you played for a while and the IOP cycle counter went past UINT_MAX

### Suggested Testing Steps
Uhh, play for a long time I guess? Otherwise, not much to test.

### Did you use AI to help find, test, or implement this issue or feature?
No