### PR TITLE
GS/HW: Improve source channel requirements for source lookups

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -3526,13 +3526,14 @@ void GSRendererHW::Draw()
 		const u32 color_mask = (m_vt.m_max.c > GSVector4i::zero()).mask();
 		const bool texture_function_color = m_cached_ctx.TEX0.TFX == TFX_DECAL || (color_mask & 0xFFF) || (m_cached_ctx.TEX0.TFX > TFX_DECAL && (color_mask & 0xF000));
 		const bool texture_function_alpha = m_cached_ctx.TEX0.TFX != TFX_MODULATE || (color_mask & 0xF000);
-		const bool req_color = (is_possible_channel_shuffle && channel_shuffle_targets != ChannelFetch_ALPHA) || (!is_possible_channel_shuffle && ((texture_function_color && (!PRIM->ABE || GSLocalMemory::m_psm[m_cached_ctx.TEX0.PSM].bpp < 16 || (NeedsBlending() && IsUsingCsInBlend())) && (possible_shuffle || (m_cached_ctx.FRAME.FBMSK & (fm_mask & 0x00FFFFFF)) != (fm_mask & 0x00FFFFFF))) || need_aem_color));
-		const bool alpha_used = (GSUtil::GetChannelMask(m_context->TEX0.PSM) == 0x8 || (m_context->TEX0.TCC && texture_function_alpha)) && ((NeedsBlending() && IsUsingAsInBlend()) || (m_cached_ctx.TEST.ATE && m_cached_ctx.TEST.ATST > ATST_ALWAYS) || (possible_shuffle || (m_cached_ctx.FRAME.FBMSK & (fm_mask & 0xFF000000)) != (fm_mask & 0xFF000000)));
-		const bool req_alpha = (is_possible_channel_shuffle && channel_shuffle_targets == ChannelFetch_ALPHA) || (!is_possible_channel_shuffle && (GSUtil::GetChannelMask(m_context->TEX0.PSM) & 0x8) && alpha_used);
+		const bool color_used = (is_possible_channel_shuffle && channel_shuffle_targets != ChannelFetch_ALPHA) || (!is_possible_channel_shuffle && ((texture_function_color && (!PRIM->ABE || (NeedsBlending() && IsUsingCsInBlend())) && ((m_cached_ctx.FRAME.FBMSK & (fm_mask & 0x00FFFFFF)) != (fm_mask & 0x00FFFFFF))) || need_aem_color));
+		const bool alpha_used = (is_possible_channel_shuffle && channel_shuffle_targets == ChannelFetch_ALPHA) || (!is_possible_channel_shuffle && (m_context->TEX0.TCC && texture_function_alpha) && ((NeedsBlending() && IsUsingAsInBlend()) || (m_cached_ctx.TEST.ATE && m_cached_ctx.TEST.ATST > ATST_ALWAYS) || (m_cached_ctx.FRAME.FBMSK & (fm_mask & 0xFF000000)) != (fm_mask & 0xFF000000)));
+		const bool req_color = (GSUtil::GetChannelMask(m_context->TEX0.PSM) & 0x7) && color_used;
+		const bool req_alpha = (GSUtil::GetChannelMask(m_context->TEX0.PSM) == 0x8 && (color_used || alpha_used)) || ((GSUtil::GetChannelMask(m_context->TEX0.PSM) & 0x8) && alpha_used);
 
 		// TODO: Be able to send an alpha of 1.0 (blended with vertex alpha maybe?) so we can avoid sending the texture, since we don't always need it.
 		// Example games: Evolution Snowboarding, Final Fantasy Dirge of Cerberus, Red Dead Revolver, Stuntman, Tony Hawk's Underground 2, Ultimate Spider-Man.
-		if (!req_color && !alpha_used)
+		if (!req_color && !req_alpha)
 		{
 			m_process_texture = false;
 			possible_shuffle = false;


### PR DESCRIPTION
### Description of Changes
Improves the checks for what channels are required in source lookups

### Rationale behind Changes
Sometimes for some formats it was requesting channels it didn't actually need, causing lookups to be done for no reason, these optimisations have saved 1 to several uploads on many games.

### Suggested Testing Steps
Test random stuff, nothing particular, just make sure it's ok.

### Did you use AI to help find, test, or implement this issue or feature?
No

Some example upload reductions (there are some duplicates as there's mutiple for some games doing different numbers of uploads)

-115  Drakengard_SLUS-20732_20230407052604
-6    Armored Core - Last Raven_SLPS-25462_20260206184521
-6    Gun_SLUS-21139_20240418231822
-4    Call of Duty - World at War - Final Fronts_SLUS-21746_20240120133217
-4    Gun_SLUS-21139_20250215044542
-4    True Crime - New York City_SLUS-21106_20220629114028
-3    Gun_SLES-53523_20240324151240
-3    True Crime - New York City_SLUS-21106_20220531214738
-2    Call of Duty - World at War - Final Fronts_SLUS-21746_20240120133157
-2    Gran Turismo 4_SCUS-97328_20250206230323
-2    NFS-HP-Busted2
-2    Star_Wars_Battlefront_II_SLUS-21240_20230131230225
-2    Test Drive - Eve of Destruction _NTSC-U__SLUS-20910_20230204010413
-2    Tony_Hawks_American_Wasteland_SLUS-21208_20240407173350
-2    True_Crime_-_New_York_City_SLUS-21106_20230224173626
-2    Virtua Quest _NTSC-U__SLUS-20977
-2    WRC Rally Evolved_SCES-53247_In_Game
-1    007AgentUnderFire
-1    007_-_Everything_or_Nothing_SLUS-20751_20230225144134
-1    Armored Core - Nexus [Disc 1]_SLPS-25338_20230815105529
-1    Armored Core 2_SLPS-25007_20231226144119
-1    Armored_Core_-_Last_Raven_SLES-53820_20221020170502
-1    Armored_Core_-_Last_Raven_SLUS-21338_20230214020254
-1    ATV Offroad Fury 2_SCUS-97211_20240301062917
-1    Battle Assault 3 featuring Gundam Seed_SLUS-20929_20240719215022
-1    Battlefield 2 - Modern Combat_SLUS-21026_20240617165053
-1    Brave_The_Search_for_Spirit_Dancer_showing_green_lines_along_geometry_
-1    Catwoman_SLUS-20992_20260523162159
-1    Crash of the Titans_SLUS-21583_20230219171145
-1    Darkwatch_SLUS-21042_20230603152041
-1    Disney-Pixar's Cars_SLUS-21151_20240302102146
-1    Dog's Life_SLUS-21018_20230222191307
-1    Dragon Quest VIII - Journey of the Cursed King _NTSC-U__SLUS-21207_20220426095332
-1    Driv3r_SLES-52153_20230317214948
-1    Driver - Parallel Lines_SLUS-21271_20250501081114