### PR TITLE
Expose PS2 memory to same-user tools via named shm

### DIFF
--- a/common/Linux/LnxHostSys.cpp
+++ b/common/Linux/LnxHostSys.cpp
@@ -61,10 +61,18 @@ std::string HostSys::GetFileMappingName(const char* prefix)
 #endif
 }
 
+static std::string s_data_shm_name;
+static bool s_data_shm_name_valid = false;
+
 void* HostSys::CreateSharedMemory(const char* name, size_t size)
 {
-	// We don't close this mapping, so a user with the same UID can use it for modding and patches
 	const int fd = shm_open(name, O_CREAT | O_EXCL | O_RDWR, 0600);
+	if (fd < 0 && errno == EEXIST)
+	{
+		// Stale object left by a crashed instance that reused our pid
+		shm_unlink(name);
+		fd = shm_open(name, O_CREAT | O_EXCL | O_RDWR, 0600);
+	}
 	if (fd < 0)
 	{
 		std::fprintf(stderr, "shm_open failed: %d\n", errno);
@@ -78,12 +86,24 @@ void* HostSys::CreateSharedMemory(const char* name, size_t size)
 		return nullptr;
 	}
 
+	// We don't close the mapping immediately, so a user with the same UID can use it for modding and patches
+	// Removed on clean shutdown and cleared above if prev. session didn't shut down cleanly
+	s_data_shm_name = name;
+	s_data_shm_name_valid = true;
+
 	return reinterpret_cast<void*>(static_cast<intptr_t>(fd));
 }
 
 void HostSys::DestroySharedMemory(void* ptr)
 {
 	close(static_cast<int>(reinterpret_cast<intptr_t>(ptr)));
+
+	if (s_data_shm_name_valid)
+	{
+		// remove unused object from /dev/shm
+		shm_unlink(s_data_shm_name.c_str());
+		s_data_shm_name_valid = false;
+	}
 }
 
 #ifndef __APPLE__

--- a/common/Linux/LnxHostSys.cpp
+++ b/common/Linux/LnxHostSys.cpp
@@ -63,15 +63,13 @@ std::string HostSys::GetFileMappingName(const char* prefix)
 
 void* HostSys::CreateSharedMemory(const char* name, size_t size)
 {
+	// We don't close this mapping, so a user with the same UID can use it for modding and patches
 	const int fd = shm_open(name, O_CREAT | O_EXCL | O_RDWR, 0600);
 	if (fd < 0)
 	{
 		std::fprintf(stderr, "shm_open failed: %d\n", errno);
 		return nullptr;
 	}
-
-	// we're not going to be opening this mapping in other processes, so remove the file
-	shm_unlink(name);
 
 	// ensure it's the correct size
 	if (ftruncate(fd, static_cast<off_t>(size)) < 0)

--- a/common/Linux/LnxHostSys.cpp
+++ b/common/Linux/LnxHostSys.cpp
@@ -66,7 +66,7 @@ static bool s_data_shm_name_valid = false;
 
 void* HostSys::CreateSharedMemory(const char* name, size_t size)
 {
-	const int fd = shm_open(name, O_CREAT | O_EXCL | O_RDWR, 0600);
+	int fd = shm_open(name, O_CREAT | O_EXCL | O_RDWR, 0600);
 	if (fd < 0 && errno == EEXIST)
 	{
 		// Stale object left by a crashed instance that reused our pid


### PR DESCRIPTION
… Linux

### Description of Changes
- Keeps emulated memory object open to same-user processes for easy debugging/live-patching on native Linux builds.
- Safely discards named object on shutdown, and properly handles named object in new session if for some reason the program previously did not shut down cleanly.

### Rationale behind Changes
Makes reading game memory on Linux much easier to work with, this specific patch is being done for DC1AP (Archipelago mod for Dark Cloud), but would have reaching benefits to other mods running natively on Linux, too.

Technically strips away a layer of security, but the implications are quite narrow (same-user, should only affect emulated game memory), and the new behaviour would mirror what happens on Windows with EEmem for debuggers anyway, so to my knowledge we wouldn't be crossing a previously unviolated security barrier, from a cross-platform perspective.

At the very least, I think we should add a CLI flag to keep it open, but if possible, it would be nice to just have this as default behaviour!

### Suggested Testing Steps
I built and ran my changes to ensure they worked as intended, it seemed pretty good, though obviously this isn't the most scientific method of testing.

Changes are quite small, so I don't think there is anything in particular to add to test, though if you wanted to be thorough a unit test to ensure the named object is actually unlinked when re-running after a bad shutdown couldn't hurt!

### Did you use AI to help find, test, or implement this issue or feature?
I'm not very familiar with this codebase (made these changes to help with compat for downstream projects), so I used AI to run a semantic search through the codebase to quickly identify the bits I wanted to interact with based on what was causing issues downstream, as well as to give me a rough architectural overview of the project itself.

All code, reasoning, and stupid mistakes are my own!

As a side-note, I had to cherry-pick b6cccd87e65a3204cf8154a479f6b3849c1c18d9 to get it to build since I'm on Arch  with ffmpeg 9.0+, but this fix seems staged and ready to go and I don't think it's a major issue in terms of my proposed changes specifically. 