### PR TITLE
GS/HW: Fix target stride handling in Warrior Within

### DIFF
--- a/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -4657,6 +4657,10 @@ void GSRendererHW::Draw()
 			if (FRAME_TEX0.TBW != 1 || (m_r.width() > frame_psm.pgs.x || m_r.height() > frame_psm.pgs.y) || (scale_draw == 1 && !scaled_copy))
 			{
 				FRAME_TEX0.TBP0 = rt->m_TEX0.TBP0;
+				// Alpha-only draws at a narrower stride must preserve the cached RGB layout.
+				// Warrior Within reduces FBW in these draws; other games need proper testing.
+				if (!valid_width_change && FRAME_TEX0.TBW < rt->m_TEX0.TBW && rt->m_TEX0.PSM == FRAME_TEX0.PSM)
+					FRAME_TEX0.TBW = rt->m_TEX0.TBW;
 				rt->m_TEX0 = FRAME_TEX0;
 			}
 

--- a/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -17,6 +17,7 @@
 
 #include "fmt/format.h"
 
+#include <algorithm>
 #include <cinttypes>
 #include <math.h>
 
@@ -3979,8 +3980,9 @@ GSTextureCache::Target* GSTextureCache::LookupDisplayTarget(GIFRegTEX0 TEX0, con
 				{
 					const GSVector4i dirty_rect = t->m_dirty.GetTotalRect(t->m_TEX0, t->m_unscaled_size);
 					// It's dirty with the data we want at the right width, so just change it to that.
-					// Prince of Persia - Sands of Time
-					if (t->m_dirty.size() == 1 && t->m_dirty[0].bw == TEX0.TBW)
+					// (AI-assisted) Multiple channel masks can describe writes at the same stride.
+					// Prince of Persia - Sands of Time / Warrior Within
+					if (std::all_of(t->m_dirty.begin(), t->m_dirty.end(), [&TEX0](const GSDirtyRect& dirty) { return dirty.bw == TEX0.TBW; }))
 					{
 						t->m_TEX0.TBW = TEX0.TBW;
 						t->m_valid = dirty_rect;


### PR DESCRIPTION
### Description of Changes

Fix render-target stride handling in the hardware renderer for Prince of Persia: Warrior Within.

Preserve the cached target's RGB stride when an alpha-only draw uses a narrower framebuffer stride with the same pixel format. Also allow display-target stride recovery with multiple dirty records when all records match the requested stride.

### Rationale behind Changes

Addresses the black frames during perspective changes and the partially updated map reported in #14934.

Narrower alpha-only draws changed the cached target's stride while its valid RGB data still used the previous layout. Subsequent CPU uploads then updated only part of the target, leaving scene content visible on the right side of the map.

Display-target lookup also rejected compatible updates represented by multiple dirty records. This could discard the display target and produce a black presentation during perspective changes.

### Suggested Testing Steps

Validated with the supplied transition and map GS dumps on Linux, using Intel Iris Xe and the OpenGL hardware renderer:

- Built the Qt frontend and GS dump runner successfully.
- Replayed the transition dump for two passes: the baseline produced 16 blank presentations across 48 VSync events; the patched build produced none.
- Replayed the map dump and confirmed that the full map appears in the affected frames, including the right-hand region.
- Compared actual presented output against the Software renderer.