### PR TITLE
GS: Update dirty area in special HW local->local transfers

### DIFF
--- a/pcsx2/GS/GSState.cpp
+++ b/pcsx2/GS/GSState.cpp
@@ -1359,8 +1359,9 @@ void GSState::DumpTransferImages()
 				transfer.rect.x, transfer.rect.y, transfer.rect.z, transfer.rect.w);
 		}
 
-		m_mem.SaveBMP(filename, transfer.blit.DBP, transfer.blit.DBW, transfer.blit.DPSM,
-			transfer.rect.width(), transfer.rect.height(), transfer.rect.x, transfer.rect.y);
+		if (!transfer.was_hardware_only)
+			m_mem.SaveBMP(filename, transfer.blit.DBP, transfer.blit.DBW, transfer.blit.DPSM,
+				transfer.rect.width(), transfer.rect.height(), transfer.rect.x, transfer.rect.y);
 	}
 }
 
@@ -2932,11 +2933,12 @@ void GSState::Write(const u8* mem, int len)
 			m_draw_transfers.pop_back();
 			transfer.rect = transfer.rect.runion(r);
 			transfer.draw = s_n;
+			transfer.was_hardware_only = false;
 			m_draw_transfers.push_back(transfer);
 		}
 		else
 		{
-			const GSUploadQueue new_transfer = {blit, s_n, r, EEGS_TransferType::EE_to_GS};
+			const GSUploadQueue new_transfer = {blit, s_n, r, EEGS_TransferType::EE_to_GS, false};
 			m_draw_transfers.push_back(new_transfer);
 		}
 
@@ -3131,11 +3133,12 @@ void GSState::Move()
 		m_draw_transfers.pop_back();
 		transfer.rect = transfer.rect.runion(r);
 		transfer.draw = s_n;
+		transfer.was_hardware_only = false;
 		m_draw_transfers.push_back(transfer);
 	}
 	else
 	{
-		const GSUploadQueue new_transfer = {m_env.BITBLTBUF, s_n, r, EEGS_TransferType::GS_to_GS};
+		const GSUploadQueue new_transfer = {m_env.BITBLTBUF, s_n, r, EEGS_TransferType::GS_to_GS, false};
 		m_draw_transfers.push_back(new_transfer);
 	}
 

--- a/pcsx2/GS/GSState.h
+++ b/pcsx2/GS/GSState.h
@@ -269,6 +269,7 @@ public:
 		u64 draw;
 		GSVector4i rect;
 		EEGS_TransferType transfer_type;
+		bool was_hardware_only;
 	};
 
 	enum NoGapsType

--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -2364,6 +2364,23 @@ void GSRendererHW::Move()
 	if (g_texture_cache->Move(m_env.BITBLTBUF.SBP, m_env.BITBLTBUF.SBW, m_env.BITBLTBUF.SPSM, sx, sy,
 			m_env.BITBLTBUF.DBP, m_env.BITBLTBUF.DBW, m_env.BITBLTBUF.DPSM, dx, dy, w, h))
 	{
+		// Store the transfer for preloading new RT's.
+		if ((m_draw_transfers.size() > 0 && m_env.BITBLTBUF.DBP == m_draw_transfers.back().blit.DBP && m_draw_transfers.back().transfer_type == EEGS_TransferType::GS_to_GS))
+		{
+			// Same BP, let's update the rect.
+			GSUploadQueue transfer = m_draw_transfers.back();
+			m_draw_transfers.pop_back();
+			transfer.rect = transfer.rect.runion(GSVector4i(dx, dy, dx + w, dy + h));
+			transfer.draw = s_n;
+			transfer.was_hardware_only = true;
+			m_draw_transfers.push_back(transfer);
+		}
+		else
+		{
+			const GSUploadQueue new_transfer = {m_env.BITBLTBUF, s_n, GSVector4i(dx, dy, dx + w, dy + h), EEGS_TransferType::GS_to_GS, true};
+			m_draw_transfers.push_back(new_transfer);
+		}
+
 		m_env.TRXDIR.XDIR = 3;
 		// Handled entirely in TC, no need to update local memory.
 		return;
@@ -10321,6 +10338,7 @@ bool GSRendererHW::TryGSMemClear(bool no_rt, bool preserve_rt, bool invalidate_r
 			clear_queue.blit.DBP = m_cached_ctx.FRAME.Block();
 			clear_queue.blit.DBW = m_cached_ctx.FRAME.FBW;
 			clear_queue.blit.DPSM = m_cached_ctx.FRAME.PSM;
+			clear_queue.was_hardware_only = false;
 			m_draw_transfers.push_back(clear_queue);
 		}
 		else
@@ -10351,6 +10369,7 @@ bool GSRendererHW::TryGSMemClear(bool no_rt, bool preserve_rt, bool invalidate_r
 			clear_queue.blit.DBP = m_cached_ctx.ZBUF.Block();
 			clear_queue.blit.DBW = m_cached_ctx.FRAME.FBW;
 			clear_queue.blit.DPSM = m_cached_ctx.ZBUF.PSM;
+			clear_queue.was_hardware_only = false;
 			m_draw_transfers.push_back(clear_queue);
 		}
 	}

--- a/pcsx2/GS/Renderers/HW/GSRendererHWMultiISA.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHWMultiISA.cpp
@@ -570,6 +570,7 @@ bool GSRendererHWFunctions::SwPrimRender(GSRendererHW& hw, bool invalidate_tc, b
 		uq.blit.DPSM = hw.m_cached_ctx.FRAME.PSM;
 		uq.draw = GSState::s_n;
 		uq.rect = bbox;
+		uq.was_hardware_only = false;
 		hw.m_draw_transfers.push_back(uq);
 	}
 

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -4105,6 +4105,9 @@ GSTextureCache::Target* GSTextureCache::LookupDisplayTarget(GIFRegTEX0 TEX0, con
 			if (last_draw - iter->draw > 500)
 				break;
 
+			if (iter->was_hardware_only)
+				continue;
+
 			const u32 transfer_end = GSLocalMemory::GetUnwrappedEndBlockAddress(iter->blit.DBP, iter->blit.DBW, iter->blit.DPSM, iter->rect);
 
 			// If the format, and location doesn't overlap

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -5653,6 +5653,8 @@ bool GSTextureCache::ShuffleMove(u32 BP, u32 BW, u32 PSM, int sx, int sy, int dx
 	if (read_ba || !write_rg)
 		tgt->UnscaleRTAlpha();
 
+	tgt->Update();
+
 	GSHWDrawConfig& config = GSRendererHW::GetInstance()->BeginHLEHardwareDraw(tgt->m_texture, nullptr, tgt->m_scale, tgt->m_texture, tgt->m_scale, bbox);
 	config.colormask.wrgba = (write_rg ? (1 | 2) : (4 | 8));
 	config.ps.process_ba = read_ba ? 1 : 0;
@@ -5733,6 +5735,15 @@ bool GSTextureCache::PageMove(u32 SBP, u32 DBP, u32 BW, u32 PSM, int sx, int sy,
 		GL_INS("TC: Effective SBP of %x or DBP of %x is not page aligned.", SBP - stgt->m_TEX0.TBP0, DBP - dtgt->m_TEX0.TBP0);
 		return false;
 	}
+
+	// We don't want to copy "old" data that the game has overwritten with writes,
+	// so flush any overlapping dirty area.
+	// We pass that this is an invalidation to the translate function just to get a rough rect, we don't care if it's slightly for an overlap check.
+	stgt->UpdateIfDirtyIntersects(TranslateAlignedRectByPage(stgt, SBP, PSM, BW, GSVector4i(sx, sy, sx + w, sy + h), true));
+
+	// The main point of HW moves is so GPU data can get used as sources. If we don't flush all writes,
+	// we're not going to be able to use it as a source.
+	dtgt->Update();
 
 	// Need to offset based on the target's actual BP.
 	const u32 real_src_offset = ((SBP - stgt->m_TEX0.TBP0) / GS_BLOCKS_PER_PAGE) + src_page_offset;


### PR DESCRIPTION
### Description of Changes
Updates dirty areas that overlap GS local->local transfers for special page/shuffle handling
Also adds local->local hardware transfers to the transfer dumping

### Rationale behind Changes
There were conditions where there would be dirty data which later got overwritten by the local->local GS transfer. In the case of Busin 0 - Wizardry Alternative Neo it would upload an entire frame/garbage to 0x3000,. then later copy the real framebuffer to the same address, however as soon as it was used, it was updating the target from GS memory, overwriting the good newer data, which is of course incorrect.

### Suggested Testing Steps
Test Busin 0 - Wizardry Alternative Neo and Dark Cloud to make sure the graphics are correct.

### Did you use AI to help find, test, or implement this issue or feature?
No

Fixes the death scene in Busin 0 - Wizardry Alternative Neo and the lighting in Dark Cloud in some situations.

Busin 0 - Wizardry Alternative Neo:
Master:
<img width="597" height="448" alt="image" src="https://github.com/user-attachments/assets/f5322511-8a9a-41a8-a21b-c420a7812953" />
PR:
<img width="597" height="448" alt="image" src="https://github.com/user-attachments/assets/7b82ef59-032d-4168-9d92-e44e1da6f82a" />

Dark Cloud:
Master:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/5d89e661-035b-4ee4-aa7a-2dcbbf333a8c" />
PR (This now matches software):
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/6479c798-dfeb-4652-a005-893613a1502b" />
