### PR TITLE
GS: Use "coords" in UserHacks_RewriteLargeST for clarity.

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -4706,7 +4706,7 @@ SCES-50000:
     gpuPaletteConversion: 2 # Lots of CLUTs in large textures.
     cpuSpriteRenderBW: 1 # Fixes car textures.
     cpuSpriteRenderLevel: 1 # Needed for above.
-    rewriteLargeST: 1 # Fix reflections on cars.
+    rewriteLargeSTCoords: 1 # Fix reflections on cars.
 SCES-50001:
   name: "Tekken Tag Tournament"
   region: "PAL-M5"
@@ -35388,7 +35388,7 @@ SLPM-60109:
     gpuPaletteConversion: 2 # Lots of CLUTs in large textures.
     cpuSpriteRenderBW: 1 # Fixes car textures.
     cpuSpriteRenderLevel: 1 # Needed for above.
-    rewriteLargeST: 1 # Fix reflections on cars.
+    rewriteLargeSTCoords: 1 # Fix reflections on cars.
 SLPM-60112:
   name: "フレースヴェルグ [体験版]"
   name-sort: "ふれーすヴぇるぐ [たいけんばん]"
@@ -54811,7 +54811,7 @@ SLPS-20001:
     gpuPaletteConversion: 2 # Lots of CLUTs in large textures.
     cpuSpriteRenderBW: 1 # Fixes car textures.
     cpuSpriteRenderLevel: 1 # Needed for above.
-    rewriteLargeST: 1 # Fix reflections on cars.
+    rewriteLargeSTCoords: 1 # Fix reflections on cars.
 SLPS-20002:
   name: "撞球 ビリヤードマスター2"
   name-sort: "どうきゅう びりやーどますたー2"
@@ -63504,7 +63504,7 @@ SLPS-71502:
     gpuPaletteConversion: 2 # Lots of CLUTs in large textures.
     cpuSpriteRenderBW: 1 # Fixes car textures.
     cpuSpriteRenderLevel: 1 # Needed for above.
-    rewriteLargeST: 1 # Fix reflections on cars.
+    rewriteLargeSTCoords: 1 # Fix reflections on cars.
 SLPS-72501:
   name: "ファイナルファンタジーⅩ [MEGA HITS!]"
   name-sort: "ふぁいなるふぁんたじー10 [MEGA HITS!]"
@@ -64507,7 +64507,7 @@ SLUS-20002:
     gpuPaletteConversion: 2 # Lots of CLUTs in large textures.
     cpuSpriteRenderBW: 1 # Fixes car textures.
     cpuSpriteRenderLevel: 1 # Needed for above.
-    rewriteLargeST: 1 # Fix reflections on cars.
+    rewriteLargeSTCoords: 1 # Fix reflections on cars.
 SLUS-20003:
   name: "Portal Runner"
   region: "NTSC-U"

--- a/pcsx2-qt/Settings/GraphicsHardwareFixesSettingsTab.ui
+++ b/pcsx2-qt/Settings/GraphicsHardwareFixesSettingsTab.ui
@@ -272,7 +272,7 @@
    <item row="7" column="0" colspan="2">
    <layout class="QGridLayout" name="hwFixesLayout">
      <item row="5" column="0">
-      <widget class="QCheckBox" name="rewriteLargeST">
+      <widget class="QCheckBox" name="rewriteLargeSTCoords">
        <property name="text">
         <string>Rewrite Large ST</string>
        </property>
@@ -396,7 +396,7 @@
   <tabstop>disableRenderFixes</tabstop>
   <tabstop>readTCOnClose</tabstop>
   <tabstop>estimateTextureRegion</tabstop>
-  <tabstop>rewriteLargeST</tabstop>
+  <tabstop>rewriteLargeSTCoords</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GraphicsSettingsWidget.cpp
@@ -155,7 +155,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_fixes.readTCOnClose, "EmuCore/GS", "UserHacks_ReadTCOnClose", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_fixes.estimateTextureRegion, "EmuCore/GS", "UserHacks_EstimateTextureRegion", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_fixes.drawBuffering, "EmuCore/GS", "UserHacks_DrawBuffering", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_fixes.rewriteLargeST, "EmuCore/GS", "UserHacks_RewriteLargeST", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_fixes.rewriteLargeSTCoords, "EmuCore/GS", "UserHacks_RewriteLargeSTCoords", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_fixes.gpuPaletteConversion, "EmuCore/GS", "paltex", false);
 	connect(m_fixes.cpuSpriteRenderBW, &QComboBox::currentIndexChanged, this,
 		&GraphicsSettingsWidget::onCPUSpriteRenderBWChanged);
@@ -638,8 +638,8 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* settings_dialog, 
 		dialog()->registerWidgetHelp(m_fixes.drawBuffering, tr("Draw Buffering"), tr("Unchecked"),
 			tr("Attempts to reduce draw calls in games which do heavy context switching for blending purposes."));
 		
-		dialog()->registerWidgetHelp(m_fixes.rewriteLargeST, tr("Rewrite Large ST"), tr("Unchecked"),
-			tr("Rewrite large ST coordinates and clamp the values (mainly for Ridge Racer V)."));
+		dialog()->registerWidgetHelp(m_fixes.rewriteLargeSTCoords, tr("Rewrite Large ST"), tr("Unchecked"),
+			tr("Rewrite large ST coordinates and clamp the values (mainly for Ridge Racer V and Destruction Derby Arena)."));
 	}
 
 	// Upscaling Fixes tab

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -811,7 +811,7 @@ struct Pcsx2Config
 					UserHacks_NativePaletteDraw : 1,
 					UserHacks_EstimateTextureRegion : 1,
 					UserHacks_DrawBuffering : 1,
-					UserHacks_RewriteLargeST : 1,
+					UserHacks_RewriteLargeSTCoords : 1,
 					FXAA : 1,
 					ShadeBoost : 1,
 					DumpGSData : 1,

--- a/pcsx2/Docs/GameIndex.md
+++ b/pcsx2/Docs/GameIndex.md
@@ -175,7 +175,7 @@ The clamp modes are also numerically based.
 * cpuSpriteRenderLevel        [`0` or `1` or `2`]    {Sprites only, Sprites/Triangles, Blended Sprites/Triangles}  Default: Off unless cpuSpriteRenderBW has value other than Off then it is 'Sprites only' (`0`)
 * estimateTextureRegion       [`0` or `1`]          {Off, On}                               Default: Off (`0`)
 * drawBuffering               [`0` or `1`]          {Off, On}                               Default: Off (`0`)
-* rewriteLargeST              [`0` or `1`]          {Off, On} Default: Off (`0`)
+* rewriteLargeSTCoords        [`0` or `1`]          {Off, On} Default: Off (`0`)
 * getSkipCount                {`GSC` with suffix }  {None unless specific game GSC}         Default: Disabled (`0`) unless valid variable name (ex. GSC_PolyphonyDigitalGames, GSC_UrbanReign, ...)
 * gpuPaletteConversion        [`0` or `1`]          {Off, On}                               Default: Off (`0`)
 * gpuTargetCLUT               [`0` or `1` or `2`]   {Disabled, Enabled (Exact Match), Enabled (Check Inside Target)}                     Default: Disabled (`0`)

--- a/pcsx2/Docs/gamedb-schema.json
+++ b/pcsx2/Docs/gamedb-schema.json
@@ -209,7 +209,7 @@
               "minimum": 0,
               "maximum": 1
             },
-            "rewriteLargeST": {
+            "rewriteLargeSTCoords": {
               "type": "integer",
               "minimum": 0,
               "maximum": 1

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2904,7 +2904,7 @@ void GSRendererHW::Draw()
 	
 	// Ridge Racer V and Destruction Derby Arena have large ST coordinates in reflection map draws that cause
 	// speckled artifacts on cars. Detect and rewrite such vertices here.
-	if (GSConfig.UserHacks_RewriteLargeST)
+	if (GSConfig.UserHacks_RewriteLargeSTCoords)
 	{
 		// The threshold is chosen to be low enough to fix the artifacts in Ridge Racer V and Destruction Derby Arena
 		// while not breaking anything.

--- a/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
+++ b/pcsx2/GS/Renderers/SW/GSRendererSW.cpp
@@ -308,7 +308,7 @@ MULTI_ISA_UNSHARED_END
 void GSRendererSW::Draw()
 {
 	const GSDrawingContext* context = m_context;
-	if (!GSConfig.UserHacks_RewriteLargeST)
+	if (!GSConfig.UserHacks_RewriteLargeSTCoords)
 	{
 		// SW rasterizer stores UV in 1.15.16 format so clamp to +/- (2^15 - 2) (-2 so bilinear doesn't overflow).
 		// Also only do this for CLAMP and CLAMP_REGION modes to reduce the performance impact.

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -376,7 +376,7 @@ static const char* s_gs_hw_fix_names[] = {
 	"nativePaletteDraw",
 	"estimateTextureRegion",
 	"drawBuffering",
-	"rewriteLargeST",
+	"rewriteLargeSTCoords",
 	"PCRTCOffsets",
 	"PCRTCOverscan",
 	"trilinearFiltering",
@@ -624,8 +624,8 @@ bool GameDatabaseSchema::GameEntry::configMatchesHWFix(const Pcsx2Config::GSOpti
 		case GSHWFixId::DrawBuffering:
 			return (static_cast<int>(config.UserHacks_DrawBuffering) == value);
 		
-		case GSHWFixId::RewriteLargeST:
-			return (static_cast<int>(config.UserHacks_RewriteLargeST) == value);
+		case GSHWFixId::RewriteLargeSTCoords:
+			return (static_cast<int>(config.UserHacks_RewriteLargeSTCoords) == value);
 
 		case GSHWFixId::PCRTCOffsets:
 			return (static_cast<int>(config.PCRTCOffsets) == value);
@@ -797,8 +797,8 @@ void GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions&
 				config.UserHacks_DrawBuffering = (value > 0);
 				break;
 
-			case GSHWFixId::RewriteLargeST:
-				config.UserHacks_RewriteLargeST = (value > 0);
+			case GSHWFixId::RewriteLargeSTCoords:
+				config.UserHacks_RewriteLargeSTCoords = (value > 0);
 				break;
 
 			case GSHWFixId::PCRTCOffsets:

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -61,7 +61,7 @@ namespace GameDatabaseSchema
 		NativePaletteDraw,
 		EstimateTextureRegion,
 		DrawBuffering,
-		RewriteLargeST,
+		RewriteLargeSTCoords,
 		PCRTCOffsets,
 		PCRTCOverscan,
 

--- a/pcsx2/ImGui/FullscreenUI_Settings.cpp
+++ b/pcsx2/ImGui/FullscreenUI_Settings.cpp
@@ -3238,7 +3238,7 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 				"UserHacks_EstimateTextureRegion", false, manual_hw_fixes);
 			DrawToggleSetting(bsi, FSUI_CSTR("Rewrite Large ST"),
 				FSUI_CSTR("Rewrite large ST coordinates and clamp the values."), "EmuCore/GS",
-				"UserHacks_RewriteLargeST", false, manual_hw_fixes);
+				"UserHacks_RewriteLargeSTCoords", false, manual_hw_fixes);
 			DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_PALETTE, "GPU Palette Conversion"),
 				FSUI_CSTR("When enabled GPU converts colormap-textures, otherwise the CPU will. It is a trade-off between GPU and CPU."),
 				"EmuCore/GS", "paltex", false, manual_hw_fixes);

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -1021,7 +1021,7 @@ __ri void ImGuiManager::DrawSettingsOverlay(float scale, float margin, float spa
 			APPEND("ETR ");
 		if (GSConfig.UserHacks_DrawBuffering)
 			APPEND("DRWB ");
-		if (GSConfig.UserHacks_RewriteLargeST)
+		if (GSConfig.UserHacks_RewriteLargeSTCoords)
 			APPEND("RWST ");
 		if (GSConfig.HWSpinGPUForReadbacks)
 			APPEND("RBSG ");

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1005,7 +1005,7 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapIntEnumEx(UserHacks_Limit24BitDepth, "UserHacks_Limit24BitDepth");
 	SettingsWrapBitBoolEx(UserHacks_EstimateTextureRegion, "UserHacks_EstimateTextureRegion");
 	SettingsWrapBitBoolEx(UserHacks_DrawBuffering, "UserHacks_DrawBuffering");
-	SettingsWrapBitBoolEx(UserHacks_RewriteLargeST, "UserHacks_RewriteLargeST");
+	SettingsWrapBitBoolEx(UserHacks_RewriteLargeSTCoords, "UserHacks_RewriteLargeSTCoords");
 	SettingsWrapBitBoolEx(FXAA, "fxaa");
 	SettingsWrapBitBool(ShadeBoost);
 	SettingsWrapBitBoolEx(DumpGSData, "DumpGSData");
@@ -1146,7 +1146,7 @@ void Pcsx2Config::GSOptions::MaskUserHacks()
 	UserHacks_Limit24BitDepth = GSLimit24BitDepth::Disabled;
 	UserHacks_EstimateTextureRegion = false;
 	UserHacks_DrawBuffering = false;
-	UserHacks_RewriteLargeST = false;
+	UserHacks_RewriteLargeSTCoords = false;
 	UserHacks_TCOffsetX = 0;
 	UserHacks_TCOffsetY = 0;
 	UserHacks_CPUSpriteRenderBW = 0;

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -3279,7 +3279,7 @@ void VMManager::WarnAboutUnsafeSettings()
 			append(ICON_FA_CIRCLE_EXCLAMATION,
 				TRANSLATE_SV("VMManager", "Draw Buffering is enabled, this may result in graphical errors."));
 		}
-		if (EmuConfig.GS.UserHacks_RewriteLargeST)
+		if (EmuConfig.GS.UserHacks_RewriteLargeSTCoords)
 		{
 			append(ICON_FA_CIRCLE_EXCLAMATION,
 				TRANSLATE_SV("VMManager", "Rewrite large ST is enabled, this may reduce performance."));


### PR DESCRIPTION
### Description of Changes
Uses the word "coords" (coordinates) for clarity in option/variable names related to UserHacks_RewriteLargeST (changed to UserHacks_RewriteLargeSTCoords).

### Rationale behind Changes
Clarity, the hack is user facing in GameDB.

### Suggested Testing Steps
Shouldn't need testing, the changes are cosmetic (as long as it compiles).

### Did you use AI to help find, test, or implement this issue or feature?
No.