### PR TITLE
GS/GL: Misc fixes

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSTexture.cpp
+++ b/pcsx2/GS/Renderers/Common/GSTexture.cpp
@@ -200,7 +200,7 @@ u32 GSTexture::CalcUploadSize(Format format, u32 height, u32 pitch)
 
 bool GSTexture::IsFeedbackFormat(Format format)
 {
-	return format == Format::Color || format == Format::ColorClip ||
+	return format == Format::Color || format == Format::ColorClip || format == Format::ColorHDR ||
 		format == Format::DepthColor || format == Format::DepthStencil;
 }
 

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -724,9 +724,9 @@ bool GSDeviceOGL::CreateTextureFX()
 
 bool GSDeviceOGL::CheckFeatures()
 {
-	//bool vendor_id_amd = false;
-	//bool vendor_id_nvidia = false;
-	//bool vendor_id_intel = false;
+	bool vendor_id_amd = false;
+	bool vendor_id_nvidia = false;
+	bool vendor_id_intel = false;
 
 	memset(&m_bugs, 0, sizeof(m_bugs));
 
@@ -735,18 +735,18 @@ bool GSDeviceOGL::CheckFeatures()
 		std::strstr(vendor, "ATI"))
 	{
 		Console.WriteLn(Color_StrongRed, "GL: AMD GPU detected.");
-		//vendor_id_amd = true;
+		vendor_id_amd = true;
 	}
 	else if (std::strstr(vendor, "NVIDIA Corporation"))
 	{
 		Console.WriteLn(Color_StrongGreen, "GL: NVIDIA GPU detected.");
-		//vendor_id_nvidia = true;
+		vendor_id_nvidia = true;
 		m_bugs.broken_blend_coherency = true;
 	}
 	else if (std::strstr(vendor, "Intel"))
 	{
 		Console.WriteLn(Color_StrongBlue, "GL: Intel GPU detected.");
-		//vendor_id_intel = true;
+		vendor_id_intel = true;
 	}
 
 	GLint major_gl = 0;
@@ -906,15 +906,27 @@ bool GSDeviceOGL::CheckFeatures()
 	glGetIntegerv(GL_MAX_TEXTURE_SIZE, &max_texture_size);
 	m_max_texture_size = std::max(1024u, static_cast<u32>(max_texture_size));
 
-	Console.WriteLn("GL: Using %s for point expansion, %s for line expansion and %s for sprite expansion.",
-		m_features.point_expand ? "hardware" : (m_features.vs_expand ? "vertex expanding" : "UNSUPPORTED"),
-		m_features.line_expand ? "hardware" : (m_features.vs_expand ? "vertex expanding" : "UNSUPPORTED"),
-		m_features.vs_expand ? "vertex expanding" : "CPU");
+	// Unlikely to be supported on Windows if device is stuck on GL 3.3 which is usually equivalent to feature level 10.0.
+	// This should also target any proprietary drivers on linux.
+	// Open source drivers shouldn't be hit since they have different vendor names.
+	if ((vendor_id_amd || vendor_id_nvidia || vendor_id_intel) && GLAD_GL_VERSION_3_3 && !GLAD_GL_VERSION_4_0)
+		m_rgba16_unorm_hw_blend = false;
+	else
+		m_rgba16_unorm_hw_blend = true;
 
 	if (!GLAD_GL_ARB_conservative_depth)
 	{
 		Console.Warning("GLAD_GL_ARB_conservative_depth is not supported. This will reduce performance.");
 	}
+
+	Console.WriteLn("GL: Using %s for point expansion, %s for line expansion and %s for sprite expansion.",
+		m_features.point_expand ? "hardware" : (m_features.vs_expand ? "vertex expanding" : "UNSUPPORTED"),
+		m_features.line_expand ? "hardware" : (m_features.vs_expand ? "vertex expanding" : "UNSUPPORTED"),
+		m_features.vs_expand ? "vertex expanding" : "CPU");
+	
+	Console.WriteLnFmt("GL: DXTn Texture Compression: {}", m_features.dxt_textures ? "Supported" : "Not Supported");
+	Console.WriteLnFmt("GL: BC6/7 Texture Compression: {}", m_features.bptc_textures ? "Supported" : "Not Supported");
+	Console.WriteLnFmt("GL: RGBA16 UNORM Hardware Blending: {}", m_rgba16_unorm_hw_blend ? "Supported" : "Not Supported");
 	
 	m_features.aa1 = GSConfig.HWAA1 && m_features.vs_expand && m_features.feedback_loops();
 	
@@ -2898,7 +2910,7 @@ void GSDeviceOGL::RenderHW(GSHWDrawConfig& config)
 		{
 			config.colclip_update_area = config.drawarea;
 
-			colclip_rt = CreateFeedbackTarget(rtsize.x, rtsize.y, GSTexture::Format::ColorClip, false);
+			colclip_rt = CreateFeedbackTarget(rtsize.x, rtsize.y, m_rgba16_unorm_hw_blend ? GSTexture::Format::ColorClip : GSTexture::Format::ColorHDR, false);
 
 			if (!colclip_rt)
 			{

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.h
@@ -159,6 +159,7 @@ private:
 	} m_bugs;
 
 	bool m_disable_download_pbo = false;
+	bool m_rgba16_unorm_hw_blend = false;
 
 	GLuint m_fbo = 0; // frame buffer container
 	GLuint m_fbo_read = 0; // frame buffer container only for reading

--- a/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSTextureOGL.cpp
@@ -34,7 +34,7 @@ GSTextureOGL::GSTextureOGL(Usage usage, int width, int height, int levels, Forma
 	// Bunch of constant parameter
 	switch (m_format)
 	{
-		// 1 Channel integer
+		// 1 channel integer
 		case Format::PrimID:
 			m_gl_format = GL_R32F;
 			m_int_format = GL_RED;
@@ -54,7 +54,7 @@ GSTextureOGL::GSTextureOGL(Usage usage, int width, int height, int levels, Forma
 			m_int_shift = 1;
 			break;
 
-		// 1 Channel normalized
+		// 1 channel normalized
 		case Format::UNorm8:
 			m_gl_format = GL_R8;
 			m_int_format = GL_RED;
@@ -72,15 +72,29 @@ GSTextureOGL::GSTextureOGL(Usage usage, int width, int height, int levels, Forma
 
 		// 4 channel normalized
 		case Format::Color:
-		case Format::ColorHQ:
-		case Format::ColorHDR:
 			m_gl_format = GL_RGBA8;
 			m_int_format = GL_RGBA;
 			m_int_type = GL_UNSIGNED_BYTE;
 			m_int_shift = 2;
 			break;
 
+		// 4 channel normalized with 2 bits of alpha
+		case Format::ColorHQ:
+			m_gl_format = GL_RGB10_A2;
+			m_int_format = GL_RGBA;
+			m_int_type = GL_UNSIGNED_INT_2_10_10_10_REV;
+			m_int_shift = 2;
+			break;
+
 		// 4 channel float
+		case Format::ColorHDR:
+			m_gl_format = GL_RGBA16F;
+			m_int_format = GL_RGBA;
+			m_int_type = GL_HALF_FLOAT;
+			m_int_shift = 3;
+			break;
+
+		// 4 channel normalized  
 		case Format::ColorClip:
 			m_gl_format = GL_RGBA16;
 			m_int_format = GL_RGBA;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
GS: Make sure ColorHDR is treated as a feedbackloop format.
It is used as a fallback when hw blending isn't supported on RGBA16 UNORM.

GS/GL: Use correct formats for ColorHQ, ColorHDR.
ColorHQ: GL_RGB10_A2.
ColorHDR: GL_RGBA16F.

GS/GL: Check if RGBA16 UNORM is hw blendable, if not then fallback to RGBA16 Float.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
Better support on older gpus. 
Follow up from https://github.com/PCSX2/pcsx2/pull/13922 for GL this time.
It is unlikely for a gpu/driver stuck on 3.3 to support hw blending on RGBA16 UNORM so let's fallback to using GL_RGBA16F with less precision. Open source drivers are excluded as they should work, even if the reported version is gl 3.3 on older hardware.

Fixes the gl api errors:
```
Software processing fallback in rasterization. Blending is not hardware accelerated with ALPHA formats.
Buffer performance warning: Buffer object 4 (bound to GL_UNIFORM_BUFFER (1), usage hint is GL_STREAM_DRAW) is being copied/moved from VIDEO memory to HOST memory.
```

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
Smoke test Sly 2 on GL, make sure shadows work on newer hardware, smoke test some other games too. For older hardware Sly 2 has precision issues which is expected.

Dump run completed with no regressions.

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation as to how you used it. Please see the Large Language Model (LLM) Usage Policy for more information: https://pcsx2.net/docs/contributing/#large-language-model-llm-usage-policy -->
Yes, to make sure the updated color formats are correct.