### PR TITLE
Pad/Recording: Fix buttons getting stuck when stopping playback

### DIFF
--- a/pcsx2/Recording/InputRecording.cpp
+++ b/pcsx2/Recording/InputRecording.cpp
@@ -23,8 +23,6 @@ bool SaveStateBase::InputRecordingFreeze()
 
 #include "common/FileSystem.h"
 #include "common/StringUtil.h"
-#include "Counters.h"
-#include "SaveState.h"
 #include "VMManager.h"
 #include "Host.h"
 #include "ImGui/ImGuiOverlays.h"
@@ -32,7 +30,7 @@ bool SaveStateBase::InputRecordingFreeze()
 #include "GameDatabase.h"
 #include "fmt/format.h"
 #include "GS.h"
-#include "Host.h"
+#include "SIO/Pad/Pad.h"
 
 InputRecording g_InputRecording;
 
@@ -139,6 +137,7 @@ void InputRecording::closeActiveFile()
 	if (m_file.close())
 	{
 		m_is_active = false;
+		Pad::ResetAllControllerInputs();
 		InputRec::log(TRANSLATE_STR("InputRecording", "Input recording stopped"), Host::OSD_ERROR_DURATION);
 		MTGS::PresentCurrentFrame();
 	}

--- a/pcsx2/Recording/InputRecordingControls.cpp
+++ b/pcsx2/Recording/InputRecordingControls.cpp
@@ -7,6 +7,7 @@
 #include "InputRecording.h"
 #include "InputRecordingControls.h"
 #include "Utilities/InputRecordingLogger.h"
+#include "SIO/Pad/Pad.h"
 
 #include "Host.h"
 #include "MTGS.h"
@@ -29,6 +30,7 @@ void InputRecordingControls::setRecordMode(bool waitForFrameToEnd)
 	if (!waitForFrameToEnd || VMManager::GetState() == VMState::Paused)
 	{
 		m_state = Mode::Recording;
+		Pad::ResetAllControllerInputs();
 		InputRec::log(TRANSLATE("InputRecordingControls","Record Mode Enabled"), Host::OSD_INFO_DURATION);
 		MTGS::PresentCurrentFrame();
 	}
@@ -36,6 +38,7 @@ void InputRecordingControls::setRecordMode(bool waitForFrameToEnd)
 	{
 		m_controlQueue.push([&]() {
 			m_state = Mode::Recording;
+			Pad::ResetAllControllerInputs();
 			InputRec::log(TRANSLATE("InputRecordingControls","Record Mode Enabled"), Host::OSD_INFO_DURATION);
 		});
 	}

--- a/pcsx2/SIO/Pad/Pad.cpp
+++ b/pcsx2/SIO/Pad/Pad.cpp
@@ -554,6 +554,32 @@ void Pad::SetControllerState(u32 controller, u32 bind, float value)
 	s_controllers[controller]->Set(bind, value);
 }
 
+void Pad::ResetControllerInputs(u32 controller)
+{
+	if (controller >= NUM_CONTROLLER_PORTS || !HasConnectedPad(controller))
+		return;
+
+	for (InputBindingInfo binding : s_controllers[controller]->GetInfo().bindings)
+	{
+		switch (binding.bind_type)
+		{
+			case InputBindingInfo::Type::Button:
+			case InputBindingInfo::Type::Axis:
+			case InputBindingInfo::Type::HalfAxis:
+				s_controllers[controller]->Set(binding.bind_index, 0);
+				break;
+			default:
+				break;
+		}
+	}
+}
+
+void Pad::ResetAllControllerInputs()
+{
+	for (u32 port = 0; port < NUM_CONTROLLER_PORTS; port++)
+		ResetControllerInputs(port);
+}
+
 bool Pad::Freeze(StateWrapper& sw)
 {
 	if (sw.IsReading())

--- a/pcsx2/SIO/Pad/Pad.h
+++ b/pcsx2/SIO/Pad/Pad.h
@@ -66,6 +66,10 @@ namespace Pad
 	// Sets the specified bind on a controller to the specified pressure (normalized to 0..1).
 	void SetControllerState(u32 controller, u32 bind, float value);
 
+	// Resets all input binds on a controller to their default state.
+	void ResetControllerInputs(u32 controller);
+	void ResetAllControllerInputs();
+
 	bool Freeze(StateWrapper& sw);
 
 	// Sets the state of the specified macro button.


### PR DESCRIPTION
### Description of Changes
- Two new helper functions to Pad.cpp that reset the default (unpressed) state of all buttons in a specific controller and in every controller
- Use of the new functions in Input recording code to make sure buttons don't get stuck when playback is stopped for a recording while they are pressed

### Rationale behind Changes
If a button is pressed when Input recording playback is stopped, it should not get stuck until it's pressed again
Fixes #13235
Also, cool helper functions that might be useful elsewhere

### Suggested Testing Steps
Create and play Input recordings on any game (or the Padtest ELF for simplicity) with button presses and check that buttons never get stuck if the recording is stopped while they are pressed
Try these:
- Stopping playback/toggling recording (with the hotkey) at the end of a recording that ends in a button press
- Stopping playback/toggling recording (with the hotkey) in the middle of a recording while a button is pressed

Are there any other cases I didn't cover? Tell me and I'll try fixing those too

### Did you use AI to help find, test, or implement this issue or feature?
No