### PR TITLE
DEV9: configurable/generated MAC address, and show the selected adapter

### DIFF
--- a/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.cpp
@@ -4,11 +4,13 @@
 #include <QtWidgets/QMessageBox>
 #include <QtWidgets/QFileDialog>
 #include <algorithm>
+#include <random>
 
 #include "common/FileSystem.h"
 #include "common/Path.h"
 #include "common/StringUtil.h"
 
+#include "pcsx2/DEV9/AdapterUtils.h"
 #include "pcsx2/Host.h"
 #include "pcsx2/INISettingsInterface.h"
 
@@ -112,6 +114,47 @@ DEV9SettingsWidget::DEV9SettingsWidget(SettingsWindow* settings_dialog, QWidget*
 	connect(m_ui.ethDNS1Addr,    &QLineEdit::editingFinished, this, [&]() { onEthIPChanged(m_ui.ethDNS1Addr,    "DEV9/Eth", "DNS1"   ); });
 	connect(m_ui.ethDNS2Addr,    &QLineEdit::editingFinished, this, [&]() { onEthIPChanged(m_ui.ethDNS2Addr,    "DEV9/Eth", "DNS2"   ); });
 	// clang-format on
+
+	// MAC address. Blank means "generate one on first boot and keep it", which
+	// is what stops every install sharing the built-in default.
+	m_ui.ethMacAddr->setText(QString::fromUtf8(dialog()->getStringValue("DEV9/Eth", "Mac", "").value().c_str()));
+	connect(m_ui.ethMacAddr, &QLineEdit::editingFinished, this, [&]() { onEthMacChanged(); });
+	connect(m_ui.ethMacGenerate, &QPushButton::clicked, this, [&]() {
+		u8 mac[6];
+		std::random_device rd;
+		for (int i = 0; i < 6; i++)
+			mac[i] = static_cast<u8>(rd() & 0xFF);
+
+		// unicast + locally administered, so a generated address can never be
+		// mistaken for, or collide with, real vendor-assigned hardware
+		mac[0] = static_cast<u8>((mac[0] & 0xFC) | 0x02);
+
+		m_ui.ethMacAddr->setText(QString::fromUtf8(StringUtil::StdStringFromFormat(
+			"%02X:%02X:%02X:%02X:%02X:%02X",
+			mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]).c_str()));
+		onEthMacChanged();
+	});
+
+	// Reroll only the host octet, keeping the subnet. A fully random address
+	// would land off-subnet or on the router, which is never what you want.
+	connect(m_ui.ethPS2AddrGenerate, &QPushButton::clicked, this, [&]() {
+		u8 ip[4] = {192, 168, 1, 2};
+		const std::string cur = m_ui.ethPS2Addr->text().toStdString();
+		sscanf(cur.c_str(), "%hhu.%hhu.%hhu.%hhu", &ip[0], &ip[1], &ip[2], &ip[3]);
+
+		std::random_device rd;
+		const u8 was = ip[3];
+		do
+		{
+			ip[3] = static_cast<u8>(2 + (rd() % 253));	// skip .0, .1 and .255
+		} while (ip[3] == was);
+
+		m_ui.ethPS2Addr->setText(QString::fromUtf8(StringUtil::StdStringFromFormat(
+			"%u.%u.%u.%u", ip[0], ip[1], ip[2], ip[3]).c_str()));
+		onEthIPChanged(m_ui.ethPS2Addr, "DEV9/Eth", "PS2IP");
+	});
+
+	refreshAdapterInfo();
 
 	//Auto
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.ethNetMaskAuto, "DEV9/Eth", "AutoMask", true);
@@ -284,6 +327,57 @@ void DEV9SettingsWidget::onEthDeviceChanged(int index)
 		dialog()->setStringSettingValue("DEV9/Eth", "EthApi", std::nullopt);
 		dialog()->setStringSettingValue("DEV9/Eth", "EthDevice", std::nullopt);
 	}
+
+	refreshAdapterInfo();
+}
+
+/*
+    Show what the selected host adapter actually is.
+
+    DEV9 stores the adapter by GUID, so when a NIC changes or a VPN/virtual
+    adapter appears the config can silently point at something that no longer
+    exists and bridging fails opaquely. This reads the adapter's own details --
+    address, MAC, gateway -- locally via AdapterUtils. Nothing is sent anywhere;
+    an emulator settings page has no business making outbound requests.
+*/
+void DEV9SettingsWidget::refreshAdapterInfo()
+{
+    const std::string guid = dialog()->getStringValue("DEV9/Eth", "EthDevice", "").value();
+    if (guid.empty())
+    {
+        m_ui.ethAdapterInfo->setText(tr("No adapter selected."));
+        return;
+    }
+
+    AdapterUtils::Adapter adapter;
+    AdapterUtils::AdapterBuffer buffer;
+    if (!AdapterUtils::GetAdapter(guid, &adapter, &buffer))
+    {
+        m_ui.ethAdapterInfo->setText(
+            tr("Selected adapter not found on this system - bridging will fail. "
+               "Pick one from the list above."));
+        return;
+    }
+
+    QStringList bits;
+
+    const std::optional<PacketReader::IP::IP_Address> ip = AdapterUtils::GetAdapterIP(&adapter);
+    bits << tr("IP: %1").arg(ip.has_value()
+        ? QString::asprintf("%u.%u.%u.%u", ip->bytes[0], ip->bytes[1], ip->bytes[2], ip->bytes[3])
+        : tr("none"));
+
+    const std::optional<PacketReader::MAC_Address> mac = AdapterUtils::GetAdapterMAC(&adapter);
+    if (mac.has_value())
+        bits << QString::asprintf("MAC: %02X:%02X:%02X:%02X:%02X:%02X",
+            mac->bytes[0], mac->bytes[1], mac->bytes[2],
+            mac->bytes[3], mac->bytes[4], mac->bytes[5]);
+
+    const std::vector<PacketReader::IP::IP_Address> gws = AdapterUtils::GetGateways(&adapter);
+    if (!gws.empty())
+        bits << tr("Gateway: %1").arg(QString::asprintf("%u.%u.%u.%u",
+            gws[0].bytes[0], gws[0].bytes[1], gws[0].bytes[2], gws[0].bytes[3]));
+
+    m_ui.ethAdapterInfo->setText(bits.join(QStringLiteral("    ")));
 }
 
 void DEV9SettingsWidget::onEthDHCPInterceptChanged(Qt::CheckState state)
@@ -315,6 +409,36 @@ void DEV9SettingsWidget::onEthDHCPInterceptChanged(Qt::CheckState state)
 	m_ui.ethDNS2AddrLabel->setEnabled(enabled);
 	m_ui.ethDNS2Mode->setEnabled(enabled);
 	onEthDNSModeChanged(m_ui.ethDNS2Mode, m_ui.ethDNS2Mode->currentIndex(), m_ui.ethDNS2Addr, "DEV9/Eth", "ModeDNS2");
+}
+
+void DEV9SettingsWidget::onEthMacChanged()
+{
+	const QString text = m_ui.ethMacAddr->text().trimmed();
+
+	// empty is meaningful: it clears the setting so DEV9 generates one
+	if (text.isEmpty())
+	{
+		if (dialog()->getStringValue("DEV9/Eth", "Mac", std::nullopt).has_value())
+			dialog()->setStringSettingValue("DEV9/Eth", "Mac", std::nullopt);
+		return;
+	}
+
+	u8 mac[6];
+	if (6 != sscanf(text.toUtf8().constData(), "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
+					&mac[0], &mac[1], &mac[2], &mac[3], &mac[4], &mac[5]))
+	{
+		QMessageBox::critical(this, tr("Invalid MAC Address"),
+			tr("MAC addresses look like 00:11:22:33:44:55."));
+		m_ui.ethMacAddr->setText(QString::fromUtf8(
+			dialog()->getStringValue("DEV9/Eth", "Mac", "").value().c_str()));
+		return;
+	}
+
+	const std::string neat = StringUtil::StdStringFromFormat(
+		"%02X:%02X:%02X:%02X:%02X:%02X", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+
+	m_ui.ethMacAddr->setText(QString::fromUtf8(neat.c_str()));
+	dialog()->setStringSettingValue("DEV9/Eth", "Mac", neat.c_str());
 }
 
 void DEV9SettingsWidget::onEthIPChanged(QLineEdit* sender, const char* section, const char* key)

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.h
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.h
@@ -22,6 +22,8 @@ private Q_SLOTS:
 	void onEthDeviceTypeChanged(int index);
 	void onEthDeviceChanged(int index);
 	void onEthDHCPInterceptChanged(Qt::CheckState state);
+	void refreshAdapterInfo();
+	void onEthMacChanged();
 	void onEthIPChanged(QLineEdit* sender, const char* section, const char* key);
 	void onEthAutoChanged(QCheckBox* sender, Qt::CheckState state, QLineEdit* input, const char* section, const char* key);
 	void onEthDNSModeChanged(QComboBox* sender, int index, QLineEdit* input, const char* section, const char* key);

--- a/pcsx2-qt/Settings/DEV9SettingsWidget.ui
+++ b/pcsx2-qt/Settings/DEV9SettingsWidget.ui
@@ -53,6 +53,49 @@
        </widget>
       </item>
       <item row="3" column="0" colspan="3">
+       <widget class="QLabel" name="ethAdapterInfo">
+        <property name="toolTip">
+         <string>Live details of the selected host adapter. Everything here is read locally from the adapter itself; nothing is sent anywhere.</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::TextSelectableByMouse</set>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="ethMacLabel">
+        <property name="text">
+         <string>MAC Address:</string>
+        </property>
+        <property name="buddy">
+         <cstring>ethMacAddr</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QLineEdit" name="ethMacAddr">
+        <property name="toolTip">
+         <string>MAC address the emulated PS2 presents on the network. Leave blank to generate a unique one, which is then saved and reused. Ignored if you supply your own eeprom.dat.</string>
+        </property>
+        <property name="placeholderText">
+         <string>Generated automatically</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="2">
+       <widget class="QPushButton" name="ethMacGenerate">
+        <property name="toolTip">
+         <string>Generate a new random MAC address.</string>
+        </property>
+        <property name="text">
+         <string>Generate</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0" colspan="3">
        <widget class="QTabWidget" name="ethTabWidget">
         <property name="currentIndex">
          <number>0</number>
@@ -119,6 +162,16 @@
             </property>
             <property name="buddy">
              <cstring>ethInterceptDHCP</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QPushButton" name="ethPS2AddrGenerate">
+            <property name="toolTip">
+             <string>Pick a different address on the same subnet. Useful when running more than one instance against a local server.</string>
+            </property>
+            <property name="text">
+             <string>Generate</string>
             </property>
            </widget>
           </item>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1066,6 +1066,14 @@ struct Pcsx2Config
 
 		std::vector<HostEntry> EthHosts;
 
+		// PS2 SMAP MAC. All-zero means "not set yet"; with AutoMac a unique
+		// address is generated once and persisted, so each install is
+		// distinguishable on the network instead of sharing the built-in
+		// default. Generated once rather than per boot: a MAC that changes
+		// every launch breaks DHCP leases and switch MAC tables.
+		u8 Mac[6]{};
+		bool AutoMac{true};
+
 		bool HddEnable{false};
 		std::string HddFile;
 
@@ -1079,6 +1087,8 @@ struct Pcsx2Config
 	protected:
 		static void LoadIPHelper(u8* field, const std::string& setting);
 		static std::string SaveIPHelper(u8* field);
+		static void LoadMacHelper(u8* field, const std::string& setting);
+		static std::string SaveMacHelper(u8* field);
 	};
 
 	// ------------------------------------------------------------------------

--- a/pcsx2/DEV9/DEV9.cpp
+++ b/pcsx2/DEV9/DEV9.cpp
@@ -5,6 +5,10 @@
 #include "common/Path.h"
 #include "common/StringUtil.h"
 
+#include <cstring>
+#include <random>
+
+#include "Host.h"
 #include "IopDma.h"
 
 #ifdef _WIN32
@@ -69,6 +73,36 @@ u8 eeprom[] = {
 	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 };
 // clang-format on
+
+// The MAC occupies EEPROM words 0-2, with word 3 holding their 16-bit sum.
+// Verified against the default above: 0x6D76 + 0x6361 + 0x3130 == 0x10207,
+// truncated to 0x0207, which is exactly the 0x07,0x02 stored there.
+static u16 DEV9MacChecksum(const u8* mac)
+{
+	const u16 w0 = static_cast<u16>(mac[0] | (mac[1] << 8));
+	const u16 w1 = static_cast<u16>(mac[2] | (mac[3] << 8));
+	const u16 w2 = static_cast<u16>(mac[4] | (mac[5] << 8));
+	return static_cast<u16>(w0 + w1 + w2);
+}
+
+static void DEV9SetEepromMac(u8* ee, const u8* mac)
+{
+	std::memcpy(ee, mac, 6);
+	const u16 sum = DEV9MacChecksum(ee);
+	ee[6] = static_cast<u8>(sum & 0xFF);
+	ee[7] = static_cast<u8>(sum >> 8);
+}
+
+// A generated address must never be mistakable for a vendor-assigned one:
+// clear the multicast bit and set the locally-administered bit.
+static void DEV9GenerateMac(u8* mac)
+{
+	std::random_device rd;
+	for (int i = 0; i < 6; i++)
+		mac[i] = static_cast<u8>(rd() & 0xFF);
+
+	mac[0] = static_cast<u8>((mac[0] & 0xFC) | 0x02);
+}
 
 #ifdef _WIN32
 HANDLE hEeprom;
@@ -158,6 +192,36 @@ s32 DEV9init()
 		}
 	}
 #endif
+
+	// Only ever touch the built-in image. If the user supplied an eeprom.dat
+	// it is theirs, MAC included, and must be left exactly as found.
+	if (dev9.eeprom == reinterpret_cast<u16*>(eeprom))
+	{
+		u8 mac[6];
+		std::memcpy(mac, EmuConfig.DEV9.Mac, 6);
+
+		const bool unset = (mac[0] | mac[1] | mac[2] | mac[3] | mac[4] | mac[5]) == 0;
+		if (unset && EmuConfig.DEV9.AutoMac)
+		{
+			DEV9GenerateMac(mac);
+			std::memcpy(EmuConfig.DEV9.Mac, mac, 6);
+
+			// EmuConfig is a runtime copy populated FROM the settings store, so
+			// writing it alone is discarded on exit and a fresh MAC would be
+			// generated every boot. Persist through the host settings instead,
+			// which is what makes this stable across restarts.
+			const std::string macStr = StringUtil::StdStringFromFormat(
+				"%02X:%02X:%02X:%02X:%02X:%02X",
+				mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+			Host::SetBaseStringSettingValue("DEV9/Eth", "Mac", macStr.c_str());
+			Host::CommitBaseSettingChanges();
+
+			Console.WriteLn("DEV9: generated MAC %s", macStr.c_str());
+		}
+
+		if (!unset || EmuConfig.DEV9.AutoMac)
+			DEV9SetEepromMac(eeprom, mac);
+	}
 
 	for (int rxbi = 0; rxbi < (SMAP_BD_SIZE / 8); rxbi++)
 	{

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1323,6 +1323,14 @@ void Pcsx2Config::DEV9Options::LoadSave(SettingsWrapper& wrap)
 		SettingsWrapEntry(EthLogDHCP);
 		SettingsWrapEntry(EthLogDNS);
 
+		// Persisted so a generated MAC is stable across restarts. Rotating it
+		// every boot would break DHCP leases and switch MAC tables.
+		SettingsWrapEntry(AutoMac);
+		std::string macStr = SaveMacHelper(Mac);
+		SettingsWrapEntryEx(macStr, "Mac");
+		if (wrap.IsLoading())
+			LoadMacHelper(Mac, macStr);
+
 		SettingsWrapEntry(InterceptDHCP);
 
 		std::string ps2IPStr = "0.0.0.0";
@@ -1444,6 +1452,31 @@ void Pcsx2Config::DEV9Options::LoadIPHelper(u8* field, const std::string& settin
 std::string Pcsx2Config::DEV9Options::SaveIPHelper(u8* field)
 {
 	return StringUtil::StdStringFromFormat("%u.%u.%u.%u", field[0], field[1], field[2], field[3]);
+}
+
+void Pcsx2Config::DEV9Options::LoadMacHelper(u8* field, const std::string& setting)
+{
+	if (setting.empty())
+	{
+		std::fill(field, field + 6, 0);		// unset; DEV9 will generate one
+		return;
+	}
+
+	if (6 == sscanf(setting.c_str(), "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
+			&field[0], &field[1], &field[2], &field[3], &field[4], &field[5]))
+		return;
+
+	Console.Error("Invalid MAC address in settings file");
+	std::fill(field, field + 6, 0);
+}
+
+std::string Pcsx2Config::DEV9Options::SaveMacHelper(u8* field)
+{
+	if ((field[0] | field[1] | field[2] | field[3] | field[4] | field[5]) == 0)
+		return std::string();				// keep "unset" out of the ini
+
+	return StringUtil::StdStringFromFormat("%02X:%02X:%02X:%02X:%02X:%02X",
+		field[0], field[1], field[2], field[3], field[4], field[5]);
 }
 
 bool Pcsx2Config::DEV9Options::HostEntry::operator==(const HostEntry& right) const


### PR DESCRIPTION
### Problem

The PS2's SMAP MAC lives in the first four words of the DEV9 EEPROM. The built-in image in `DEV9.cpp` hardcodes it:

```c
u8 eeprom[] = {
    0x76, 0x6D, 0x61, 0x63, 0x30, 0x31, 0x07, 0x02,   // "vmac01" + checksum
```

That is `76:6D:61:63:30:31`, and it is only replaced if the user happens to have an `eeprom.dat` beside the binary — which almost nobody does. **Every PCSX2 install therefore presents the same MAC address.**

Two instances bridged onto the same LAN are an address collision: switch MAC tables flap and DHCP hands out a single lease. Nothing on the network can distinguish two emulated consoles.

### Changes

**1. Configurable / generated MAC** (`d51a413`)

- Adds `DEV9Options::Mac` and `DEV9Options::AutoMac`.
- On init, **and only when the built-in image is in use**, the configured MAC is written into the EEPROM with a corrected checksum. A user-supplied `eeprom.dat` is never touched.
- With no MAC configured and `AutoMac` set, one is generated, persisted through the host settings, and reused.

Generated **once and persisted**, not per boot — re-rolling every launch would break DHCP leases and switch MAC tables, i.e. the problems this fixes. Generated addresses clear the multicast bit and set the locally-administered bit so they cannot collide with vendor-assigned hardware.

The checksum rule was derived from the shipped data and verified against it: EEPROM words 0-2 hold the MAC, word 3 their 16-bit sum. `0x6D76 + 0x6361 + 0x3130 = 0x10207`, truncated to `0x0207` — exactly the `0x07, 0x02` in the existing default.

**2. UI, plus adapter diagnostics** (`34a586f`)

- MAC Address field with a Generate button; input validated and normalised, clearing it restores automatic generation.
- A read-only line showing the selected host adapter's IP, MAC and gateway, read locally via `AdapterUtils`. No outbound requests.
- A Generate button beside PS2 IP that rerolls the host octet while preserving the subnet.

The adapter line addresses a real failure: DEV9 stores the adapter by **GUID**, so when a NIC re-enumerates (driver update, virtual adapter appearing) the saved GUID silently refers to nothing and bridging fails with no indication. It now reports this explicitly. I hit exactly this on a live config where a Realtek NIC had re-enumerated as `#2`, orphaning the stored GUID — PCSX2 gave no clue.

### Testing

Built and run on Windows (MSVC 14.44, Qt 6.11.1). Verified:

- Generates a valid locally-administered MAC on first boot and logs it
- Persists to the ini and **reuses it** on subsequent boots (an earlier revision regenerated per boot — writing `EmuConfig` alone is discarded, it must go through the host settings)
- A user `eeprom.dat` is left untouched
- Adapter line reports IP/MAC/gateway, and reports the not-found case correctly

Only compile-tested on Windows so far; CI coverage for Linux/macOS would be welcome.

### Note

The two commits are independent — the MAC feature and the adapter diagnostics can be split into separate PRs if you would prefer one concern each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
