### PR TITLE
Qt: Memory card settings fixes and tweaks

### DIFF
--- a/pcsx2-qt/Settings/MemoryCardConvertDialog.cpp
+++ b/pcsx2-qt/Settings/MemoryCardConvertDialog.cpp
@@ -239,12 +239,8 @@ void MemoryCardConvertDialog::ConvertCard()
 	}
 	else
 	{
-		QString baseName = m_selectedCard;
-
-		// Get our destination file name
-		size_t extensionPos = baseName.lastIndexOf(".ps2", -1);
-		// Strip the extension off of it
-		baseName.replace(extensionPos, 4, "");
+		// Strip the extension off
+		QString baseName = QFileInfo(m_selectedCard).completeBaseName();
 		// Add _converted to the end of it
 		baseName.append("_converted");
 

--- a/pcsx2-qt/Settings/MemoryCardConvertWorker.cpp
+++ b/pcsx2-qt/Settings/MemoryCardConvertWorker.cpp
@@ -109,7 +109,24 @@ bool MemoryCardConvertWorker::ConvertToFolder(const std::string& srcFileName, co
 	config.Enabled = true;
 	config.Type = MemoryCardType::Folder;
 
-	std::optional<std::vector<u8>> sourceBufferOpt = FileSystem::ReadBinaryFile(srcPath.c_str());
+	// If we're dealing with a non-ECC Memory Card, convert to a temporary RAW file first.
+	std::string noECCToRAWPath;
+	if (FileMcd_IsNoECCCard(srcPath))
+	{
+		noECCToRAWPath = srcPath + "_raw_tmp";
+		if (!ConvertNoECCtoRAW(srcPath.c_str(), noECCToRAWPath.c_str()))
+		{
+			Console.Error("%s(%s, %s, %d) Failed to convert non-ECC Memory Card to RAW!", __FUNCTION__, srcFileName.c_str(), destFolderName.c_str(), type);
+			FileSystem::DeleteFilePath(noECCToRAWPath.c_str());
+			return false;
+		}
+	}
+
+	const std::string& pathToUse = noECCToRAWPath.empty() ? srcPath : noECCToRAWPath;
+	std::optional<std::vector<u8>> sourceBufferOpt = FileSystem::ReadBinaryFile(pathToUse.c_str());
+
+	if (!noECCToRAWPath.empty())
+		FileSystem::DeleteFilePath(noECCToRAWPath.c_str());
 
 	if (!sourceBufferOpt.has_value())
 	{

--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
@@ -266,12 +266,29 @@ void MemoryCardSettingsWidget::renameCard()
 	if (newName.isEmpty() || newName == selectedCard)
 		return;
 
-	if (!newName.endsWith(QStringLiteral(".ps2")) || newName.length() <= 4)
+	const std::optional<AvailableMcdInfo> cardInfo = FileMcd_GetCardInfo(selectedCard.toStdString());
+	const bool isPS1 = cardInfo.has_value() && (cardInfo.value().file_type == MemoryCardFileType::PS1);
+	const bool isNoECC = cardInfo.has_value() && FileMcd_IsNoECCCard(cardInfo.value().path);
+	const bool filenameTooShort = newName.length() <= 4;
+
+	if (isPS1 && ((!newName.endsWith(QStringLiteral(".mcr")) && !newName.endsWith(QStringLiteral(".mcd"))) || filenameTooShort))
 	{
-		QMessageBox::critical(
-			QtUtils::GetRootWidget(this), tr("Rename Memory Card"), tr("New name is invalid, it must end with .ps2"));
+		QMessageBox::critical(QtUtils::GetRootWidget(this), tr("Rename Memory Card"),
+			tr("New name is invalid, a PS1 card must have at least 1 character and a .mcr or .mcd extension."));
 		return;
 	}
+	if (isNoECC && ((!newName.endsWith(QStringLiteral(".bin")) && !newName.endsWith(QStringLiteral(".mc2"))) || filenameTooShort))
+	{
+		QMessageBox::critical(QtUtils::GetRootWidget(this), tr("Rename Memory Card"),
+			tr("New name is invalid, a PS2 card with no ECC must have at least 1 character and a .bin or .mc2 extension."));
+		return;
+	}
+	if (!isPS1 && !isNoECC && (!newName.endsWith(QStringLiteral(".ps2")) || filenameTooShort))
+ 	{
+ 		QMessageBox::critical(QtUtils::GetRootWidget(this), tr("Rename Memory Card"),
+			tr("New name is invalid, a PS2 card must have at least 1 character and a .ps2 extension."));
+ 		return;
+ 	}
 
 	const std::string newNameStr(newName.toStdString());
 	if (FileMcd_GetCardInfo(newNameStr).has_value())

--- a/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/MemoryCardSettingsWidget.cpp
@@ -334,6 +334,8 @@ void MemoryCardSettingsWidget::listContextMenuRequested(const QPoint& pos)
 	const QString selectedCard(getSelectedCard());
 	if (!selectedCard.isEmpty())
 	{
+		const std::optional<AvailableMcdInfo> cardInfo = FileMcd_GetCardInfo(selectedCard.toStdString());
+		const bool isPS1 = cardInfo.has_value() && cardInfo.value().file_type == MemoryCardFileType::PS1;
 		for (u32 slot = 0; slot < MAX_SLOTS; slot++)
 		{
 			connect(menu.addAction(tr("Use for Slot %1").arg(slot + 1)), &QAction::triggered, this,
@@ -342,7 +344,8 @@ void MemoryCardSettingsWidget::listContextMenuRequested(const QPoint& pos)
 		menu.addSeparator();
 
 		connect(menu.addAction(tr("Rename")), &QAction::triggered, this, &MemoryCardSettingsWidget::renameCard);
-		connect(menu.addAction(tr("Convert")), &QAction::triggered, this, &MemoryCardSettingsWidget::convertCard);
+		if (!isPS1)
+			connect(menu.addAction(tr("Convert")), &QAction::triggered, this, &MemoryCardSettingsWidget::convertCard);
 		connect(menu.addAction(tr("Delete")), &QAction::triggered, this, &MemoryCardSettingsWidget::deleteCard);
 		menu.addSeparator();
 	}

--- a/pcsx2/SIO/Memcard/MemoryCardFile.cpp
+++ b/pcsx2/SIO/Memcard/MemoryCardFile.cpp
@@ -81,7 +81,7 @@ static u32 CalculateECC(u8* buf)
 	return column_parity | (line_parity_0 << 8) | (line_parity_1 << 16);
 }
 
-static bool ConvertNoECCtoRAW(const char* file_in, const char* file_out)
+bool ConvertNoECCtoRAW(const char* file_in, const char* file_out)
 {
 	auto fin = FileSystem::OpenManagedCFile(file_in, "rb");
 	if (!fin)
@@ -1137,4 +1137,14 @@ bool FileMcd_DeleteCard(const std::string_view name)
 	}
 
 	return true;
+}
+
+bool FileMcd_IsNoECCCard(const std::string& path)
+{
+	auto fp = FileSystem::OpenManagedSharedCFile(path.c_str(), "rb", FileSystem::FileShareMode::DenyNone);
+	if (!fp)
+		return false;
+
+	const s64 size = FileSystem::FSize64(fp.get());
+	return (size == _8mb) || (size == _16mb) || (size == _32mb) || (size == _64mb);
 }

--- a/pcsx2/SIO/Memcard/MemoryCardFile.h
+++ b/pcsx2/SIO/Memcard/MemoryCardFile.h
@@ -60,3 +60,5 @@ bool FileMcd_IsMemoryCardFormatted(std::FILE* fp);
 bool FileMcd_CreateNewCard(const std::string_view name, MemoryCardType type, MemoryCardFileType file_type);
 bool FileMcd_RenameCard(const std::string_view name, const std::string_view new_name);
 bool FileMcd_DeleteCard(const std::string_view name);
+bool FileMcd_IsNoECCCard(const std::string& path);
+bool ConvertNoECCtoRAW(const char* file_in, const char* file_out);

--- a/pcsx2/SIO/Memcard/MemoryCardFolder.cpp
+++ b/pcsx2/SIO/Memcard/MemoryCardFolder.cpp
@@ -897,7 +897,15 @@ bool FolderMemoryCard::ReadFromFile(u8* dest, u32 adr, u32 dataLength)
 	const u32 page = adr / PageSizeRaw;
 	const u32 offset = adr % PageSizeRaw;
 	const u32 cluster = adr / ClusterSizeRaw;
-	const u32 fatCluster = cluster - m_superBlock.data.alloc_offset;
+
+	const u32 startDataCluster = m_superBlock.data.alloc_offset;
+	const u32 endDataCluster = startDataCluster + m_superBlock.data.alloc_end;
+	if (cluster < startDataCluster || cluster >= endDataCluster)
+	{
+		return false;
+	}
+
+	const u32 fatCluster = cluster - startDataCluster;
 
 	// if the cluster is unused according to FAT, just return
 	if ((m_fat.data[0][0][fatCluster] & DataClusterInUseMask) == 0)
@@ -1503,7 +1511,15 @@ bool FolderMemoryCard::WriteToFile(const u8* src, u32 adr, u32 dataLength)
 	const u32 cluster = adr / ClusterSizeRaw;
 	const u32 page = adr / PageSizeRaw;
 	const u32 offset = adr % PageSizeRaw;
-	const u32 fatCluster = cluster - m_superBlock.data.alloc_offset;
+
+	const u32 startDataCluster = m_superBlock.data.alloc_offset;
+	const u32 endDataCluster = startDataCluster + m_superBlock.data.alloc_end;
+	if (cluster < startDataCluster || cluster >= endDataCluster)
+	{
+		return false;
+	}
+
+	const u32 fatCluster = cluster - startDataCluster;
 
 	// if the cluster is unused according to FAT, just skip all this, we're not gonna find anything anyway
 	if ((m_fat.data[0][0][fatCluster] & DataClusterInUseMask) == 0)


### PR DESCRIPTION
### Description of Changes
1. Don't always force .ps2 as valid extension when renaming a card.
2. Don't show "Convert" option from right click for PS1 cards.
3. Make it possible to convert non-ECC cards to folders by converting them to a temporary RAW file first.
4. Prevents a crash when converting some types of cards to folder.

I'm not a coding expert and I hesitated before submitting this PR fearing that it might not be good enough, but I think even if it's not and if it ends up being closed it might still "motivate" more experienced devs to fix these issues.

Closes #13340 

### Rationale behind Changes
1. PS1 cards should be .mcr/.mcd, non-ECC cards should be .bin/.mc2 (so they can be converted on open/close, see [here](https://github.com/PCSX2/pcsx2/blob/67aadac40cff9245c93c0eb0b61fcc9b38596296/pcsx2/SIO/Memcard/MemoryCardFile.cpp#L297-L309) and [here](https://github.com/PCSX2/pcsx2/blob/67aadac40cff9245c93c0eb0b61fcc9b38596296/pcsx2/SIO/Memcard/MemoryCardFile.cpp#L360-L365)).
2. Folder conversion doesn't support PS1 cards (the option is already disabled from the UI but not from the right click).
3. The converter currently treats any card as ECC cards, so assuming 528 bytes pages.
4. In [`WriteToFile()`](https://github.com/PCSX2/pcsx2/blob/67aadac40cff9245c93c0eb0b61fcc9b38596296/pcsx2/SIO/Memcard/MemoryCardFolder.cpp#L1501-L1562) if `cluster` value is outside of the cluster data range, `fatCluster` will end up with an incorrect value and cause a crash.

### Suggested Testing Steps
Mess around with renaming/converting cards.
Here's the 2 non-ECC cards I used for testing: [memcards.zip](https://github.com/user-attachments/files/31697442/memcards.zip)
* "8.mc2" is a memory card I created myself by creating a 8388608 bytes file filled with 0xFF and formatting it in the PS2 BIOS. It converted fine with just the 3rd commit (i.e. by converting to a temp RAW file first and without the boundary check added yet).
* "SLUS-21567-1.mc2" is from #11317 (it's a MemCard PRO2 file), it uses a different cluster offset and it was still crashing after being converted to a RAW file, this is why a boundary check was added in the 4th commit, now it converts just fine (I even tried converting it back to 8/16/32/64MB .ps2 file, no issue).

### Did you use AI to help find, test, or implement this issue or feature?
Yes, code-wise I used AI in 2 places:
* For the crash fix (the boundary check in MemoryCardFolder.cpp) because I didn't know how to handle it.
* For `auto fp = FileSystem::OpenManagedSharedCFile(path.c_str(), "rb", FileSystem::FileShareMode::DenyNone);` (in MemoryCardFile.cpp) because I wasn't sure what function and args to use to open the file.

Otherwise I only used it to help me have a better understanding of ECC, pages, clusters, etc.