### PR TITLE
Qt: Preserve game list column widths across relayouts

### DIFF
--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -881,17 +881,22 @@ bool GameListWidget::eventFilter(QObject* watched, QEvent* event)
 
 void GameListWidget::resizeTableViewColumnsToFit()
 {
+	const auto column_width = [this](int column) {
+		return (DEFAULT_COLUMN_WIDTHS[column] < 0) ? DEFAULT_COLUMN_WIDTHS[column] :
+		                                             m_table_view->columnWidth(column);
+	};
+
 	QtUtils::ResizeColumnsForTableView(m_table_view, {
-														 DEFAULT_COLUMN_WIDTHS[GameListModel::Column_Type],
-														 DEFAULT_COLUMN_WIDTHS[GameListModel::Column_Serial],
-														 DEFAULT_COLUMN_WIDTHS[GameListModel::Column_Title],
-														 DEFAULT_COLUMN_WIDTHS[GameListModel::Column_FileTitle],
-														 DEFAULT_COLUMN_WIDTHS[GameListModel::Column_CRC],
-														 DEFAULT_COLUMN_WIDTHS[GameListModel::Column_TimePlayed],
-														 DEFAULT_COLUMN_WIDTHS[GameListModel::Column_LastPlayed],
-														 DEFAULT_COLUMN_WIDTHS[GameListModel::Column_Size],
-														 DEFAULT_COLUMN_WIDTHS[GameListModel::Column_Region],
-														 DEFAULT_COLUMN_WIDTHS[GameListModel::Column_Compatibility],
+														 column_width(GameListModel::Column_Type),
+														 column_width(GameListModel::Column_Serial),
+														 column_width(GameListModel::Column_Title),
+														 column_width(GameListModel::Column_FileTitle),
+														 column_width(GameListModel::Column_CRC),
+														 column_width(GameListModel::Column_TimePlayed),
+														 column_width(GameListModel::Column_LastPlayed),
+														 column_width(GameListModel::Column_Size),
+														 column_width(GameListModel::Column_Region),
+														 column_width(GameListModel::Column_Compatibility),
 													 });
 }
 


### PR DESCRIPTION
Resolves #14746

### Description of Changes
This change keeps the width a column currently has whenever that column has a fixed default, and lets only the stretch columns take up the slack.

### Rationale behind Changes
`GameListWidget::resizeTableViewColumnsToFit()` rebuilt the whole header from the hardcoded `DEFAULT_COLUMN_WIDTHS` table on every call. `QtUtils::ResizeColumnsForView()` walks each visible column and calls `setColumnWidth()` on it, so every column with a fixed default was pinned straight back to that default and only the stretch columns absorbed the leftover viewport width.

### Suggested Testing Steps
1. Drag a header divider on a fixed-width column in the game list table view (Serial, Time Played, Last Played, Size, Region or Compatibility).
2. Close PCSX2 and reopen it. The column keeps the width you set (previously it snapped back to its default).
3. Resize the main window. Fixed columns keep their widths and Title continues to absorb the slack.
4. Switch to grid view and back to list view, and toggle in and out of a game (both of which route through `resizeTableViewColumnsToFit()`). Widths should be stable across all of it.
5. Right-click the header and use "Reset All Columns": this should still restore the stock layout, since that path deliberately writes the defaults before fitting.
6. Delete the `HeaderState` line from `[GameListTableView]` in `PCSX2.ini` and start fresh: this confirms first-launch defaults still fill the window correctly.

### Did you use AI to help find, test, or implement this issue or feature?
No, I intentionally chose an issue that seems easy to fix to avoid writing code with LLM on my first contribution.