### PR TITLE
mVU: Correct mask for ignoring mac flags on non exact matches

### DIFF
--- a/.github/workflows/check_pr_commits.yml
+++ b/.github/workflows/check_pr_commits.yml
@@ -16,7 +16,7 @@ jobs:
         uses: gsactions/commit-message-checker@16fa2d5de096ae0d35626443bcd24f1e756cafee
         with:
           accessToken: ${{ secrets.GITHUB_TOKEN }}
-          pattern: '^[A-Z0-9][A-Za-z0-9 \["\/\\]+:.+'
+          pattern: '^[A-Z0-9][A-Za-z0-9 \["\/\\-]+:.+'
           excludeTitle: true
           excludeDescription: true
           checkAllCommitMessages: true

--- a/pcsx2/x86/microVU.h
+++ b/pcsx2/x86/microVU.h
@@ -237,7 +237,8 @@ public:
 				// if we're using the flag hack, ignore the mac flags going in to the new block too if an exact match wasn't requested.
 				if (mVUsFlagHack)
 				{
-					if ((ref.quick & ~0x0C04) != (quick64 & ~0x0C04)) continue;
+					if ((ref.quick & ~0x3002) != (quick64 & ~0x3002))
+						continue;
 				}
 				else if (ref.quick != quick64) continue;
 


### PR DESCRIPTION
### Description of Changes
Fix mask for ignoring mac flags when exact match on VU block not needed

### Rationale behind Changes
The flags used in #13353 were incorrect and pointing to clip flags and other nonsense (my fault, not Jordan's), this corrects them to properly mask out the bits for macs only.

### Suggested Testing Steps
test a lot of games with the mvu flag hack enabled (which is the default), make sure the graphics/physics aren't broken

### Did you use AI to help find, test, or implement this issue or feature?
No

Fixes #14494 Zombie Hunters 2