### PR TITLE
IOP: Clear jit cache on DEV9 DMA

### DIFF
--- a/pcsx2/DEV9/DEV9.cpp
+++ b/pcsx2/DEV9/DEV9.cpp
@@ -1068,8 +1068,6 @@ void DEV9readDMA8Mem(u32* pMem, int size)
 	if (!EmuConfig.DEV9.EthEnable && !EmuConfig.DEV9.HddEnable)
 		return;
 
-	size >>= 1;
-
 	DevCon.WriteLn("DEV9: *DEV9readDMA8Mem: size %x", size);
 
 	if (dev9.dma_ctrl & SPD_DMA_TO_SMAP)
@@ -1097,8 +1095,6 @@ void DEV9writeDMA8Mem(u32* pMem, int size)
 {
 	if (!EmuConfig.DEV9.EthEnable && !EmuConfig.DEV9.HddEnable)
 		return;
-
-	size >>= 1;
 
 	DevCon.WriteLn("DEV9: *DEV9writeDMA8Mem: size %x", size);
 

--- a/pcsx2/IopDma.cpp
+++ b/pcsx2/IopDma.cpp
@@ -151,18 +151,19 @@ void psxDma6(u32 madr, u32 bcr, u32 chcr)
 
 void psxDma8(u32 madr, u32 bcr, u32 chcr)
 {
-	const int size = (bcr >> 16) * (bcr & 0xFFFF) * 8;
+	const int size = (bcr >> 16) * (bcr & 0xFFFF);
 
 	switch (chcr & 0x01000201)
 	{
 		case 0x01000201: //cpu to dev9 transfer
 			PSXDMA_LOG("*** DMA 8 - DEV9 mem2dev9 *** %lx addr = %lx size = %lx", chcr, madr, bcr);
-			DEV9writeDMA8Mem((u32*)iopPhysMem(madr), size);
+			DEV9writeDMA8Mem((u32*)iopPhysMem(madr), size * 8);
 			break;
 
 		case 0x01000200: //dev9 to cpu transfer
 			PSXDMA_LOG("*** DMA 8 - DEV9 dev9mem *** %lx addr = %lx size = %lx", chcr, madr, bcr);
-			DEV9readDMA8Mem((u32*)iopPhysMem(madr), size);
+			DEV9readDMA8Mem((u32*)iopPhysMem(madr), size * 8);
+			psxCpu->Clear(madr, size);
 			break;
 
 		default:

--- a/pcsx2/IopDma.cpp
+++ b/pcsx2/IopDma.cpp
@@ -157,12 +157,12 @@ void psxDma8(u32 madr, u32 bcr, u32 chcr)
 	{
 		case 0x01000201: //cpu to dev9 transfer
 			PSXDMA_LOG("*** DMA 8 - DEV9 mem2dev9 *** %lx addr = %lx size = %lx", chcr, madr, bcr);
-			DEV9writeDMA8Mem((u32*)iopPhysMem(madr), size * 8);
+			DEV9writeDMA8Mem((u32*)iopPhysMem(madr), size * 4);
 			break;
 
 		case 0x01000200: //dev9 to cpu transfer
 			PSXDMA_LOG("*** DMA 8 - DEV9 dev9mem *** %lx addr = %lx size = %lx", chcr, madr, bcr);
-			DEV9readDMA8Mem((u32*)iopPhysMem(madr), size * 8);
+			DEV9readDMA8Mem((u32*)iopPhysMem(madr), size * 4);
 			psxCpu->Clear(madr, size);
 			break;
 


### PR DESCRIPTION
### Description of Changes
Clear IOP cache on DEV9 DMA to memory.

### Rationale behind Changes
Needed to fix #14876 

### Suggested Testing Steps
This shouldn't be able to break anything that already works. Just sanity check things I guess.

### Did you use AI to help find, test, or implement this issue or feature?
No