### PR TITLE
GHActions:MacOS: Add MoltenVK patch for older GPUs

### DIFF
--- a/.github/workflows/scripts/macos/4cf93f0f16b1503580cdb7ffdedb056321446677.patch
+++ b/.github/workflows/scripts/macos/4cf93f0f16b1503580cdb7ffdedb056321446677.patch
@@ -1,0 +1,159 @@
+From 4cf93f0f16b1503580cdb7ffdedb056321446677 Mon Sep 17 00:00:00 2001
+From: squidbus <175574877+squidbus@users.noreply.github.com>
+Date: Sat, 9 May 2026 16:53:22 -0700
+Subject: [PATCH] Restore some checks for Mac1 GPUs.
+
+---
+ MoltenVK/MoltenVK/GPUObjects/MVKDevice.h      |  1 +
+ MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm     | 34 +++++++++++--------
+ MoltenVK/MoltenVK/GPUObjects/MVKImage.mm      |  2 +-
+ .../MoltenVK/GPUObjects/MVKPixelFormats.mm    |  2 +-
+ 4 files changed, 23 insertions(+), 16 deletions(-)
+
+diff --git a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+index ba3914de5..8923d23f0 100644
+--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
++++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+@@ -112,6 +112,7 @@ typedef struct MVKMTLDeviceCapabilities {
+ 	bool supportsApple8;
+ 	bool supportsApple9;
+ 	bool supportsApple10;
++	bool supportsMac1;
+ 	bool supportsMac2;
+ 	bool supportsMetal3;
+ 	bool supportsMetal4;
+diff --git a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+index 2c930b004..2e212645a 100644
+--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
++++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+@@ -110,7 +110,8 @@
+ #if MVK_XCODE_26
+ 	supportsApple10 = supportsGPUFam(Apple10, mtlDev);
+ #endif
+-	supportsMac2 = MVK_MACOS;	// Incl Mac2 & MacCatalyst2
++	supportsMac1 = MVK_MACOS;
++	supportsMac2 = supportsGPUFam(Mac2, mtlDev) || supportsGPUFam(MacCatalyst2, mtlDev);
+ 
+ 	isAppleGPU = supportsApple1;
+ 
+@@ -1547,7 +1548,7 @@
+ 	const auto placementHeapFlags = VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT |
+ 	                                VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT |
+ 	                                VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT;
+-	if (!getMVKConfig().useMTLHeap && mvkIsAnyFlagEnabled(flags, placementHeapFlags)) {
++	if (!_metalFeatures.placementHeaps && mvkIsAnyFlagEnabled(flags, placementHeapFlags)) {
+ 		return VK_ERROR_FORMAT_NOT_SUPPORTED;
+ 	}
+ 
+@@ -2456,9 +2457,10 @@
+ 
+ 	// AMD support for MTLHeap is buggy.
+ 	auto cfgUseMTLHeap = getMVKConfig().useMTLHeap;
+-	_metalFeatures.placementHeaps = (_properties.vendorID == kAMDVendorId
+-	                                 ? cfgUseMTLHeap == MVK_CONFIG_USE_MTLHEAP_ALWAYS
+-	                                 : cfgUseMTLHeap != MVK_CONFIG_USE_MTLHEAP_NEVER);
++	auto allowMTLHeap = (_properties.vendorID == kAMDVendorId
++	                     ? cfgUseMTLHeap == MVK_CONFIG_USE_MTLHEAP_ALWAYS
++	                     : cfgUseMTLHeap != MVK_CONFIG_USE_MTLHEAP_NEVER);
++	_metalFeatures.placementHeaps = allowMTLHeap && (supportsMTLGPUFamily(Apple2) || supportsMTLGPUFamily(Mac2));
+ 	_metalFeatures.multisampleArrayTextures = !MVK_TVOS || mvkOSVersionIsAtLeast(16.0);
+ 
+ 	// Dynamic vertex stride needs to have everything aligned - compiled with support for vertex stride calls, and supported by both runtime OS and GPU.
+@@ -2467,7 +2469,7 @@
+ 
+ 	_metalFeatures.renderLinearTextures = _gpuCapabilities.supportsRenderLinearTextures;
+ 
+-	if (supportsMTLGPUFamily(Mac2)) {
++	if (supportsMTLGPUFamily(Mac1)) {
+ 		_metalFeatures.mtlBufferAlignment = 256;
+ 		_metalFeatures.mtlConstantBufferAlignment = 32;
+ 		_metalFeatures.mtlCopyBufferAlignment = 4;
+@@ -2489,15 +2491,18 @@
+ 		_metalFeatures.presentModeImmediate = true;
+ 		_metalFeatures.nonUniformThreadgroups = true;
+ 		_metalFeatures.native3DCompressedTextures = true;
+-		_metalFeatures.multisampleLayeredRendering = _metalFeatures.layeredRendering;
++		_metalFeatures.simdPermute = true;
++		_metalFeatures.memoryBarriers = true;
++	}
++
++    if (supportsMTLGPUFamily(Mac2)) {
++		_metalFeatures.multisampleLayeredRendering = true;
+ 		_metalFeatures.stencilFeedback = true;
+ 		_metalFeatures.depthResolve = true;
+ 		_metalFeatures.stencilResolve = true;
+-		_metalFeatures.simdPermute = true;
+ 		_metalFeatures.quadPermute = true;
+ 		_metalFeatures.simdReduction = true;
+-		_metalFeatures.memoryBarriers = true;
+-	}
++    }
+ 
+     if (supportsMTLGPUFamily(Apple1)) {
+ 		_metalFeatures.mtlBufferAlignment = 64;
+@@ -2798,7 +2803,7 @@
+         _features.shaderResourceMinLod = true;
+ 	}
+ 
+-    if (supportsMTLGPUFamily(Mac2)) {
++    if (supportsMTLGPUFamily(Mac1)) {
+ 		_features.occlusionQueryPrecise = true;
+     	_features.imageCubeArray = true;
+ 		_features.tessellationShader = true;
+@@ -2970,19 +2975,19 @@
+ 
+     if (supportsMTLGPUFamily(Apple3)) {
+         _properties.limits.optimalBufferCopyOffsetAlignment = 16;
+-    } else if (supportsMTLGPUFamily(Mac2)) {
++    } else if (supportsMTLGPUFamily(Mac1)) {
+         _properties.limits.optimalBufferCopyOffsetAlignment = 256;
+     } else {
+         _properties.limits.optimalBufferCopyOffsetAlignment = 64;
+     }
+ 
+-    if (supportsMTLGPUFamily(Apple4) || supportsMTLGPUFamily(Mac2)) {
++    if (supportsMTLGPUFamily(Apple4) || supportsMTLGPUFamily(Mac1)) {
+         _properties.limits.maxFragmentInputComponents = 124;
+     } else {
+         _properties.limits.maxFragmentInputComponents = 60;
+     }
+ 
+-    if (supportsMTLGPUFamily(Apple5) || supportsMTLGPUFamily(Mac2)) {
++    if (supportsMTLGPUFamily(Apple5) || supportsMTLGPUFamily(Mac1)) {
+         _properties.limits.maxTessellationGenerationLevel = 64;
+         _properties.limits.maxTessellationPatchSize = 32;
+     } else if (supportsMTLGPUFamily(Apple3)) {
+@@ -3653,6 +3658,7 @@ static uint32_t mvkGetEntryProperty(io_registry_entry_t entry, CFStringRef prope
+ 	if (supportsMTLGPUFamily(Apple2)) { logMsg += "\n\t\tGPU Family Apple 2"; } else
+ 	if (supportsMTLGPUFamily(Apple1)) { logMsg += "\n\t\tGPU Family Apple 1"; }
+ 
++	if (supportsMTLGPUFamily(Mac1)) { logMsg += "\n\t\tGPU Family Mac 1"; }
+ 	if (supportsMTLGPUFamily(Mac2)) { logMsg += "\n\t\tGPU Family Mac 2"; }
+ 
+ 	logMsg += "\n\t\tRead-Write Texture Tier ";
+diff --git a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+index d2fdd4020..696ec4467 100644
+--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
++++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+@@ -1382,7 +1382,7 @@ static MTLRegion getMTLRegion(const ImgRgn& imgRgn) {
+ 	const auto placementHeapFlags = VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT |
+ 	                                VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT |
+ 	                                VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT;
+-	if (!getMVKConfig().useMTLHeap && mvkIsAnyFlagEnabled(pCreateInfo->flags, placementHeapFlags)) {
++	if (!getMetalFeatures().placementHeaps && mvkIsAnyFlagEnabled(pCreateInfo->flags, placementHeapFlags)) {
+ 		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImage() : MTLHeap must be enabled to create 2D-on-3D or block texel view compatible images."));
+ 	}
+ 
+diff --git a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+index d16d6c8f6..11ca10a03 100644
+--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
++++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+@@ -1343,7 +1343,7 @@
+ 
+ 	addMTLVertexFormatDesc( UChar4Normalized_BGRA );
+ 	
+-	if (gpuCaps.supportsApple5 || gpuCaps.supportsMac2) {
++	if (gpuCaps.supportsApple5 || gpuCaps.supportsMac1) {
+ 		addMTLVertexFormatDesc( FloatRG11B10 );
+ 		addMTLVertexFormatDesc( FloatRGB9E5 );
+ 	}

--- a/.github/workflows/scripts/macos/build-dependencies-universal.sh
+++ b/.github/workflows/scripts/macos/build-dependencies-universal.sh
@@ -289,6 +289,8 @@ echo "Installing MoltenVK..."
 rm -fr "MoltenVK-${MOLTENVK}"
 tar xf "MoltenVK-$MOLTENVK.tar.gz"
 cd "MoltenVK-${MOLTENVK}"
+patch -p1 < "$SCRIPTDIR/4cf93f0f16b1503580cdb7ffdedb056321446677.patch"
+patch -p1 < "$SCRIPTDIR/mvk-texture-swizzle.patch"
 ./fetchDependencies --macos
 make macos MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS=0 MVK_CONFIG_USE_METAL_PRIVATE_API=1
 cp Package/Latest/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib "$INSTALLDIR/lib/"

--- a/.github/workflows/scripts/macos/build-dependencies.sh
+++ b/.github/workflows/scripts/macos/build-dependencies.sh
@@ -78,7 +78,7 @@ e4ab7009bf0629fd11982d4c2aa83964cf244cffba7347ecd39019a9e38c4564  libwebp-$LIBWE
 eee7dea22ed502868017971c86c63c4ed1e6085de0baebfdcc3d3322f00f3eb0  libpng-$LIBPNG-apng.patch.gz
 6f30092cef9fb839779646608f4ee14ae3cbac989c47fa05e841b0841f09878e  libjpeg-turbo-$LIBJPEGTURBO.tar.gz
 cf38e0e28c7e5605942c4a77755349b0145804a397af37eb1fb4c77cb237f635  ffmpeg-$FFMPEG.tar.xz
-9985f141902a17de818e264d17c1ce334b748e499ee02fcb4703e4dc0038f89c  v$MOLTENVK.tar.gz
+9985f141902a17de818e264d17c1ce334b748e499ee02fcb4703e4dc0038f89c  MoltenVK-$MOLTENVK.tar.gz
 5cd9495d9316cf6cc937bb328a7fd491c3248ef2469cfa42511f1039f6148aca  KDDockWidgets-$KDDOCKWIDGETS.tar.gz
 7bd4e79ce18b1d47517e7e91fbb7cf19d4f01942804a519bc7c0bf32b6325dd5  plutovg-$PLUTOVG.tar.gz
 78561b571ac224030cdc450ca2986b4de915c2ba7616004a6d71a379bffd15f3  plutosvg-$PLUTOSVG.tar.gz
@@ -102,7 +102,7 @@ if ! shasum -sa 256 --check SHASUMS 2> /dev/null; then
 		-O "https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/$LIBJPEGTURBO/libjpeg-turbo-$LIBJPEGTURBO.tar.gz" \
 		-O "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-$LIBWEBP.tar.gz" \
 		-O "https://ffmpeg.org/releases/ffmpeg-$FFMPEG.tar.xz" \
-		-O "https://github.com/KhronosGroup/MoltenVK/archive/refs/tags/v$MOLTENVK.tar.gz" \
+		-O "https://github.com/KhronosGroup/MoltenVK/archive/v$MOLTENVK/MoltenVK-$MOLTENVK.tar.gz" \
 		-O "https://download.qt.io/archive/qt/${QT%.*}/$QT/submodules/qtbase-everywhere-src-$QT.tar.xz" \
 		-O "https://download.qt.io/archive/qt/${QT%.*}/$QT/submodules/qtimageformats-everywhere-src-$QT.tar.xz" \
 		-O "https://download.qt.io/archive/qt/${QT%.*}/$QT/submodules/qtsvg-everywhere-src-$QT.tar.xz" \
@@ -228,8 +228,10 @@ cd ..
 # MoltenVK already builds universal binaries, nothing special to do here.
 echo "Installing MoltenVK..."
 rm -fr "MoltenVK-${MOLTENVK}"
-tar xf "v$MOLTENVK.tar.gz"
+tar xf "MoltenVK-$MOLTENVK.tar.gz"
 cd "MoltenVK-${MOLTENVK}"
+patch -p1 < "$SCRIPTDIR/4cf93f0f16b1503580cdb7ffdedb056321446677.patch"
+patch -p1 < "$SCRIPTDIR/mvk-texture-swizzle.patch"
 sed -i '' 's/xcodebuild "$@"/xcodebuild $XCODEBUILD_EXTRA_ARGS "$@"/g' fetchDependencies
 sed -i '' 's/XCODEBUILD :=/XCODEBUILD ?=/g' Makefile
 XCODEBUILD_EXTRA_ARGS="VALID_ARCHS=x86_64" ./fetchDependencies --macos

--- a/.github/workflows/scripts/macos/mvk-texture-swizzle.patch
+++ b/.github/workflows/scripts/macos/mvk-texture-swizzle.patch
@@ -1,0 +1,139 @@
+From f6be31a110761ea494a938d62473abc085ea447b Mon Sep 17 00:00:00 2001
+From: TellowKrinkle <tellowkrinkle@gmail.com>
+Date: Mon, 31 Aug 2026 02:52:38 -0500
+Subject: [PATCH] Re-add native texture swizzle checks
+
+---
+ MoltenVK/MoltenVK/API/mvk_deprecated_api.h    |  2 +-
+ MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm     |  3 +-
+ MoltenVK/MoltenVK/GPUObjects/MVKImage.mm      | 51 ++++++++++++++++++-
+ .../MoltenVK/GPUObjects/MVKPixelFormats.mm    |  3 ++
+ 4 files changed, 56 insertions(+), 3 deletions(-)
+
+diff --git a/MoltenVK/MoltenVK/API/mvk_deprecated_api.h b/MoltenVK/MoltenVK/API/mvk_deprecated_api.h
+index 74fef844..8d16f86c 100644
+--- a/MoltenVK/MoltenVK/API/mvk_deprecated_api.h
++++ b/MoltenVK/MoltenVK/API/mvk_deprecated_api.h
+@@ -118,7 +118,7 @@ typedef struct {
+ 	VkBool32 fences;								/**< If true, Metal synchronization fences (MTLFence) are supported. Deprecated. Will always be true on all platforms. */
+ 	VkBool32 rasterOrderGroups;						/**< If true, Raster order groups in fragment shaders are supported. */
+ 	VkBool32 native3DCompressedTextures;			/**< If true, 3D compressed images are supported natively, without manual decompression. */
+-	VkBool32 nativeTextureSwizzle;					/**< If true, component swizzle is supported natively, without manual swizzling in shaders. Deprecated. Will always be true on all platforms. */
++	VkBool32 nativeTextureSwizzle;					/**< If true, component swizzle is supported natively, without manual swizzling in shaders. */
+ 	VkBool32 placementHeaps;						/**< If true, MTLHeap objects support placement of resources. */
+ 	VkDeviceSize pushConstantSizeAlignment;			/**< The alignment used internally when allocating memory for push constants. Must be PoT. */
+ 	uint32_t maxTextureLayers;						/**< The maximum number of layers in an array texture. */
+diff --git a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+index aaf5945b..c7da8256 100644
+--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
++++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+@@ -2496,6 +2496,7 @@
+ 		_metalFeatures.stencilResolve = true;
+ 		_metalFeatures.quadPermute = true;
+ 		_metalFeatures.simdReduction = true;
++		_metalFeatures.nativeTextureSwizzle = true;
+     }
+ 
+     if (supportsMTLGPUFamily(Apple1)) {
+@@ -2504,6 +2505,7 @@
+ 		_metalFeatures.maxPerStageTextureCount = 31;
+ 		_metalFeatures.maxTextureDimension = (8 * KIBI);
+ 		_metalFeatures.maxQueryBufferSize = (64 * KIBI);
++		_metalFeatures.nativeTextureSwizzle = true;
+ 
+ 		_metalFeatures.maxPerStageDynamicMTLBufferCount = _metalFeatures.maxPerStageBufferCount;
+ 		_metalFeatures.renderLinearTextures = true;
+@@ -2727,7 +2729,6 @@
+ 	_metalFeatures.events = true;
+ 	_metalFeatures.ioSurfaces = true;
+ 	_metalFeatures.renderWithoutAttachments = true;
+-	_metalFeatures.nativeTextureSwizzle = true;
+ }
+ 
+ bool MVKPhysicalDevice::isTier2MetalArgumentBuffers() {
+diff --git a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+index 8eda5515..392a4f98 100644
+--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
++++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+@@ -1925,7 +1925,7 @@ static void signalAndUntrack(const MVKSwapchainSignaler& signaler) {
+     }
+ 
+     id<MTLTexture> texView = nil;
+-    if (_useSwizzle) {
++    if (_useSwizzle && getMetalFeatures().nativeTextureSwizzle) {
+         texView = [mtlTex newTextureViewWithPixelFormat: _mtlPixFmt
+                                             textureType: _imageView->_mtlTextureType
+                                                  levels: levelRange
+@@ -2103,6 +2103,55 @@ static void signalAndUntrack(const MVKSwapchainSignaler& signaler) {
+ 		}
+ 	}
+ 
++#define SWIZZLE_MATCHES(R, G, B, A)    mvkVkComponentMappingsMatch(_componentSwizzle, {VK_COMPONENT_SWIZZLE_ ##R, VK_COMPONENT_SWIZZLE_ ##G, VK_COMPONENT_SWIZZLE_ ##B, VK_COMPONENT_SWIZZLE_ ##A} )
++#define VK_COMPONENT_SWIZZLE_ANY       VK_COMPONENT_SWIZZLE_MAX_ENUM
++
++	if (_imageView->_image->hasPixelFormatView(_planeIndex)) {
++		switch (_mtlPixFmt) {
++			case MTLPixelFormatR8Unorm:
++				if (SWIZZLE_MATCHES(ZERO, ANY, ANY, R)) {
++					_mtlPixFmt = MTLPixelFormatA8Unorm;
++					return VK_SUCCESS;
++				}
++				break;
++
++			case MTLPixelFormatA8Unorm:
++				if (SWIZZLE_MATCHES(A, ANY, ANY, ZERO)) {
++					_mtlPixFmt = MTLPixelFormatR8Unorm;
++					return VK_SUCCESS;
++				}
++				break;
++
++			case MTLPixelFormatRGBA8Unorm:
++				if (SWIZZLE_MATCHES(B, G, R, A)) {
++					_mtlPixFmt = MTLPixelFormatBGRA8Unorm;
++					return VK_SUCCESS;
++				}
++				break;
++
++			case MTLPixelFormatRGBA8Unorm_sRGB:
++				if (SWIZZLE_MATCHES(B, G, R, A)) {
++					_mtlPixFmt = MTLPixelFormatBGRA8Unorm_sRGB;
++					return VK_SUCCESS;
++				}
++				break;
++
++			case MTLPixelFormatBGRA8Unorm:
++				if (SWIZZLE_MATCHES(B, G, R, A)) {
++					_mtlPixFmt = MTLPixelFormatRGBA8Unorm;
++					return VK_SUCCESS;
++				}
++				break;
++
++			case MTLPixelFormatBGRA8Unorm_sRGB:
++				if (SWIZZLE_MATCHES(B, G, R, A)) {
++					_mtlPixFmt = MTLPixelFormatRGBA8Unorm_sRGB;
++					return VK_SUCCESS;
++				}
++				break;
++		}
++	}
++
+ 	_useSwizzle = !mvkVkComponentMappingsMatch(_componentSwizzle, {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A});
+ 	return VK_SUCCESS;
+ }
+diff --git a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+index 316d7c6f..31a2c6a1 100644
+--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
++++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+@@ -654,6 +654,9 @@
+ 
+ 	bool pfv = false;
+ 
++	// Swizzle emulation may need to reinterpret
++	needsReinterpretation |= !_physicalDevice->getMetalFeatures()->nativeTextureSwizzle;
++
+ 	pfv |= isColorFormat && needsReinterpretation &&
+ 	       mvkIsAnyFlagEnabled(vkImageUsageFlags, (VK_IMAGE_USAGE_SAMPLED_BIT |
+ 	                                               VK_IMAGE_USAGE_STORAGE_BIT |
+-- 
+2.39.5 (Apple Git-154)
+

--- a/pcsx2/GS/Renderers/Vulkan/GSTextureVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSTextureVK.cpp
@@ -104,9 +104,9 @@ std::unique_ptr<GSTextureVK> GSTextureVK::Create(Usage usage, Format format, int
 
 	if (format == Format::UNorm8)
 	{
-		// for r8 textures, swizzle it across all 4 components. the shaders depend on it being in alpha.. why?
+		// UNorm8 wants value in alpha, not red.
 		static constexpr const VkComponentMapping r8_swizzle = {
-			VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R };
+			VK_COMPONENT_SWIZZLE_ZERO, VK_COMPONENT_SWIZZLE_ZERO, VK_COMPONENT_SWIZZLE_ZERO, VK_COMPONENT_SWIZZLE_R };
 		vci.components = r8_swizzle;
 	}
 


### PR DESCRIPTION
### Description of Changes
MoltenVK 1.4.1 completely broke support for Mac1 GPUs, making PCSX2 crash if you attempt to use the Vulkan renderer.  This cherry picks the fix to that (not going to grab 1.4.2 yet because it requires macOS 12, which a lot of the Macs with Mac1 GPUs can't run) so that we no longer crash on older Macs.

### Rationale behind Changes
Not crashing is good

### Suggested Testing Steps
Try to use the Vulkan renderer on a Mac with a family Mac1 GPU (Nvidia 7xx, Intel HD 4xxx/5xxx/6xxx, Radeon R9 M3xx)

### Did you use AI to help find, test, or implement this issue or feature?
No