### PR TITLE
GS/DX11: DS as RT/UAV binding fixes.

### DIFF
--- a/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/pcsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -1094,12 +1094,34 @@ GSDevice::PresentResult GSDevice11::BeginPresent(bool frame_skip)
 	m_state.rtv = m_swap_chain_rtv.get();
 	m_state.rtv->AddRef();
 	m_state.current_rt = nullptr;
+
+	if (m_state.dsv_as_rtv)
+	{
+		m_state.dsv_as_rtv->Release();
+		m_state.dsv_as_rtv = nullptr;
+	}
+	m_state.current_ds_as_rt = nullptr;
+
 	if (m_state.dsv)
 	{
 		m_state.dsv->Release();
 		m_state.dsv = nullptr;
 	}
 	m_state.current_ds = nullptr;
+
+	if (m_state.rt_uav)
+	{
+		m_state.rt_uav->Release();
+		m_state.rt_uav = nullptr;
+	}
+	m_state.current_rt_uav = nullptr;
+
+	if (m_state.ds_uav)
+	{
+		m_state.ds_uav->Release();
+		m_state.ds_uav = nullptr;
+	}
+	m_state.current_ds_uav = nullptr;
 
 	g_perfmon.Put(GSPerfMon::RenderPasses, 1);
 
@@ -2926,7 +2948,7 @@ void GSDevice11::OMSetRenderTargets(GSTexture* rt, GSTexture* ds_as_rt, GSTextur
 			m_state.dsv_as_rtv->Release();
 		if (dsv_as_rtv)
 			dsv_as_rtv->AddRef();
-		m_state.rtv = dsv_as_rtv;
+		m_state.dsv_as_rtv = dsv_as_rtv;
 		m_state.current_ds_as_rt = ds_as_rt;
 	}
 	if (m_state.dsv != dsv)
@@ -2984,6 +3006,7 @@ void GSDevice11::OMSetRenderTargets(GSTexture* rt, GSTexture* ds_as_rt, GSTextur
 	{
 		const GSVector2i size =
 			rt ? rt->GetSize() :
+			ds_as_rt ? ds_as_rt->GetSize() :
 			ds ? ds->GetSize() :
 			(rt_uav_tex && rt_uav_tex != m_null_texture) ? rt_uav_tex->GetSize() :
 			ds_uav_tex->GetSize();


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS/DX11: DS as RT/UAV/ROV binding fixes.

Properly unbind state in BeginPresent.
- In BeginPresent second rtv is unbound in gpu state but the cached state was left unchanged which can cause issues with wrong bindings which can also lead to crashes.
- Also update UAVs state as well as the gpu state should've been unbound.

Properly update state in OMSetRenderTargets.
- In OMSetRenderTargets we were setting the wrong target view for ds as rt which lead to access violation crashes.

Also use ds as rt size for Viewport.
- In cases where rtv and dsv are not used but dsv as rtv is used as a cached state without setting the proper size it can lead to access violation crashes. Not yet an issue since ds as rt works in combination with regular ds but in the future if we want to go down that path it could've caused issues, plus we already do that on GL and I forgot to backport it.

Note: The crash issues are only occurring when AAT/AA1 is used but even with AAT off some games such as Hot Shots Golf will still use accurate alpha test even with the option off since we use barriers on the draws anyway.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Regression crash fixes, see the above.
Must go in a stable release 2.8 branch as it affects a vast variety of games.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Dump run did not show any differences with aat/aa1 enabled.
Smoke test a couple of games that use AAT/AA1, do note accurate alpha test, with and without ROV.
Also test if OSD still works as expected.
Reproducing the crashes is not always consistent and may or may not happen.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation as to how you used it. Please see the Large Language Model (LLM) Usage Policy for more information: https://pcsx2.net/docs/contributing/#large-language-model-llm-usage-policy -->
No.