### PR TITLE
CMake: Set minimum Qt version to 6.10

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -104,7 +104,7 @@ disable_compiler_warnings_for_target(speex)
 
 # Find the Qt components that we need.
 if(ENABLE_QT_UI)
-	find_package(Qt6 6.11.1 COMPONENTS CoreTools Core GuiTools Gui WidgetsTools Widgets LinguistTools REQUIRED)
+	find_package(Qt6 6.10 COMPONENTS CoreTools Core GuiTools Gui WidgetsTools Widgets LinguistTools REQUIRED)
 
 	if(NOT WIN32 AND NOT APPLE)
 		if (Qt6_VERSION VERSION_GREATER_EQUAL 6.10.0)


### PR DESCRIPTION
### Description of Changes
Sets minimum qt version to 6.10

### Rationale behind Changes
- We build just fine against Qt 6.10
- Rebuilding deps is a pain
- Writing more patches to edit version numbers for my copr builds is a pain

### Suggested Testing Steps
- [x] Build against Qt 6.10

### Did you use AI to help find, test, or implement this issue or feature?
No