### PR TITLE
Achievements: Fix deadlock when enabling achievements in FullscreenUI

### DIFF
--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -136,7 +136,7 @@ namespace Achievements
 	// Size of the EE physical memory exposed to RetroAchievements.
 	static u32 GetExposedEEMemorySize();
 
-	static bool CreateClient(rc_client_t** client, std::unique_ptr<HTTPDownloader>* http);
+	static bool CreateClient(rc_client_t** client, std::unique_ptr<HTTPDownloader>* http, const std::string& custom_host);
 	static void DestroyClient(rc_client_t** client, std::unique_ptr<HTTPDownloader>* http);
 	static void ClientMessageCallback(const char* message, const rc_client_t* client);
 	static uint32_t ClientReadMemory(uint32_t address, uint8_t* buffer, uint32_t num_bytes, rc_client_t* client);
@@ -433,28 +433,8 @@ bool Achievements::Initialize()
 
 	EnsureCacheDirectoriesExist();
 
-	auto lock = GetLock();
-	pxAssertRel(EmuConfig.Achievements.Enabled, "Achievements are enabled");
-	pxAssertRel(!s_client && !s_http_downloader, "No client and downloader");
-
-	if (!CreateClient(&s_client, &s_http_downloader))
-		return false;
-
-	// Hardcore starts off. We enable it on first boot.
-	s_hardcore_mode = false;
-
-	rc_client_set_event_handler(s_client, ClientEventHandler);
-
-	rc_client_set_hardcore_enabled(s_client, s_hardcore_mode);
-	rc_client_set_encore_mode_enabled(s_client, EmuConfig.Achievements.EncoreMode);
-	rc_client_set_unofficial_enabled(s_client, EmuConfig.Achievements.UnofficialTestMode);
-	rc_client_set_spectator_mode_enabled(s_client, EmuConfig.Achievements.SpectatorMode);
-
-	// Begin disc identification early, before the login finishes.
-	if (VMManager::HasValidVM())
-		IdentifyGame(VMManager::GetDiscCRC(), VMManager::GetCurrentCRC());
-
 	const std::string username = Host::GetBaseStringSettingValue("Achievements", "Username");
+	const std::string custom_host = Host::GetBaseStringSettingValue("Achievements", "Host", "");
 
 	// Check the base settings file to see if the token is defined inside. Move if found.
 	std::string oldToken = Host::GetBaseStringSettingValue("Achievements", "Token");
@@ -474,6 +454,28 @@ bool Achievements::Initialize()
 	}
 
 	const std::string api_token = Host::GetStringSettingValue("Achievements", "Token");
+
+	auto lock = GetLock();
+	pxAssertRel(EmuConfig.Achievements.Enabled, "Achievements are enabled");
+	pxAssertRel(!s_client && !s_http_downloader, "No client and downloader");
+
+	if (!CreateClient(&s_client, &s_http_downloader, custom_host))
+		return false;
+
+	// Hardcore starts off. We enable it on first boot.
+	s_hardcore_mode = false;
+
+	rc_client_set_event_handler(s_client, ClientEventHandler);
+
+	rc_client_set_hardcore_enabled(s_client, s_hardcore_mode);
+	rc_client_set_encore_mode_enabled(s_client, EmuConfig.Achievements.EncoreMode);
+	rc_client_set_unofficial_enabled(s_client, EmuConfig.Achievements.UnofficialTestMode);
+	rc_client_set_spectator_mode_enabled(s_client, EmuConfig.Achievements.SpectatorMode);
+
+	// Begin disc identification early, before the login finishes.
+	if (VMManager::HasValidVM())
+		IdentifyGame(VMManager::GetDiscCRC(), VMManager::GetCurrentCRC());
+
 	if (!username.empty() && !api_token.empty())
 	{
 		Console.WriteLn("Achievements: Attempting login with user '%s'...", username.c_str());
@@ -496,7 +498,7 @@ u32 Achievements::GetExposedEEMemorySize()
 	return Ps2MemSize::ExposedRam + Ps2MemSize::Scratch;
 }
 
-bool Achievements::CreateClient(rc_client_t** client, std::unique_ptr<HTTPDownloader>* http)
+bool Achievements::CreateClient(rc_client_t** client, std::unique_ptr<HTTPDownloader>* http, const std::string& custom_host)
 {
 	*http = HTTPDownloader::Create(Host::GetHTTPUserAgent());
 	if (!*http)
@@ -524,7 +526,6 @@ bool Achievements::CreateClient(rc_client_t** client, std::unique_ptr<HTTPDownlo
 
 	rc_client_set_userdata(new_client, http->get());
 
-	const std::string custom_host = Host::GetBaseStringSettingValue("Achievements", "Host", "");
 	if (!custom_host.empty())
 	{
 		Console.WriteLn("Achievements: Using custom host %s", custom_host.c_str());
@@ -1794,6 +1795,8 @@ bool Achievements::CanEnableHardcoreMode()
 
 bool Achievements::Login(const char* username, const char* password, Error* error)
 {
+	const std::string custom_host = Host::GetBaseStringSettingValue("Achievements", "Host", "");
+
 	auto lock = GetLock();
 
 	// We need to use a temporary client if achievements aren't currently active.
@@ -1807,7 +1810,7 @@ bool Achievements::Login(const char* username, const char* password, Error* erro
 	};
 	if (is_temporary_client)
 	{
-		if (!CreateClient(&client, &temporary_downloader))
+		if (!CreateClient(&client, &temporary_downloader, custom_host))
 		{
 			Error::SetString(error, "Failed to create client.");
 			return false;

--- a/pcsx2/ImGui/FullscreenUI_Internal.h
+++ b/pcsx2/ImGui/FullscreenUI_Internal.h
@@ -412,7 +412,7 @@ namespace FullscreenUI
 	void DrawMemoryCardSettingsPage();
 	void DrawNetworkHDDSettingsPage();
 	void DrawFoldersSettingsPage();
-	void DrawAchievementsSettingsPage(std::unique_lock<std::mutex>& settings_lock);
+	void DrawAchievementsSettingsPage();
 	void DrawControllerSettingsPage();
 	void DrawHotkeySettingsPage();
 	void DrawAdvancedSettingsPage();

--- a/pcsx2/ImGui/FullscreenUI_Settings.cpp
+++ b/pcsx2/ImGui/FullscreenUI_Settings.cpp
@@ -1984,7 +1984,7 @@ void FullscreenUI::DrawSettingsWindow()
 				break;
 
 			case SettingsPage::Achievements:
-				DrawAchievementsSettingsPage(lock);
+				DrawAchievementsSettingsPage();
 				break;
 
 			case SettingsPage::Controller:
@@ -4560,15 +4560,9 @@ void FullscreenUI::DrawAchievementsLoginWindow()
 
 								Host::SetBaseBoolSettingValue("Achievements", "ChallengeMode", true);
 								Host::CommitBaseSettingChanges();
-								VMManager::ApplySettings();
+								Host::RunOnCPUThread([]() { VMManager::ApplySettings(); });
 
-								bool has_active_game;
-								{
-									auto lock = Achievements::GetLock();
-									has_active_game = Achievements::HasActiveGame();
-								}
-
-								if (has_active_game)
+								if (VMManager::HasValidVM())
 								{
 									OpenConfirmMessageDialog(FSUI_STR("Reset System"),
 										FSUI_STR("Hardcore mode will not be enabled until the system is reset. Do you want to reset the system now?"),
@@ -4590,10 +4584,9 @@ void FullscreenUI::DrawAchievementsLoginWindow()
 								{
 									Host::SetBaseBoolSettingValue("Achievements", "Enabled", true);
 									Host::CommitBaseSettingChanges();
-									VMManager::ApplySettings();
+									Host::RunOnCPUThread([]() { VMManager::ApplySettings(); });
+									prompt_hardcore();
 								}
-
-								prompt_hardcore();
 							});
 					}
 					else
@@ -4687,7 +4680,7 @@ void FullscreenUI::DrawAchievementsLoginWindow()
 	ImGui::PopStyleVar(2);
 }
 
-void FullscreenUI::DrawAchievementsSettingsPage(std::unique_lock<std::mutex>& settings_lock)
+void FullscreenUI::DrawAchievementsSettingsPage()
 {
 #ifdef ENABLE_RAINTEGRATION
 	if (Achievements::IsUsingRAIntegration())


### PR DESCRIPTION
### Description of Changes
Moved reading the achievement settings before taking the lock, and made FullscreenUI cheevo login apply its settings on the CPU thread instead (I should've done that in the first place -_-). Also removed an unused lock param from FullscreenUI.

### Rationale behind Changes
Fixes #14899 

### Suggested Testing Steps
Boot a game in Big Picture mode and turn achievements on and off in settings.

### Did you use AI to help find, test, or implement this issue or feature?
No