### PR TITLE
Patch: Show bundled patches for all CRCs

### DIFF
--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -393,6 +393,39 @@ void Patch::EnumeratePnachFiles(const std::string_view serial, u32 crc, bool che
 	if (cheats || unlabeled_patch_found || !OpenPatchesZip())
 		return;
 
+	// Enumerate all bundled patches matching the game serial when requested by the UI.
+	if (for_ui && !serial.empty())
+	{
+		const std::string prefix = fmt::format("{}_", serial);
+		const zip_int64_t num_entries = zip_get_num_entries(s_patches_zip, 0);
+		for (zip_int64_t i = 0; i < num_entries; i++)
+		{
+			const zip_uint64_t index = static_cast<zip_uint64_t>(i);
+			const char* entry_name = zip_get_name(s_patches_zip, index, 0);
+			if (!entry_name)
+				continue;
+
+			const std::string_view name(entry_name);
+			if (!StringUtil::StartsWithNoCase(name, prefix) || !StringUtil::EndsWithNoCase(name, ".pnach"))
+				continue;
+
+			auto file = zip_fopen_index_managed(s_patches_zip, index, 0);
+			if (!file)
+				continue;
+
+			std::optional<std::string> pnach_data = ReadFileInZipToString(file.get());
+			if (pnach_data.has_value())
+				f(std::string(name), std::move(pnach_data.value()));
+		}
+
+		// Also include the legacy CRC-only filename for the selected CRC.
+		std::string zip_filename = GetPnachTemplate(serial, crc, false, false, false);
+		std::optional<std::string> pnach_data = ReadFileInZipToString(s_patches_zip, zip_filename.c_str());
+		if (pnach_data.has_value())
+			f(std::move(zip_filename), std::move(pnach_data.value()));
+		return;
+	}
+
 	// Prefer filename with serial.
 	std::string zip_filename = GetPnachTemplate(serial, crc, true, false, false);
 	std::optional<std::string> pnach_data(ReadFileInZipToString(s_patches_zip, zip_filename.c_str()));


### PR DESCRIPTION
> **This PR is a direct replacement for #14656.**
>
> The previous PR was closed only because I accidentally deleted the fork containing its source branch. The code change in this PR is the same.

### Description of Changes

Updated bundled patch enumeration so **All CRCs** also lists matching `SERIAL_*.pnach` files from `patches.zip`.

Runtime loading is unchanged: PCSX2 still applies only the patch matching the currently loaded ELF CRC.

### Rationale behind Changes

Some games load secondary ELF files with CRCs different from the main executable.

This affects already merged patches for games such as:

* **The King of Fighters NESTS Collection**
* **The Last Blade 1 & 2**

When these patch files are placed in the local `patches` directory, they are visible with **All CRCs** enabled.

After being bundled into `patches.zip`, patches targeting secondary ELF CRCs are not listed in the UI, even though they can still be loaded and applied when the corresponding ELF is running.

This change makes bundled patch enumeration consistent with local patch enumeration.

### Suggested Testing Steps

Test the already merged patches for:

* **The King of Fighters NESTS Collection**
* **The Last Blade 1 & 2**

Confirm that patches targeting secondary ELF CRCs are visible with **All CRCs** enabled when loaded from `patches.zip`.

### Did you use AI to help find, test, or implement this issue or feature?

Yes. AI was used to compare the local and bundled patch enumeration paths, identify the missing ZIP enumeration behavior, help implement the change, and prepare the PR description.
