### PR TITLE
GS:HW: Fix bpp assertion in GetConvertShader().

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -465,7 +465,7 @@ static inline ShaderConvertSelector GetConvertShader(GSTexture::Format src, GSTe
 			switch (dst)
 			{
 				case GSTexture::Format::Color:
-					pxAssert(src_bpp == 32 && dst_bpp == 32);
+					pxAssert(src_bpp == dst_bpp);
 					shader = ShaderConvert::COPY; // bpp is handled by mask
 					break;
 				case GSTexture::Format::DepthColor:


### PR DESCRIPTION
### Description of Changes
Fixes a debug assertion.

### Rationale behind Changes
Avoid false positives on debug builds.

### Suggested Testing Steps
Try the attached dump on a debug build. Master fails the assertion but PR should not.

[Virtua_Fighter_4_SLUS-20323_20230124224525.gs.xz.zip](https://github.com/user-attachments/files/31982144/Virtua_Fighter_4_SLUS-20323_20230124224525.gs.xz.zip)

### Did you use AI to help find, test, or implement this issue or feature?
No.