### PR TITLE
Qt/VMManager: Add -gamecfg command-line argument

### DIFF
--- a/pcsx2-qt/QtHost.cpp
+++ b/pcsx2-qt/QtHost.cpp
@@ -2136,7 +2136,8 @@ void QtHost::PrintCommandLineHelp(const std::string_view progname)
 	std::fprintf(stderr, "  -portable: Force enable portable mode to store data in local PCSX2 path instead of the default configuration path. Overrides '-datapath'.\n");
 	std::fprintf(stderr, "  -datapath <path>: Specify the directory to be used for all application data.\n");
 	std::fprintf(stderr, "  -elf <file>: Overrides the boot ELF with the specified filename.\n");
-	std::fprintf(stderr, "  -gameargs <string>: passes the specified quoted space-delimited string of launch arguments.\n");
+	std::fprintf(stderr, "  -gameargs <string>: Passes the specified quoted space-delimited string of launch arguments.\n");
+	std::fprintf(stderr, "  -gamecfg <file>: Overrides the game settings with the ones in the specified INI file.\n");
 	std::fprintf(stderr, "  -disc <path>: Uses the specified host DVD drive as a source.\n");
 	std::fprintf(stderr, "  -logfile <path>: Writes the application log to path instead of emulog.txt.\n");
 	std::fprintf(stderr, "  -bios: Starts the BIOS (System Menu/OSDSYS).\n");
@@ -2247,6 +2248,11 @@ bool QtHost::ParseCommandLineOptions(const QStringList& args, std::shared_ptr<VM
 			else if (CHECK_ARG_PARAM(QStringLiteral("-gameargs")))
 			{
 				EmuConfig.CurrentGameArgs = (++it)->toStdString();
+				continue;
+			}
+			else if (CHECK_ARG_PARAM(QStringLiteral("-gamecfg")))
+			{
+				AutoBoot(autoboot)->game_config = (++it)->toStdString();
 				continue;
 			}
 			else if (CHECK_ARG_PARAM(QStringLiteral("-disc")))

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -179,6 +179,7 @@ static std::string s_elf_path;
 static std::pair<u32, u32> s_elf_text_range;
 static bool s_elf_executed = false;
 static std::string s_elf_override;
+static std::string s_game_settings_override;
 static std::string s_input_profile_name;
 static u32 s_frame_advance_count = 0;
 static bool s_fast_boot_requested = false;
@@ -812,6 +813,10 @@ bool VMManager::ReloadGameSettings()
 
 std::string VMManager::GetGameSettingsPath(const std::string_view game_serial, u32 game_crc)
 {
+	// Game settings override via -gamecfg command line flag
+	if (!s_game_settings_override.empty())
+		return s_game_settings_override;
+
 	std::string sanitized_serial(Path::SanitizeFileName(game_serial));
 
 	return game_serial.empty() ?
@@ -1467,6 +1472,23 @@ VMBootResult VMManager::Initialize(const VMBootParameters& boot_params, Error* e
 	}
 	ScopedGuard close_cdvd(&DoCDVDclose);
 
+	if (!boot_params.game_config.empty())
+	{	
+		if (!StringUtil::compareNoCase(Path::GetExtension(boot_params.game_config), "ini"))
+		{
+			Error::SetStringFmt(error,
+				TRANSLATE_FS("VMManager", "Requested game config '{}' is not an INI file."), boot_params.game_config);
+			return VMBootResult::StartupFailure;
+		}
+		else if (!FileSystem::FileExists(boot_params.game_config.c_str()))
+		{
+			Error::SetStringFmt(error,
+				TRANSLATE_FS("VMManager", "Requested game config '{}' does not exist."), boot_params.game_config);
+			return VMBootResult::StartupFailure;
+		}
+		s_game_settings_override = boot_params.game_config;
+	}
+
 	// Figure out which game we're running! This also loads game settings.
 	UpdateDiscDetails(true);
 
@@ -1683,6 +1705,7 @@ void VMManager::Shutdown(bool save_resume_state)
 
 	SaveSessionTime(s_disc_serial);
 	s_elf_override = {};
+	s_game_settings_override = {};
 	ClearELFInfo();
 	CDVDsys_ClearFiles();
 

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -32,6 +32,7 @@ struct VMBootParameters
 	std::string filename;
 	std::string elf_override;
 	std::string save_state;
+	std::string game_config;
 	std::optional<s32> state_index;
 	std::optional<CDVD_SourceType> source_type;
 

--- a/tools/generate_redump_yaml.py
+++ b/tools/generate_redump_yaml.py
@@ -5,7 +5,7 @@ import xml.etree.ElementTree as ET
 import re
 import yaml
 
-# Database downloadable from http://redump.org/datfile/ps2/serial,version,description
+# Database downloadable from https://redump.info/datfile/PS2/serial,version
 
 def parse_serials(serials_text):
     serials = []


### PR DESCRIPTION
### Description of Changes
Adds a new command-line argument: `-gamecfg`, used to override the default/per-game INI configuration file with one specified at startup. The framework was there already, so I tried to integrate the code for the new option
An error message is displayed when the file with the provided name does not exist or does not have the correct extension (and game boot is blocked).
While the VM is running the override will survive game resets (and editing the config through the GUI will change the external one), but as soon as the game is stopped, config returns to normal and at the next boot the game will use its default settings.

### Rationale behind Changes
More parity with the old WX version, and generally a good addition to the emulator.
Closes #12244

### Suggested Testing Steps
Try out the new argument! Example (on Windows):
`pcsx2-qt -gamecfg "path\to\cfgfile.ini" "path\to\game.iso"`
I can only test on Windows, so try other operating systems

Check that:
- Only existing files with an INI extension are loaded (otherwise an error message is displayed and the game refuses to run)
- The options in the file are loaded and persist after resets (without stopping the game)
- Modifying the config through the GUI changes the external one
- After stopping the game the override is gone and any game started afterwards uses its default config

### Did you use AI to help find, test, or implement this issue or feature?
No