### PR TITLE
VIF/GIF: Give 64bit back pressure when not transferring in to GIF FIFO

### DIFF
--- a/pcsx2/Gif.cpp
+++ b/pcsx2/Gif.cpp
@@ -354,6 +354,9 @@ static __fi void GIFchain()
 
 	const int transferred = WRITERING_DMA((u32*)pMem, gifch.qwc);
 	gif.gscycles += transferred * BIAS;
+	
+	if (transferred > 16) // Assume we're going past the fast 16qw FIFO and in to the 2x slower 64bit FIFO.
+		g_vif1Cycles += (transferred - 16) *BIAS;
 
 	if (!gifUnit.Path3Masked() || (gif_fifo.fifoSize < 16))
 		GifDMAInt(gif.gscycles);

--- a/pcsx2/Vif_Codes.cpp
+++ b/pcsx2/Vif_Codes.cpp
@@ -158,6 +158,7 @@ __fi int _vifCode_Direct(int pass, const u8* data, bool isDirectHL)
 
 		vif1.tag.size -= ret / 4; // Convert to u32's
 		vif1Regs.stat.VGW = false;
+		g_vif1Cycles += ((ret >> 3) * BIAS); // Add extra backpressure to the VIF (we do QW * BIAS for VIF, so double that)
 
 		if (ret & 3)
 			DevCon.Warning("Vif %s: Ret wasn't a multiple of 4!", name); // Shouldn't happen


### PR DESCRIPTION
### Description of Changes
Adds additional cycle delay back pressure to the GIF and VIF DMA channels when transferring to the GS  (or with more data than would fit in the GIF FIFO with the GIF channel)

### Rationale behind Changes
The bus between the main DMA and the GS is only 64bits wide at the same 147mhz as the DMA bus, so the data will take twice as long to upload to it, but we weren't accounting for this, and some games (Valkyrie Profile 2 FMV's) seem to rely on this delay being there so it can correctly time its frames.

### Suggested Testing Steps
Try lots of games and make sure there's no graphical glitches.

### Did you use AI to help find, test, or implement this issue or feature?
No

Fixes #1634 Valkyrie Profile 2 PAL FMV Desync