### PR TITLE
GS/HW: Fix regression with bilinear filtering of target updates

### DIFF
--- a/bin/resources/shaders/dx11/convert.fx
+++ b/bin/resources/shaders/dx11/convert.fx
@@ -334,7 +334,7 @@ OUTPUT_TYPE ps_convert_depth32_depth24(PS_INPUT input) : OUTPUT_SV
 	float depthTR = CONVERT_FN(Texture.Load(int3(coords.zy, 0))); \
 	float depthBL = CONVERT_FN(Texture.Load(int3(coords.xw, 0))); \
 	float depthBR = CONVERT_FN(Texture.Load(int3(coords.zw, 0))); \
-	return lerp(lerp(depthTL, depthTR, mix_vals.x), lerp(depthBL, depthBR, mix_vals.x), mix_vals.y);
+	return floor(lerp(lerp(depthTL, depthTR, mix_vals.x), lerp(depthBL, depthBR, mix_vals.x), mix_vals.y) * exp2(32.0f)) * exp2(-32.0f); 
 
 #if defined(__ps_convert_rgba8_depth32__)
 OUTPUT_TYPE ps_convert_rgba8_depth32(PS_INPUT input) : OUTPUT_SV

--- a/bin/resources/shaders/opengl/convert.glsl
+++ b/bin/resources/shaders/opengl/convert.glsl
@@ -222,7 +222,7 @@ void ps_convert_depth32_depth24()
 	float depthTR = CONVERT_FN(texelFetch(TextureSampler, coords.zy, 0)); \
 	float depthBL = CONVERT_FN(texelFetch(TextureSampler, coords.xw, 0)); \
 	float depthBR = CONVERT_FN(texelFetch(TextureSampler, coords.zw, 0)); \
-	OUTPUT = mix(mix(depthTL, depthTR, mix_vals.x), mix(depthBL, depthBR, mix_vals.x), mix_vals.y);
+	OUTPUT = floor(mix(mix(depthTL, depthTR, mix_vals.x), mix(depthBL, depthBR, mix_vals.x), mix_vals.y) * exp2(32.0f)) * exp2(-32.0f);
 
 #ifdef ps_convert_rgba8_depth32
 void ps_convert_rgba8_depth32()

--- a/bin/resources/shaders/vulkan/convert.glsl
+++ b/bin/resources/shaders/vulkan/convert.glsl
@@ -291,7 +291,7 @@ void ps_convert_depth32_depth24()
 	float depthTR = CONVERT_FN(texelFetch(samp0, coords.zy, 0)); \
 	float depthBL = CONVERT_FN(texelFetch(samp0, coords.xw, 0)); \
 	float depthBR = CONVERT_FN(texelFetch(samp0, coords.zw, 0)); \
-	OUTPUT = mix(mix(depthTL, depthTR, mix_vals.x), mix(depthBL, depthBR, mix_vals.x), mix_vals.y);
+	OUTPUT = floor(mix(mix(depthTL, depthTR, mix_vals.x), mix(depthBL, depthBR, mix_vals.x), mix_vals.y) * exp2(32.0f)) * exp2(-32.0f);
 
 #ifdef ps_convert_rgba8_depth32
 void ps_convert_rgba8_depth32()

--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -375,6 +375,13 @@ public:
 		return ShaderEntryPoint(Shader());
 	}
 
+	constexpr ShaderConvertSelector SetShader(ShaderConvert shader = ShaderConvert::COPY)
+	{
+		ShaderConvertSelector tmp = *this;
+		tmp.fields.shader = static_cast<u32>(shader);
+		return tmp;
+	}
+
 	constexpr ShaderConvertSelector SetMask(u8 mask = 0xf) const
 	{
 		ShaderConvertSelector tmp = *this;
@@ -446,7 +453,7 @@ public:
 };
 
 static inline ShaderConvertSelector GetConvertShader(GSTexture::Format src, GSTexture::Format dst,
-	u32 src_bpp = 32, u32 dst_bpp = 32, u8 mask = 0xf)
+	u32 src_bpp = 32, u32 dst_bpp = 32, u8 mask = 0xf, Filter linear = Nearest)
 {
 	ShaderConvert shader = static_cast<ShaderConvert>(-1);
 	switch (src)
@@ -531,7 +538,7 @@ static inline ShaderConvertSelector GetConvertShader(GSTexture::Format src, GSTe
 			break;
 	}
 
-	return ShaderConvertSelector(shader, mask, dst == GSTexture::Format::DepthStencil);
+	return ShaderConvertSelector(shader, mask, dst == GSTexture::Format::DepthStencil, linear);
 }
 
 static inline ShaderConvertSelector GetConvertShader(const GSTexture* src, const GSTexture* dst, u32 src_bpp, u32 dst_bpp, u8 mask = 0xf)

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -7955,8 +7955,9 @@ void GSTextureCache::Target::Update(bool cannot_scale)
 	// Bilinear filtering this is probably not a good thing, at least in native, but upscaling Nearest can be gross and messy.
 	// It's needed for depth, though.. filtering depth doesn't make much sense, but SMT3 needs it..
 	const bool upscaled = (m_scale != 1.0f);
+	const bool is_depth = m_type == DepthStencil;
 	const bool override_linear = (upscaled && GSConfig.UserHacks_BilinearHack == GSBilinearDirtyMode::ForceBilinear);
-	const bool linear = (m_type == RenderTarget && upscaled && GSConfig.UserHacks_BilinearHack != GSBilinearDirtyMode::ForceNearest);
+	const bool linear = (upscaled && ((!is_depth && GSConfig.UserHacks_BilinearHack != GSBilinearDirtyMode::ForceNearest) || is_depth));
 
 	GSDevice::MultiStretchRect* drects = static_cast<GSDevice::MultiStretchRect*>(
 		alloca(sizeof(GSDevice::MultiStretchRect) * static_cast<u32>(m_dirty.size())));
@@ -8018,7 +8019,7 @@ void GSTextureCache::Target::Update(bool cannot_scale)
 		drect.src = t;
 		drect.src_rect = GSVector4(update_r - t_offset) / t_sizef;
 		drect.dst_rect = GSVector4(update_r) * GSVector4(m_scale);
-		drect.filter = BilnIf(linear && (m_dirty[i].req_linear || override_linear));
+		drect.filter = BilnIf(linear && (is_depth || m_dirty[i].req_linear || override_linear));
 
 		// Copy the new GS memory content into the destination texture.
 		if (m_type == RenderTarget)
@@ -8047,12 +8048,13 @@ void GSTextureCache::Target::Update(bool cannot_scale)
 				m_rt_alpha_scale = true;
 		}
 
-		const bool linear = upscaled && GSConfig.UserHacks_BilinearHack != GSBilinearDirtyMode::ForceNearest;
-
 		// No need to sort here, it's all the one texture.
-		const ShaderConvertSelector shader = (m_type == RenderTarget) ?
-			(m_rt_alpha_scale ? ShaderConvert::RTA_CORRECTION : ShaderConvert::COPY) :
-			GetConvertShader(GSTexture::Format::Color, m_texture->GetFormat(), bpp, bpp, linear);
+		ShaderConvertSelector shader = GetConvertShader(GSTexture::Format::Color, m_texture->GetFormat(), bpp, bpp, 0xF, drects[0].filter);
+
+		if (m_type == RenderTarget && m_rt_alpha_scale && shader.Shader() == ShaderConvert::COPY)
+		{
+			shader = shader.SetShader(ShaderConvert::RTA_CORRECTION);
+		}
 
 		g_gs_device->DrawMultiStretchRects(drects, ndrects, m_texture, shader);
 	}

--- a/pcsx2/GS/Renderers/Metal/convert.metal
+++ b/pcsx2/GS/Renderers/Metal/convert.metal
@@ -260,7 +260,7 @@ struct ConvertToDepthRes
 		float depthTR = convert(texture.read(coords.zy));
 		float depthBL = convert(texture.read(coords.xw));
 		float depthBR = convert(texture.read(coords.zw));
-		return mix(mix(depthTL, depthTR, mix_vals.x), mix(depthBL, depthBR, mix_vals.x), mix_vals.y);
+		return floor(mix(mix(depthTL, depthTR, mix_vals.x), mix(depthBL, depthBR, mix_vals.x), mix_vals.y) * 0x1p32) * 0x1p-32;
 	}
 
 	template <float (&convert)(half4)>

--- a/pcsx2/ShaderCacheVersion.h
+++ b/pcsx2/ShaderCacheVersion.h
@@ -3,4 +3,4 @@
 
 /// Version number for GS and other shaders. Increment whenever any of the contents of the
 /// shaders change, to invalidate the cache.
-static constexpr u32 SHADER_CACHE_VERSION = 109; // Last changed in PR 14795
+static constexpr u32 SHADER_CACHE_VERSION = 110; // Last changed in PR 14897


### PR DESCRIPTION
### Description of Changes
Fixes the bilinear functionality for shader selection when doing target updates. Also implements depth flooring on the the function to keep properly rounded values.

### Rationale behind Changes
This was broken when the convert shader functionality was changed I believe back in #14477, the mask default was using the bilinear boolean value which was being shadowed and the linear was set to nearest, a bit of a mess. 

### Suggested Testing Steps
Test SMT games mainly, and Syphon Filter - Logan's Shadow

### Did you use AI to help find, test, or implement this issue or feature?
No

Fixes #14896 SMT Nocturne upscaling artifacts
Fixes SMT Digital Devil Saga upscaling artifacts
Improves lighting and upscaling on Syphon Filter - Logan's Shadow

SMT Nocturne
Master:
<img width="1194" height="896" alt="image" src="https://github.com/user-attachments/assets/72ccd3ca-8c3a-427a-b327-281b6a3a07c2" />
PR:
<img width="1194" height="896" alt="image" src="https://github.com/user-attachments/assets/bebce441-39e3-47a8-b9a3-59fe2cfb03c0" />

SMT Digital Devil Saga
Master:
<img width="1194" height="896" alt="image" src="https://github.com/user-attachments/assets/1642f06a-ccea-4d7e-ad09-b7636b8b93e8" />
PR:
<img width="1194" height="896" alt="image" src="https://github.com/user-attachments/assets/4dc4232f-e6ed-45a3-8fe5-3258c62a192f" />

Syphon Filter - Logan's Shadow (this requires HPO Native adding to Game DB):
Master:
<img width="1344" height="896" alt="image" src="https://github.com/user-attachments/assets/22b47cad-f5b4-4833-83f6-58bb306e67b1" />
PR:
<img width="1344" height="896" alt="image" src="https://github.com/user-attachments/assets/8d54860a-44d4-451d-a7ef-f77de123b449" />
